### PR TITLE
chore: bump provider dependencies

### DIFF
--- a/packages/providers/anthropic/package.json
+++ b/packages/providers/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/anthropic",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Anthropic provider adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",
@@ -23,7 +23,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.95.0",
+    "@anthropic-ai/sdk": "^0.95.1",
     "@anvia/core": "workspace:*"
   },
   "devDependencies": {

--- a/packages/providers/gemini/package.json
+++ b/packages/providers/gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/gemini",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Gemini provider adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@anvia/core": "workspace:*",
-    "@google/genai": "^1.52.0"
+    "@google/genai": "^2.0.0"
   },
   "devDependencies": {
     "@types/node": "^24.9.1",

--- a/packages/providers/openai/package.json
+++ b/packages/providers/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/openai",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "description": "OpenAI provider adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@anvia/core": "workspace:*",
-    "openai": "^6.36.0"
+    "openai": "^6.37.0"
   },
   "devDependencies": {
     "@types/node": "^24.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,8 +335,8 @@ importers:
   packages/providers/anthropic:
     dependencies:
       '@anthropic-ai/sdk':
-        specifier: ^0.95.0
-        version: 0.95.0(zod@4.4.3)
+        specifier: ^0.95.1
+        version: 0.95.1(zod@4.4.3)
       '@anvia/core':
         specifier: workspace:*
         version: link:../../core
@@ -360,8 +360,8 @@ importers:
         specifier: workspace:*
         version: link:../../core
       '@google/genai':
-        specifier: ^1.52.0
-        version: 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
+        specifier: ^2.0.0
+        version: 2.0.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
     devDependencies:
       '@types/node':
         specifier: ^24.9.1
@@ -404,8 +404,8 @@ importers:
         specifier: workspace:*
         version: link:../../core
       openai:
-        specifier: ^6.36.0
-        version: 6.36.0(ws@8.20.0)(zod@4.4.3)
+        specifier: ^6.37.0
+        version: 6.37.0(ws@8.20.0)(zod@4.4.3)
     devDependencies:
       '@types/node':
         specifier: ^24.9.1
@@ -586,8 +586,8 @@ packages:
     resolution: {integrity: sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==}
     engines: {node: '>=18'}
 
-  '@anthropic-ai/sdk@0.95.0':
-    resolution: {integrity: sha512-7It2B76OFJH9jC/a0TicXFMq0ZZM25ei+i/mK7JnsE1Ibmo0Yfkqm+DXOHeU/ZxxKwLLGPP6qaAvKmQmgV6XhA==}
+  '@anthropic-ai/sdk@0.95.1':
+    resolution: {integrity: sha512-OO9AF7hmAoU492c/mD7Q2cPqI2WNAj7rAPHlawgBeUgpwiboLRiDs+grsErGWeHHP9ZRWfzq2OVrODTt8aITVg==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -1382,8 +1382,8 @@ packages:
       tailwindcss:
         optional: true
 
-  '@google/genai@1.52.0':
-    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
+  '@google/genai@2.0.0':
+    resolution: {integrity: sha512-6XpO+YbGutXkm5QgR7NZktISxSz0dw3pSs9NtCUQwvhJc1eyA3KhdKhE/0Uaxp3a6eul3LC0SKau1bXymjOKUg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.25.2
@@ -4741,8 +4741,8 @@ packages:
   onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
     resolution: {integrity: sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==}
 
-  openai@6.36.0:
-    resolution: {integrity: sha512-Has2YbIusMq9wQEierFsgf9c783dy1y9arX459LmphNacEkkM5yxi2RIyXP0LmkOroQyW19iTwALHL8Yf26UKA==}
+  openai@6.37.0:
+    resolution: {integrity: sha512-0H5dEGFmmLv6KSd0W1w2nyL8WsLkX6yoLeQpU+dZAOuGcany5qkYQMmj35ZrKgb6yiyYqpUzFOpR8mZQkgqeEQ==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -5770,7 +5770,7 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
-  '@anthropic-ai/sdk@0.95.0(zod@4.4.3)':
+  '@anthropic-ai/sdk@0.95.1(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
       standardwebhooks: 1.0.0
@@ -6303,7 +6303,7 @@ snapshots:
       '@tailwindcss/oxide': 4.2.4
       tailwindcss: 4.2.4
 
-  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
+  '@google/genai@2.0.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
@@ -10310,7 +10310,7 @@ snapshots:
       platform: 1.3.6
       protobufjs: 7.5.6
 
-  openai@6.36.0(ws@8.20.0)(zod@4.4.3):
+  openai@6.37.0(ws@8.20.0)(zod@4.4.3):
     optionalDependencies:
       ws: 8.20.0
       zod: 4.4.3


### PR DESCRIPTION
## Summary
- bump Anthropic, Gemini, and OpenAI provider runtime dependencies
- bump provider package patch versions for published releases
- refresh pnpm lockfile

## Verification
- ./bin/check-upstream-deps.sh --fail-on-update
- pnpm --filter @anvia/gemini --filter @anvia/openai --filter @anvia/anthropic typecheck
- pnpm --filter @anvia/gemini --filter @anvia/openai --filter @anvia/anthropic test
- pnpm --filter @anvia/anthropic --filter @anvia/gemini --filter @anvia/openai build