### PR TITLE
feat: add Studio persistence and pipeline inspection

### DIFF
--- a/apps/docs/content/docs/guides/agents/agent-tools.mdx
+++ b/apps/docs/content/docs/guides/agents/agent-tools.mdx
@@ -83,24 +83,21 @@ const response = await agent.prompt("Where is order A-100?").maxTurns(3).send();
 
 ## Require Approval
 
-Use hook-based tool approval when a tool should not run until your app approves it.
+Use hook-based tool approval when a tool should not run until an approval-capable runtime approves it.
 
 ```ts
 import { createHook } from "@anvia/core";
 
 const approvalHook = createHook({
-  async onToolCall({ toolName, args, tool }) {
+  onToolCall({ toolName, tool }) {
     if (toolName !== "refund_order") {
       return tool.run();
     }
 
-    const approved = await approvals.waitForDecision({
-      toolName,
-      args,
+    return tool.requestApproval({
       reason: "Refunds require staff approval.",
+      rejectMessage: "Refund was not approved.",
     });
-
-    return approved ? tool.run() : tool.skip("Refund was not approved.");
   },
 });
 
@@ -109,5 +106,7 @@ const response = await agent
   .requestHook(approvalHook)
   .send();
 ```
+
+Studio handles `tool.requestApproval(...)` automatically. Without an approval handler, core cancels clearly instead of running the guarded tool.
 
 For the full approval flow, read [Human in the Loop](/docs/guides/human-in-the-loop).

--- a/apps/docs/content/docs/guides/agents/runtime-hooks.mdx
+++ b/apps/docs/content/docs/guides/agents/runtime-hooks.mdx
@@ -46,33 +46,30 @@ const hook = createHook({
 });
 ```
 
-`tool.run()` executes the tool. `tool.skip(...)` does not execute the tool; the message becomes the tool result sent back to the model.
+`tool.run()` executes the tool. `tool.skip(...)` does not execute the tool; the message becomes the tool result sent back to the model. `tool.requestApproval(...)` asks an approval-capable runtime such as Studio to pause the tool call for a human decision.
 
 Tool result middleware runs after this decision produces a result string and before `onToolResult(...)` observes it.
 
 ## Await Human Approval
 
-Approval is application code awaited inside the hook.
+Approval can be requested from inside the hook. Studio handles this action automatically when the agent is run through Studio.
 
 ```ts
 const hook = createHook({
-  async onToolCall({ toolName, args, tool }) {
+  onToolCall({ toolName, tool }) {
     if (toolName !== "refund_order") {
       return tool.run();
     }
 
-    const approved = await approvals.waitForDecision({
-      toolName,
-      args,
+    return tool.requestApproval({
       reason: "Refunds require staff approval.",
+      rejectMessage: "Refund was not approved.",
     });
-
-    return approved ? tool.run() : tool.skip("Refund was not approved.");
   },
 });
 ```
 
-Anvia does not own the approval UI, database, queue, or notification system. Your hook can await any runtime your app provides.
+Without Studio or another approval handler, `tool.requestApproval(...)` cancels clearly instead of running the tool. If your application owns a custom approval system, you can still await it in the hook and return `tool.run()` or `tool.skip(...)` yourself.
 
 Timeouts are optional. If the awaited approval never resolves, the agent run keeps waiting; add a timeout in your app code when the caller needs bounded latency.
 

--- a/apps/docs/content/docs/guides/human-in-the-loop/approval-settings.mdx
+++ b/apps/docs/content/docs/guides/human-in-the-loop/approval-settings.mdx
@@ -94,6 +94,6 @@ approval: {
 
 ## When to Use Hooks Instead
 
-Use [approval by hooks](/docs/guides/human-in-the-loop/tool-approval) when approval depends on request-local state, app permissions, external policy services, or a frontend/backend approval flow that is not tied to one tool definition.
+Use [approval by hooks](/docs/guides/human-in-the-loop/tool-approval) when approval depends on request-local state, app permissions, external policy services, or policy that is not tied to one tool definition.
 
-Agent hooks run before Studio approval metadata. If an agent hook returns `tool.skip(...)` or `tool.cancel(...)`, Studio does not ask for approval.
+Agent hooks run before Studio approval metadata. If an agent hook returns `tool.skip(...)` or `tool.cancel(...)`, Studio does not ask for approval. If it returns `tool.requestApproval(...)`, Studio handles that approval request directly.

--- a/apps/docs/content/docs/guides/human-in-the-loop/index.mdx
+++ b/apps/docs/content/docs/guides/human-in-the-loop/index.mdx
@@ -5,14 +5,14 @@ description: Choose where human approval and feedback belong.
 
 Human-in-the-loop means the agent run waits for a person before continuing. Use it for approvals, operator feedback, missing context, escalation decisions, outbound messages, refunds, account changes, deletes, and other workflows where the model should not decide alone.
 
-Anvia keeps the core execution model small: tools run, hooks can run/skip/cancel, and awaited promises pause the run. Studio adds a zero-config UI layer for common approval and question flows.
+Anvia keeps the core execution model small: tools run, hooks can run/skip/cancel/request approval, and awaited promises pause the run. Studio adds a zero-config UI layer for common approval and question flows.
 
 ## Choose a Pattern
 
 | Pattern | Best for | Where it lives |
 | --- | --- | --- |
 | [Approval settings in tools](/docs/guides/human-in-the-loop/approval-settings) | Studio approval UI with no custom hook | Tool metadata |
-| [Approval by hooks](/docs/guides/human-in-the-loop/tool-approval) | Custom policy, custom UI, or request-specific rules | `onToolCall(...)` |
+| [Approval by hooks](/docs/guides/human-in-the-loop/tool-approval) | Dynamic policy or request-specific rules | `onToolCall(...)` |
 | [Ask question tools](/docs/guides/human-in-the-loop/ask-question) | Missing user input while a run is active | Normal tools |
 | [Approval runtimes](/docs/guides/human-in-the-loop/approval-handlers) | Databases, queues, notifications, audit logs, optional timeouts | Your app |
 
@@ -45,24 +45,19 @@ Core stores this metadata but does not enforce it. Studio reads it and installs 
 
 ## Hook Approval
 
-Use a hook when approval is not a property of the tool itself, or when your app already owns the approval workflow.
-
-In this example, `approvalRuntime` is your application object. It is not exported by Anvia; create it with your database, queue, or reviewer UI. See [Approval Runtimes](/docs/guides/human-in-the-loop/approval-handlers).
+Use a hook when approval is not a property of the tool itself. Studio handles `tool.requestApproval(...)` with the same approval UI and API used for tool metadata.
 
 ```ts
 const approvalHook = createHook({
-  async onToolCall({ toolName, args, tool }) {
+  onToolCall({ toolName, tool }) {
     if (toolName !== "refund_order") {
       return tool.run();
     }
 
-    const approved = await approvalRuntime.waitForDecision({
-      toolName,
-      args,
+    return tool.requestApproval({
       reason: "Refunds require staff approval.",
+      rejectMessage: "Refund was not approved.",
     });
-
-    return approved ? tool.run() : tool.skip("Refund was not approved.");
   },
 });
 

--- a/apps/docs/content/docs/guides/human-in-the-loop/tool-approval.mdx
+++ b/apps/docs/content/docs/guides/human-in-the-loop/tool-approval.mdx
@@ -3,11 +3,9 @@ title: Approval by Hooks
 description: Await custom approval logic before selected tool calls execute.
 ---
 
-Use `onToolCall(...)` when approval is runtime behavior rather than tool metadata. A hook can call your database, queue, websocket, permissions service, or internal admin UI before it returns `tool.run()`, `tool.skip(...)`, or `tool.cancel(...)`.
+Use `onToolCall(...)` when approval is runtime behavior rather than tool metadata. A hook can request approval before it returns `tool.run()`, `tool.skip(...)`, or `tool.cancel(...)`.
 
-This is the advanced escape hatch. For Studio-managed approval UI, start with [approval settings](/docs/guides/human-in-the-loop/approval-settings).
-
-The examples use `approvalRuntime` as an application-owned object. Do not import it from Anvia. Build it in your app, then call it from the hook. For the runtime shape, read [Approval Runtimes](/docs/guides/human-in-the-loop/approval-handlers).
+Studio handles `tool.requestApproval(...)` automatically. Without Studio or another approval handler, the run cancels clearly instead of executing the guarded tool.
 
 ## Require Approval for One Tool
 
@@ -15,25 +13,20 @@ The examples use `approvalRuntime` as an application-owned object. Do not import
 import { createHook } from "@anvia/core";
 
 const approvalHook = createHook({
-  async onToolCall({ toolName, args, tool }) {
+  onToolCall({ toolName, tool }) {
     if (toolName !== "refund_order") {
       return tool.run();
     }
 
-    const approved = await approvalRuntime.waitForDecision({
-      toolName,
-      args,
-      reason: `Review refund request: ${args}`,
+    return tool.requestApproval({
+      reason: "Review this refund request.",
+      rejectMessage: "Refund was not approved.",
     });
-
-    return approved
-      ? tool.run()
-      : tool.skip("Refund was not approved.");
   },
 });
 ```
 
-The `args` value is the JSON string Anvia will send to the tool. Use it to show reviewers exactly what the model is trying to do.
+Use the `args` value when the reviewer needs to see exactly what the model is trying to do.
 
 ## Attach the Hook
 
@@ -64,20 +57,15 @@ Keep the approval rule explicit.
 const sensitiveTools = new Set(["refund_order", "cancel_subscription"]);
 
 const approvalHook = createHook({
-  async onToolCall({ toolName, args, tool }) {
+  onToolCall({ toolName, tool }) {
     if (!sensitiveTools.has(toolName)) {
       return tool.run();
     }
 
-    const approved = await approvalRuntime.waitForDecision({
-      toolName,
-      args,
+    return tool.requestApproval({
       reason: `${toolName} requires human review.`,
+      rejectMessage: `${toolName} was not approved.`,
     });
-
-    return approved
-      ? tool.run()
-      : tool.skip(`${toolName} was not approved.`);
   },
 });
 ```
@@ -92,7 +80,7 @@ Parse the pending tool arguments when only some calls need review.
 import { createHook, parseToolArgs } from "@anvia/core";
 
 const approvalHook = createHook({
-  async onToolCall({ toolName, args, tool }) {
+  onToolCall({ toolName, args, tool }) {
     if (toolName !== "issue_refund") {
       return tool.run();
     }
@@ -111,13 +99,10 @@ const approvalHook = createHook({
       return tool.run();
     }
 
-    const approved = await approvalRuntime.waitForDecision({
-      toolName,
-      args,
+    return tool.requestApproval({
       reason: `Refund amount is $${parsed.amount}.`,
+      rejectMessage: "Refund was not approved.",
     });
-
-    return approved ? tool.run() : tool.skip("Refund was not approved.");
   },
 });
 ```
@@ -146,17 +131,20 @@ const agent = new AgentBuilder("support", model)
 
 ## Rejected Approval
 
-When approval is rejected, skip the tool with a clear message.
+When approval is rejected, Studio sends the configured rejection message back to the model as the tool result.
 
 ```ts
-return tool.skip("The reviewer rejected this action.");
+return tool.requestApproval({
+  reason: "Review this action.",
+  rejectMessage: "The reviewer rejected this action.",
+});
 ```
 
 The model receives this text as the tool result, then it can produce a final answer.
 
 ## Timeout Policy
 
-Anvia does not require a timeout. If the awaited approval promise never resolves, the run waits. Add a timeout in your app when the caller needs bounded latency.
+Anvia does not require a timeout. Studio approval waits until a reviewer approves or rejects. If your application owns a custom approval system, add a timeout in that app code when the caller needs bounded latency.
 
 ```ts
 const approved = await Promise.race([

--- a/apps/docs/content/docs/reference/core/agent.mdx
+++ b/apps/docs/content/docs/reference/core/agent.mdx
@@ -296,10 +296,16 @@ Notable errors: terminal failures are yielded as `{ type: "error" }` and also or
 
 ```ts
 type HookAction = { type: "continue" } | { type: "terminate"; reason: string };
+type ToolApprovalRequestOptions = {
+  reason?: string;
+  rejectMessage?: string;
+};
+
 type ToolCallHookAction =
   | { type: "continue" }
   | { type: "skip"; reason: string }
-  | { type: "terminate"; reason: string };
+  | { type: "terminate"; reason: string }
+  | ({ type: "approval_request" } & ToolApprovalRequestOptions);
 
 type RunControl = {
   continue(): HookAction;
@@ -310,6 +316,7 @@ type ToolCallControl = {
   run(): ToolCallHookAction;
   skip(reason: string): ToolCallHookAction;
   cancel(reason: string): ToolCallHookAction;
+  requestApproval(options?: ToolApprovalRequestOptions): ToolCallHookAction;
 };
 
 type HookResult = HookAction | undefined;
@@ -349,13 +356,14 @@ const toolCallControl: ToolCallControl;
 function createHook<RawResponse = unknown>(hook: PromptHook<RawResponse>): PromptHook<RawResponse>;
 function cancelPrompt(reason: string): HookAction;
 function skipTool(reason: string): ToolCallHookAction;
+function requestToolApproval(options?: ToolApprovalRequestOptions): ToolCallHookAction;
 ```
 
 Purpose: intercept completion calls, completion responses, tool calls, and tool results.
 
-Return behavior: callback controls such as `tool.run()`, `tool.skip(...)`, `tool.cancel(...)`, `run.continue()`, and `run.cancel(...)` create actions consumed by `PromptRequest`. The low-level `cancelPrompt(...)` and `skipTool(...)` helpers are also available.
+Return behavior: callback controls such as `tool.run()`, `tool.skip(...)`, `tool.cancel(...)`, `tool.requestApproval(...)`, `run.continue()`, and `run.cancel(...)` create actions consumed by `PromptRequest`. The low-level `cancelPrompt(...)`, `skipTool(...)`, and `requestToolApproval(...)` helpers are also available.
 
-Notable errors: a terminating hook produces `PromptCancelledError`.
+Notable errors: a terminating hook produces `PromptCancelledError`. If `tool.requestApproval(...)` reaches core without Studio or another approval handler, the request cancels with `PromptCancelledError`.
 
 ## Error Classes
 

--- a/apps/docs/content/docs/reference/core/pipeline.mdx
+++ b/apps/docs/content/docs/reference/core/pipeline.mdx
@@ -37,31 +37,127 @@ Notable errors: invalid values are normalized to at least `1`.
 
 ```ts
 class Pipeline<Input, Output> implements PipelineOp<Input, Awaited<Output>> {
-  run(input: Input): Promise<Awaited<Output>>;
+  readonly id: string;
+  readonly name: string | undefined;
+  readonly description: string | undefined;
+  readonly metadata: JsonObject | undefined;
+  run(input: Input, options?: PipelineRunOptions): Promise<Awaited<Output>>;
   batch<I extends Iterable<Input>>(
     inputs: I,
     options: PipelineBatchOptions,
   ): Promise<Array<Awaited<Output>>>;
+  graph(): PipelineGraph;
 }
 ```
 
 Purpose: runnable pipeline returned by `PipelineBuilder.build()`.
 
-Return behavior: `run(...)` resolves the final stage output; `batch(...)` preserves input order.
+Return behavior: `run(...)` resolves the final stage output; `batch(...)` preserves input order; `graph()` returns inspectable pipeline metadata, nodes, and edges.
 
 Notable errors: forwards stage errors.
+
+## Pipeline Graph Types
+
+```ts
+type PipelineMetadata = {
+  id?: string;
+  name?: string;
+  description?: string;
+  metadata?: JsonObject;
+};
+
+type PipelineStageMetadata = {
+  id?: string;
+  name?: string;
+  description?: string;
+  metadata?: JsonObject;
+};
+
+type PipelineStageKind =
+  | "input"
+  | "step"
+  | "pipeline"
+  | "parallel"
+  | "branch"
+  | "agent"
+  | "extractor"
+  | "output";
+
+type PipelineGraphNode = {
+  id: string;
+  kind: PipelineStageKind;
+  label: string;
+  description?: string;
+  metadata?: JsonObject;
+  agentId?: string;
+  agentName?: string;
+  pipelineId?: string;
+  branchKey?: string;
+};
+
+type PipelineGraphEdge = {
+  id: string;
+  source: string;
+  target: string;
+  label?: string;
+};
+
+type PipelineGraph = PipelineMetadata & {
+  id: string;
+  nodes: PipelineGraphNode[];
+  edges: PipelineGraphEdge[];
+};
+```
+
+Purpose: automatic graph metadata for Studio and other inspectors.
+
+Return behavior: stage ids and labels are generated from build order unless optional metadata supplies better values.
+
+Notable errors: none directly.
+
+## Pipeline Run Events
+
+```ts
+type PipelineRunEvent =
+  | { type: "stage_started"; node: PipelineGraphNode }
+  | { type: "stage_completed"; node: PipelineGraphNode; durationMs: number }
+  | { type: "stage_failed"; node: PipelineGraphNode; durationMs: number; error: unknown };
+
+type PipelineRunObserver = {
+  onEvent(event: PipelineRunEvent): void | Promise<void>;
+};
+
+type PipelineRunOptions = {
+  observer?: PipelineRunObserver;
+};
+```
+
+Purpose: metadata-only execution events for runtimes such as Studio.
+
+Return behavior: pass an observer to `pipeline.run(input, { observer })` to receive stage status changes.
+
+Notable errors: observer errors propagate to the run.
 
 ## PipelineBuilder
 
 ```ts
 class PipelineBuilder<Input, Output = Input> {
-  step<Next>(fn: (input: Awaited<Output>) => Next | Promise<Next>): PipelineBuilder<Input, Awaited<Next>>;
-  use<Next>(op: PipelineOp<Awaited<Output>, Next>): PipelineBuilder<Input, Awaited<Next>>;
+  constructor();
+  constructor(metadata: PipelineMetadata);
+  step<Next>(
+    fn: (input: Awaited<Output>) => Next | Promise<Next>,
+    metadata?: PipelineStageMetadata,
+  ): PipelineBuilder<Input, Awaited<Next>>;
+  use<Next>(
+    op: PipelineOp<Awaited<Output>, Next>,
+    metadata?: PipelineStageMetadata,
+  ): PipelineBuilder<Input, Awaited<Next>>;
   parallel<Branches extends Record<string, PipelineOp<Awaited<Output>, unknown>>>(
     branches: Branches,
+    metadata?: PipelineStageMetadata,
   ): PipelineBuilder<Input, ParallelOutput<Branches>>;
-  prompt(agent: Agent<CompletionModel>): PipelineBuilder<Input, string>;
-  extract<T>(extractor: Extractor<T, CompletionModel>): PipelineBuilder<Input, T>;
+  prompt(agent: Agent<CompletionModel>, metadata?: PipelineStageMetadata): PipelineBuilder<Input, string>;
+  extract<T>(extractor: Extractor<T, CompletionModel>, metadata?: PipelineStageMetadata): PipelineBuilder<Input, T>;
   build(): Pipeline<Input, Awaited<Output>>;
 }
 ```

--- a/apps/docs/content/docs/reference/studio/runtime.mdx
+++ b/apps/docs/content/docs/reference/studio/runtime.mdx
@@ -9,7 +9,7 @@ Import from `@anvia/studio`.
 
 ```ts
 class Studio implements AnviaStudio {
-  constructor(agents?: Agent[], options?: StudioOptions);
+  constructor(targets?: StudioTarget[], options?: StudioOptions);
   get app(): Hono;
   fetch(request: Request): Response | Promise<Response>;
   config(): StudioConfig;
@@ -21,7 +21,7 @@ class Studio implements AnviaStudio {
 
 Purpose: local Studio HTTP runtime and UI/API host.
 
-Return behavior: `start(...)` starts an HTTP server and returns `this`; `fetch(...)` delegates to the Hono app.
+Return behavior: pass built agents, built pipelines, or both in the first array. `start(...)` starts an HTTP server and returns `this`; `fetch(...)` delegates to the Hono app.
 
 Notable errors: server startup can fail when the port is unavailable; route handlers return structured `StudioErrorResponse` values for request errors.
 
@@ -48,6 +48,8 @@ Notable errors: none directly.
 type StudioOptions = {
   quickPrompts?: Record<string, string[]>;
 };
+
+type StudioTarget = Agent | Pipeline<unknown, unknown>;
 
 type StudioServeOptions = {
   port?: number;

--- a/apps/docs/content/docs/reference/studio/sessions.mdx
+++ b/apps/docs/content/docs/reference/studio/sessions.mdx
@@ -121,11 +121,58 @@ type StudioSessionRunTranscriptInput = {
   status: StudioSessionRunStatus;
   error?: JsonValue;
 };
+
+type StudioSessionLogLevel = "debug" | "info" | "warn" | "error";
+
+type StudioSessionLogCategory =
+  | "session"
+  | "run"
+  | "memory"
+  | "prompt"
+  | "model"
+  | "tool"
+  | "approval"
+  | "question"
+  | "api";
+
+type StudioSessionLogEntry = {
+  id: string;
+  sessionId: string;
+  runId?: string;
+  sequence: number;
+  timestamp: string;
+  level: StudioSessionLogLevel;
+  category: StudioSessionLogCategory;
+  event: string;
+  message: string;
+  metadata?: JsonObject;
+};
+
+type StudioSessionLogAppendInput = {
+  sessionId: string;
+  runId?: string;
+  level: StudioSessionLogLevel;
+  category: StudioSessionLogCategory;
+  event: string;
+  message: string;
+  metadata?: JsonObject;
+};
+
+type StudioSessionLogListOptions = {
+  sessionId: string;
+  limit: number;
+  after?: number;
+};
+
+type StudioSessionLogEvent = {
+  type: "session_log";
+  log: StudioSessionLogEntry;
+};
 ```
 
 Purpose: arguments for session store methods.
 
-Return behavior: used by `StudioSessionStore`.
+Return behavior: used by `StudioSessionStore` and streaming session log events.
 
 Notable errors: store implementations may reject invalid or conflicting inputs.
 
@@ -140,12 +187,14 @@ type StudioSessionStore = MemoryStore & {
   saveSessionRunTranscript(
     input: StudioSessionRunTranscriptInput,
   ): StudioSession | undefined | Promise<StudioSession | undefined>;
+  appendSessionLog?(input: StudioSessionLogAppendInput): StudioSessionLogEntry | Promise<StudioSessionLogEntry>;
+  listSessionLogs?(options: StudioSessionLogListOptions): StudioSessionLogEntry[] | Promise<StudioSessionLogEntry[]>;
   deleteSession?(id: string): boolean | Promise<boolean>;
 };
 ```
 
 Purpose: persistence adapter for Studio sessions.
 
-Return behavior: methods may be sync or async. Because the store extends `MemoryStore`, it also loads, appends, and clears model messages for Studio-backed sessions.
+Return behavior: methods may be sync or async. Because the store extends `MemoryStore`, it also loads, appends, and clears model messages for Studio-backed sessions. Log methods are optional for custom stores; the default SQLite store implements them.
 
 Notable errors: persistence failures should throw or reject.

--- a/apps/docs/content/docs/reference/studio/sessions.mdx
+++ b/apps/docs/content/docs/reference/studio/sessions.mdx
@@ -146,6 +146,6 @@ type StudioSessionStore = MemoryStore & {
 
 Purpose: persistence adapter for Studio sessions.
 
-Return behavior: methods may be sync or async. Because the store extends `MemoryStore`, it also loads, appends, and clears model transcript messages for Studio-backed sessions.
+Return behavior: methods may be sync or async. Because the store extends `MemoryStore`, it also loads, appends, and clears model messages for Studio-backed sessions.
 
 Notable errors: persistence failures should throw or reject.

--- a/apps/docs/content/docs/reference/studio/stores.mdx
+++ b/apps/docs/content/docs/reference/studio/stores.mdx
@@ -11,12 +11,13 @@ Import from `@anvia/studio`.
 type StudioStores = {
   sessions?: StudioSessionStore | false;
   traces?: StudioTraceStore;
+  pipelineLogs?: StudioPipelineLogStore | false;
 };
 ```
 
-Purpose: optional persistence stores for Studio sessions and traces.
+Purpose: optional persistence stores for Studio sessions, traces, and pipeline logs.
 
-Return behavior: `false` disables sessions; omitted traces disable trace routes unless the session store also implements `StudioTraceStore`.
+Return behavior: `false` disables sessions or pipeline logs. Omitted traces disable trace routes unless the session store also implements `StudioTraceStore`. The default SQLite store implements session, trace, and pipeline log storage.
 
 Notable errors: none directly.
 
@@ -29,10 +30,10 @@ type SqliteSessionStoreOptions = {
 
 function createSqliteSessionStore(
   options?: SqliteSessionStoreOptions,
-): StudioSessionStore & StudioTraceStore;
+): StudioSessionStore & StudioTraceStore & StudioPipelineLogStore;
 ```
 
-Purpose: create a SQLite-backed session and trace store.
+Purpose: create a SQLite-backed session, trace, and pipeline log store.
 
 Return behavior: defaults to in-memory SQLite when `path` is omitted.
 

--- a/apps/docs/content/docs/reference/studio/types.mdx
+++ b/apps/docs/content/docs/reference/studio/types.mdx
@@ -77,12 +77,13 @@ type AgentRunStreamEvent =
   | StudioToolApprovalRequestEvent
   | StudioToolApprovalResultEvent
   | StudioToolQuestionRequestEvent
-  | StudioToolQuestionResultEvent;
+  | StudioToolQuestionResultEvent
+  | StudioSessionLogEvent;
 ```
 
 Purpose: HTTP request and response contracts for Studio agent runs.
 
-Return behavior: non-streaming runs return `AgentRunResponse`; streaming runs emit newline-delimited `AgentRunStreamEvent` values.
+Return behavior: non-streaming runs return `AgentRunResponse`; streaming runs emit newline-delimited `AgentRunStreamEvent` values. `session_log` events are Studio-owned metadata-only runtime logs for session runs.
 
 Notable errors: invalid run request bodies return `bad_request`; unsupported stores or capabilities return `unsupported_capability`.
 

--- a/apps/docs/content/docs/reference/studio/types.mdx
+++ b/apps/docs/content/docs/reference/studio/types.mdx
@@ -14,6 +14,7 @@ type StudioCapability =
   | "knowledge"
   | "mcps"
   | "observability"
+  | "pipelines"
   | "sessions"
   | "tools"
   | "traces";
@@ -35,6 +36,32 @@ type StudioAgentConfig = {
   metadata?: JsonObject;
 };
 
+type StudioTarget = Agent | Pipeline<unknown, unknown>;
+
+type StudioPipeline = {
+  id: string;
+  pipeline: Pipeline<unknown, unknown>;
+  name?: string;
+  description?: string;
+  metadata?: JsonObject;
+};
+
+type StudioPipelineConfig = {
+  id: string;
+  name?: string;
+  description?: string;
+  metadata?: JsonObject;
+  stageCount: number;
+  edgeCount: number;
+  hasParallelStages: boolean;
+  agentCount: number;
+  extractorCount: number;
+};
+
+type StudioPipelineDetail = StudioPipelineConfig & {
+  graph: PipelineGraph;
+};
+
 type StudioCapabilityConfig = {
   enabled: boolean;
   reason?: string;
@@ -46,6 +73,7 @@ type StudioConfig = {
   description?: string;
   version?: string;
   agents: StudioAgentConfig[];
+  pipelines: StudioPipelineConfig[];
   chat: { quickPrompts: Record<string, string[]> };
   capabilities: Partial<Record<StudioCapability, StudioCapabilityConfig>>;
   unsupportedCapabilities: StudioCapability[];
@@ -54,7 +82,7 @@ type StudioConfig = {
 
 Purpose: configuration returned by Studio runtime and HTTP config endpoints.
 
-Return behavior: `Studio.config()` returns `StudioConfig`.
+Return behavior: `Studio.config()` returns `StudioConfig`. Pipelines are top-level Studio targets beside agents.
 
 Notable errors: none directly.
 
@@ -133,14 +161,90 @@ type AgentRunStreamEvent =
   | StudioToolApprovalResultEvent
   | StudioToolQuestionRequestEvent
   | StudioToolQuestionResultEvent
-  | StudioSessionLogEvent;
+  | StudioSessionLogEvent
+  | StudioPipelineLogEvent
+  | StudioPipelineFinalEvent;
 ```
 
 Purpose: HTTP request and response contracts for Studio agent runs.
 
-Return behavior: non-streaming runs return `AgentRunResponse`; streaming runs emit newline-delimited `AgentRunStreamEvent` values. `session_log` events are Studio-owned metadata-only runtime logs for session runs.
+Return behavior: non-streaming agent runs return `AgentRunResponse`; streaming agent runs emit newline-delimited `AgentRunStreamEvent` values. `session_log` and `pipeline_log` events are Studio-owned metadata-only runtime logs.
 
 Notable errors: invalid run request bodies return `bad_request`; unsupported stores or capabilities return `unsupported_capability`.
+
+## Pipeline Run Types
+
+```ts
+type StudioPipelineLogLevel = "debug" | "info" | "warn" | "error";
+
+type StudioPipelineLogCategory =
+  | "pipeline"
+  | "run"
+  | "stage"
+  | "parallel"
+  | "agent"
+  | "extractor"
+  | "api";
+
+type StudioPipelineLogEntry = {
+  id: string;
+  pipelineId: string;
+  runId?: string;
+  sequence: number;
+  timestamp: string;
+  level: StudioPipelineLogLevel;
+  category: StudioPipelineLogCategory;
+  event: string;
+  message: string;
+  metadata?: JsonObject;
+};
+
+type StudioPipelineLogAppendInput = {
+  pipelineId: string;
+  runId?: string;
+  level: StudioPipelineLogLevel;
+  category: StudioPipelineLogCategory;
+  event: string;
+  message: string;
+  metadata?: JsonObject;
+};
+
+type StudioPipelineLogListOptions = {
+  pipelineId: string;
+  limit: number;
+  after?: number;
+};
+
+type StudioPipelineLogEvent = {
+  type: "pipeline_log";
+  log: StudioPipelineLogEntry;
+};
+
+type StudioPipelineFinalEvent = {
+  type: "pipeline_final";
+  runId: string;
+  pipelineId: string;
+  output: JsonValue;
+};
+
+type StudioPipelineRunRequest = {
+  input: JsonValue;
+  stream?: boolean;
+  metadata?: JsonObject;
+};
+
+type StudioPipelineRunResponse = {
+  runId: string;
+  pipelineId: string;
+  output: JsonValue;
+};
+```
+
+Purpose: HTTP request, response, stream, and persisted log contracts for Studio pipeline runs.
+
+Return behavior: non-streaming pipeline runs return `StudioPipelineRunResponse`; streaming runs emit `pipeline_log` events and one `pipeline_final` event.
+
+Notable errors: Studio HTTP pipeline inputs must be JSON-compatible. Use direct `pipeline.run(...)` for non-JSON inputs.
 
 ## Knowledge Types
 

--- a/apps/docs/content/docs/reference/studio/types.mdx
+++ b/apps/docs/content/docs/reference/studio/types.mdx
@@ -12,8 +12,10 @@ type StudioCapability =
   | "agents"
   | "approvals"
   | "knowledge"
+  | "mcps"
   | "observability"
   | "sessions"
+  | "tools"
   | "traces";
 
 type StudioAgent = {
@@ -55,6 +57,59 @@ Purpose: configuration returned by Studio runtime and HTTP config endpoints.
 Return behavior: `Studio.config()` returns `StudioConfig`.
 
 Notable errors: none directly.
+
+## Tool Metadata Types
+
+```ts
+type StudioAgentToolSource = "static" | "dynamic";
+
+type StudioAgentToolApprovalMetadata = {
+  required: boolean;
+  reason?: string;
+  rejectMessage?: string;
+};
+
+type StudioAgentToolMetadata = {
+  agentId: string;
+  name: string;
+  description: string;
+  parameters: JsonObject;
+  source: StudioAgentToolSource;
+  approval: StudioAgentToolApprovalMetadata;
+};
+
+type StudioAgentToolsSummary = {
+  agentId: string;
+  tools: StudioAgentToolMetadata[];
+};
+
+type StudioAgentMcpToolMetadata = {
+  name: string;
+  description: string;
+  parameters: JsonObject;
+  source: StudioAgentToolSource;
+};
+
+type StudioAgentMcpServerMetadata = {
+  agentId: string;
+  name: string;
+  toolCount: number;
+  tools: StudioAgentMcpToolMetadata[];
+};
+
+type StudioAgentMcpsSummary = {
+  agentId: string;
+  servers: StudioAgentMcpServerMetadata[];
+};
+```
+
+Purpose: metadata returned by `GET /agents/:agentId/tools` and used by the Studio Tools inspector.
+
+Return behavior: static tools come from `agent.toolSet`; dynamic tools are listed when the dynamic tool index exposes its underlying `ToolSet`.
+
+Notable errors: unknown agents return `not_found`.
+
+`GET /agents/:agentId/mcps` returns the MCP subset grouped by server name. MCP metadata is available for tools registered through `.mcp(...)`.
 
 ## Run Types
 

--- a/apps/docs/content/docs/studio/configure/capabilities.mdx
+++ b/apps/docs/content/docs/studio/configure/capabilities.mdx
@@ -13,6 +13,7 @@ curl http://localhost:4021/config
 {
   "id": "anvia-studio",
   "agents": [],
+  "pipelines": [],
   "chat": {
     "quickPrompts": {}
   },
@@ -34,6 +35,7 @@ curl http://localhost:4021/config
 | `traces` | Trace storage is available |
 | `tools` | At least one registered agent has static tools or dynamic tool indexes |
 | `mcps` | At least one registered agent has tools registered from an MCP server |
+| `pipelines` | At least one pipeline is registered |
 | `observability` | At least one registered agent has observers |
 | `approvals` | At least one registered agent has a tool with approval metadata or a runtime hook |
 | `knowledge` | At least one registered agent has static context, dynamic context, or dynamic tools |

--- a/apps/docs/content/docs/studio/configure/capabilities.mdx
+++ b/apps/docs/content/docs/studio/configure/capabilities.mdx
@@ -33,7 +33,7 @@ curl http://localhost:4021/config
 | `sessions` | Session storage is available |
 | `traces` | Trace storage is available |
 | `observability` | At least one registered agent has observers |
-| `approvals` | At least one registered agent has a tool with approval metadata |
+| `approvals` | At least one registered agent has a tool with approval metadata or a runtime hook |
 | `knowledge` | At least one registered agent has static context, dynamic context, or dynamic tools |
 
 ## Unsupported Capabilities

--- a/apps/docs/content/docs/studio/configure/capabilities.mdx
+++ b/apps/docs/content/docs/studio/configure/capabilities.mdx
@@ -32,6 +32,8 @@ curl http://localhost:4021/config
 | `agents` | Always enabled |
 | `sessions` | Session storage is available |
 | `traces` | Trace storage is available |
+| `tools` | At least one registered agent has static tools or dynamic tool indexes |
+| `mcps` | At least one registered agent has tools registered from an MCP server |
 | `observability` | At least one registered agent has observers |
 | `approvals` | At least one registered agent has a tool with approval metadata or a runtime hook |
 | `knowledge` | At least one registered agent has static context, dynamic context, or dynamic tools |

--- a/apps/docs/content/docs/studio/configure/storage-and-persistence.mdx
+++ b/apps/docs/content/docs/studio/configure/storage-and-persistence.mdx
@@ -1,9 +1,9 @@
 ---
 title: Storage and Persistence
-description: Understand Studio's local SQLite storage for sessions and traces.
+description: Understand Studio's local SQLite storage for sessions, traces, and pipeline logs.
 ---
 
-Studio creates a local SQLite store by default. It stores sessions, runtime messages, transcript entries, and traces for local inspection.
+Studio creates a local SQLite store by default. It stores sessions, runtime messages, transcript entries, traces, and pipeline logs for local inspection.
 
 ## Default Path
 
@@ -29,6 +29,7 @@ ANVIA_STUDIO_DB=.data/studio.sqlite pnpm tsx studio.ts
 | Messages | Runtime history used when continuing a session, stored as message and message-part rows |
 | Transcript entries | UI-friendly run output with messages, reasoning, tool calls, approvals, and questions |
 | Traces | Generation and tool observations captured during runs |
+| Pipeline logs | Metadata-only audit events for Studio pipeline runs |
 
 ## Sessions and Traces
 

--- a/apps/docs/content/docs/studio/configure/storage-and-persistence.mdx
+++ b/apps/docs/content/docs/studio/configure/storage-and-persistence.mdx
@@ -3,7 +3,7 @@ title: Storage and Persistence
 description: Understand Studio's local SQLite storage for sessions and traces.
 ---
 
-Studio creates a local SQLite store by default. It stores sessions, transcript entries, and traces for local inspection.
+Studio creates a local SQLite store by default. It stores sessions, runtime messages, transcript entries, and traces for local inspection.
 
 ## Default Path
 
@@ -26,8 +26,8 @@ ANVIA_STUDIO_DB=.data/studio.sqlite pnpm tsx studio.ts
 | Data | Purpose |
 | --- | --- |
 | Sessions | Local conversations for one registered agent |
-| Messages | Runtime history used when continuing a session |
-| Transcript entries | UI-friendly messages, reasoning, tool calls, approvals, and questions |
+| Messages | Runtime history used when continuing a session, stored as message and message-part rows |
+| Transcript entries | UI-friendly run output with messages, reasoning, tool calls, approvals, and questions |
 | Traces | Generation and tool observations captured during runs |
 
 ## Sessions and Traces

--- a/apps/docs/content/docs/studio/http-api/endpoints.mdx
+++ b/apps/docs/content/docs/studio/http-api/endpoints.mdx
@@ -16,6 +16,7 @@ Studio exposes the same runtime used by the bundled UI as an HTTP API.
 | `/agents/:agentId/runs` | `POST` | Run an agent |
 | `/sessions` | `GET`, `POST` | List or create sessions |
 | `/sessions/:sessionId` | `GET`, `DELETE` | Read or delete a session |
+| `/sessions/:sessionId/logs` | `GET` | Read metadata-only session audit logs |
 | `/sessions/:sessionId/traces` | `GET` | List traces for a session |
 | `/traces` | `GET` | List traces |
 | `/traces/:traceId` | `GET` | Read one trace |

--- a/apps/docs/content/docs/studio/http-api/endpoints.mdx
+++ b/apps/docs/content/docs/studio/http-api/endpoints.mdx
@@ -13,6 +13,8 @@ Studio exposes the same runtime used by the bundled UI as an HTTP API.
 | `/config` | `GET` | Read agents, quick prompts, and enabled capabilities |
 | `/agents` | `GET` | List registered agents |
 | `/agents/:agentId` | `GET` | Read one agent config |
+| `/agents/:agentId/tools` | `GET` | Inspect registered tool metadata for one agent |
+| `/agents/:agentId/mcps` | `GET` | Inspect registered MCP server and tool metadata for one agent |
 | `/agents/:agentId/runs` | `POST` | Run an agent |
 | `/sessions` | `GET`, `POST` | List or create sessions |
 | `/sessions/:sessionId` | `GET`, `DELETE` | Read or delete a session |

--- a/apps/docs/content/docs/studio/http-api/endpoints.mdx
+++ b/apps/docs/content/docs/studio/http-api/endpoints.mdx
@@ -16,6 +16,10 @@ Studio exposes the same runtime used by the bundled UI as an HTTP API.
 | `/agents/:agentId/tools` | `GET` | Inspect registered tool metadata for one agent |
 | `/agents/:agentId/mcps` | `GET` | Inspect registered MCP server and tool metadata for one agent |
 | `/agents/:agentId/runs` | `POST` | Run an agent |
+| `/pipelines` | `GET` | List registered pipelines |
+| `/pipelines/:pipelineId` | `GET` | Read pipeline metadata and graph |
+| `/pipelines/:pipelineId/runs` | `POST` | Run a pipeline with JSON input |
+| `/pipelines/:pipelineId/logs` | `GET` | Read metadata-only pipeline audit logs |
 | `/sessions` | `GET`, `POST` | List or create sessions |
 | `/sessions/:sessionId` | `GET`, `DELETE` | Read or delete a session |
 | `/sessions/:sessionId/logs` | `GET` | Read metadata-only session audit logs |

--- a/apps/docs/content/docs/studio/human-in-the-loop/tool-approvals.mdx
+++ b/apps/docs/content/docs/studio/human-in-the-loop/tool-approvals.mdx
@@ -3,7 +3,7 @@ title: Tool Approvals
 description: Use Studio to approve protected tool calls.
 ---
 
-Studio can handle tool approvals from passive tool metadata. Core still runs tools normally; Studio installs a per-run request hook that interprets the metadata, creates an approval, and waits for a human decision.
+Studio can handle tool approvals from passive tool metadata or `tool.requestApproval(...)` in runtime hooks. Core still runs tools normally; Studio installs a per-run request hook that creates approvals and waits for human decisions.
 
 ## 1. Add Approval Metadata
 
@@ -84,11 +84,34 @@ curl -X POST http://localhost:4021/approvals/approval_123/decision \
   -d '{"approved":false,"reason":"Amount needs finance review."}'
 ```
 
+## Hook-Based Approval
+
+Use a hook when the approval rule depends on request-local state or crosses multiple tools.
+
+```ts
+import { createHook } from "@anvia/core";
+
+const approvalHook = createHook({
+  onToolCall({ toolName, tool }) {
+    if (toolName !== "refund_order") {
+      return tool.run();
+    }
+
+    return tool.requestApproval({
+      reason: "Review this refund before it is issued.",
+      rejectMessage: "Refund rejected in Anvia Studio.",
+    });
+  },
+});
+```
+
+Attach the hook to the agent with `.hook(approvalHook)` or to one run with `.requestHook(approvalHook)`. Studio emits the same approval request and result events for hook-based approvals.
+
 ## Approval Flow
 
 1. The model requests a tool call.
-2. Studio finds approval metadata on the tool.
-3. `approval.when(...)` returns `true`.
+2. Studio finds approval metadata on the tool or receives `tool.requestApproval(...)` from a hook.
+3. The metadata policy or hook request says approval is required.
 4. Studio creates a pending approval.
 5. A human approves or rejects it in the UI or API.
 6. Anvia either runs the tool or sends the rejection message back to the model.
@@ -97,4 +120,4 @@ Use tool approval for side effects such as refunds, account changes, deletes, ex
 
 ## Advanced Control
 
-Core hooks remain the escape hatch. If your app needs a custom approval service, conditional policy outside the tool, or a different human-feedback flow, use an `onToolCall` request hook and return `tool.run()`, `tool.skip(...)`, or `tool.cancel(...)`.
+If your app owns a custom approval service outside Studio, use an `onToolCall` request hook and return `tool.run()` or `tool.skip(...)` after your service resolves.

--- a/apps/docs/content/docs/studio/meta.json
+++ b/apps/docs/content/docs/studio/meta.json
@@ -10,6 +10,7 @@
     "run-studio",
     "configure",
     "agents",
+    "pipelines",
     "runs",
     "human-in-the-loop",
     "inspect-context",

--- a/apps/docs/content/docs/studio/overview.mdx
+++ b/apps/docs/content/docs/studio/overview.mdx
@@ -19,7 +19,7 @@ new Studio([agent]).start();
 
 | Primitive | What it does |
 | --- | --- |
-| `new Studio([agent])` | Registers one or more built Anvia agents |
+| `new Studio([agent, pipeline])` | Registers built Anvia agents and pipelines |
 | `.start(...)` | Starts the local HTTP runtime and bundled Studio UI |
 | `.fetch(request)` | Lets tests or another runtime call the same Studio API without opening a port |
 
@@ -28,6 +28,7 @@ Studio also exposes development surfaces around the runtime:
 | Surface | What it helps inspect |
 | --- | --- |
 | Agents | Registered agents, names, descriptions, and quick prompts |
+| Pipelines | Registered pipeline graphs, stage status, JSON test runs, and pipeline logs |
 | Runs | One-off prompts, streaming output, max turns, tool concurrency, and trace options |
 | Sessions | Persisted local conversation history and transcripts |
 | Traces | Model generations, tool spans, usage, errors, and run metadata |

--- a/apps/docs/content/docs/studio/pipelines/inspect-pipelines.mdx
+++ b/apps/docs/content/docs/studio/pipelines/inspect-pipelines.mdx
@@ -1,0 +1,57 @@
+---
+title: Inspect Pipelines
+description: Register pipelines in Studio and inspect graph, runs, and logs.
+---
+
+Studio can inspect built pipelines beside agents. Register both as top-level targets:
+
+```ts
+import { AgentBuilder, PipelineBuilder } from "@anvia/core";
+import { Studio } from "@anvia/studio";
+
+const supportAgent = new AgentBuilder("support", model).build();
+
+const ticketPipeline = new PipelineBuilder<string>({
+  id: "ticket-pipeline",
+  name: "Ticket Pipeline",
+})
+  .step((ticket) => ticket.trim(), { name: "Normalize" })
+  .prompt(supportAgent, { name: "Draft Reply" })
+  .build();
+
+new Studio([supportAgent, ticketPipeline]).start({ port: 4021 });
+```
+
+Studio reads pipeline graph metadata automatically from build order. Optional pipeline and stage metadata improves labels, descriptions, and inspector details, but every stage gets a generated id and label when metadata is omitted.
+
+## What Studio Shows
+
+| Surface | What it shows |
+| --- | --- |
+| Graph | Input, steps, nested pipelines, parallel branches, agents, extractors, and output |
+| Node details | Kind, label, description, metadata, branch key, agent id, or nested pipeline id |
+| Run controls | JSON-compatible input sent to `POST /pipelines/:pipelineId/runs` |
+| Logs | Persisted metadata-only pipeline audit logs with live stream updates |
+
+Pipeline logs include ids, stage kinds, status, durations, counts, and byte lengths. They do not persist raw input, output, prompt text, model output, tool arguments, tool results, documents, images, or reasoning text.
+
+## HTTP Routes
+
+```bash
+curl http://localhost:4021/pipelines
+curl http://localhost:4021/pipelines/ticket-pipeline
+curl 'http://localhost:4021/pipelines/ticket-pipeline/logs?limit=200'
+```
+
+Run a pipeline with JSON input:
+
+```bash
+curl -X POST http://localhost:4021/pipelines/ticket-pipeline/runs \
+  -H 'content-type: application/json' \
+  -d '{
+    "input": "Customer cannot check out",
+    "stream": true
+  }'
+```
+
+Studio HTTP pipeline inputs must be JSON-compatible. Use direct `pipeline.run(...)` in application code when a pipeline takes non-JSON values.

--- a/apps/docs/content/docs/studio/pipelines/meta.json
+++ b/apps/docs/content/docs/studio/pipelines/meta.json
@@ -1,0 +1,6 @@
+{
+  "title": "Pipelines",
+  "defaultOpen": false,
+  "collapsible": true,
+  "pages": ["inspect-pipelines"]
+}

--- a/apps/docs/content/docs/studio/runs/streaming-runs.mdx
+++ b/apps/docs/content/docs/studio/runs/streaming-runs.mdx
@@ -38,7 +38,7 @@ Streaming is the best mode for approvals and questions because the run can pause
 
 ## Persisting Streaming Runs
 
-When `sessionId` is present, Studio persists the transcript after the final event.
+When `sessionId` is present, Studio persists transcript updates while the stream runs.
 
 ```bash
 curl -N -X POST http://localhost:4021/agents/support-operations/runs \

--- a/examples/cli-agent/package.json
+++ b/examples/cli-agent/package.json
@@ -27,7 +27,7 @@
     "marked": "^15.0.12",
     "marked-terminal": "^7.3.0",
     "react": "^19.2.5",
-    "zod": "^4.4.2"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.13",

--- a/examples/cookbook/02_tools/08-tool-permission-hook.ts
+++ b/examples/cookbook/02_tools/08-tool-permission-hook.ts
@@ -47,13 +47,16 @@ const deleteAccountTool = createTool({
 
 const permissionHook = createHook({
   onToolCall({ toolName, tool }) {
-    // Hooks can allow, skip, or terminate tool calls before execution.
+    // Hooks can allow, skip, request approval, or terminate tool calls before execution.
     if (toolName === "read_payroll") {
       return tool.skip("Payroll data is restricted. Summarize that access was denied.");
     }
 
     if (toolName === "delete_account") {
-      return tool.cancel("Account deletion requires explicit human approval.");
+      return tool.requestApproval({
+        reason: "Account deletion requires explicit human approval.",
+        rejectMessage: "Account deletion was not approved.",
+      });
     }
 
     return tool.run();
@@ -85,6 +88,7 @@ try {
   console.log(response.output);
 } catch (error) {
   if (error instanceof PromptCancelledError) {
+    // Without Studio or another approval handler, requestApproval cancels clearly.
     console.log("prompt cancelled:", error.reason);
   } else {
     throw error;

--- a/examples/cookbook/09_studio/03-tool-approval.ts
+++ b/examples/cookbook/09_studio/03-tool-approval.ts
@@ -1,4 +1,4 @@
-import { AgentBuilder } from "@anvia/core/agent";
+import { AgentBuilder, createHook } from "@anvia/core/agent";
 import { createTool } from "@anvia/core/tool";
 import { OpenAIClient } from "@anvia/openai";
 import { Studio } from "@anvia/studio";
@@ -58,6 +58,36 @@ const issueRefund = createTool({
   }),
 });
 
+const cancelOrder = createTool({
+  name: "cancel_order",
+  description: "Cancel an order before fulfillment. This is guarded by a hook approval.",
+  input: z.object({
+    orderId: z.string().describe("The order id to cancel."),
+    reason: z.string().describe("The reason to record with the cancellation."),
+  }),
+  output: z.object({
+    orderId: z.string(),
+    status: z.enum(["cancelled"]),
+  }),
+  execute: ({ orderId }) => ({
+    orderId,
+    status: "cancelled" as const,
+  }),
+});
+
+const approvalHook = createHook({
+  onToolCall({ toolName, args, tool }) {
+    if (toolName === "cancel_order") {
+      return tool.requestApproval({
+        reason: `Review order cancellation request: ${args}`,
+        rejectMessage: "Order cancellation rejected in Anvia Studio.",
+      });
+    }
+
+    return tool.run();
+  },
+});
+
 const agentModel = client.completionModel("deepseek/deepseek-v4-pro");
 const agent = new AgentBuilder("studio-support-operations", agentModel)
   .name("Studio Support Operations")
@@ -65,11 +95,12 @@ const agent = new AgentBuilder("studio-support-operations", agentModel)
   .instructions(
     [
       "Use tools for private order data and refund operations.",
-      "Look up an order before issuing a refund.",
-      "Keep responses short and mention whether the refund was issued or denied.",
+      "Look up an order before issuing a refund or cancellation.",
+      "Keep responses short and mention whether the guarded action was issued, cancelled, or denied.",
     ].join("\n"),
   )
-  .tools([getOrder, issueRefund])
+  .tools([getOrder, issueRefund, cancelOrder])
+  .hook(approvalHook)
   .defaultMaxTurns(5)
   .build();
 

--- a/examples/cookbook/09_studio/07-pipeline-inspector.ts
+++ b/examples/cookbook/09_studio/07-pipeline-inspector.ts
@@ -1,0 +1,74 @@
+import { AgentBuilder } from "@anvia/core/agent";
+import { PipelineBuilder } from "@anvia/core/pipeline";
+import { OpenAIClient } from "@anvia/openai";
+import { Studio } from "@anvia/studio";
+
+const client = new OpenAIClient({
+  baseUrl: "https://openrouter.ai/api/v1",
+  apiKey: process.env.OPENROUTER_API_KEY,
+});
+
+const replyModel = client.completionModel("deepseek/deepseek-v4-pro");
+const replyAgent = new AgentBuilder("studio-reply-drafter", replyModel)
+  .name("Studio Reply Drafter")
+  .description("Drafts short support replies from normalized ticket context.")
+  .instructions(
+    [
+      "Draft concise customer support replies.",
+      "Use only the ticket context provided by the pipeline.",
+      "Mention the priority and the next operational step.",
+    ].join("\n"),
+  )
+  .build();
+
+const ticketPipeline = new PipelineBuilder<string>({
+  id: "ticket-triage-pipeline",
+  name: "Ticket Triage Pipeline",
+  description: "Normalizes a ticket, computes metadata, then drafts a reply.",
+  metadata: {
+    owner: "support-operations",
+  },
+})
+  .step((ticket) => ticket.trim(), {
+    name: "Normalize Ticket",
+    description: "Trim pasted ticket text before branching.",
+  })
+  .parallel(
+    {
+      classification: new PipelineBuilder<string>()
+        .step((ticket) => ({
+          topic: ticket.toLowerCase().includes("payment") ? "billing" : "operations",
+        }))
+        .build(),
+      priority: new PipelineBuilder<string>()
+        .step((ticket) => ({
+          priority:
+            ticket.toLowerCase().includes("outage") || ticket.toLowerCase().includes("enterprise")
+              ? "high"
+              : "normal",
+        }))
+        .build(),
+    },
+    {
+      name: "Analyze Ticket",
+      description: "Run deterministic branch checks for Studio graph inspection.",
+    },
+  )
+  .step(
+    ({ classification, priority }) =>
+      [
+        `Topic: ${classification.topic}`,
+        `Priority: ${priority.priority}`,
+        "Ticket: Enterprise customer reports payment retries causing checkout outage.",
+      ].join("\n"),
+    {
+      name: "Prepare Reply Prompt",
+    },
+  )
+  .prompt(replyAgent, {
+    name: "Draft Reply",
+    description: "Send the prepared context to the reply agent.",
+  })
+  .build();
+
+new Studio([replyAgent, ticketPipeline]).start();

--- a/examples/cookbook/package.json
+++ b/examples/cookbook/package.json
@@ -158,7 +158,7 @@
     "@opentelemetry/exporter-trace-otlp-http": "^0.216.0",
     "@opentelemetry/sdk-node": "^0.216.0",
     "dotenv": "^17.4.2",
-    "zod": "^4.4.2"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^24.9.1",

--- a/examples/cookbook/package.json
+++ b/examples/cookbook/package.json
@@ -79,6 +79,7 @@
     "studio:04": "tsx -r dotenv/config 09_studio/04-ask-question.ts dotenv_config_path=../../.env",
     "studio:05": "tsx -r dotenv/config 09_studio/05-knowledge-inspector.ts dotenv_config_path=../../.env",
     "studio:06": "tsx -r dotenv/config 09_studio/06-subagents.ts dotenv_config_path=../../.env",
+    "studio:07": "tsx -r dotenv/config 09_studio/07-pipeline-inspector.ts dotenv_config_path=../../.env",
     "integrations": "tsx -r dotenv/config 10_integrations/01-mcp-tools.ts dotenv_config_path=../../.env",
     "integrations:01": "tsx -r dotenv/config 10_integrations/01-mcp-tools.ts dotenv_config_path=../../.env",
     "integrations:02": "tsx -r dotenv/config 10_integrations/02-local-skills.ts dotenv_config_path=../../.env",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "cookbook:studio:04": "pnpm --filter cookbook studio:04",
     "cookbook:studio:05": "pnpm --filter cookbook studio:05",
     "cookbook:studio:06": "pnpm --filter cookbook studio:06",
+    "cookbook:studio:07": "pnpm --filter cookbook studio:07",
     "cookbook:integrations": "pnpm --filter cookbook integrations",
     "cookbook:integrations:01": "pnpm --filter cookbook integrations:01",
     "cookbook:integrations:02": "pnpm --filter cookbook integrations:02",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/core",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "Core runtime primitives for context-aware Anvia agents.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/core/src/agent/hooks.ts
+++ b/packages/core/src/agent/hooks.ts
@@ -1,10 +1,16 @@
 import type { CompletionResponse, Message } from "../completion/index";
 
 export type HookAction = { type: "continue" } | { type: "terminate"; reason: string };
+export type ToolApprovalRequestOptions = {
+  reason?: string;
+  rejectMessage?: string;
+};
+
 export type ToolCallHookAction =
   | { type: "continue" }
   | { type: "skip"; reason: string }
-  | { type: "terminate"; reason: string };
+  | { type: "terminate"; reason: string }
+  | ({ type: "approval_request" } & ToolApprovalRequestOptions);
 
 export type RunControl = {
   continue(): HookAction;
@@ -15,6 +21,7 @@ export type ToolCallControl = {
   run(): ToolCallHookAction;
   skip(reason: string): ToolCallHookAction;
   cancel(reason: string): ToolCallHookAction;
+  requestApproval(options?: ToolApprovalRequestOptions): ToolCallHookAction;
 };
 
 export type HookResult = HookAction | undefined;
@@ -69,6 +76,14 @@ export function skipTool(reason: string): ToolCallHookAction {
   return { type: "skip", reason };
 }
 
+export function requestToolApproval(options: ToolApprovalRequestOptions = {}): ToolCallHookAction {
+  return {
+    type: "approval_request",
+    ...(options.reason === undefined ? {} : { reason: options.reason }),
+    ...(options.rejectMessage === undefined ? {} : { rejectMessage: options.rejectMessage }),
+  };
+}
+
 export const runControl: RunControl = {
   continue() {
     return { type: "continue" };
@@ -87,6 +102,9 @@ export const toolCallControl: ToolCallControl = {
   },
   cancel(reason: string) {
     return { type: "terminate", reason };
+  },
+  requestApproval(options) {
+    return requestToolApproval(options);
   },
 };
 

--- a/packages/core/src/agent/request.ts
+++ b/packages/core/src/agent/request.ts
@@ -483,6 +483,18 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
         );
         throw this.cancelled(newMessages, callAction.reason);
       }
+      if (callAction?.type === "approval_request") {
+        const reason = `Tool approval was requested for ${toolCall.function.name}, but no approval handler is installed.`;
+        await this.recordToolError(
+          toolObservers,
+          observation?.turn,
+          toolCall,
+          internalCallId,
+          args,
+          reason,
+        );
+        throw this.cancelled(newMessages, reason);
+      }
 
       let output: string;
       let skipped = false;

--- a/packages/core/src/mcp/connect.ts
+++ b/packages/core/src/mcp/connect.ts
@@ -7,7 +7,7 @@ export async function connectMcp(connection: McpConnection): Promise<McpServer> 
 
   return {
     name: connection.name,
-    tools: tools.map((tool) => createMcpTool(tool, client)),
+    tools: tools.map((tool) => createMcpTool(tool, client, connection.name)),
     close: () => client.close(),
   };
 }

--- a/packages/core/src/mcp/tool.ts
+++ b/packages/core/src/mcp/tool.ts
@@ -3,8 +3,14 @@ import type { Tool } from "../tool/index";
 import { createCallToolParams, mapMcpToolResult } from "./result";
 import type { McpClient, McpToolDefinition } from "./types";
 
-export function createMcpTool(definition: McpToolDefinition, client: McpClient): Tool {
-  return {
+const MCP_TOOL_METADATA_KEY = Symbol.for("anvia.mcp.tool.metadata");
+
+export function createMcpTool(
+  definition: McpToolDefinition,
+  client: McpClient,
+  serverName?: string,
+): Tool {
+  const tool: Tool = {
     name: definition.name,
     definition(): ToolDefinition {
       return {
@@ -18,4 +24,11 @@ export function createMcpTool(definition: McpToolDefinition, client: McpClient):
       return mapMcpToolResult(result);
     },
   };
+  if (serverName !== undefined) {
+    Object.defineProperty(tool, MCP_TOOL_METADATA_KEY, {
+      value: { serverName },
+      enumerable: false,
+    });
+  }
+  return tool;
 }

--- a/packages/core/src/pipeline/index.ts
+++ b/packages/core/src/pipeline/index.ts
@@ -1,5 +1,5 @@
 import type { Agent } from "../agent";
-import type { CompletionModel } from "../completion";
+import type { CompletionModel, JsonObject } from "../completion";
 import type { Extractor } from "../extractor";
 
 /** Minimal interface for anything that can run as a pipeline stage. */
@@ -18,13 +18,117 @@ type ParallelOutput<Branches extends Record<string, PipelineOp<unknown, unknown>
   [Key in keyof Branches]: AwaitedOutput<Branches[Key]>;
 };
 
+export type PipelineMetadata = {
+  id?: string | undefined;
+  name?: string | undefined;
+  description?: string | undefined;
+  metadata?: JsonObject | undefined;
+};
+
+export type PipelineStageMetadata = {
+  id?: string | undefined;
+  name?: string | undefined;
+  description?: string | undefined;
+  metadata?: JsonObject | undefined;
+};
+
+export type PipelineStageKind =
+  | "input"
+  | "step"
+  | "pipeline"
+  | "parallel"
+  | "branch"
+  | "agent"
+  | "extractor"
+  | "output";
+
+export type PipelineGraphNode = {
+  id: string;
+  kind: PipelineStageKind;
+  label: string;
+  description?: string | undefined;
+  metadata?: JsonObject | undefined;
+  agentId?: string | undefined;
+  agentName?: string | undefined;
+  pipelineId?: string | undefined;
+  branchKey?: string | undefined;
+};
+
+export type PipelineGraphEdge = {
+  id: string;
+  source: string;
+  target: string;
+  label?: string | undefined;
+};
+
+export type PipelineGraph = PipelineMetadata & {
+  id: string;
+  nodes: PipelineGraphNode[];
+  edges: PipelineGraphEdge[];
+};
+
+export type PipelineRunEvent =
+  | {
+      type: "stage_started";
+      node: PipelineGraphNode;
+    }
+  | {
+      type: "stage_completed";
+      node: PipelineGraphNode;
+      durationMs: number;
+    }
+  | {
+      type: "stage_failed";
+      node: PipelineGraphNode;
+      durationMs: number;
+      error: unknown;
+    };
+
+export type PipelineRunObserver = {
+  onEvent(event: PipelineRunEvent): void | Promise<void>;
+};
+
+export type PipelineRunOptions = {
+  observer?: PipelineRunObserver | undefined;
+};
+
+type PipelineRunContext = {
+  observer?: PipelineRunObserver | undefined;
+};
+
+type PipelineExecutor<Input, Output> = (
+  input: Input,
+  context: PipelineRunContext,
+) => Output | Promise<Output>;
+
+type PipelineBuilderState = {
+  graph: PipelineGraph;
+  terminalNodeId: string;
+  terminalNodeIds: string[];
+  nextNodeIndex: number;
+  nextEdgeIndex: number;
+};
+
 /** Runnable pipeline returned by `PipelineBuilder.build()`. */
 export class Pipeline<Input, Output> implements PipelineOp<Input, Awaited<Output>> {
-  constructor(private readonly executor: (input: Input) => Output | Promise<Output>) {}
+  readonly id: string;
+  readonly name: string | undefined;
+  readonly description: string | undefined;
+  readonly metadata: JsonObject | undefined;
+
+  constructor(
+    private readonly executor: PipelineExecutor<Input, Output>,
+    private readonly pipelineGraph: PipelineGraph = initialGraph({}),
+  ) {
+    this.id = pipelineGraph.id;
+    this.name = pipelineGraph.name;
+    this.description = pipelineGraph.description;
+    this.metadata = pipelineGraph.metadata;
+  }
 
   /** Run one input through the built pipeline and return the final stage output. */
-  async run(input: Input): Promise<Awaited<Output>> {
-    return await this.executor(input);
+  async run(input: Input, options: PipelineRunOptions = {}): Promise<Awaited<Output>> {
+    return (await this.executor(input, { observer: options.observer })) as Awaited<Output>;
   }
 
   /** Run many inputs through the same pipeline with bounded concurrency. */
@@ -34,68 +138,407 @@ export class Pipeline<Input, Output> implements PipelineOp<Input, Awaited<Output
   ): Promise<Array<Awaited<Output>>> {
     return mapWithConcurrency([...inputs], options.concurrency, (input) => this.run(input));
   }
+
+  graph(): PipelineGraph {
+    return cloneGraph(this.pipelineGraph);
+  }
 }
 
 /** Builds a typed pipeline from an original input type to an inferred output type. */
 export class PipelineBuilder<Input, Output = Input> {
+  private readonly executor: PipelineExecutor<Input, Output>;
+  private readonly state: PipelineBuilderState;
+
+  constructor();
+  constructor(metadata: PipelineMetadata);
+  constructor(executor: (input: Input) => Output | Promise<Output>);
+  constructor(executor: PipelineExecutor<Input, Output>, state: PipelineBuilderState);
   constructor(
-    private readonly executor: (input: Input) => Output | Promise<Output> = identity as (
-      input: Input,
-    ) => Output,
-  ) {}
+    metadataOrExecutor?:
+      | PipelineMetadata
+      | ((input: Input) => Output | Promise<Output>)
+      | PipelineExecutor<Input, Output>,
+    state?: PipelineBuilderState,
+  ) {
+    if (state !== undefined) {
+      this.executor = metadataOrExecutor as PipelineExecutor<Input, Output>;
+      this.state = state;
+      return;
+    }
+
+    if (typeof metadataOrExecutor === "function") {
+      const executor = metadataOrExecutor as (input: Input) => Output | Promise<Output>;
+      this.executor = ((input) => executor(input)) as PipelineExecutor<Input, Output>;
+      this.state = initialBuilderState({});
+      return;
+    }
+
+    this.executor = identity as PipelineExecutor<Input, Output>;
+    this.state = initialBuilderState(metadataOrExecutor ?? {});
+  }
 
   /** Add a synchronous or asynchronous transform stage. */
   step<Next>(
     fn: (input: Awaited<Output>) => Next | Promise<Next>,
+    metadata?: PipelineStageMetadata,
   ): PipelineBuilder<Input, Awaited<Next>> {
-    return new PipelineBuilder<Input, Awaited<Next>>(async (input): Promise<Awaited<Next>> => {
-      const result = await fn(await this.runStep(input));
-      return result as Awaited<Next>;
-    });
+    const next = appendNode(
+      this.state,
+      "step",
+      metadata?.name ?? nextStageLabel(this.state, "Step"),
+      {
+        description: metadata?.description,
+        metadata: metadata?.metadata,
+        preferredId: metadata?.id,
+      },
+    );
+    return new PipelineBuilder<Input, Awaited<Next>>(
+      async (input, context): Promise<Awaited<Next>> => {
+        const value = await this.runStep(input, context);
+        const result = await runNode(context, next.node, () => fn(value));
+        return result as Awaited<Next>;
+      },
+      next.state,
+    );
   }
 
   /** Compose another pipeline operation after the current stage. */
-  use<Next>(op: PipelineOp<Awaited<Output>, Next>): PipelineBuilder<Input, Awaited<Next>> {
-    return new PipelineBuilder<Input, Awaited<Next>>(async (input): Promise<Awaited<Next>> => {
-      const result = await op.run(await this.runStep(input));
-      return result as Awaited<Next>;
-    });
+  use<Next>(
+    op: PipelineOp<Awaited<Output>, Next>,
+    metadata?: PipelineStageMetadata,
+  ): PipelineBuilder<Input, Awaited<Next>> {
+    const nested = op instanceof Pipeline ? op : undefined;
+    const next = appendNode(
+      this.state,
+      nested === undefined ? "step" : "pipeline",
+      metadata?.name ??
+        nested?.name ??
+        nested?.id ??
+        nextStageLabel(this.state, nested === undefined ? "Operation" : "Pipeline"),
+      {
+        description: metadata?.description ?? nested?.description,
+        metadata: metadata?.metadata ?? nested?.metadata,
+        preferredId: metadata?.id,
+        pipelineId: nested?.id,
+      },
+    );
+    return new PipelineBuilder<Input, Awaited<Next>>(
+      async (input, context): Promise<Awaited<Next>> => {
+        const value = await this.runStep(input, context);
+        const result = await runNode(context, next.node, () => op.run(value));
+        return result as Awaited<Next>;
+      },
+      next.state,
+    );
   }
 
   /** Run named branch operations concurrently from the current value. */
   parallel<Branches extends Record<string, PipelineOp<Awaited<Output>, unknown>>>(
     branches: Branches,
+    metadata?: PipelineStageMetadata,
   ): PipelineBuilder<Input, ParallelOutput<Branches>> {
-    return new PipelineBuilder<Input, ParallelOutput<Branches>>(async (input) => {
-      const value = await this.runStep(input);
-      const entries = await Promise.all(
-        Object.entries(branches).map(async ([key, op]) => [key, await op.run(value)] as const),
+    const parallel = appendNode(
+      this.state,
+      "parallel",
+      metadata?.name ?? `${Object.keys(branches).length} parallel branches`,
+      {
+        description: metadata?.description,
+        metadata: metadata?.metadata,
+        preferredId: metadata?.id,
+      },
+    );
+    let nextState = parallel.state;
+    const branchNodes: Record<string, PipelineGraphNode> = {};
+    for (const key of Object.keys(branches)) {
+      const branch = appendChildNode(nextState, parallel.node.id, "branch", key, {
+        branchKey: key,
+      });
+      nextState = branch.state;
+      branchNodes[key] = branch.node;
+    }
+    nextState = withTerminalNodes(
+      nextState,
+      Object.values(branchNodes).map((node) => node.id),
+    );
+
+    return new PipelineBuilder<Input, ParallelOutput<Branches>>(async (input, context) => {
+      const value = await this.runStep(input, context);
+      const entries = await runNode(context, parallel.node, () =>
+        Promise.all(
+          Object.entries(branches).map(async ([key, op]) => {
+            const node = branchNodes[key] as PipelineGraphNode;
+            const output = await runNode(context, node, () => op.run(value));
+            return [key, output] as const;
+          }),
+        ),
       );
       return Object.fromEntries(entries) as ParallelOutput<Branches>;
-    });
+    }, nextState);
   }
 
   /** Send the current value to an agent as text and continue with the agent output. */
-  prompt(agent: Agent<CompletionModel>): PipelineBuilder<Input, string> {
-    return this.step(async (input) => {
-      const response = await agent.prompt(String(input)).send();
-      return response.output;
+  prompt(
+    agent: Agent<CompletionModel>,
+    metadata?: PipelineStageMetadata,
+  ): PipelineBuilder<Input, string> {
+    const next = appendNode(this.state, "agent", metadata?.name ?? agent.name ?? agent.id, {
+      description: metadata?.description ?? agent.description,
+      metadata: metadata?.metadata,
+      preferredId: metadata?.id,
+      agentId: agent.id,
+      agentName: agent.name,
     });
+    return new PipelineBuilder<Input, string>(async (input, context) => {
+      const value = await this.runStep(input, context);
+      return runNode(context, next.node, async () => {
+        const response = await agent.prompt(String(value)).send();
+        return response.output;
+      });
+    }, next.state);
   }
 
   /** Send the current value to an extractor as text and continue with typed schema data. */
-  extract<T>(extractor: Extractor<T, CompletionModel>): PipelineBuilder<Input, T> {
-    return this.step((input) => extractor.extract(String(input)));
+  extract<T>(
+    extractor: Extractor<T, CompletionModel>,
+    metadata?: PipelineStageMetadata,
+  ): PipelineBuilder<Input, T> {
+    const next = appendNode(
+      this.state,
+      "extractor",
+      metadata?.name ?? nextStageLabel(this.state, "Extractor"),
+      {
+        description: metadata?.description,
+        metadata: metadata?.metadata,
+        preferredId: metadata?.id,
+      },
+    );
+    return new PipelineBuilder<Input, T>(async (input, context) => {
+      const value = await this.runStep(input, context);
+      return runNode(context, next.node, () => extractor.extract(String(value)));
+    }, next.state);
   }
 
   /** Finish the builder and return a runnable pipeline. */
   build(): Pipeline<Input, Awaited<Output>> {
-    return new Pipeline<Input, Awaited<Output>>((input) => this.runStep(input));
+    const graph = withOutputNode(this.state);
+    return new Pipeline<Input, Awaited<Output>>(
+      (input, context) => this.runStep(input, context) as Promise<Awaited<Output>>,
+      graph,
+    );
   }
 
-  private async runStep(input: Input): Promise<Awaited<Output>> {
-    return (await this.executor(input)) as Awaited<Output>;
+  private async runStep(input: Input, context: PipelineRunContext): Promise<Awaited<Output>> {
+    return (await this.executor(input, context)) as Awaited<Output>;
   }
+}
+
+function initialBuilderState(metadata: PipelineMetadata): PipelineBuilderState {
+  return {
+    graph: initialGraph(metadata),
+    terminalNodeId: "input",
+    terminalNodeIds: ["input"],
+    nextNodeIndex: 1,
+    nextEdgeIndex: 1,
+  };
+}
+
+function initialGraph(metadata: PipelineMetadata): PipelineGraph {
+  const id = normalizeId(metadata.id ?? "pipeline");
+  return {
+    id,
+    ...(metadata.name === undefined ? {} : { name: metadata.name }),
+    ...(metadata.description === undefined ? {} : { description: metadata.description }),
+    ...(metadata.metadata === undefined ? {} : { metadata: metadata.metadata }),
+    nodes: [{ id: "input", kind: "input", label: "Input" }],
+    edges: [],
+  };
+}
+
+function appendNode(
+  state: PipelineBuilderState,
+  kind: PipelineStageKind,
+  label: string,
+  options: {
+    description?: string | undefined;
+    metadata?: JsonObject | undefined;
+    preferredId?: string | undefined;
+    agentId?: string | undefined;
+    agentName?: string | undefined;
+    pipelineId?: string | undefined;
+  } = {},
+): { state: PipelineBuilderState; node: PipelineGraphNode } {
+  const node = graphNode(kind, label, state.nextNodeIndex, {
+    ...options,
+    existingIds: new Set(state.graph.nodes.map((item) => item.id)),
+  });
+  return {
+    node,
+    state: appendGraphNode(state, node, activeTerminalNodeIds(state), [node.id]),
+  };
+}
+
+function appendChildNode(
+  state: PipelineBuilderState,
+  parentId: string,
+  kind: PipelineStageKind,
+  label: string,
+  options: {
+    branchKey?: string | undefined;
+  } = {},
+): { state: PipelineBuilderState; node: PipelineGraphNode } {
+  const node = graphNode(kind, label, state.nextNodeIndex, {
+    ...options,
+    existingIds: new Set(state.graph.nodes.map((item) => item.id)),
+  });
+  return {
+    node,
+    state: appendGraphNode(state, node, [parentId], activeTerminalNodeIds(state)),
+  };
+}
+
+function appendGraphNode(
+  state: PipelineBuilderState,
+  node: PipelineGraphNode,
+  sourceIds: string[],
+  terminalNodeIds: string[],
+): PipelineBuilderState {
+  const edges = sourceIds.map((sourceId, index) => ({
+    id: `edge_${state.nextEdgeIndex + index}`,
+    source: sourceId,
+    target: node.id,
+  }));
+  const terminalNodeId = terminalNodeIds.at(-1) ?? state.terminalNodeId;
+  return {
+    graph: {
+      ...state.graph,
+      nodes: [...state.graph.nodes, node],
+      edges: [...state.graph.edges, ...edges],
+    },
+    terminalNodeId,
+    terminalNodeIds,
+    nextNodeIndex: state.nextNodeIndex + 1,
+    nextEdgeIndex: state.nextEdgeIndex + edges.length,
+  };
+}
+
+function activeTerminalNodeIds(state: PipelineBuilderState): string[] {
+  return state.terminalNodeIds.length > 0 ? state.terminalNodeIds : [state.terminalNodeId];
+}
+
+function withTerminalNodes(
+  state: PipelineBuilderState,
+  terminalNodeIds: string[],
+): PipelineBuilderState {
+  return {
+    ...state,
+    terminalNodeId: terminalNodeIds.at(-1) ?? state.terminalNodeId,
+    terminalNodeIds,
+  };
+}
+
+function graphNode(
+  kind: PipelineStageKind,
+  label: string,
+  index: number,
+  options: {
+    description?: string | undefined;
+    metadata?: JsonObject | undefined;
+    preferredId?: string | undefined;
+    agentId?: string | undefined;
+    agentName?: string | undefined;
+    pipelineId?: string | undefined;
+    branchKey?: string | undefined;
+    existingIds?: Set<string> | undefined;
+  } = {},
+): PipelineGraphNode {
+  const id = uniqueGraphNodeId(
+    normalizeId(options.preferredId ?? `${kind}_${index}`),
+    options.existingIds ?? new Set(),
+  );
+  return {
+    id,
+    kind,
+    label,
+    ...(options.description === undefined ? {} : { description: options.description }),
+    ...(options.metadata === undefined ? {} : { metadata: options.metadata }),
+    ...(options.agentId === undefined ? {} : { agentId: options.agentId }),
+    ...(options.agentName === undefined ? {} : { agentName: options.agentName }),
+    ...(options.pipelineId === undefined ? {} : { pipelineId: options.pipelineId }),
+    ...(options.branchKey === undefined ? {} : { branchKey: options.branchKey }),
+  };
+}
+
+function withOutputNode(state: PipelineBuilderState): PipelineGraph {
+  const graph = cloneGraph(state.graph);
+  if (graph.nodes.some((node) => node.id === "output")) {
+    return graph;
+  }
+  graph.nodes.push({ id: "output", kind: "output", label: "Output" });
+  graph.edges.push(
+    ...activeTerminalNodeIds(state).map((sourceId, index) => ({
+      id: `edge_${state.nextEdgeIndex + index}`,
+      source: sourceId,
+      target: "output",
+    })),
+  );
+  return graph;
+}
+
+async function runNode<Output>(
+  context: PipelineRunContext,
+  node: PipelineGraphNode,
+  fn: () => Output | Promise<Output>,
+): Promise<Awaited<Output>> {
+  const startedAt = Date.now();
+  await context.observer?.onEvent({ type: "stage_started", node });
+  try {
+    const output = (await fn()) as Awaited<Output>;
+    await context.observer?.onEvent({
+      type: "stage_completed",
+      node,
+      durationMs: Date.now() - startedAt,
+    });
+    return output;
+  } catch (error) {
+    await context.observer?.onEvent({
+      type: "stage_failed",
+      node,
+      durationMs: Date.now() - startedAt,
+      error,
+    });
+    throw error;
+  }
+}
+
+function nextStageLabel(state: PipelineBuilderState, prefix: string): string {
+  return `${prefix} ${state.nextNodeIndex}`;
+}
+
+function cloneGraph(graph: PipelineGraph): PipelineGraph {
+  return {
+    ...graph,
+    nodes: graph.nodes.map((node) => ({ ...node })),
+    edges: graph.edges.map((edge) => ({ ...edge })),
+  };
+}
+
+function normalizeId(value: string): string {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return normalized.length === 0 ? "pipeline" : normalized;
+}
+
+function uniqueGraphNodeId(baseId: string, existingIds: Set<string>): string {
+  let id = baseId;
+  let suffix = 2;
+  while (existingIds.has(id)) {
+    id = `${baseId}_${suffix}`;
+    suffix += 1;
+  }
+  return id;
 }
 
 function identity<T>(input: T): T {

--- a/packages/core/test/pipeline.test.ts
+++ b/packages/core/test/pipeline.test.ts
@@ -161,6 +161,75 @@ describe("PipelineBuilder", () => {
     await expect(op.run(5)).resolves.toBe(15);
   });
 
+  it("exposes an automatic graph", () => {
+    const model = new QueueModel([response([AssistantContent.text("answer")])]);
+    const agent = new AgentBuilder("support", model).name("Support").build();
+    const op = new PipelineBuilder<string>({
+      id: "ticket_triage",
+      name: "Ticket triage",
+      description: "Prepare a support answer.",
+      metadata: { owner: "support" },
+    })
+      .step((value) => value.trim())
+      .parallel({
+        upper: new PipelineBuilder<string>().step((value) => value.toUpperCase()).build(),
+        length: new PipelineBuilder<string>().step((value) => value.length).build(),
+      })
+      .prompt(agent)
+      .build();
+
+    expect(op.graph()).toMatchObject({
+      id: "ticket_triage",
+      name: "Ticket triage",
+      description: "Prepare a support answer.",
+      metadata: { owner: "support" },
+      nodes: [
+        { id: "input", kind: "input", label: "Input" },
+        { kind: "step", label: "Step 1" },
+        { kind: "parallel", label: "2 parallel branches" },
+        { kind: "branch", label: "upper", branchKey: "upper" },
+        { kind: "branch", label: "length", branchKey: "length" },
+        { kind: "agent", label: "Support", agentId: "support", agentName: "Support" },
+        { id: "output", kind: "output", label: "Output" },
+      ],
+    });
+    expect(op.graph().edges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source: "input", target: "step_1" }),
+        expect.objectContaining({ source: "step_1", target: "parallel_2" }),
+        expect.objectContaining({ source: "parallel_2", target: "branch_3" }),
+        expect.objectContaining({ source: "parallel_2", target: "branch_4" }),
+        expect.objectContaining({ source: "branch_3", target: "agent_5" }),
+        expect.objectContaining({ source: "branch_4", target: "agent_5" }),
+        expect.objectContaining({ source: "agent_5", target: "output" }),
+      ]),
+    );
+  });
+
+  it("emits pipeline stage run events without changing output", async () => {
+    const events: string[] = [];
+    const op = new PipelineBuilder<number>()
+      .step((value) => value + 1)
+      .step((value) => value * 2)
+      .build();
+
+    await expect(
+      op.run(2, {
+        observer: {
+          onEvent(event) {
+            events.push(`${event.type}:${event.node.id}`);
+          },
+        },
+      }),
+    ).resolves.toBe(6);
+    expect(events).toEqual([
+      "stage_started:step_1",
+      "stage_completed:step_1",
+      "stage_started:step_2",
+      "stage_completed:step_2",
+    ]);
+  });
+
   it("does not expose the old helper-first methods at type level", () => {
     const builder = new PipelineBuilder<number>();
     const op = builder.step((value) => value + 1).build();

--- a/packages/core/test/prompt-request.test.ts
+++ b/packages/core/test/prompt-request.test.ts
@@ -13,6 +13,7 @@ import {
   MaxTurnsError,
   Message,
   PromptCancelledError,
+  requestToolApproval,
   Usage,
 } from "../src/index";
 
@@ -325,6 +326,37 @@ describe("PromptRequest", () => {
     expect(model.requests).toHaveLength(1);
   });
 
+  it("cancels clearly when a tool call hook requests approval without a handler", async () => {
+    let executed = false;
+    const guardedTool = createTool({
+      name: "guarded",
+      description: "A guarded tool",
+      input: z.object({}),
+      output: z.string(),
+      execute() {
+        executed = true;
+        return "should not run";
+      },
+    });
+    const model = new QueueModel([
+      response([AssistantContent.toolCall("call_1", "guarded", {})]),
+      response([AssistantContent.text("should not be requested")]),
+    ]);
+    const hook = createHook({
+      onToolCall({ tool }) {
+        return tool.requestApproval({ reason: "Guarded action." });
+      },
+    });
+    const agent = new AgentBuilder("test-agent", model).tool(guardedTool).hook(hook).build();
+
+    await expect(agent.prompt("run guarded").send()).rejects.toMatchObject({
+      name: "PromptCancelledError",
+      reason: "Tool approval was requested for guarded, but no approval handler is installed.",
+    });
+    expect(executed).toBe(false);
+    expect(model.requests).toHaveLength(1);
+  });
+
   it("executes a tool after async approval-style hook allows it", async () => {
     let executed = false;
     const guardedTool = createTool({
@@ -421,6 +453,10 @@ describe("PromptRequest", () => {
 
   it("keeps low-level hook action helpers available", () => {
     expect(cancelPrompt("blocked")).toEqual({ type: "terminate", reason: "blocked" });
+    expect(requestToolApproval({ reason: "review" })).toEqual({
+      type: "approval_request",
+      reason: "review",
+    });
   });
 
   it("uses requestHook for one request instead of the agent hook", async () => {

--- a/packages/tools/studio/package.json
+++ b/packages/tools/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/studio",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Studio UI and HTTP runtime for Anvia agents.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/tools/studio/package.json
+++ b/packages/tools/studio/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@xyflow/react": "^12.10.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "hono": "^4.12.18",

--- a/packages/tools/studio/src/runtime/approvals.ts
+++ b/packages/tools/studio/src/runtime/approvals.ts
@@ -4,6 +4,9 @@ import type {
   PromptHook,
   ToolApprovalContext,
   ToolApprovalPolicy,
+  ToolApprovalRequestOptions,
+  ToolCallHookAction,
+  ToolCallHookArgs,
 } from "@anvia/core";
 import { createHook, parseToolArgs } from "@anvia/core";
 import type { Context, Hono } from "hono";
@@ -42,7 +45,7 @@ type ApprovalRequest = {
 
 export type ApprovalRuntime = {
   approvals: Map<string, PendingApproval | StudioToolApproval>;
-  createHook(context: ApprovalHookContext): PromptHook;
+  createHook(context: ApprovalHookContext): StudioApprovalHook;
   list(options: ApprovalListOptions): StudioToolApproval[];
   decide(
     id: string,
@@ -55,6 +58,13 @@ type ApprovalListOptions = {
   runId?: string;
   agentId?: string;
   sessionId?: string;
+};
+
+export type StudioApprovalHook = PromptHook & {
+  handleApprovalRequest(
+    args: ToolCallHookArgs,
+    request: ToolApprovalRequestOptions,
+  ): Promise<ToolCallHookAction>;
 };
 
 export function registerApprovalRoutes(app: Hono, approvals: ApprovalRuntime): void {
@@ -147,51 +157,74 @@ export function createApprovalRuntime(): ApprovalRuntime {
   return {
     approvals,
     createHook(context) {
-      return createHook({
-        async onToolCall({ toolName, toolCallId, internalCallId, args, tool: control }) {
-          const registeredTool = context.getTool(toolName);
-          if (registeredTool?.approval === undefined) {
-            return control.run();
-          }
-          const approval = registeredTool.approval as ToolApprovalPolicy<unknown>;
+      const handleApprovalRequest: StudioApprovalHook["handleApprovalRequest"] = async (
+        { toolName, toolCallId, internalCallId, args, tool: control },
+        request,
+      ) => {
+        const decision = await requestApproval(approvals, context, {
+          toolName,
+          ...(toolCallId === undefined ? {} : { toolCallId }),
+          internalCallId,
+          args,
+          ...(request.reason === undefined ? {} : { reason: request.reason }),
+          ...(request.rejectMessage === undefined ? {} : { rejectMessage: request.rejectMessage }),
+        });
 
-          const rawParsedArgs = parseToolArgs(args);
-          const parsedArgs = registeredTool.parseApprovalArgs?.(rawParsedArgs) ?? rawParsedArgs;
-          const approvalContext = {
-            toolName,
-            args: parsedArgs,
-            rawArgs: args,
-            ...(toolCallId === undefined ? {} : { toolCallId }),
-            internalCallId,
-            run: {
-              agentId: context.agentId,
-              runId: context.runId,
-              ...(context.sessionId === undefined ? {} : { sessionId: context.sessionId }),
-              ...(context.metadata === undefined ? {} : { metadata: context.metadata }),
-            },
-          };
+        return decision.approved
+          ? control.run()
+          : control.skip(decision.reason ?? request.rejectMessage ?? "Rejected in Anvia Studio.");
+      };
+      return {
+        ...createHook({
+          async onToolCall({ toolName, toolCallId, internalCallId, args, tool: control }) {
+            const registeredTool = context.getTool(toolName);
+            if (registeredTool?.approval === undefined) {
+              return control.run();
+            }
+            const approval = registeredTool.approval as ToolApprovalPolicy<unknown>;
 
-          const required = await approval.when(approvalContext);
-          if (!required) {
-            return control.run();
-          }
+            const rawParsedArgs = parseToolArgs(args);
+            const parsedArgs = registeredTool.parseApprovalArgs?.(rawParsedArgs) ?? rawParsedArgs;
+            const approvalContext = {
+              toolName,
+              args: parsedArgs,
+              rawArgs: args,
+              ...(toolCallId === undefined ? {} : { toolCallId }),
+              internalCallId,
+              run: {
+                agentId: context.agentId,
+                runId: context.runId,
+                ...(context.sessionId === undefined ? {} : { sessionId: context.sessionId }),
+                ...(context.metadata === undefined ? {} : { metadata: context.metadata }),
+              },
+            };
 
-          const reason = await resolveApprovalText(approval.reason, approvalContext);
-          const rejectMessage = await resolveApprovalText(approval.rejectMessage, approvalContext);
-          const decision = await requestApproval(approvals, context, {
-            toolName,
-            ...(toolCallId === undefined ? {} : { toolCallId }),
-            internalCallId,
-            args,
-            ...(reason === undefined ? {} : { reason }),
-            ...(rejectMessage === undefined ? {} : { rejectMessage }),
-          });
+            const required = await approval.when(approvalContext);
+            if (!required) {
+              return control.run();
+            }
 
-          return decision.approved
-            ? control.run()
-            : control.skip(decision.reason ?? rejectMessage ?? "Rejected in Anvia Studio.");
-        },
-      });
+            const reason = await resolveApprovalText(approval.reason, approvalContext);
+            const rejectMessage = await resolveApprovalText(
+              approval.rejectMessage,
+              approvalContext,
+            );
+            const decision = await requestApproval(approvals, context, {
+              toolName,
+              ...(toolCallId === undefined ? {} : { toolCallId }),
+              internalCallId,
+              args,
+              ...(reason === undefined ? {} : { reason }),
+              ...(rejectMessage === undefined ? {} : { rejectMessage }),
+            });
+
+            return decision.approved
+              ? control.run()
+              : control.skip(decision.reason ?? rejectMessage ?? "Rejected in Anvia Studio.");
+          },
+        }),
+        handleApprovalRequest,
+      };
     },
     list(options) {
       return [...approvals.values()]

--- a/packages/tools/studio/src/runtime/mcps.ts
+++ b/packages/tools/studio/src/runtime/mcps.ts
@@ -1,0 +1,75 @@
+import type { Hono } from "hono";
+import type {
+  StudioAgent,
+  StudioAgentMcpServerMetadata,
+  StudioAgentMcpToolMetadata,
+} from "../types";
+import { errorResponse } from "./shared";
+import { agentToolItems, mcpServerName } from "./tool-metadata";
+
+export function registerMcpRoutes(
+  app: Hono,
+  props: {
+    agentMap: Map<string, StudioAgent>;
+  },
+): void {
+  app.get("/agents/:agentId/mcps", async (c) => {
+    const agentId = c.req.param("agentId");
+    const agent = props.agentMap.get(agentId);
+    if (agent === undefined) {
+      return errorResponse(c, 404, "not_found", "Agent not found");
+    }
+
+    return c.json({
+      agentId,
+      servers: await agentMcpMetadata(agent),
+    });
+  });
+}
+
+export async function agentMcpMetadata(
+  agent: StudioAgent,
+): Promise<StudioAgentMcpServerMetadata[]> {
+  const servers = new Map<string, StudioAgentMcpToolMetadata[]>();
+  const seen = new Set<string>();
+
+  for (const { tool, source } of agentToolItems(agent)) {
+    const serverName = mcpServerName(tool);
+    if (serverName === undefined) {
+      continue;
+    }
+
+    const definition = await tool.definition("");
+    const key = `${serverName}:${source}:${definition.name}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+
+    const tools = servers.get(serverName) ?? [];
+    tools.push({
+      name: definition.name,
+      description: definition.description,
+      parameters: definition.parameters,
+      source,
+    });
+    servers.set(serverName, tools);
+  }
+
+  return [...servers.entries()]
+    .map(([name, tools]) => {
+      const sortedTools = tools.sort((left, right) => {
+        if (left.source !== right.source) {
+          return left.source === "static" ? -1 : 1;
+        }
+        return left.name.localeCompare(right.name);
+      });
+      return {
+        agentId: agent.id,
+        name,
+        toolCount: sortedTools.length,
+        tools: sortedTools,
+      };
+    })
+    .sort((left, right) => left.name.localeCompare(right.name));
+}

--- a/packages/tools/studio/src/runtime/pipeline-logs.ts
+++ b/packages/tools/studio/src/runtime/pipeline-logs.ts
@@ -1,0 +1,195 @@
+import type { JsonObject, PipelineGraphNode, PipelineRunEvent } from "@anvia/core";
+import type {
+  StudioPipeline,
+  StudioPipelineLogAppendInput,
+  StudioPipelineLogEntry,
+  StudioPipelineLogStore,
+} from "../types";
+import { serializeError } from "./shared";
+
+export async function appendPipelineLog(
+  store: StudioPipelineLogStore | undefined,
+  input: StudioPipelineLogAppendInput,
+): Promise<StudioPipelineLogEntry | undefined> {
+  return store?.appendPipelineLog(input);
+}
+
+export async function* emitPipelineLog(
+  store: StudioPipelineLogStore | undefined,
+  input: StudioPipelineLogAppendInput,
+): AsyncIterable<{ type: "pipeline_log"; log: StudioPipelineLogEntry }> {
+  const log = await appendPipelineLog(store, input);
+  if (log !== undefined) {
+    yield { type: "pipeline_log", log };
+  }
+}
+
+export function pipelineRunReceivedLog(props: {
+  pipeline: StudioPipeline;
+  runId: string;
+  stream: boolean;
+  input: unknown;
+  metadata?: JsonObject;
+}): StudioPipelineLogAppendInput {
+  return {
+    pipelineId: props.pipeline.id,
+    runId: props.runId,
+    level: "info",
+    category: "api",
+    event: "pipeline.run_received",
+    message: "Pipeline run request received",
+    metadata: cleanMetadata({
+      stream: props.stream,
+      inputBytes: byteLength(formatUnknown(props.input)),
+      metadataKeys: Object.keys(props.metadata ?? {}),
+    }),
+  };
+}
+
+export function pipelineRunStartedLog(
+  pipeline: StudioPipeline,
+  runId: string,
+): StudioPipelineLogAppendInput {
+  const graph = pipeline.pipeline.graph();
+  return {
+    pipelineId: pipeline.id,
+    runId,
+    level: "info",
+    category: "run",
+    event: "pipeline.run_started",
+    message: "Pipeline run started",
+    metadata: cleanMetadata({
+      stageCount: graph.nodes.filter((node) => node.kind !== "input" && node.kind !== "output")
+        .length,
+      edgeCount: graph.edges.length,
+    }),
+  };
+}
+
+export function pipelineRunCompletedLog(props: {
+  pipelineId: string;
+  runId: string;
+  durationMs: number;
+  output: unknown;
+}): StudioPipelineLogAppendInput {
+  return {
+    pipelineId: props.pipelineId,
+    runId: props.runId,
+    level: "info",
+    category: "run",
+    event: "pipeline.run_completed",
+    message: "Pipeline run completed",
+    metadata: cleanMetadata({
+      durationMs: props.durationMs,
+      outputBytes: byteLength(formatUnknown(props.output)),
+    }),
+  };
+}
+
+export function pipelineRunFailedLog(
+  pipelineId: string,
+  runId: string,
+  error: unknown,
+  startedAt: number,
+): StudioPipelineLogAppendInput {
+  return {
+    pipelineId,
+    runId,
+    level: "error",
+    category: "run",
+    event: "pipeline.run_failed",
+    message: "Pipeline run failed",
+    metadata: cleanMetadata({
+      durationMs: Date.now() - startedAt,
+      error: serializeError(error),
+    }),
+  };
+}
+
+export function pipelineStageLog(
+  pipelineId: string,
+  runId: string,
+  event: PipelineRunEvent,
+): StudioPipelineLogAppendInput {
+  const category = stageCategory(event.node);
+  if (event.type === "stage_started") {
+    return {
+      pipelineId,
+      runId,
+      level: "debug",
+      category,
+      event: `${event.node.kind}.started`,
+      message: `${event.node.label} started`,
+      metadata: nodeMetadata(event.node),
+    };
+  }
+  if (event.type === "stage_completed") {
+    return {
+      pipelineId,
+      runId,
+      level: "debug",
+      category,
+      event: `${event.node.kind}.completed`,
+      message: `${event.node.label} completed`,
+      metadata: cleanMetadata({
+        ...nodeMetadata(event.node),
+        durationMs: event.durationMs,
+      }),
+    };
+  }
+  return {
+    pipelineId,
+    runId,
+    level: "error",
+    category,
+    event: `${event.node.kind}.failed`,
+    message: `${event.node.label} failed`,
+    metadata: cleanMetadata({
+      ...nodeMetadata(event.node),
+      durationMs: event.durationMs,
+      error: serializeError(event.error),
+    }),
+  };
+}
+
+function stageCategory(node: PipelineGraphNode): StudioPipelineLogAppendInput["category"] {
+  if (node.kind === "parallel" || node.kind === "branch") {
+    return "parallel";
+  }
+  if (node.kind === "agent") {
+    return "agent";
+  }
+  if (node.kind === "extractor") {
+    return "extractor";
+  }
+  return "stage";
+}
+
+function nodeMetadata(node: PipelineGraphNode): JsonObject {
+  return cleanMetadata({
+    nodeId: node.id,
+    kind: node.kind,
+    label: node.label,
+    agentId: node.agentId,
+    pipelineId: node.pipelineId,
+    branchKey: node.branchKey,
+  });
+}
+
+function cleanMetadata(value: Record<string, unknown>): JsonObject {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, item]) => item !== undefined),
+  ) as JsonObject;
+}
+
+function byteLength(value: string | undefined): number | undefined {
+  return value === undefined ? undefined : new TextEncoder().encode(value).length;
+}
+
+function formatUnknown(value: unknown): string | undefined {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/tools/studio/src/runtime/pipelines.ts
+++ b/packages/tools/studio/src/runtime/pipelines.ts
@@ -1,0 +1,347 @@
+import type { JsonValue, PipelineRunEvent } from "@anvia/core";
+import type { Context, Hono } from "hono";
+import { stream as streamResponse } from "hono/streaming";
+import type {
+  AgentRunStreamEvent,
+  StudioPipeline,
+  StudioPipelineDetail,
+  StudioPipelineLogStore,
+  StudioPipelineRunRequest,
+  StudioPipelineRunResponse,
+} from "../types";
+import {
+  appendPipelineLog,
+  emitPipelineLog,
+  pipelineRunCompletedLog,
+  pipelineRunFailedLog,
+  pipelineRunReceivedLog,
+  pipelineRunStartedLog,
+  pipelineStageLog,
+} from "./pipeline-logs";
+import { AsyncEventQueue } from "./runs";
+import { errorResponse, isJsonObject, isObject, pipelineConfig, serializeError } from "./shared";
+
+export function registerPipelineRoutes(
+  app: Hono,
+  props: {
+    pipelines: StudioPipeline[];
+    pipelineMap: Map<string, StudioPipeline>;
+    store?: StudioPipelineLogStore;
+  },
+): void {
+  app.get("/pipelines", (c) =>
+    c.json({
+      pipelines: props.pipelines.map(pipelineConfig),
+    }),
+  );
+
+  app.get("/pipelines/:pipelineId", (c) => {
+    const pipeline = props.pipelineMap.get(c.req.param("pipelineId"));
+    if (pipeline === undefined) {
+      return errorResponse(c, 404, "not_found", "Pipeline not found");
+    }
+    return c.json(pipelineDetail(pipeline));
+  });
+
+  app.get("/pipelines/:pipelineId/logs", async (c) => {
+    const pipelineId = c.req.param("pipelineId");
+    if (!props.pipelineMap.has(pipelineId)) {
+      return errorResponse(c, 404, "not_found", "Pipeline not found");
+    }
+    if (props.store === undefined) {
+      return errorResponse(
+        c,
+        501,
+        "unsupported_capability",
+        'Capability "pipelines.logs" is not implemented by this runner',
+        { capability: "pipelines", operation: "logs" },
+      );
+    }
+
+    const limit = parsePipelineLogLimit(c.req.query("limit"));
+    if (limit === undefined) {
+      return errorResponse(c, 400, "bad_request", "limit must be a positive integer");
+    }
+    const after = parsePipelineLogAfter(c.req.query("after"));
+    if (after === false) {
+      return errorResponse(c, 400, "bad_request", "after must be a non-negative integer");
+    }
+
+    const logs = await props.store.listPipelineLogs({
+      pipelineId,
+      limit,
+      ...(after === undefined ? {} : { after }),
+    });
+    const last = logs.at(-1);
+    return c.json({
+      logs,
+      ...(logs.length === limit && last !== undefined ? { nextCursor: last.sequence } : {}),
+    });
+  });
+
+  app.post("/pipelines/:pipelineId/runs", async (c) => {
+    const pipeline = props.pipelineMap.get(c.req.param("pipelineId"));
+    if (pipeline === undefined) {
+      return errorResponse(c, 404, "not_found", "Pipeline not found");
+    }
+
+    const body = await parsePipelineRunRequest(c);
+    if ("error" in body) {
+      return body.error;
+    }
+
+    const runId = globalThis.crypto.randomUUID();
+    const startedAt = Date.now();
+    await appendPipelineLog(
+      props.store,
+      pipelineRunReceivedLog({
+        pipeline,
+        runId,
+        stream: body.stream === true,
+        input: body.input,
+        ...(body.metadata === undefined ? {} : { metadata: body.metadata }),
+      }),
+    );
+
+    if (body.stream === true) {
+      return streamPipelineRun(c, {
+        pipeline,
+        runId,
+        input: body.input,
+        startedAt,
+        ...(props.store === undefined ? {} : { store: props.store }),
+      });
+    }
+
+    try {
+      await appendPipelineLog(props.store, pipelineRunStartedLog(pipeline, runId));
+      const output = await pipeline.pipeline.run(body.input, {
+        observer: {
+          async onEvent(event) {
+            await appendPipelineLog(props.store, pipelineStageLog(pipeline.id, runId, event));
+          },
+        },
+      });
+      const jsonOutput = toJsonValue(output);
+      await appendPipelineLog(
+        props.store,
+        pipelineRunCompletedLog({
+          pipelineId: pipeline.id,
+          runId,
+          durationMs: Date.now() - startedAt,
+          output: jsonOutput,
+        }),
+      );
+      const response: StudioPipelineRunResponse = {
+        runId,
+        pipelineId: pipeline.id,
+        output: jsonOutput,
+      };
+      return c.json(response);
+    } catch (error) {
+      await appendPipelineLog(
+        props.store,
+        pipelineRunFailedLog(pipeline.id, runId, error, startedAt),
+      );
+      return errorResponse(c, 500, "internal_error", "Pipeline run failed", serializeError(error));
+    }
+  });
+}
+
+function pipelineDetail(pipeline: StudioPipeline): StudioPipelineDetail {
+  const graph = pipeline.pipeline.graph();
+  graph.id = pipeline.id;
+  return {
+    ...pipelineConfig(pipeline),
+    graph,
+  };
+}
+
+function streamPipelineRun(
+  c: Context,
+  props: {
+    pipeline: StudioPipeline;
+    runId: string;
+    input: JsonValue;
+    startedAt: number;
+    store?: StudioPipelineLogStore;
+  },
+): Response {
+  c.header("content-type", "application/x-ndjson; charset=utf-8");
+  c.header("cache-control", "no-cache, no-transform");
+  c.header("connection", "keep-alive");
+  c.header("transfer-encoding", "chunked");
+  c.header("x-accel-buffering", "no");
+
+  return streamResponse(
+    c,
+    async (stream) => {
+      for await (const event of pipelineRunEvents(props)) {
+        await stream.write(`${JSON.stringify(event)}\n`);
+      }
+    },
+    async (error, stream) => {
+      await stream.write(`${JSON.stringify({ type: "error", error: serializeError(error) })}\n`);
+    },
+  );
+}
+
+async function* pipelineRunEvents(props: {
+  pipeline: StudioPipeline;
+  runId: string;
+  input: JsonValue;
+  startedAt: number;
+  store?: StudioPipelineLogStore;
+}): AsyncIterable<AgentRunStreamEvent> {
+  yield* emitPipelineLog(props.store, pipelineRunStartedLog(props.pipeline, props.runId));
+
+  const events = new AsyncEventQueue<AgentRunStreamEvent>();
+  const run = props.pipeline.pipeline
+    .run(props.input, {
+      observer: {
+        async onEvent(event: PipelineRunEvent) {
+          const log = await appendPipelineLog(
+            props.store,
+            pipelineStageLog(props.pipeline.id, props.runId, event),
+          );
+          if (log !== undefined) {
+            events.push({ type: "pipeline_log", log });
+          }
+        },
+      },
+    })
+    .then(async (output) => {
+      const jsonOutput = toJsonValue(output);
+      const log = await appendPipelineLog(
+        props.store,
+        pipelineRunCompletedLog({
+          pipelineId: props.pipeline.id,
+          runId: props.runId,
+          durationMs: Date.now() - props.startedAt,
+          output: jsonOutput,
+        }),
+      );
+      if (log !== undefined) {
+        events.push({ type: "pipeline_log", log });
+      }
+      events.push({
+        type: "pipeline_final",
+        runId: props.runId,
+        pipelineId: props.pipeline.id,
+        output: jsonOutput,
+      });
+    })
+    .catch(async (error) => {
+      const log = await appendPipelineLog(
+        props.store,
+        pipelineRunFailedLog(props.pipeline.id, props.runId, error, props.startedAt),
+      );
+      if (log !== undefined) {
+        events.push({ type: "pipeline_log", log });
+      }
+      events.push({ type: "error", error: serializeError(error) } as AgentRunStreamEvent);
+    })
+    .finally(() => events.close());
+
+  try {
+    while (true) {
+      const next = await events.next();
+      if (next.done === true) {
+        break;
+      }
+      yield next.value;
+    }
+  } finally {
+    await run;
+  }
+}
+
+async function parsePipelineRunRequest(
+  c: Context,
+): Promise<StudioPipelineRunRequest | { error: Response }> {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return { error: errorResponse(c, 400, "bad_request", "Request body must be JSON") };
+  }
+
+  if (!isObject(body)) {
+    return { error: errorResponse(c, 400, "bad_request", "Request body must be an object") };
+  }
+  if (!("input" in body) || !isJsonValue(body.input)) {
+    return { error: errorResponse(c, 400, "bad_request", "input must be JSON-compatible") };
+  }
+
+  const request: StudioPipelineRunRequest = {
+    input: body.input,
+  };
+  if ("stream" in body) {
+    if (typeof body.stream !== "boolean") {
+      return { error: errorResponse(c, 400, "bad_request", "stream must be a boolean") };
+    }
+    request.stream = body.stream;
+  }
+  if ("metadata" in body) {
+    if (!isJsonObject(body.metadata)) {
+      return { error: errorResponse(c, 400, "bad_request", "metadata must be an object") };
+    }
+    request.metadata = body.metadata;
+  }
+  return request;
+}
+
+function parsePipelineLogLimit(value: string | undefined): number | undefined {
+  if (value === undefined || value.trim().length === 0) {
+    return 200;
+  }
+  const limit = Number(value);
+  if (!Number.isInteger(limit) || limit <= 0) {
+    return undefined;
+  }
+  return Math.min(limit, 1000);
+}
+
+function parsePipelineLogAfter(value: string | undefined): number | undefined | false {
+  if (value === undefined || value.trim().length === 0) {
+    return undefined;
+  }
+  const after = Number(value);
+  if (!Number.isInteger(after) || after < 0) {
+    return false;
+  }
+  return after;
+}
+
+function isJsonValue(value: unknown): value is JsonValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return Number.isFinite(value) || typeof value !== "number";
+  }
+  if (Array.isArray(value)) {
+    return value.every(isJsonValue);
+  }
+  if (isObject(value)) {
+    return Object.values(value).every((item) => item === undefined || isJsonValue(item));
+  }
+  return false;
+}
+
+function toJsonValue(value: unknown): JsonValue {
+  if (isJsonValue(value)) {
+    return value;
+  }
+  if (value === undefined) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(JSON.stringify(value)) as unknown;
+    return isJsonValue(parsed) ? parsed : String(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/packages/tools/studio/src/runtime/session-logs.ts
+++ b/packages/tools/studio/src/runtime/session-logs.ts
@@ -1,0 +1,571 @@
+import type { JsonObject, JsonValue, Message } from "@anvia/core";
+import type {
+  AgentRunStreamEvent,
+  StudioSession,
+  StudioSessionLogAppendInput,
+  StudioSessionLogEntry,
+  StudioSessionStore,
+} from "../types";
+import { serializeError } from "./shared";
+
+export async function appendSessionLog(
+  store: StudioSessionStore | undefined,
+  input: StudioSessionLogAppendInput,
+): Promise<StudioSessionLogEntry | undefined> {
+  return store?.appendSessionLog?.(input);
+}
+
+export async function* streamSessionRunLogs(props: {
+  stream: AsyncIterable<AgentRunStreamEvent>;
+  store: StudioSessionStore;
+  session: StudioSession;
+  runId: string;
+  startedAt: number;
+}): AsyncIterable<AgentRunStreamEvent> {
+  yield* emitLog(props.store, runStartedLog(props.session, props.runId));
+  yield* emitLog(props.store, memoryLoadedLog(props.session, props.runId));
+
+  try {
+    for await (const event of props.stream) {
+      for (const input of logsFromStreamEvent({
+        event,
+        runId: props.runId,
+        sessionId: props.session.id,
+        startedAt: props.startedAt,
+      })) {
+        yield* emitLog(props.store, input);
+      }
+      yield event;
+    }
+  } catch (error) {
+    yield* emitLog(
+      props.store,
+      runFailedLog(props.session.id, props.runId, error, props.startedAt),
+    );
+    throw error;
+  }
+}
+
+export function sessionCreatedLog(
+  session: StudioSession | { id: string; agentId: string; title?: string },
+): StudioSessionLogAppendInput {
+  return {
+    sessionId: session.id,
+    level: "info",
+    category: "session",
+    event: "session.created",
+    message: "Session created",
+    metadata: cleanMetadata({
+      agentId: session.agentId,
+      hasTitle: session.title !== undefined,
+      titleLength: session.title?.length ?? 0,
+    }),
+  };
+}
+
+export function runReceivedLog(props: {
+  sessionId: string;
+  runId: string;
+  agentId: string;
+  message: string | Message;
+  stream: boolean;
+  maxTurns?: number;
+  toolConcurrency?: number;
+  hasTrace: boolean;
+  metadata?: JsonObject;
+}): StudioSessionLogAppendInput {
+  return {
+    sessionId: props.sessionId,
+    runId: props.runId,
+    level: "info",
+    category: "api",
+    event: "run.received",
+    message: "Run request received",
+    metadata: cleanMetadata({
+      agentId: props.agentId,
+      stream: props.stream,
+      message: messageSummary(props.message),
+      maxTurns: props.maxTurns,
+      toolConcurrency: props.toolConcurrency,
+      hasTrace: props.hasTrace,
+      metadataKeys: Object.keys(props.metadata ?? {}),
+    }),
+  };
+}
+
+export function runStartedLog(session: StudioSession, runId: string): StudioSessionLogAppendInput {
+  return {
+    sessionId: session.id,
+    runId,
+    level: "info",
+    category: "run",
+    event: "run.started",
+    message: "Run started",
+    metadata: cleanMetadata({
+      agentId: session.agentId,
+      existingMessageCount: session.messageCount,
+    }),
+  };
+}
+
+export function memoryLoadedLog(
+  session: StudioSession,
+  runId: string,
+): StudioSessionLogAppendInput {
+  return {
+    sessionId: session.id,
+    runId,
+    level: "debug",
+    category: "memory",
+    event: "memory.loaded",
+    message: "Session memory loaded",
+    metadata: cleanMetadata({
+      messageCount: session.messageCount,
+      transcriptEntries: session.transcript.length,
+    }),
+  };
+}
+
+export function runCompletedLog(props: {
+  sessionId: string;
+  runId: string;
+  durationMs: number;
+  usage?: unknown;
+  output?: string;
+  messageCount?: number;
+}): StudioSessionLogAppendInput {
+  return {
+    sessionId: props.sessionId,
+    runId: props.runId,
+    level: "info",
+    category: "run",
+    event: "run.completed",
+    message: "Run completed",
+    metadata: cleanMetadata({
+      durationMs: props.durationMs,
+      usage: usageSummary(props.usage),
+      outputBytes: byteLength(props.output),
+      messageCount: props.messageCount,
+    }),
+  };
+}
+
+export function memorySavedLog(props: {
+  sessionId: string;
+  runId: string;
+  messageCount?: number;
+}): StudioSessionLogAppendInput {
+  return {
+    sessionId: props.sessionId,
+    runId: props.runId,
+    level: "debug",
+    category: "memory",
+    event: "memory.saved",
+    message: "Session memory saved",
+    metadata: cleanMetadata({
+      messageCount: props.messageCount,
+    }),
+  };
+}
+
+export function runFailedLog(
+  sessionId: string,
+  runId: string,
+  error: unknown,
+  startedAt: number,
+): StudioSessionLogAppendInput {
+  return {
+    sessionId,
+    runId,
+    level: "error",
+    category: "run",
+    event: "run.failed",
+    message: "Run failed",
+    metadata: cleanMetadata({
+      durationMs: Date.now() - startedAt,
+      error: serializeError(error),
+    }),
+  };
+}
+
+function logsFromStreamEvent(props: {
+  event: AgentRunStreamEvent;
+  sessionId: string;
+  runId: string;
+  startedAt: number;
+}): StudioSessionLogAppendInput[] {
+  const { event, sessionId, runId } = props;
+  if (event.type === "turn_start") {
+    return [
+      {
+        sessionId,
+        runId,
+        level: "debug",
+        category: "prompt",
+        event: "prompt.prepared",
+        message: `Turn ${event.turn} prompt prepared`,
+        metadata: cleanMetadata({
+          turn: event.turn,
+          prompt: messageSummary(event.prompt),
+          historyCount: event.history.length,
+        }),
+      },
+    ];
+  }
+  if (event.type === "tool_call") {
+    return [
+      {
+        sessionId,
+        runId,
+        level: "info",
+        category: "tool",
+        event: "tool.called",
+        message: `Tool ${event.toolCall.function.name} called`,
+        metadata: cleanMetadata({
+          turn: event.turn,
+          toolName: event.toolCall.function.name,
+          callId: event.toolCall.callId ?? event.toolCall.id,
+          argumentBytes: byteLength(formatUnknown(event.toolCall.function.arguments)),
+        }),
+      },
+    ];
+  }
+  if (event.type === "tool_result") {
+    return [
+      {
+        sessionId,
+        runId,
+        level: "info",
+        category: "tool",
+        event: "tool.completed",
+        message: `Tool ${event.toolName} completed`,
+        metadata: cleanMetadata({
+          turn: event.turn,
+          toolName: event.toolName,
+          callId: event.toolCallId,
+          internalCallId: event.internalCallId,
+          argumentBytes: byteLength(event.args),
+          resultBytes: byteLength(event.result),
+        }),
+      },
+    ];
+  }
+  if (event.type === "turn_end") {
+    return [
+      {
+        sessionId,
+        runId,
+        level: "debug",
+        category: "model",
+        event: "model.turn.completed",
+        message: `Model turn ${event.turn} completed`,
+        metadata: cleanMetadata({
+          turn: event.turn,
+          contentCount: event.response.choice.length,
+          usage: usageSummary(event.response.usage),
+        }),
+      },
+    ];
+  }
+  if (event.type === "final") {
+    return [
+      runCompletedLog({
+        sessionId,
+        runId,
+        durationMs: Date.now() - props.startedAt,
+        usage: event.usage,
+        output: event.output,
+        messageCount: event.messages.length,
+      }),
+      memorySavedLog({ sessionId, runId, messageCount: event.messages.length }),
+    ];
+  }
+  if (event.type === "error") {
+    return [runFailedLog(sessionId, runId, event.error, props.startedAt)];
+  }
+  if (event.type === "tool_approval_request") {
+    return [
+      {
+        sessionId,
+        runId,
+        level: "info",
+        category: "approval",
+        event: "approval.requested",
+        message: `Approval requested for ${event.approval.toolName}`,
+        metadata: cleanMetadata({
+          approvalId: event.approval.id,
+          toolName: event.approval.toolName,
+          callId: event.approval.callId,
+          status: event.approval.status,
+          hasReason: event.approval.reason !== undefined,
+          argumentBytes: byteLength(event.approval.args),
+        }),
+      },
+    ];
+  }
+  if (event.type === "tool_approval_result") {
+    return [
+      {
+        sessionId,
+        runId,
+        level: event.approval.status === "approved" ? "info" : "warn",
+        category: "approval",
+        event: "approval.resolved",
+        message: `Approval ${event.approval.status} for ${event.approval.toolName}`,
+        metadata: cleanMetadata({
+          approvalId: event.approval.id,
+          toolName: event.approval.toolName,
+          callId: event.approval.callId,
+          status: event.approval.status,
+          hasReason: event.approval.reason !== undefined,
+        }),
+      },
+    ];
+  }
+  if (event.type === "tool_question_request") {
+    return [
+      {
+        sessionId,
+        runId,
+        level: "info",
+        category: "question",
+        event: "question.requested",
+        message: `Question requested by ${event.question.toolName}`,
+        metadata: cleanMetadata({
+          questionId: event.question.id,
+          toolName: event.question.toolName,
+          callId: event.question.callId,
+          status: event.question.status,
+          questionCount: event.question.questions.length,
+          argumentBytes: byteLength(event.question.args),
+        }),
+      },
+    ];
+  }
+  if (event.type === "tool_question_result") {
+    return [
+      {
+        sessionId,
+        runId,
+        level: "info",
+        category: "question",
+        event: "question.answered",
+        message: `Question answered for ${event.question.toolName}`,
+        metadata: cleanMetadata({
+          questionId: event.question.id,
+          toolName: event.question.toolName,
+          callId: event.question.callId,
+          status: event.question.status,
+          answerCount: event.question.answers?.length ?? 0,
+        }),
+      },
+    ];
+  }
+  if (event.type === "agent_tool_event") {
+    return childAgentLog(event, sessionId, runId);
+  }
+  return [];
+}
+
+async function* emitLog(
+  store: StudioSessionStore,
+  input: StudioSessionLogAppendInput,
+): AsyncIterable<AgentRunStreamEvent> {
+  const log = await appendSessionLog(store, input);
+  if (log !== undefined) {
+    yield { type: "session_log", log };
+  }
+}
+
+function childAgentLog(
+  event: Extract<AgentRunStreamEvent, { type: "agent_tool_event" }>,
+  sessionId: string,
+  runId: string,
+): StudioSessionLogAppendInput[] {
+  const child = event.event;
+  if (child.type === "tool_call") {
+    return [
+      {
+        sessionId,
+        runId,
+        level: "debug",
+        category: "tool",
+        event: "child_tool.called",
+        message: `Child agent ${event.agentName ?? event.agentId} called ${child.toolCall.function.name}`,
+        metadata: cleanMetadata({
+          parentToolName: event.toolName,
+          agentId: event.agentId,
+          hasAgentName: event.agentName !== undefined,
+          turn: event.turn,
+          childTurn: child.turn,
+          toolName: child.toolCall.function.name,
+          callId: child.toolCall.callId ?? child.toolCall.id,
+          argumentBytes: byteLength(formatUnknown(child.toolCall.function.arguments)),
+        }),
+      },
+    ];
+  }
+  if (child.type === "tool_result") {
+    return [
+      {
+        sessionId,
+        runId,
+        level: "debug",
+        category: "tool",
+        event: "child_tool.completed",
+        message: `Child agent ${event.agentName ?? event.agentId} completed ${child.toolName}`,
+        metadata: cleanMetadata({
+          parentToolName: event.toolName,
+          agentId: event.agentId,
+          hasAgentName: event.agentName !== undefined,
+          turn: event.turn,
+          childTurn: child.turn,
+          toolName: child.toolName,
+          callId: child.toolCallId,
+          resultBytes: byteLength(child.result),
+        }),
+      },
+    ];
+  }
+  if (child.type === "turn_start") {
+    return [
+      {
+        sessionId,
+        runId,
+        level: "debug",
+        category: "run",
+        event: "child_agent.turn_started",
+        message: `Child agent ${event.agentName ?? event.agentId} turn ${child.turn} started`,
+        metadata: cleanMetadata({
+          parentToolName: event.toolName,
+          agentId: event.agentId,
+          hasAgentName: event.agentName !== undefined,
+          childTurn: child.turn,
+          historyCount: child.history.length,
+        }),
+      },
+    ];
+  }
+  if (child.type === "final") {
+    return [
+      {
+        sessionId,
+        runId,
+        level: "debug",
+        category: "run",
+        event: "child_agent.completed",
+        message: `Child agent ${event.agentName ?? event.agentId} completed`,
+        metadata: cleanMetadata({
+          parentToolName: event.toolName,
+          agentId: event.agentId,
+          hasAgentName: event.agentName !== undefined,
+          usage: usageSummary(child.usage),
+          outputBytes: byteLength(child.output),
+          messageCount: child.messages.length,
+        }),
+      },
+    ];
+  }
+  if (child.type === "error") {
+    return [
+      {
+        sessionId,
+        runId,
+        level: "error",
+        category: "run",
+        event: "child_agent.failed",
+        message: `Child agent ${event.agentName ?? event.agentId} failed`,
+        metadata: cleanMetadata({
+          parentToolName: event.toolName,
+          agentId: event.agentId,
+          hasAgentName: event.agentName !== undefined,
+          error: serializeError(child.error),
+        }),
+      },
+    ];
+  }
+  return [];
+}
+
+function messageSummary(message: string | Message): JsonObject {
+  if (typeof message === "string") {
+    return {
+      role: "user",
+      contentKind: "text",
+      byteLength: byteLength(message),
+    };
+  }
+  return {
+    role: message.role,
+    contentKind: Array.isArray(message.content) ? "parts" : "text",
+    partCount: Array.isArray(message.content) ? message.content.length : 1,
+    byteLength: byteLength(formatUnknown(message.content)),
+  };
+}
+
+function usageSummary(value: unknown): JsonObject | undefined {
+  if (value === undefined || value === null || typeof value !== "object") {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  return cleanMetadata({
+    inputTokens: numericValue(record.inputTokens),
+    outputTokens: numericValue(record.outputTokens),
+    totalTokens: numericValue(record.totalTokens),
+    cachedInputTokens: numericValue(record.cachedInputTokens),
+    cacheCreationInputTokens: numericValue(record.cacheCreationInputTokens),
+  });
+}
+
+function cleanMetadata(value: Record<string, unknown>): JsonObject {
+  const cleaned: JsonObject = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (item === undefined) {
+      continue;
+    }
+    const jsonValue = cleanJsonValue(item);
+    if (jsonValue !== undefined) {
+      cleaned[key] = jsonValue;
+    }
+  }
+  return cleaned;
+}
+
+function cleanJsonValue(value: unknown): JsonValue | undefined {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => cleanJsonValue(item))
+      .filter((item): item is JsonValue => item !== undefined);
+  }
+  if (typeof value === "object" && value !== null) {
+    return cleanMetadata(value as Record<string, unknown>);
+  }
+  return undefined;
+}
+
+function numericValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function byteLength(value: string | undefined): number {
+  return value === undefined ? 0 : new TextEncoder().encode(value).byteLength;
+}
+
+function formatUnknown(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/packages/tools/studio/src/runtime/sessions.ts
+++ b/packages/tools/studio/src/runtime/sessions.ts
@@ -1,6 +1,7 @@
 import type { JsonObject } from "@anvia/core";
 import type { Context, Hono } from "hono";
 import type { StudioAgent, StudioSessionStore, StudioTraceStore } from "../types";
+import { appendSessionLog, sessionCreatedLog } from "./session-logs";
 import {
   errorResponse,
   isJsonObject,
@@ -51,6 +52,7 @@ export function registerSessionRoutes(
       ...(body.title === undefined ? {} : { title: body.title }),
       ...(body.metadata === undefined ? {} : { metadata: body.metadata }),
     });
+    await appendSessionLog(props.sessionStore, sessionCreatedLog(session));
     return c.json(session, 201);
   });
 
@@ -60,6 +62,43 @@ export function registerSessionRoutes(
       return errorResponse(c, 404, "not_found", "Session not found");
     }
     return c.json(session);
+  });
+
+  app.get("/sessions/:sessionId/logs", async (c) => {
+    const sessionId = c.req.param("sessionId");
+    const session = await props.sessionStore.getSession(sessionId);
+    if (session === undefined) {
+      return errorResponse(c, 404, "not_found", "Session not found");
+    }
+    if (props.sessionStore.listSessionLogs === undefined) {
+      return errorResponse(
+        c,
+        501,
+        "unsupported_capability",
+        'Capability "sessions.logs" is not implemented by this runner',
+        { capability: "sessions", operation: "logs" },
+      );
+    }
+
+    const limit = parseSessionLogLimit(c.req.query("limit"));
+    if (limit === undefined) {
+      return errorResponse(c, 400, "bad_request", "limit must be a positive integer");
+    }
+    const after = parseSessionLogAfter(c.req.query("after"));
+    if (after === false) {
+      return errorResponse(c, 400, "bad_request", "after must be a non-negative integer");
+    }
+
+    const logs = await props.sessionStore.listSessionLogs({
+      sessionId,
+      limit,
+      ...(after === undefined ? {} : { after }),
+    });
+    const last = logs.at(-1);
+    return c.json({
+      logs,
+      ...(logs.length === limit && last !== undefined ? { nextCursor: last.sequence } : {}),
+    });
   });
 
   app.delete("/sessions/:sessionId", async (c) => {
@@ -98,6 +137,28 @@ export function registerSessionRoutes(
     const traces = await props.traceStore.listSessionTraces({ sessionId, limit });
     return c.json({ traces });
   });
+}
+
+function parseSessionLogLimit(value: string | undefined): number | undefined {
+  if (value === undefined || value.trim().length === 0) {
+    return 200;
+  }
+  const limit = Number(value);
+  if (!Number.isInteger(limit) || limit <= 0) {
+    return undefined;
+  }
+  return Math.min(limit, 1000);
+}
+
+function parseSessionLogAfter(value: string | undefined): number | undefined | false {
+  if (value === undefined || value.trim().length === 0) {
+    return undefined;
+  }
+  const after = Number(value);
+  if (!Number.isInteger(after) || after < 0) {
+    return false;
+  }
+  return after;
 }
 
 async function parseCreateSessionRequest(c: Context): Promise<

--- a/packages/tools/studio/src/runtime/shared.ts
+++ b/packages/tools/studio/src/runtime/shared.ts
@@ -162,7 +162,13 @@ export function capabilityConfig(
   if (agents.some((agent) => agent.agent.observers.length > 0)) {
     capabilities.observability = { enabled: true };
   }
-  if (agents.some((agent) => agent.agent.toolSet.values().some((tool) => tool.approval))) {
+  if (
+    agents.some(
+      (agent) =>
+        agent.agent.hook !== undefined ||
+        agent.agent.toolSet.values().some((tool) => tool.approval),
+    )
+  ) {
     capabilities.approvals = { enabled: true };
   }
   if (

--- a/packages/tools/studio/src/runtime/shared.ts
+++ b/packages/tools/studio/src/runtime/shared.ts
@@ -10,6 +10,9 @@ import type {
   StudioConfig,
   StudioErrorCode,
   StudioErrorResponse,
+  StudioPipeline,
+  StudioPipelineConfig,
+  StudioPipelineLogStore,
   StudioSessionStore,
   StudioStores,
   StudioTraceStatus,
@@ -21,6 +24,7 @@ import { agentHasMcpTools } from "./tool-metadata";
 export type ResolvedStores = {
   sessions?: StudioSessionStore;
   traces?: StudioTraceStore;
+  pipelineLogs?: StudioPipelineLogStore;
 };
 
 export type StudioRuntimeOptions = {
@@ -29,6 +33,7 @@ export type StudioRuntimeOptions = {
   description?: string;
   version?: string;
   agents: StudioAgent[];
+  pipelines: StudioPipeline[];
   stores?: StudioStores;
   ui?: boolean | StudioUiOptions;
 };
@@ -41,9 +46,11 @@ export function resolveStores(options: StudioRuntimeOptions): ResolvedStores {
   const defaultStore = createSqliteSessionStore({ path: defaultPath });
   const sessions = resolveSessionStore(options, defaultStore);
   const traces = resolveTraceStore(options, sessions, defaultStore);
+  const pipelineLogs = resolvePipelineLogStore(options, sessions, defaultStore);
   return {
     ...(sessions === undefined ? {} : { sessions }),
     ...(traces === undefined ? {} : { traces }),
+    ...(pipelineLogs === undefined ? {} : { pipelineLogs }),
   };
 }
 
@@ -78,12 +85,39 @@ function resolveTraceStore(
   return defaultStore;
 }
 
+function resolvePipelineLogStore(
+  options: StudioRuntimeOptions,
+  sessionStore: StudioSessionStore | undefined,
+  defaultStore: StudioPipelineLogStore,
+): StudioPipelineLogStore | undefined {
+  if (options.stores?.pipelineLogs === false) {
+    return undefined;
+  }
+  if (options.stores?.pipelineLogs !== undefined) {
+    return options.stores.pipelineLogs;
+  }
+  if (sessionStore !== undefined && isPipelineLogStore(sessionStore)) {
+    return sessionStore;
+  }
+  return defaultStore;
+}
+
 function isTraceStore(store: StudioSessionStore): store is StudioSessionStore & StudioTraceStore {
   const candidate = store as Partial<StudioTraceStore>;
   return (
     typeof candidate.listSessionTraces === "function" &&
     typeof candidate.getTrace === "function" &&
     typeof candidate.saveTrace === "function"
+  );
+}
+
+function isPipelineLogStore(
+  store: StudioSessionStore,
+): store is StudioSessionStore & StudioPipelineLogStore {
+  const candidate = store as Partial<StudioPipelineLogStore>;
+  return (
+    typeof candidate.appendPipelineLog === "function" &&
+    typeof candidate.listPipelineLogs === "function"
   );
 }
 
@@ -109,9 +143,25 @@ export function normalizeAgents(agents: StudioAgent[]): StudioAgent[] {
   });
 }
 
+export function normalizePipelines(pipelines: StudioPipeline[]): StudioPipeline[] {
+  const ids = new Set<string>();
+  return pipelines.map((pipeline) => {
+    const id = pipeline.id.trim();
+    if (id.length === 0) {
+      throw new Error("Studio pipeline id cannot be empty");
+    }
+    if (ids.has(id)) {
+      throw new Error(`Duplicate Studio pipeline id: ${id}`);
+    }
+    ids.add(id);
+    return { ...pipeline, id };
+  });
+}
+
 export function buildConfig(
   options: StudioRuntimeOptions,
   agents: StudioAgent[],
+  pipelines: StudioPipeline[],
   stores: ResolvedStores,
 ): StudioConfig {
   return {
@@ -120,10 +170,11 @@ export function buildConfig(
     ...(options.description === undefined ? {} : { description: options.description }),
     ...(options.version === undefined ? {} : { version: options.version }),
     agents: agents.map(agentConfig),
+    pipelines: pipelines.map(pipelineConfig),
     chat: {
       quickPrompts: Object.fromEntries(agents.map((agent) => [agent.id, agent.quickPrompts ?? []])),
     },
-    capabilities: capabilityConfig(options, agents, stores),
+    capabilities: capabilityConfig(options, agents, pipelines, stores),
     unsupportedCapabilities: unsupportedCapabilities(stores),
   };
 }
@@ -144,9 +195,26 @@ export function agentConfig(agent: StudioAgent): StudioAgentConfig {
   };
 }
 
+export function pipelineConfig(pipeline: StudioPipeline): StudioPipelineConfig {
+  const graph = pipeline.pipeline.graph();
+  const stageNodes = graph.nodes.filter((node) => node.kind !== "input" && node.kind !== "output");
+  return {
+    id: pipeline.id,
+    ...(pipeline.name === undefined ? {} : { name: pipeline.name }),
+    ...(pipeline.description === undefined ? {} : { description: pipeline.description }),
+    ...(pipeline.metadata === undefined ? {} : { metadata: pipeline.metadata }),
+    stageCount: stageNodes.length,
+    edgeCount: graph.edges.length,
+    hasParallelStages: graph.nodes.some((node) => node.kind === "parallel"),
+    agentCount: graph.nodes.filter((node) => node.kind === "agent").length,
+    extractorCount: graph.nodes.filter((node) => node.kind === "extractor").length,
+  };
+}
+
 export function capabilityConfig(
   _options: StudioRuntimeOptions,
   agents: StudioAgent[],
+  pipelines: StudioPipeline[],
   stores: ResolvedStores,
 ): Partial<Record<StudioCapability, StudioCapabilityConfig>> {
   const capabilities: Partial<Record<StudioCapability, StudioCapabilityConfig>> = {
@@ -158,6 +226,9 @@ export function capabilityConfig(
   }
   if (stores.traces !== undefined) {
     capabilities.traces = { enabled: true };
+  }
+  if (pipelines.length > 0) {
+    capabilities.pipelines = { enabled: true };
   }
   if (
     agents.some(

--- a/packages/tools/studio/src/runtime/shared.ts
+++ b/packages/tools/studio/src/runtime/shared.ts
@@ -16,6 +16,7 @@ import type {
   StudioTraceStore,
   StudioUiOptions,
 } from "../types";
+import { agentHasMcpTools } from "./tool-metadata";
 
 export type ResolvedStores = {
   sessions?: StudioSessionStore;
@@ -157,6 +158,16 @@ export function capabilityConfig(
   }
   if (stores.traces !== undefined) {
     capabilities.traces = { enabled: true };
+  }
+  if (
+    agents.some(
+      (agent) => agent.agent.toolSet.values().length > 0 || agent.agent.dynamicTools.length > 0,
+    )
+  ) {
+    capabilities.tools = { enabled: true };
+  }
+  if (agents.some(agentHasMcpTools)) {
+    capabilities.mcps = { enabled: true };
   }
 
   if (agents.some((agent) => agent.agent.observers.length > 0)) {

--- a/packages/tools/studio/src/runtime/studio.ts
+++ b/packages/tools/studio/src/runtime/studio.ts
@@ -29,7 +29,11 @@ import {
   resolveStudioUiOptions,
   studioUiEntryPath,
 } from "../ui/routes";
-import { createApprovalRuntime, registerApprovalRoutes } from "./approvals";
+import {
+  createApprovalRuntime,
+  registerApprovalRoutes,
+  type StudioApprovalHook,
+} from "./approvals";
 import { registerKnowledgeRoutes } from "./knowledge";
 import { createQuestionRuntime, registerQuestionRoutes } from "./questions";
 import {
@@ -170,6 +174,7 @@ function agentMetadata(agent: Agent): JsonObject {
     dynamicContextCount: agent.dynamicContexts.length,
     dynamicToolCount: agent.dynamicTools.length,
     hasOutputSchema: agent.outputSchema !== undefined,
+    hasHook: agent.hook !== undefined,
     observerCount: agent.observers.length,
     approvalToolCount: agent.toolSet.values().filter((tool) => tool.approval !== undefined).length,
   };
@@ -502,6 +507,9 @@ function composeHooks(
       if (firstAction?.type === "skip" || firstAction?.type === "terminate") {
         return firstAction;
       }
+      if (firstAction?.type === "approval_request") {
+        return (await approvalRequestHandler(second)?.(args, firstAction)) ?? firstAction;
+      }
       const secondAction = await second.onToolCall?.(args);
       return secondAction ?? firstAction ?? undefined;
     },
@@ -512,4 +520,13 @@ function composeHooks(
         : ((await second.onToolResult?.(args)) ?? undefined);
     },
   });
+}
+
+function approvalRequestHandler(
+  hook: PromptHook,
+): StudioApprovalHook["handleApprovalRequest"] | undefined {
+  const candidate = hook as Partial<StudioApprovalHook>;
+  return typeof candidate.handleApprovalRequest === "function"
+    ? candidate.handleApprovalRequest
+    : undefined;
 }

--- a/packages/tools/studio/src/runtime/studio.ts
+++ b/packages/tools/studio/src/runtime/studio.ts
@@ -5,6 +5,7 @@ import {
   type HookAction,
   type JsonObject,
   Message,
+  Pipeline,
   type PromptHook,
   resolveMemoryOptions,
   type ToolCallHookAction,
@@ -19,8 +20,10 @@ import type {
   StudioAgent,
   StudioConfig,
   StudioOptions,
+  StudioPipeline,
   StudioServeOptions,
   StudioSessionStore,
+  StudioTarget,
   StudioTraceStore,
 } from "../types";
 import {
@@ -36,6 +39,7 @@ import {
 } from "./approvals";
 import { registerKnowledgeRoutes } from "./knowledge";
 import { registerMcpRoutes } from "./mcps";
+import { registerPipelineRoutes } from "./pipelines";
 import { createQuestionRuntime, registerQuestionRoutes } from "./questions";
 import {
   AsyncEventQueue,
@@ -63,6 +67,7 @@ import {
   buildConfig,
   errorResponse,
   normalizeAgents,
+  normalizePipelines,
   resolveStores,
   runnerId,
   type StudioRuntimeOptions,
@@ -84,8 +89,8 @@ export class Studio implements AnviaStudio {
   private server: ReturnType<typeof serve> | undefined;
   private sigintHandler: (() => void) | undefined;
 
-  constructor(agents: Agent[] = [], options: StudioOptions = {}) {
-    this.options = studioOptionsFromAgents(agents, options);
+  constructor(targets: StudioTarget[] = [], options: StudioOptions = {}) {
+    this.options = studioOptionsFromTargets(targets, options);
     this.studio = createStudioApp(this.options);
   }
 
@@ -149,9 +154,17 @@ export class Studio implements AnviaStudio {
   }
 }
 
-function studioOptionsFromAgents(agents: Agent[], options: StudioOptions): StudioRuntimeOptions {
+function studioOptionsFromTargets(
+  targets: StudioTarget[],
+  options: StudioOptions,
+): StudioRuntimeOptions {
+  const agents = targets.filter((target): target is Agent => target instanceof Agent);
+  const pipelines = targets.filter(
+    (target): target is Pipeline<unknown, unknown> => target instanceof Pipeline,
+  );
   return {
     agents: inferStudioAgents(agents, options.quickPrompts ?? {}),
+    pipelines: inferStudioPipelines(pipelines),
   };
 }
 
@@ -164,6 +177,20 @@ function inferStudioAgents(agents: Agent[], quickPrompts: Record<string, string[
       agent,
       quickPrompts: quickPrompts[id] ?? [],
       metadata: agentMetadata(agent),
+    };
+  });
+}
+
+function inferStudioPipelines(pipelines: Array<Pipeline<unknown, unknown>>): StudioPipeline[] {
+  const ids = new Set<string>();
+  return pipelines.map((pipeline) => {
+    const id = uniqueAgentId(pipeline.id || "pipeline", ids);
+    return {
+      id,
+      pipeline,
+      ...(pipeline.name === undefined ? {} : { name: pipeline.name }),
+      ...(pipeline.description === undefined ? {} : { description: pipeline.description }),
+      ...(pipeline.metadata === undefined ? {} : { metadata: pipeline.metadata }),
     };
   });
 }
@@ -197,7 +224,9 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
   const agents = normalizeAgents(options.agents)
     .map((agent) => withStudioSessionMemory(agent, stores.sessions))
     .map((agent) => withStudioTraceObserver(agent, stores.traces));
+  const pipelines = normalizePipelines(options.pipelines);
   const agentMap = new Map(agents.map((agent) => [agent.id, agent]));
+  const pipelineMap = new Map(pipelines.map((pipeline) => [pipeline.id, pipeline]));
   const approvalRuntime = createApprovalRuntime();
   const questionRuntime = createQuestionRuntime();
   const app = new HonoApp();
@@ -222,7 +251,7 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
     }),
   );
 
-  app.get("/config", (c) => c.json(buildConfig(options, agents, stores)));
+  app.get("/config", (c) => c.json(buildConfig(options, agents, pipelines, stores)));
 
   app.get("/agents", (c) => c.json({ agents: agents.map(agentConfig) }));
 
@@ -242,6 +271,11 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
   registerKnowledgeRoutes(app, {
     agents,
     ...(stores.traces === undefined ? {} : { traceStore: stores.traces }),
+  });
+  registerPipelineRoutes(app, {
+    pipelines,
+    pipelineMap,
+    ...(stores.pipelineLogs === undefined ? {} : { store: stores.pipelineLogs }),
   });
 
   app.post("/agents/:agentId/runs", async (c) => {
@@ -459,7 +493,7 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
       return app.fetch(request);
     },
     config(): StudioConfig {
-      return buildConfig(options, agents, stores);
+      return buildConfig(options, agents, pipelines, stores);
     },
     close() {},
     ...(stores.sessions === undefined ? {} : { sessionStore: stores.sessions }),

--- a/packages/tools/studio/src/runtime/studio.ts
+++ b/packages/tools/studio/src/runtime/studio.ts
@@ -35,6 +35,7 @@ import {
   type StudioApprovalHook,
 } from "./approvals";
 import { registerKnowledgeRoutes } from "./knowledge";
+import { registerMcpRoutes } from "./mcps";
 import { createQuestionRuntime, registerQuestionRoutes } from "./questions";
 import {
   AsyncEventQueue,
@@ -69,6 +70,7 @@ import {
   unsupportedCapabilities,
   unsupportedCapability,
 } from "./shared";
+import { registerToolRoutes } from "./tools";
 import { registerTraceRoutes } from "./trace-routes";
 
 type StudioApp = AnviaStudio & {
@@ -233,6 +235,8 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
     return c.json(agentConfig(agent));
   });
 
+  registerMcpRoutes(app, { agentMap });
+  registerToolRoutes(app, { agentMap });
   registerApprovalRoutes(app, approvalRuntime);
   registerQuestionRoutes(app, questionRuntime);
   registerKnowledgeRoutes(app, {

--- a/packages/tools/studio/src/runtime/studio.ts
+++ b/packages/tools/studio/src/runtime/studio.ts
@@ -46,6 +46,16 @@ import {
   traceForRun,
   transcriptFromMessages,
 } from "./runs";
+import {
+  appendSessionLog,
+  memoryLoadedLog,
+  memorySavedLog,
+  runCompletedLog,
+  runFailedLog,
+  runReceivedLog,
+  runStartedLog,
+  streamSessionRunLogs,
+} from "./session-logs";
 import { registerSessionRoutes } from "./sessions";
 import {
   agentConfig,
@@ -256,6 +266,23 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
     }
 
     const runId = globalThis.crypto.randomUUID();
+    const runStartedAt = Date.now();
+    if (session !== undefined) {
+      await appendSessionLog(
+        stores.sessions,
+        runReceivedLog({
+          sessionId: session.id,
+          runId,
+          agentId,
+          message: body.message,
+          stream: body.stream === true,
+          ...(body.maxTurns === undefined ? {} : { maxTurns: body.maxTurns }),
+          ...(body.toolConcurrency === undefined ? {} : { toolConcurrency: body.toolConcurrency }),
+          hasTrace: body.trace !== undefined,
+          ...(body.metadata === undefined ? {} : { metadata: body.metadata }),
+        }),
+      );
+    }
     const memoryMetadata = {
       agentId,
       ...(body.metadata ?? {}),
@@ -311,7 +338,13 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
         session === undefined || stores.sessions === undefined
           ? runStream
           : persistStreamingSessionTranscript({
-              stream: runStream,
+              stream: streamSessionRunLogs({
+                stream: runStream,
+                store: stores.sessions,
+                session,
+                runId,
+                startedAt: runStartedAt,
+              }),
               store: stores.sessions,
               session,
               message: body.message,
@@ -321,6 +354,10 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
     }
 
     try {
+      if (session !== undefined) {
+        await appendSessionLog(stores.sessions, runStartedLog(session, runId));
+        await appendSessionLog(stores.sessions, memoryLoadedLog(session, runId));
+      }
       const effectiveHook = composeHooks(
         composeHooks(
           agent.agent.hook,
@@ -351,6 +388,25 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
           transcript: transcriptFromMessages(response.messages),
           status: "success",
         });
+        await appendSessionLog(
+          stores.sessions,
+          runCompletedLog({
+            sessionId: session.id,
+            runId,
+            durationMs: Date.now() - runStartedAt,
+            usage: response.usage,
+            output: response.output,
+            messageCount: response.messages.length,
+          }),
+        );
+        await appendSessionLog(
+          stores.sessions,
+          memorySavedLog({
+            sessionId: session.id,
+            runId,
+            messageCount: response.messages.length,
+          }),
+        );
       }
       return c.json(response);
     } catch (error) {
@@ -367,6 +423,10 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
           status: "error",
           error: serializeError(error),
         });
+        await appendSessionLog(
+          stores.sessions,
+          runFailedLog(session.id, runId, error, runStartedAt),
+        );
       }
       return errorResponse(c, 500, "internal_error", "Agent run failed", serializeError(error));
     }

--- a/packages/tools/studio/src/runtime/tool-metadata.ts
+++ b/packages/tools/studio/src/runtime/tool-metadata.ts
@@ -1,0 +1,52 @@
+import { type AnyTool, ToolSet } from "@anvia/core";
+import type { StudioAgent, StudioAgentToolApprovalMetadata, StudioAgentToolSource } from "../types";
+
+export type AgentToolItem = {
+  tool: AnyTool;
+  source: StudioAgentToolSource;
+};
+
+const MCP_TOOL_METADATA_KEY = Symbol.for("anvia.mcp.tool.metadata");
+
+export function agentToolItems(agent: StudioAgent): AgentToolItem[] {
+  return [
+    ...agent.agent.toolSet.values().map((tool) => ({ tool, source: "static" as const })),
+    ...agent.agent.dynamicTools.flatMap((registration) => {
+      const maybeToolSet = (registration.index as { toolSet?: unknown }).toolSet;
+      if (!(maybeToolSet instanceof ToolSet)) {
+        return [];
+      }
+      return maybeToolSet.values().map((tool) => ({ tool, source: "dynamic" as const }));
+    }),
+  ];
+}
+
+export function approvalMetadata(tool: AnyTool): StudioAgentToolApprovalMetadata {
+  const approval = tool.approval;
+  if (approval === undefined || typeof approval !== "object" || approval === null) {
+    return { required: false };
+  }
+
+  const policy = approval as {
+    reason?: unknown;
+    rejectMessage?: unknown;
+  };
+  return {
+    required: true,
+    ...(typeof policy.reason === "string" ? { reason: policy.reason } : {}),
+    ...(typeof policy.rejectMessage === "string" ? { rejectMessage: policy.rejectMessage } : {}),
+  };
+}
+
+export function mcpServerName(tool: AnyTool): string | undefined {
+  const metadata = (tool as { [MCP_TOOL_METADATA_KEY]?: unknown })[MCP_TOOL_METADATA_KEY];
+  if (typeof metadata !== "object" || metadata === null) {
+    return undefined;
+  }
+  const serverName = (metadata as { serverName?: unknown }).serverName;
+  return typeof serverName === "string" && serverName.length > 0 ? serverName : undefined;
+}
+
+export function agentHasMcpTools(agent: StudioAgent): boolean {
+  return agentToolItems(agent).some(({ tool }) => mcpServerName(tool) !== undefined);
+}

--- a/packages/tools/studio/src/runtime/tools.ts
+++ b/packages/tools/studio/src/runtime/tools.ts
@@ -1,0 +1,52 @@
+import type { Hono } from "hono";
+import type { StudioAgent, StudioAgentToolMetadata } from "../types";
+import { errorResponse } from "./shared";
+import { agentToolItems, approvalMetadata } from "./tool-metadata";
+
+export function registerToolRoutes(
+  app: Hono,
+  props: {
+    agentMap: Map<string, StudioAgent>;
+  },
+): void {
+  app.get("/agents/:agentId/tools", async (c) => {
+    const agentId = c.req.param("agentId");
+    const agent = props.agentMap.get(agentId);
+    if (agent === undefined) {
+      return errorResponse(c, 404, "not_found", "Agent not found");
+    }
+
+    return c.json({
+      agentId,
+      tools: await agentToolMetadata(agent),
+    });
+  });
+}
+
+export async function agentToolMetadata(agent: StudioAgent): Promise<StudioAgentToolMetadata[]> {
+  const seen = new Set<string>();
+  const metadata: StudioAgentToolMetadata[] = [];
+  for (const { tool, source } of agentToolItems(agent)) {
+    const key = `${source}:${tool.name}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    const definition = await tool.definition("");
+    metadata.push({
+      agentId: agent.id,
+      name: definition.name,
+      description: definition.description,
+      parameters: definition.parameters,
+      source,
+      approval: approvalMetadata(tool),
+    });
+  }
+
+  return metadata.sort((left, right) => {
+    if (left.source !== right.source) {
+      return left.source === "static" ? -1 : 1;
+    }
+    return left.name.localeCompare(right.name);
+  });
+}

--- a/packages/tools/studio/src/storage/sqlite-store.ts
+++ b/packages/tools/studio/src/storage/sqlite-store.ts
@@ -14,6 +14,9 @@ import type {
   StudioSession,
   StudioSessionCreateInput,
   StudioSessionListOptions,
+  StudioSessionLogAppendInput,
+  StudioSessionLogEntry,
+  StudioSessionLogListOptions,
   StudioSessionRunStatus,
   StudioSessionRunTranscriptInput,
   StudioSessionStore,
@@ -98,6 +101,19 @@ type SessionRunRow = {
   error_json: string | null;
   created_at: string;
   updated_at: string;
+};
+
+type SessionLogRow = {
+  id: string;
+  session_id: string;
+  run_id: string | null;
+  sequence: number;
+  timestamp: string;
+  level: StudioSessionLogEntry["level"];
+  category: StudioSessionLogEntry["category"];
+  event: string;
+  message: string;
+  metadata_json: string | null;
 };
 
 export function createSqliteSessionStore(
@@ -341,6 +357,99 @@ class SqliteSessionStore implements StudioSessionStore, StudioTraceStore {
     }
   }
 
+  appendSessionLog(input: StudioSessionLogAppendInput): StudioSessionLogEntry {
+    const db = this.database();
+    const now = new Date().toISOString();
+
+    try {
+      db.exec("BEGIN IMMEDIATE");
+      const row = this.getSessionRow(input.sessionId);
+      if (row === undefined) {
+        throw new Error("Session not found");
+      }
+      const sequence = this.nextSessionLogSequence(input.sessionId);
+      const entry: StudioSessionLogEntry = {
+        id: globalThis.crypto.randomUUID(),
+        sessionId: input.sessionId,
+        ...(input.runId === undefined ? {} : { runId: input.runId }),
+        sequence,
+        timestamp: now,
+        level: input.level,
+        category: input.category,
+        event: input.event,
+        message: input.message,
+        ...(input.metadata === undefined ? {} : { metadata: input.metadata }),
+      };
+
+      db.prepare(
+        `INSERT INTO runner_session_logs (
+          id,
+          session_id,
+          run_id,
+          sequence,
+          timestamp,
+          level,
+          category,
+          event,
+          message,
+          metadata_json
+        ) VALUES (
+          $id,
+          $sessionId,
+          $runId,
+          $sequence,
+          $timestamp,
+          $level,
+          $category,
+          $event,
+          $message,
+          $metadata
+        )`,
+      ).run({
+        $id: entry.id,
+        $sessionId: entry.sessionId,
+        $runId: entry.runId ?? null,
+        $sequence: entry.sequence,
+        $timestamp: entry.timestamp,
+        $level: entry.level,
+        $category: entry.category,
+        $event: entry.event,
+        $message: entry.message,
+        $metadata: entry.metadata === undefined ? null : JSON.stringify(entry.metadata),
+      });
+
+      db.exec("COMMIT");
+      return entry;
+    } catch (error) {
+      if (db.isTransaction) {
+        db.exec("ROLLBACK");
+      }
+      throw error;
+    }
+  }
+
+  listSessionLogs(options: StudioSessionLogListOptions): StudioSessionLogEntry[] {
+    const db = this.database();
+    const afterClause = options.after === undefined ? "" : "AND sequence > $after";
+    const rows = db
+      .prepare(
+        `SELECT id, session_id, run_id, sequence, timestamp, level, category, event, message,
+                metadata_json
+         FROM runner_session_logs
+         WHERE session_id = $sessionId
+         ${afterClause}
+         ORDER BY sequence ASC
+         LIMIT $limit`,
+      )
+      .all({
+        $sessionId: options.sessionId,
+        $after: options.after ?? null,
+        $limit: options.limit,
+      }) as SessionLogRow[];
+
+    return rows.map(toSessionLog);
+  }
+
   deleteSession(id: string): boolean {
     const db = this.database();
 
@@ -348,6 +457,7 @@ class SqliteSessionStore implements StudioSessionStore, StudioTraceStore {
       db.exec("BEGIN IMMEDIATE");
       db.prepare("DELETE FROM runner_traces WHERE session_id = $id").run({ $id: id });
       db.prepare("DELETE FROM runner_session_runs WHERE session_id = $id").run({ $id: id });
+      db.prepare("DELETE FROM runner_session_logs WHERE session_id = $id").run({ $id: id });
       const result = db.prepare("DELETE FROM runner_sessions WHERE id = $id").run({ $id: id }) as {
         changes: number | bigint;
       };
@@ -565,6 +675,22 @@ class SqliteSessionStore implements StudioSessionStore, StudioTraceStore {
       ) STRICT;
       CREATE INDEX IF NOT EXISTS runner_session_runs_session_created_idx
         ON runner_session_runs(session_id, created_at ASC);
+      CREATE TABLE IF NOT EXISTS runner_session_logs (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        run_id TEXT,
+        sequence INTEGER NOT NULL,
+        timestamp TEXT NOT NULL,
+        level TEXT NOT NULL,
+        category TEXT NOT NULL,
+        event TEXT NOT NULL,
+        message TEXT NOT NULL,
+        metadata_json TEXT,
+        UNIQUE(session_id, sequence),
+        FOREIGN KEY(session_id) REFERENCES runner_sessions(id) ON DELETE CASCADE
+      ) STRICT;
+      CREATE INDEX IF NOT EXISTS runner_session_logs_session_sequence_idx
+        ON runner_session_logs(session_id, sequence ASC);
       CREATE TABLE IF NOT EXISTS runner_traces (
         id TEXT PRIMARY KEY,
         session_id TEXT NOT NULL,
@@ -618,6 +744,17 @@ class SqliteSessionStore implements StudioSessionStore, StudioTraceStore {
          ORDER BY created_at ASC`,
       )
       .all({ $sessionId: sessionId }) as SessionRunRow[];
+  }
+
+  private nextSessionLogSequence(sessionId: string): number {
+    const row = this.database()
+      .prepare(
+        `SELECT COALESCE(MAX(sequence) + 1, 0) AS next_sequence
+         FROM runner_session_logs
+         WHERE session_id = $sessionId`,
+      )
+      .get({ $sessionId: sessionId }) as { next_sequence: number };
+    return row.next_sequence;
   }
 
   private listSessionMessages(sessionId: string): Message[] {
@@ -740,6 +877,22 @@ function toSessionSummary(row: SessionSummaryRow): StudioSessionSummary {
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     messageCount: row.message_count,
+    ...(metadata === undefined ? {} : { metadata }),
+  };
+}
+
+function toSessionLog(row: SessionLogRow): StudioSessionLogEntry {
+  const metadata = parseJsonValue<JsonObject>(row.metadata_json);
+  return {
+    id: row.id,
+    sessionId: row.session_id,
+    ...(row.run_id === null ? {} : { runId: row.run_id }),
+    sequence: row.sequence,
+    timestamp: row.timestamp,
+    level: row.level,
+    category: row.category,
+    event: row.event,
+    message: row.message,
     ...(metadata === undefined ? {} : { metadata }),
   };
 }

--- a/packages/tools/studio/src/storage/sqlite-store.ts
+++ b/packages/tools/studio/src/storage/sqlite-store.ts
@@ -11,6 +11,10 @@ import type {
   Message,
 } from "@anvia/core";
 import type {
+  StudioPipelineLogAppendInput,
+  StudioPipelineLogEntry,
+  StudioPipelineLogListOptions,
+  StudioPipelineLogStore,
   StudioSession,
   StudioSessionCreateInput,
   StudioSessionListOptions,
@@ -116,13 +120,26 @@ type SessionLogRow = {
   metadata_json: string | null;
 };
 
+type PipelineLogRow = {
+  id: string;
+  pipeline_id: string;
+  run_id: string | null;
+  sequence: number;
+  timestamp: string;
+  level: StudioPipelineLogEntry["level"];
+  category: StudioPipelineLogEntry["category"];
+  event: string;
+  message: string;
+  metadata_json: string | null;
+};
+
 export function createSqliteSessionStore(
   options: SqliteSessionStoreOptions = {},
-): StudioSessionStore & StudioTraceStore {
+): StudioSessionStore & StudioTraceStore & StudioPipelineLogStore {
   return new SqliteSessionStore(options.path ?? ":memory:");
 }
 
-class SqliteSessionStore implements StudioSessionStore, StudioTraceStore {
+class SqliteSessionStore implements StudioSessionStore, StudioTraceStore, StudioPipelineLogStore {
   readonly kind = "sqlite";
   private db: DatabaseSyncType | undefined;
 
@@ -450,6 +467,95 @@ class SqliteSessionStore implements StudioSessionStore, StudioTraceStore {
     return rows.map(toSessionLog);
   }
 
+  appendPipelineLog(input: StudioPipelineLogAppendInput): StudioPipelineLogEntry {
+    const db = this.database();
+    const now = new Date().toISOString();
+
+    try {
+      db.exec("BEGIN IMMEDIATE");
+      const sequence = this.nextPipelineLogSequence(input.pipelineId);
+      const entry: StudioPipelineLogEntry = {
+        id: globalThis.crypto.randomUUID(),
+        pipelineId: input.pipelineId,
+        ...(input.runId === undefined ? {} : { runId: input.runId }),
+        sequence,
+        timestamp: now,
+        level: input.level,
+        category: input.category,
+        event: input.event,
+        message: input.message,
+        ...(input.metadata === undefined ? {} : { metadata: input.metadata }),
+      };
+
+      db.prepare(
+        `INSERT INTO runner_pipeline_logs (
+          id,
+          pipeline_id,
+          run_id,
+          sequence,
+          timestamp,
+          level,
+          category,
+          event,
+          message,
+          metadata_json
+        ) VALUES (
+          $id,
+          $pipelineId,
+          $runId,
+          $sequence,
+          $timestamp,
+          $level,
+          $category,
+          $event,
+          $message,
+          $metadata
+        )`,
+      ).run({
+        $id: entry.id,
+        $pipelineId: entry.pipelineId,
+        $runId: entry.runId ?? null,
+        $sequence: entry.sequence,
+        $timestamp: entry.timestamp,
+        $level: entry.level,
+        $category: entry.category,
+        $event: entry.event,
+        $message: entry.message,
+        $metadata: entry.metadata === undefined ? null : JSON.stringify(entry.metadata),
+      });
+
+      db.exec("COMMIT");
+      return entry;
+    } catch (error) {
+      if (db.isTransaction) {
+        db.exec("ROLLBACK");
+      }
+      throw error;
+    }
+  }
+
+  listPipelineLogs(options: StudioPipelineLogListOptions): StudioPipelineLogEntry[] {
+    const db = this.database();
+    const afterClause = options.after === undefined ? "" : "AND sequence > $after";
+    const rows = db
+      .prepare(
+        `SELECT id, pipeline_id, run_id, sequence, timestamp, level, category, event, message,
+                metadata_json
+         FROM runner_pipeline_logs
+         WHERE pipeline_id = $pipelineId
+         ${afterClause}
+         ORDER BY sequence ASC
+         LIMIT $limit`,
+      )
+      .all({
+        $pipelineId: options.pipelineId,
+        $after: options.after ?? null,
+        $limit: options.limit,
+      }) as PipelineLogRow[];
+
+    return rows.map(toPipelineLog);
+  }
+
   deleteSession(id: string): boolean {
     const db = this.database();
 
@@ -691,6 +797,21 @@ class SqliteSessionStore implements StudioSessionStore, StudioTraceStore {
       ) STRICT;
       CREATE INDEX IF NOT EXISTS runner_session_logs_session_sequence_idx
         ON runner_session_logs(session_id, sequence ASC);
+      CREATE TABLE IF NOT EXISTS runner_pipeline_logs (
+        id TEXT PRIMARY KEY,
+        pipeline_id TEXT NOT NULL,
+        run_id TEXT,
+        sequence INTEGER NOT NULL,
+        timestamp TEXT NOT NULL,
+        level TEXT NOT NULL,
+        category TEXT NOT NULL,
+        event TEXT NOT NULL,
+        message TEXT NOT NULL,
+        metadata_json TEXT,
+        UNIQUE(pipeline_id, sequence)
+      ) STRICT;
+      CREATE INDEX IF NOT EXISTS runner_pipeline_logs_pipeline_sequence_idx
+        ON runner_pipeline_logs(pipeline_id, sequence ASC);
       CREATE TABLE IF NOT EXISTS runner_traces (
         id TEXT PRIMARY KEY,
         session_id TEXT NOT NULL,
@@ -754,6 +875,17 @@ class SqliteSessionStore implements StudioSessionStore, StudioTraceStore {
          WHERE session_id = $sessionId`,
       )
       .get({ $sessionId: sessionId }) as { next_sequence: number };
+    return row.next_sequence;
+  }
+
+  private nextPipelineLogSequence(pipelineId: string): number {
+    const row = this.database()
+      .prepare(
+        `SELECT COALESCE(MAX(sequence) + 1, 0) AS next_sequence
+         FROM runner_pipeline_logs
+         WHERE pipeline_id = $pipelineId`,
+      )
+      .get({ $pipelineId: pipelineId }) as { next_sequence: number };
     return row.next_sequence;
   }
 
@@ -886,6 +1018,22 @@ function toSessionLog(row: SessionLogRow): StudioSessionLogEntry {
   return {
     id: row.id,
     sessionId: row.session_id,
+    ...(row.run_id === null ? {} : { runId: row.run_id }),
+    sequence: row.sequence,
+    timestamp: row.timestamp,
+    level: row.level,
+    category: row.category,
+    event: row.event,
+    message: row.message,
+    ...(metadata === undefined ? {} : { metadata }),
+  };
+}
+
+function toPipelineLog(row: PipelineLogRow): StudioPipelineLogEntry {
+  const metadata = parseJsonValue<JsonObject>(row.metadata_json);
+  return {
+    id: row.id,
+    pipelineId: row.pipeline_id,
     ...(row.run_id === null ? {} : { runId: row.run_id }),
     sequence: row.sequence,
     timestamp: row.timestamp,

--- a/packages/tools/studio/src/storage/sqlite-store.ts
+++ b/packages/tools/studio/src/storage/sqlite-store.ts
@@ -39,10 +39,37 @@ type SessionRow = {
   agent_id: string;
   title: string | null;
   metadata_json: string | null;
-  messages_json: string;
-  transcript_json: string;
   created_at: string;
   updated_at: string;
+};
+
+type SessionSummaryRow = SessionRow & {
+  message_count: number;
+};
+
+type MessageRow = {
+  session_id: string;
+  message_index: number;
+  role: Message["role"];
+  message_id: string | null;
+  created_at: string;
+};
+
+type MessagePartRow = {
+  session_id: string;
+  message_index: number;
+  part_index: number;
+  type: string;
+  part_json: string;
+};
+
+type StoredMessagePart = {
+  type: string;
+  value: unknown;
+};
+
+type TableInfoRow = {
+  name: string;
 };
 
 type TraceRow = {
@@ -87,19 +114,22 @@ class SqliteSessionStore implements StudioSessionStore, StudioTraceStore {
 
   listSessions(options: StudioSessionListOptions): StudioSessionSummary[] {
     const db = this.database();
-    const agentClause = options.agentId === undefined ? "" : "WHERE agent_id = $agentId";
+    const agentClause = options.agentId === undefined ? "" : "WHERE s.agent_id = $agentId";
     const rows = db
       .prepare(
-        `SELECT id, agent_id, title, metadata_json, messages_json, transcript_json, created_at, updated_at
-         FROM runner_sessions
+        `SELECT s.id, s.agent_id, s.title, s.metadata_json, s.created_at, s.updated_at,
+                COUNT(m.message_index) AS message_count
+         FROM runner_sessions s
+         LEFT JOIN runner_session_messages m ON m.session_id = s.id
          ${agentClause}
-         ORDER BY updated_at DESC
+         GROUP BY s.id, s.agent_id, s.title, s.metadata_json, s.created_at, s.updated_at
+         ORDER BY s.updated_at DESC
          LIMIT $limit`,
       )
       .all({
         $agentId: options.agentId ?? null,
         $limit: options.limit,
-      }) as SessionRow[];
+      }) as SessionSummaryRow[];
 
     return rows.map(toSessionSummary);
   }
@@ -113,11 +143,9 @@ class SqliteSessionStore implements StudioSessionStore, StudioTraceStore {
         agent_id,
         title,
         metadata_json,
-        messages_json,
-        transcript_json,
         created_at,
         updated_at
-      ) VALUES ($id, $agentId, $title, $metadata, '[]', '[]', $now, $now)`,
+      ) VALUES ($id, $agentId, $title, $metadata, $now, $now)`,
     ).run({
       $id: input.id,
       $agentId: input.agentId,
@@ -140,7 +168,9 @@ class SqliteSessionStore implements StudioSessionStore, StudioTraceStore {
   getSession(id: string): StudioSession | undefined {
     const row = this.getSessionRow(id);
 
-    return row === undefined ? undefined : toSession(row, this.listSessionRunRows(id));
+    return row === undefined
+      ? undefined
+      : toSession(row, this.listSessionMessages(id), this.listSessionRunRows(id));
   }
 
   load(context: MemoryContext): Promise<Message[]> {
@@ -155,7 +185,7 @@ class SqliteSessionStore implements StudioSessionStore, StudioTraceStore {
       db.exec("BEGIN IMMEDIATE");
       const row = db
         .prepare(
-          `SELECT id, agent_id, title, metadata_json, messages_json, transcript_json, created_at, updated_at
+          `SELECT id, agent_id, title, metadata_json, created_at, updated_at
            FROM runner_sessions
            WHERE id = $id`,
         )
@@ -166,18 +196,16 @@ class SqliteSessionStore implements StudioSessionStore, StudioTraceStore {
         return Promise.resolve();
       }
 
-      const current = toSession(row);
-      const messages = [...current.messages, ...input.messages];
       const updatedAt = new Date().toISOString();
+      const nextIndex = this.nextMessageIndex(input.context.sessionId);
 
+      this.insertMessages(input.context.sessionId, input.messages, nextIndex, updatedAt);
       db.prepare(
         `UPDATE runner_sessions
-         SET messages_json = $messages,
-             updated_at = $updatedAt
+         SET updated_at = $updatedAt
          WHERE id = $id`,
       ).run({
         $id: input.context.sessionId,
-        $messages: JSON.stringify(messages),
         $updatedAt: updatedAt,
       });
       db.exec("COMMIT");
@@ -198,13 +226,14 @@ class SqliteSessionStore implements StudioSessionStore, StudioTraceStore {
       db.exec("BEGIN IMMEDIATE");
       db.prepare(
         `UPDATE runner_sessions
-         SET messages_json = '[]',
-             transcript_json = '[]',
-             updated_at = $updatedAt
+         SET updated_at = $updatedAt
          WHERE id = $id`,
       ).run({
         $id: context.sessionId,
         $updatedAt: updatedAt,
+      });
+      db.prepare("DELETE FROM runner_session_messages WHERE session_id = $id").run({
+        $id: context.sessionId,
       });
       db.prepare("DELETE FROM runner_session_runs WHERE session_id = $id").run({
         $id: context.sessionId,
@@ -247,7 +276,11 @@ class SqliteSessionStore implements StudioSessionStore, StudioTraceStore {
         db.exec("ROLLBACK");
         return undefined;
       }
-      const current = toSession(row, this.listSessionRunRows(input.id));
+      const current = toSession(
+        row,
+        this.listSessionMessages(input.id),
+        this.listSessionRunRows(input.id),
+      );
       const title = current.title ?? input.title;
 
       db.prepare(
@@ -484,18 +517,41 @@ class SqliteSessionStore implements StudioSessionStore, StudioTraceStore {
     db.exec(`
       PRAGMA journal_mode = WAL;
       PRAGMA foreign_keys = ON;
+    `);
+    guardAgainstLegacySessionSchema(db);
+    db.exec(`
       CREATE TABLE IF NOT EXISTS runner_sessions (
         id TEXT PRIMARY KEY,
         agent_id TEXT NOT NULL,
         title TEXT,
         metadata_json TEXT,
-        messages_json TEXT NOT NULL,
-        transcript_json TEXT NOT NULL,
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL
       ) STRICT;
       CREATE INDEX IF NOT EXISTS runner_sessions_agent_updated_idx
         ON runner_sessions(agent_id, updated_at DESC);
+      CREATE TABLE IF NOT EXISTS runner_session_messages (
+        session_id TEXT NOT NULL,
+        message_index INTEGER NOT NULL,
+        role TEXT NOT NULL,
+        message_id TEXT,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY(session_id, message_index),
+        FOREIGN KEY(session_id) REFERENCES runner_sessions(id) ON DELETE CASCADE
+      ) STRICT;
+      CREATE INDEX IF NOT EXISTS runner_session_messages_session_idx
+        ON runner_session_messages(session_id, message_index ASC);
+      CREATE TABLE IF NOT EXISTS runner_session_message_parts (
+        session_id TEXT NOT NULL,
+        message_index INTEGER NOT NULL,
+        part_index INTEGER NOT NULL,
+        type TEXT NOT NULL,
+        part_json TEXT NOT NULL,
+        PRIMARY KEY(session_id, message_index, part_index),
+        FOREIGN KEY(session_id, message_index)
+          REFERENCES runner_session_messages(session_id, message_index)
+          ON DELETE CASCADE
+      ) STRICT;
       CREATE TABLE IF NOT EXISTS runner_session_runs (
         run_id TEXT PRIMARY KEY,
         session_id TEXT NOT NULL,
@@ -536,7 +592,7 @@ class SqliteSessionStore implements StudioSessionStore, StudioTraceStore {
   private getSessionRow(id: string): SessionRow | undefined {
     return this.database()
       .prepare(
-        `SELECT id, agent_id, title, metadata_json, messages_json, transcript_json, created_at, updated_at
+        `SELECT id, agent_id, title, metadata_json, created_at, updated_at
          FROM runner_sessions
          WHERE id = $id`,
       )
@@ -563,23 +619,119 @@ class SqliteSessionStore implements StudioSessionStore, StudioTraceStore {
       )
       .all({ $sessionId: sessionId }) as SessionRunRow[];
   }
+
+  private listSessionMessages(sessionId: string): Message[] {
+    const db = this.database();
+    const messageRows = db
+      .prepare(
+        `SELECT session_id, message_index, role, message_id, created_at
+         FROM runner_session_messages
+         WHERE session_id = $sessionId
+         ORDER BY message_index ASC`,
+      )
+      .all({ $sessionId: sessionId }) as MessageRow[];
+
+    if (messageRows.length === 0) {
+      return [];
+    }
+
+    const partRows = db
+      .prepare(
+        `SELECT session_id, message_index, part_index, type, part_json
+         FROM runner_session_message_parts
+         WHERE session_id = $sessionId
+         ORDER BY message_index ASC, part_index ASC`,
+      )
+      .all({ $sessionId: sessionId }) as MessagePartRow[];
+    const partsByMessage = new Map<number, MessagePartRow[]>();
+    for (const partRow of partRows) {
+      const parts = partsByMessage.get(partRow.message_index) ?? [];
+      parts.push(partRow);
+      partsByMessage.set(partRow.message_index, parts);
+    }
+
+    return messageRows.map((row) =>
+      messageFromRows(row, partsByMessage.get(row.message_index) ?? []),
+    );
+  }
+
+  private nextMessageIndex(sessionId: string): number {
+    const row = this.database()
+      .prepare(
+        `SELECT COALESCE(MAX(message_index) + 1, 0) AS next_index
+         FROM runner_session_messages
+         WHERE session_id = $sessionId`,
+      )
+      .get({ $sessionId: sessionId }) as { next_index: number };
+    return row.next_index;
+  }
+
+  private insertMessages(
+    sessionId: string,
+    messages: Message[],
+    startIndex: number,
+    createdAt: string,
+  ): void {
+    const db = this.database();
+    const insertMessage = db.prepare(
+      `INSERT INTO runner_session_messages (
+        session_id,
+        message_index,
+        role,
+        message_id,
+        created_at
+      ) VALUES ($sessionId, $messageIndex, $role, $messageId, $createdAt)`,
+    );
+    const insertPart = db.prepare(
+      `INSERT INTO runner_session_message_parts (
+        session_id,
+        message_index,
+        part_index,
+        type,
+        part_json
+      ) VALUES ($sessionId, $messageIndex, $partIndex, $type, $partJson)`,
+    );
+
+    messages.forEach((message, messageOffset) => {
+      const messageIndex = startIndex + messageOffset;
+      insertMessage.run({
+        $sessionId: sessionId,
+        $messageIndex: messageIndex,
+        $role: message.role,
+        $messageId: message.role === "assistant" ? (message.id ?? null) : null,
+        $createdAt: createdAt,
+      });
+
+      messageParts(message).forEach((part, partIndex) => {
+        insertPart.run({
+          $sessionId: sessionId,
+          $messageIndex: messageIndex,
+          $partIndex: partIndex,
+          $type: part.type,
+          $partJson: JSON.stringify(part.value),
+        });
+      });
+    });
+  }
 }
 
-function toSession(row: SessionRow, runRows: SessionRunRow[] = []): StudioSession {
-  const summary = toSessionSummary(row);
-  const legacyTranscript = parseJsonArray<StudioTranscriptEntry>(row.transcript_json);
+function toSession(
+  row: SessionRow,
+  messages: Message[],
+  runRows: SessionRunRow[] = [],
+): StudioSession {
+  const summary = toSessionSummary({ ...row, message_count: messages.length });
   const runTranscript = runRows.flatMap((runRow) =>
     parseJsonArray<StudioTranscriptEntry>(runRow.transcript_json),
   );
   return {
     ...summary,
-    messages: parseJsonArray<Message>(row.messages_json),
-    transcript: renumberTranscript([...legacyTranscript, ...runTranscript]),
+    messages,
+    transcript: renumberTranscript(runTranscript),
   };
 }
 
-function toSessionSummary(row: SessionRow): StudioSessionSummary {
-  const messages = parseJsonArray<Message>(row.messages_json);
+function toSessionSummary(row: SessionSummaryRow): StudioSessionSummary {
   const metadata = parseJsonValue<JsonObject>(row.metadata_json);
   return {
     id: row.id,
@@ -587,9 +739,73 @@ function toSessionSummary(row: SessionRow): StudioSessionSummary {
     ...(row.title === null ? {} : { title: row.title }),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
-    messageCount: messages.length,
+    messageCount: row.message_count,
     ...(metadata === undefined ? {} : { metadata }),
   };
+}
+
+function messageParts(message: Message): StoredMessagePart[] {
+  if (message.role === "system") {
+    return [{ type: "text", value: { type: "text", text: message.content } }];
+  }
+
+  return message.content.map((content) => ({
+    type: content.type,
+    value: content,
+  }));
+}
+
+function messageFromRows(row: MessageRow, partRows: MessagePartRow[]): Message {
+  const parts = partRows.map((partRow) => JSON.parse(partRow.part_json) as unknown);
+
+  if (row.role === "system") {
+    return { role: "system", content: systemContentFromParts(parts) };
+  }
+  if (row.role === "user") {
+    return {
+      role: "user",
+      content: parts as Extract<Message, { role: "user" }>["content"],
+    };
+  }
+  if (row.role === "assistant") {
+    return {
+      role: "assistant",
+      ...(row.message_id === null ? {} : { id: row.message_id }),
+      content: parts as Extract<Message, { role: "assistant" }>["content"],
+    };
+  }
+  if (row.role === "tool") {
+    return {
+      role: "tool",
+      content: parts as Extract<Message, { role: "tool" }>["content"],
+    };
+  }
+
+  throw new Error(`Unsupported stored message role: ${row.role}`);
+}
+
+function systemContentFromParts(parts: unknown[]): string {
+  const first = parts[0];
+  if (
+    typeof first === "object" &&
+    first !== null &&
+    "type" in first &&
+    first.type === "text" &&
+    "text" in first &&
+    typeof first.text === "string"
+  ) {
+    return first.text;
+  }
+  return "";
+}
+
+function guardAgainstLegacySessionSchema(db: DatabaseSyncType): void {
+  const columns = db.prepare("PRAGMA table_info('runner_sessions')").all() as TableInfoRow[];
+  if (columns.some((column) => column.name === "messages_json")) {
+    throw new Error(
+      "Existing Studio SQLite DB uses the legacy messages_json schema. Delete or recreate the Studio SQLite DB to use normalized session messages.",
+    );
+  }
 }
 
 function toTrace(row: TraceRow): StudioTrace {

--- a/packages/tools/studio/src/types.ts
+++ b/packages/tools/studio/src/types.ts
@@ -16,8 +16,10 @@ export type StudioCapability =
   | "agents"
   | "approvals"
   | "knowledge"
+  | "mcps"
   | "observability"
   | "sessions"
+  | "tools"
   | "traces";
 
 export type StudioAgent = {
@@ -53,6 +55,47 @@ export type StudioConfig = {
   };
   capabilities: Partial<Record<StudioCapability, StudioCapabilityConfig>>;
   unsupportedCapabilities: StudioCapability[];
+};
+
+export type StudioAgentToolSource = "static" | "dynamic";
+
+export type StudioAgentToolApprovalMetadata = {
+  required: boolean;
+  reason?: string;
+  rejectMessage?: string;
+};
+
+export type StudioAgentToolMetadata = {
+  agentId: string;
+  name: string;
+  description: string;
+  parameters: JsonObject;
+  source: StudioAgentToolSource;
+  approval: StudioAgentToolApprovalMetadata;
+};
+
+export type StudioAgentToolsSummary = {
+  agentId: string;
+  tools: StudioAgentToolMetadata[];
+};
+
+export type StudioAgentMcpToolMetadata = {
+  name: string;
+  description: string;
+  parameters: JsonObject;
+  source: StudioAgentToolSource;
+};
+
+export type StudioAgentMcpServerMetadata = {
+  agentId: string;
+  name: string;
+  toolCount: number;
+  tools: StudioAgentMcpToolMetadata[];
+};
+
+export type StudioAgentMcpsSummary = {
+  agentId: string;
+  servers: StudioAgentMcpServerMetadata[];
 };
 
 export type StudioTranscriptChatEntry = {

--- a/packages/tools/studio/src/types.ts
+++ b/packages/tools/studio/src/types.ts
@@ -149,6 +149,48 @@ export type StudioSessionRunTranscriptInput = {
   error?: JsonValue;
 };
 
+export type StudioSessionLogLevel = "debug" | "info" | "warn" | "error";
+
+export type StudioSessionLogCategory =
+  | "session"
+  | "run"
+  | "memory"
+  | "prompt"
+  | "model"
+  | "tool"
+  | "approval"
+  | "question"
+  | "api";
+
+export type StudioSessionLogEntry = {
+  id: string;
+  sessionId: string;
+  runId?: string;
+  sequence: number;
+  timestamp: string;
+  level: StudioSessionLogLevel;
+  category: StudioSessionLogCategory;
+  event: string;
+  message: string;
+  metadata?: JsonObject;
+};
+
+export type StudioSessionLogAppendInput = {
+  sessionId: string;
+  runId?: string;
+  level: StudioSessionLogLevel;
+  category: StudioSessionLogCategory;
+  event: string;
+  message: string;
+  metadata?: JsonObject;
+};
+
+export type StudioSessionLogListOptions = {
+  sessionId: string;
+  limit: number;
+  after?: number;
+};
+
 export type StudioSessionStore = MemoryStore & {
   readonly kind?: string;
   listSessions(
@@ -161,6 +203,12 @@ export type StudioSessionStore = MemoryStore & {
   saveSessionRunTranscript(
     input: StudioSessionRunTranscriptInput,
   ): StudioSession | undefined | Promise<StudioSession | undefined>;
+  appendSessionLog?(
+    input: StudioSessionLogAppendInput,
+  ): StudioSessionLogEntry | Promise<StudioSessionLogEntry>;
+  listSessionLogs?(
+    options: StudioSessionLogListOptions,
+  ): StudioSessionLogEntry[] | Promise<StudioSessionLogEntry[]>;
   deleteSession?(id: string): boolean | Promise<boolean>;
 };
 
@@ -393,6 +441,11 @@ export type StudioToolQuestionResultEvent = {
   question: StudioToolQuestion;
 };
 
+export type StudioSessionLogEvent = {
+  type: "session_log";
+  log: StudioSessionLogEntry;
+};
+
 export type AgentRunRequest = {
   message: string | Message;
   history?: Message[];
@@ -411,7 +464,8 @@ export type AgentRunStreamEvent =
   | StudioToolApprovalRequestEvent
   | StudioToolApprovalResultEvent
   | StudioToolQuestionRequestEvent
-  | StudioToolQuestionResultEvent;
+  | StudioToolQuestionResultEvent
+  | StudioSessionLogEvent;
 
 export type StudioErrorCode =
   | "bad_request"

--- a/packages/tools/studio/src/types.ts
+++ b/packages/tools/studio/src/types.ts
@@ -7,6 +7,8 @@ import type {
   JsonValue,
   MemoryStore,
   Message,
+  Pipeline,
+  PipelineGraph,
   PromptResponse,
   Usage,
 } from "@anvia/core";
@@ -18,6 +20,7 @@ export type StudioCapability =
   | "knowledge"
   | "mcps"
   | "observability"
+  | "pipelines"
   | "sessions"
   | "tools"
   | "traces";
@@ -31,12 +34,38 @@ export type StudioAgent = {
   metadata?: JsonObject;
 };
 
+export type StudioTarget = Agent | Pipeline<unknown, unknown>;
+
 export type StudioAgentConfig = {
   id: string;
   name?: string;
   description?: string;
   quickPrompts: string[];
   metadata?: JsonObject;
+};
+
+export type StudioPipeline = {
+  id: string;
+  pipeline: Pipeline<unknown, unknown>;
+  name?: string;
+  description?: string;
+  metadata?: JsonObject;
+};
+
+export type StudioPipelineConfig = {
+  id: string;
+  name?: string;
+  description?: string;
+  metadata?: JsonObject;
+  stageCount: number;
+  edgeCount: number;
+  hasParallelStages: boolean;
+  agentCount: number;
+  extractorCount: number;
+};
+
+export type StudioPipelineDetail = StudioPipelineConfig & {
+  graph: PipelineGraph;
 };
 
 export type StudioCapabilityConfig = {
@@ -50,6 +79,7 @@ export type StudioConfig = {
   description?: string;
   version?: string;
   agents: StudioAgentConfig[];
+  pipelines: StudioPipelineConfig[];
   chat: {
     quickPrompts: Record<string, string[]>;
   };
@@ -368,6 +398,7 @@ export type StudioKnowledgeSummary = {
 export type StudioStores = {
   sessions?: StudioSessionStore | false;
   traces?: StudioTraceStore;
+  pipelineLogs?: StudioPipelineLogStore | false;
 };
 
 export type StudioUiOptions = {
@@ -489,6 +520,79 @@ export type StudioSessionLogEvent = {
   log: StudioSessionLogEntry;
 };
 
+export type StudioPipelineLogLevel = "debug" | "info" | "warn" | "error";
+
+export type StudioPipelineLogCategory =
+  | "pipeline"
+  | "run"
+  | "stage"
+  | "parallel"
+  | "agent"
+  | "extractor"
+  | "api";
+
+export type StudioPipelineLogEntry = {
+  id: string;
+  pipelineId: string;
+  runId?: string;
+  sequence: number;
+  timestamp: string;
+  level: StudioPipelineLogLevel;
+  category: StudioPipelineLogCategory;
+  event: string;
+  message: string;
+  metadata?: JsonObject;
+};
+
+export type StudioPipelineLogAppendInput = {
+  pipelineId: string;
+  runId?: string;
+  level: StudioPipelineLogLevel;
+  category: StudioPipelineLogCategory;
+  event: string;
+  message: string;
+  metadata?: JsonObject;
+};
+
+export type StudioPipelineLogListOptions = {
+  pipelineId: string;
+  limit: number;
+  after?: number;
+};
+
+export type StudioPipelineLogStore = {
+  appendPipelineLog(
+    input: StudioPipelineLogAppendInput,
+  ): StudioPipelineLogEntry | Promise<StudioPipelineLogEntry>;
+  listPipelineLogs(
+    options: StudioPipelineLogListOptions,
+  ): StudioPipelineLogEntry[] | Promise<StudioPipelineLogEntry[]>;
+};
+
+export type StudioPipelineLogEvent = {
+  type: "pipeline_log";
+  log: StudioPipelineLogEntry;
+};
+
+export type StudioPipelineFinalEvent = {
+  type: "pipeline_final";
+  runId: string;
+  pipelineId: string;
+  output: JsonValue;
+};
+
+export type StudioPipelineRunRequest = {
+  input: JsonValue;
+  stream?: boolean;
+  metadata?: JsonObject;
+};
+
+export type StudioPipelineRunResponse = {
+  runId: string;
+  pipelineId: string;
+  output: JsonValue;
+};
+
 export type AgentRunRequest = {
   message: string | Message;
   history?: Message[];
@@ -508,7 +612,9 @@ export type AgentRunStreamEvent =
   | StudioToolApprovalResultEvent
   | StudioToolQuestionRequestEvent
   | StudioToolQuestionResultEvent
-  | StudioSessionLogEvent;
+  | StudioSessionLogEvent
+  | StudioPipelineLogEvent
+  | StudioPipelineFinalEvent;
 
 export type StudioErrorCode =
   | "bad_request"

--- a/packages/tools/studio/src/ui/app/app.tsx
+++ b/packages/tools/studio/src/ui/app/app.tsx
@@ -9,6 +9,8 @@ import {
 } from "react";
 import type {
   AgentRunStreamEvent,
+  StudioAgentMcpsSummary,
+  StudioAgentToolsSummary,
   StudioConfig,
   StudioKnowledgeSummary,
   StudioSession,
@@ -30,6 +32,7 @@ import { Textarea } from "./components/ui/textarea";
 import { cn } from "./lib/utils";
 import { AgentsPage } from "./modules/agents/agents-page";
 import { KnowledgePage } from "./modules/knowledge/knowledge-page";
+import { McpsPage } from "./modules/mcps/mcps-page";
 import { TranscriptItem } from "./modules/playground/transcript-item";
 import { SessionLogsPanel } from "./modules/session-logs/session-logs-panel";
 import { DeleteSessionDialog, SessionsPage } from "./modules/sessions/sessions-page";
@@ -70,6 +73,7 @@ import type {
   TranscriptEntry,
 } from "./modules/shared/types";
 import { NavButton } from "./modules/shell/nav-button";
+import { ToolsPage } from "./modules/tools/tools-page";
 import { TraceBrowser } from "./modules/tracing/trace-browser";
 
 function applyDarkTheme(): void {
@@ -101,6 +105,8 @@ export function StudioConsole() {
   const initialLocation = pageLocationFromLocation();
   const [config, setConfig] = useState<StudioConfig | undefined>();
   const [selectedAgentId, setSelectedAgentId] = useState("");
+  const [mcpsAgentId, setMcpsAgentId] = useState("");
+  const [toolsAgentId, setToolsAgentId] = useState("");
   const [selectedSessionId, setSelectedSessionId] = useState("");
   const [allSessions, setAllSessions] = useState<StudioSessionSummary[]>([]);
   const [traces, setTraces] = useState<StudioTrace[]>([]);
@@ -123,6 +129,10 @@ export function StudioConsole() {
   const [traceLoadState, setTraceLoadState] = useState<TraceLoadState>("idle");
   const [knowledge, setKnowledge] = useState<StudioKnowledgeSummary | undefined>();
   const [knowledgeLoadState, setKnowledgeLoadState] = useState<"idle" | "loading">("idle");
+  const [mcps, setMcps] = useState<StudioAgentMcpsSummary | undefined>();
+  const [mcpsLoadState, setMcpsLoadState] = useState<"idle" | "loading">("idle");
+  const [tools, setTools] = useState<StudioAgentToolsSummary | undefined>();
+  const [toolsLoadState, setToolsLoadState] = useState<"idle" | "loading">("idle");
   const promptRef = useRef<HTMLTextAreaElement | null>(null);
 
   const loadConfig = useCallback(async () => {
@@ -141,6 +151,8 @@ export function StudioConsole() {
       const nextConfig = (await response.json()) as StudioConfig;
       setConfig(nextConfig);
       setSelectedAgentId((current) => current || nextConfig.agents[0]?.id || "");
+      setMcpsAgentId((current) => current || nextConfig.agents[0]?.id || "");
+      setToolsAgentId((current) => current || nextConfig.agents[0]?.id || "");
       setStatus("Connected");
     } catch (loadError) {
       setError(errorMessage(loadError));
@@ -155,6 +167,8 @@ export function StudioConsole() {
   const sessionsEnabled = config?.capabilities.sessions?.enabled === true;
   const tracesEnabled = config?.capabilities.traces?.enabled === true;
   const knowledgeEnabled = config?.capabilities.knowledge?.enabled === true;
+  const mcpsEnabled = config?.capabilities.mcps?.enabled === true;
+  const toolsEnabled = config?.capabilities.tools?.enabled === true;
 
   useEffect(() => {
     applyDarkTheme();
@@ -374,6 +388,66 @@ export function StudioConsole() {
       void loadKnowledge();
     }
   }, [activePage, loadKnowledge]);
+
+  const loadMcps = useCallback(
+    async (agentId: string) => {
+      if (!mcpsEnabled || agentId.length === 0) {
+        setMcps(undefined);
+        return;
+      }
+
+      setMcpsLoadState("loading");
+      try {
+        const response = await fetch(`/agents/${encodeURIComponent(agentId)}/mcps`);
+        if (!response.ok) {
+          throw new Error(`MCPs failed with HTTP ${response.status}`);
+        }
+        setMcps((await response.json()) as StudioAgentMcpsSummary);
+      } catch (loadError) {
+        setError(errorMessage(loadError));
+        setMcps(undefined);
+      } finally {
+        setMcpsLoadState("idle");
+      }
+    },
+    [mcpsEnabled],
+  );
+
+  useEffect(() => {
+    if (activePage === "mcps") {
+      void loadMcps(mcpsAgentId || selectedAgentId);
+    }
+  }, [activePage, loadMcps, mcpsAgentId, selectedAgentId]);
+
+  const loadTools = useCallback(
+    async (agentId: string) => {
+      if (!toolsEnabled || agentId.length === 0) {
+        setTools(undefined);
+        return;
+      }
+
+      setToolsLoadState("loading");
+      try {
+        const response = await fetch(`/agents/${encodeURIComponent(agentId)}/tools`);
+        if (!response.ok) {
+          throw new Error(`Tools failed with HTTP ${response.status}`);
+        }
+        setTools((await response.json()) as StudioAgentToolsSummary);
+      } catch (loadError) {
+        setError(errorMessage(loadError));
+        setTools(undefined);
+      } finally {
+        setToolsLoadState("idle");
+      }
+    },
+    [toolsEnabled],
+  );
+
+  useEffect(() => {
+    if (activePage === "tools") {
+      void loadTools(toolsAgentId || selectedAgentId);
+    }
+  }, [activePage, loadTools, selectedAgentId, toolsAgentId]);
 
   const loadSession = useCallback(
     async (sessionId: string, options: { updatePath?: boolean } = {}) => {
@@ -1148,6 +1222,18 @@ export function StudioConsole() {
             onClick={() => navigatePage("agents")}
           />
           <NavButton
+            active={activePage === "tools"}
+            icon="wrench"
+            label="Tools"
+            onClick={() => navigatePage("tools")}
+          />
+          <NavButton
+            active={activePage === "mcps"}
+            icon="plug"
+            label="MCPs"
+            onClick={() => navigatePage("mcps")}
+          />
+          <NavButton
             active={activePage === "knowledge"}
             icon="database"
             label="Knowledge"
@@ -1384,6 +1470,34 @@ export function StudioConsole() {
 
         {activePage === "agents" ? (
           <AgentsPage agents={agents} selectedAgentId={selectedAgentId} />
+        ) : null}
+
+        {activePage === "tools" ? (
+          <ToolsPage
+            agents={agents}
+            selectedAgentId={toolsAgentId || selectedAgent?.id || selectedAgentId}
+            summary={tools}
+            enabled={toolsEnabled}
+            loading={toolsLoadState === "loading"}
+            onSelectAgent={(agentId) => {
+              setToolsAgentId(agentId);
+              void loadTools(agentId);
+            }}
+          />
+        ) : null}
+
+        {activePage === "mcps" ? (
+          <McpsPage
+            agents={agents}
+            selectedAgentId={mcpsAgentId || selectedAgent?.id || selectedAgentId}
+            summary={mcps}
+            enabled={mcpsEnabled}
+            loading={mcpsLoadState === "loading"}
+            onSelectAgent={(agentId) => {
+              setMcpsAgentId(agentId);
+              void loadMcps(agentId);
+            }}
+          />
         ) : null}
 
         {activePage === "knowledge" ? (

--- a/packages/tools/studio/src/ui/app/app.tsx
+++ b/packages/tools/studio/src/ui/app/app.tsx
@@ -1,4 +1,4 @@
-import { ArrowUp, Plus, Trash2 } from "lucide-react";
+import { ArrowUp, ExternalLink, Plus, Trash2 } from "lucide-react";
 import {
   type ChangeEvent,
   type KeyboardEvent,
@@ -13,6 +13,8 @@ import type {
   StudioAgentToolsSummary,
   StudioConfig,
   StudioKnowledgeSummary,
+  StudioPipelineDetail,
+  StudioPipelineLogEntry,
   StudioSession,
   StudioSessionLogEntry,
   StudioSessionSummary,
@@ -33,6 +35,7 @@ import { cn } from "./lib/utils";
 import { AgentsPage } from "./modules/agents/agents-page";
 import { KnowledgePage } from "./modules/knowledge/knowledge-page";
 import { McpsPage } from "./modules/mcps/mcps-page";
+import { PipelinesPage } from "./modules/pipelines/pipelines-page";
 import { TranscriptItem } from "./modules/playground/transcript-item";
 import { SessionLogsPanel } from "./modules/session-logs/session-logs-panel";
 import { DeleteSessionDialog, SessionsPage } from "./modules/sessions/sessions-page";
@@ -107,12 +110,17 @@ export function StudioConsole() {
   const [selectedAgentId, setSelectedAgentId] = useState("");
   const [mcpsAgentId, setMcpsAgentId] = useState("");
   const [toolsAgentId, setToolsAgentId] = useState("");
+  const [selectedPipelineId, setSelectedPipelineId] = useState("");
   const [selectedSessionId, setSelectedSessionId] = useState("");
   const [allSessions, setAllSessions] = useState<StudioSessionSummary[]>([]);
   const [traces, setTraces] = useState<StudioTrace[]>([]);
   const [sessionLogs, setSessionLogs] = useState<StudioSessionLogEntry[]>([]);
+  const [pipelineDetail, setPipelineDetail] = useState<StudioPipelineDetail | undefined>();
+  const [pipelineLogs, setPipelineLogs] = useState<StudioPipelineLogEntry[]>([]);
   const [messages, setMessages] = useState<TranscriptEntry[]>([]);
   const [prompt, setPrompt] = useState("");
+  const [pipelineRunInput, setPipelineRunInput] = useState('"Hello from Studio"');
+  const [pipelineRunOutput, setPipelineRunOutput] = useState("");
   const [activePage, setActivePage] = useState<ActivePage>(() => initialLocation.page);
   const [selectedTraceId, setSelectedTraceId] = useState(() => initialLocation.traceId ?? "");
   const [traceSessionDetailId, setTraceSessionDetailId] = useState<string | undefined>(
@@ -133,6 +141,11 @@ export function StudioConsole() {
   const [mcpsLoadState, setMcpsLoadState] = useState<"idle" | "loading">("idle");
   const [tools, setTools] = useState<StudioAgentToolsSummary | undefined>();
   const [toolsLoadState, setToolsLoadState] = useState<"idle" | "loading">("idle");
+  const [pipelineDetailLoadState, setPipelineDetailLoadState] = useState<"idle" | "loading">(
+    "idle",
+  );
+  const [pipelineLogLoadState, setPipelineLogLoadState] = useState<"idle" | "loading">("idle");
+  const [pipelineRunState, setPipelineRunState] = useState<RunState>("idle");
   const promptRef = useRef<HTMLTextAreaElement | null>(null);
 
   const loadConfig = useCallback(async () => {
@@ -153,6 +166,7 @@ export function StudioConsole() {
       setSelectedAgentId((current) => current || nextConfig.agents[0]?.id || "");
       setMcpsAgentId((current) => current || nextConfig.agents[0]?.id || "");
       setToolsAgentId((current) => current || nextConfig.agents[0]?.id || "");
+      setSelectedPipelineId((current) => current || nextConfig.pipelines[0]?.id || "");
       setStatus("Connected");
     } catch (loadError) {
       setError(errorMessage(loadError));
@@ -169,6 +183,7 @@ export function StudioConsole() {
   const knowledgeEnabled = config?.capabilities.knowledge?.enabled === true;
   const mcpsEnabled = config?.capabilities.mcps?.enabled === true;
   const toolsEnabled = config?.capabilities.tools?.enabled === true;
+  const pipelinesEnabled = config?.capabilities.pipelines?.enabled === true;
 
   useEffect(() => {
     applyDarkTheme();
@@ -449,6 +464,72 @@ export function StudioConsole() {
     }
   }, [activePage, loadTools, selectedAgentId, toolsAgentId]);
 
+  const loadPipelineLogs = useCallback(
+    async (pipelineId: string): Promise<StudioPipelineLogEntry[]> => {
+      if (!pipelinesEnabled || pipelineId.length === 0) {
+        setPipelineLogs([]);
+        return [];
+      }
+
+      setPipelineLogLoadState("loading");
+      try {
+        const params = new URLSearchParams({ limit: "1000" });
+        const response = await fetch(`/pipelines/${encodeURIComponent(pipelineId)}/logs?${params}`);
+        if (!response.ok) {
+          throw new Error(`Pipeline logs failed with HTTP ${response.status}`);
+        }
+        const body = (await response.json()) as { logs: StudioPipelineLogEntry[] };
+        setPipelineLogs(body.logs);
+        return body.logs;
+      } catch (loadError) {
+        setError(errorMessage(loadError));
+        setPipelineLogs([]);
+        return [];
+      } finally {
+        setPipelineLogLoadState("idle");
+      }
+    },
+    [pipelinesEnabled],
+  );
+
+  const loadPipeline = useCallback(
+    async (pipelineId: string) => {
+      if (!pipelinesEnabled || pipelineId.length === 0) {
+        setPipelineDetail(undefined);
+        setPipelineLogs([]);
+        return;
+      }
+
+      setPipelineDetailLoadState("loading");
+      setError("");
+      try {
+        const response = await fetch(`/pipelines/${encodeURIComponent(pipelineId)}`);
+        if (!response.ok) {
+          throw new Error(`Pipeline load failed with HTTP ${response.status}`);
+        }
+        setSelectedPipelineId(pipelineId);
+        setPipelineDetail((await response.json()) as StudioPipelineDetail);
+        await loadPipelineLogs(pipelineId);
+      } catch (loadError) {
+        setError(errorMessage(loadError));
+        setPipelineDetail(undefined);
+      } finally {
+        setPipelineDetailLoadState("idle");
+      }
+    },
+    [loadPipelineLogs, pipelinesEnabled],
+  );
+
+  useEffect(() => {
+    if (activePage !== "pipelines") {
+      return;
+    }
+    const pipelineId = selectedPipelineId || config?.pipelines[0]?.id || "";
+    if (pipelineId.length > 0) {
+      void loadPipeline(pipelineId);
+    }
+  }, [activePage, config?.pipelines, loadPipeline, selectedPipelineId]);
+
   const loadSession = useCallback(
     async (sessionId: string, options: { updatePath?: boolean } = {}) => {
       if (runState === "running") {
@@ -677,6 +758,66 @@ export function StudioConsole() {
     }
   }
 
+  async function runPipeline() {
+    const pipelineId = selectedPipelineId || config?.pipelines[0]?.id || "";
+    if (pipelineId.length === 0 || pipelineRunState === "running") {
+      return;
+    }
+
+    let input: unknown;
+    try {
+      input = JSON.parse(pipelineRunInput);
+    } catch {
+      setError("Pipeline input must be valid JSON");
+      return;
+    }
+
+    setPipelineRunState("running");
+    setPipelineRunOutput("");
+    setError("");
+    try {
+      const response = await fetch(`/pipelines/${encodeURIComponent(pipelineId)}/runs`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          input,
+          stream: true,
+          metadata: {
+            source: "anvia-studio",
+          },
+        }),
+      });
+
+      if (!response.ok || response.body === null) {
+        throw new Error(await responseErrorMessage(response, "Pipeline run failed"));
+      }
+
+      await readJsonl(response.body, async (event) => {
+        if (isPipelineLogEvent(event)) {
+          appendPipelineLogEntry(event.log);
+          await nextPaint();
+          return;
+        }
+        if (isPipelineFinalEvent(event)) {
+          setPipelineRunOutput(JSON.stringify(event.output, null, 2));
+          await nextPaint();
+          return;
+        }
+        if (isErrorStreamEvent(event)) {
+          throw new Error(JSON.stringify(event.error));
+        }
+      });
+      await loadPipelineLogs(pipelineId);
+      setStatus("Connected");
+    } catch (runError) {
+      setError(errorMessage(runError));
+    } finally {
+      setPipelineRunState("idle");
+    }
+  }
+
   function acceptStreamEvent(event: AgentRunStreamEvent): boolean {
     if (event.type === "text_delta") {
       appendAssistantText(event.delta);
@@ -739,6 +880,15 @@ export function StudioConsole() {
 
   function appendSessionLogEntry(log: StudioSessionLogEntry) {
     setSessionLogs((current) => {
+      if (current.some((item) => item.id === log.id)) {
+        return current;
+      }
+      return [...current, log].sort((left, right) => left.sequence - right.sequence);
+    });
+  }
+
+  function appendPipelineLogEntry(log: StudioPipelineLogEntry) {
+    setPipelineLogs((current) => {
       if (current.some((item) => item.id === log.id)) {
         return current;
       }
@@ -1148,6 +1298,7 @@ export function StudioConsole() {
   }
 
   const agents = config?.agents ?? [];
+  const pipelines = config?.pipelines ?? [];
   const selectedAgent =
     agents.find((agent) => agent.id === selectedAgentId) ?? agents[0] ?? undefined;
   const selectedAgentQuickPrompts = selectedAgent?.quickPrompts ?? [];
@@ -1155,6 +1306,13 @@ export function StudioConsole() {
 
   function navigatePage(page: ActivePage) {
     setActivePage(page);
+    if (page === "pipelines") {
+      const pipelineId = selectedPipelineId || pipelines[0]?.id || "";
+      if (pipelineId.length > 0) {
+        setSelectedPipelineId(pipelineId);
+        void loadPipeline(pipelineId);
+      }
+    }
     if (page === "tracing") {
       setSelectedTraceId("");
       setTraceSessionDetailId(undefined);
@@ -1203,6 +1361,13 @@ export function StudioConsole() {
             icon="message"
             label="Chat"
             onClick={() => navigatePage("playground")}
+          />
+          <NavButton
+            active={activePage === "pipelines"}
+            icon="workflow"
+            label="Pipelines"
+            disabled={!pipelinesEnabled}
+            onClick={() => navigatePage("pipelines")}
           />
           <NavButton
             active={activePage === "sessions"}
@@ -1291,7 +1456,11 @@ export function StudioConsole() {
             </div>
           ))}
         </nav>
-        <div className="mt-auto">
+        <div className="mt-auto border-t border-sidebar-border/80 px-3 py-3">
+          <nav className="grid gap-1" aria-label="Anvia links">
+            <SidebarLink href="https://anvia.dev/docs" label="Anvia Docs" />
+            <SidebarLink href="https://anvia.dev" label="Anvia Web" />
+          </nav>
           <span className="sr-only" aria-live="polite">
             {status}
           </span>
@@ -1507,6 +1676,28 @@ export function StudioConsole() {
           />
         ) : null}
 
+        {activePage === "pipelines" ? (
+          <PipelinesPage
+            pipelines={pipelines}
+            selectedPipelineId={selectedPipelineId}
+            detail={pipelineDetail}
+            logs={pipelineLogs}
+            enabled={pipelinesEnabled}
+            detailLoading={pipelineDetailLoadState === "loading"}
+            logsLoading={pipelineLogLoadState === "loading"}
+            runState={pipelineRunState}
+            runInput={pipelineRunInput}
+            runOutput={pipelineRunOutput}
+            onSelectPipeline={(pipelineId) => {
+              setSelectedPipelineId(pipelineId);
+              setPipelineRunOutput("");
+              void loadPipeline(pipelineId);
+            }}
+            onRunInputChange={setPipelineRunInput}
+            onRun={() => void runPipeline()}
+          />
+        ) : null}
+
         {activePage === "mcps" ? (
           <McpsPage
             agents={agents}
@@ -1542,6 +1733,45 @@ export function StudioConsole() {
       />
     </div>
   );
+}
+
+function SidebarLink(props: { href: string; label: string }) {
+  return (
+    <a
+      className="flex h-8 min-h-8 items-center justify-between rounded-sm border border-transparent px-2 font-mono text-[11px] font-semibold text-sidebar-foreground/62 transition duration-200 hover:border-sidebar-border hover:bg-sidebar-accent hover:text-sidebar-foreground"
+      href={props.href}
+      target="_blank"
+      rel="noreferrer"
+    >
+      <span>{props.label}</span>
+      <ExternalLink aria-hidden="true" className="h-3 w-3 text-muted-foreground" />
+    </a>
+  );
+}
+
+function isPipelineLogEvent(event: unknown): event is {
+  type: "pipeline_log";
+  log: StudioPipelineLogEntry;
+} {
+  return isRecord(event) && event.type === "pipeline_log" && isRecord(event.log);
+}
+
+function isPipelineFinalEvent(event: unknown): event is {
+  type: "pipeline_final";
+  output: unknown;
+} {
+  return isRecord(event) && event.type === "pipeline_final" && "output" in event;
+}
+
+function isErrorStreamEvent(event: unknown): event is {
+  type: "error";
+  error: unknown;
+} {
+  return isRecord(event) && event.type === "error";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }
 
 function enrichTranscriptWithTraceIds(

--- a/packages/tools/studio/src/ui/app/app.tsx
+++ b/packages/tools/studio/src/ui/app/app.tsx
@@ -1,4 +1,4 @@
-import { ArrowUp, Plus } from "lucide-react";
+import { ArrowUp, Plus, Trash2 } from "lucide-react";
 import {
   type ChangeEvent,
   type KeyboardEvent,
@@ -1182,19 +1182,22 @@ export function StudioConsole() {
   }
 
   return (
-    <div className="grid min-h-screen overflow-hidden bg-background text-foreground lg:grid-cols-[224px_minmax(0,1fr)]">
-      <aside className="flex min-h-screen flex-col border-r border-sidebar-border bg-sidebar text-sidebar-foreground">
-        <div className="flex h-20 items-center border-b border-sidebar-border px-5">
-          <div className="flex min-w-0 items-center gap-3">
-            <img className="h-11 w-11 shrink-0 object-contain" src={logoSrc} alt="" />
-            <span className="grid min-w-0">
-              <span className="anvia-wordmark truncate text-2xl font-semibold tracking-normal text-sidebar-foreground">
-                Anvia
+    <div className="grid min-h-[100dvh] overflow-hidden bg-background text-foreground lg:grid-cols-[228px_minmax(0,1fr)]">
+      <aside className="flex min-h-[100dvh] flex-col border-r border-sidebar-border bg-sidebar/95 text-sidebar-foreground shadow-xl shadow-black/20">
+        <div className="flex h-15 items-center border-b border-sidebar-border/80 px-4">
+          <div className="flex min-w-0 items-center gap-2.5">
+            <img className="h-7 w-7 shrink-0 object-contain" src={logoSrc} alt="" />
+            <span className="min-w-0 truncate">
+              <span className="anvia-wordmark text-[1.08rem] font-semibold tracking-normal text-sidebar-foreground">
+                Anvia Studio
               </span>
             </span>
           </div>
         </div>
-        <nav className="grid gap-1 border-b border-sidebar-border px-3 py-3" aria-label="Main">
+        <nav className="grid gap-1 border-b border-sidebar-border/80 px-3 py-3" aria-label="Main">
+          <div className="px-2 pb-1 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Workspace
+          </div>
           <NavButton
             active={activePage === "playground"}
             icon="message"
@@ -1214,7 +1217,10 @@ export function StudioConsole() {
             onClick={() => navigatePage("tracing")}
           />
         </nav>
-        <nav className="grid gap-1 border-b border-sidebar-border px-3 py-3" aria-label="Studio">
+        <nav className="grid gap-1 border-b border-sidebar-border/80 px-3 py-3" aria-label="Studio">
+          <div className="px-2 pb-1 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Inspect
+          </div>
           <NavButton
             active={activePage === "agents"}
             icon="bot"
@@ -1241,46 +1247,60 @@ export function StudioConsole() {
           />
         </nav>
         <nav
-          className="grid min-h-0 gap-1 overflow-auto border-b border-sidebar-border px-3 py-3"
+          className="grid min-h-0 gap-1 overflow-auto border-b border-sidebar-border/80 px-3 py-3"
           aria-label="Recent sessions"
         >
           <div className="px-2 pb-1 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
             Recent
           </div>
           {allSessions.slice(0, 8).map((session) => (
-            <Button
+            <div
               className={cn(
-                "grid h-auto min-h-9 min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 rounded-sm border-0 bg-transparent px-2 py-1 text-left text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
-                session.id === selectedSessionId && "bg-sidebar-accent text-primary",
+                "group grid min-h-9 min-w-0 grid-cols-[minmax(0,1fr)_24px] items-center gap-1 rounded-sm border border-transparent pr-1 transition duration-200 hover:border-sidebar-border hover:bg-sidebar-accent",
+                session.id === selectedSessionId && "border-sidebar-border bg-sidebar-accent",
               )}
-              type="button"
-              variant="ghost"
-              onClick={() => void loadSession(session.id)}
               key={session.id}
             >
-              <span className="min-w-0 truncate text-xs font-medium">
-                {session.title ?? "Untitled chat"}
-              </span>
-              <time className="font-mono text-[10px] font-medium tabular-nums text-muted-foreground">
-                {formatRelativeTime(session.updatedAt)}
-              </time>
-            </Button>
+              <Button
+                className={cn(
+                  "grid h-auto min-h-8 min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 rounded-sm border-0 bg-transparent px-2 py-1 text-left text-sidebar-foreground/72 shadow-none hover:bg-transparent hover:text-sidebar-foreground",
+                  session.id === selectedSessionId && "text-sidebar-accent-foreground",
+                )}
+                type="button"
+                variant="ghost"
+                onClick={() => void loadSession(session.id)}
+              >
+                <span className="min-w-0 truncate text-xs font-medium">
+                  {session.title ?? "Untitled chat"}
+                </span>
+                <time className="font-mono text-[10px] font-medium tabular-nums text-muted-foreground">
+                  {formatRelativeTime(session.updatedAt)}
+                </time>
+              </Button>
+              <Button
+                aria-label={`Delete ${session.title ?? "Untitled chat"}`}
+                className="h-6 min-h-6 w-6 border-0 bg-transparent p-0 text-muted-foreground opacity-55 shadow-none hover:bg-transparent hover:text-destructive hover:opacity-100 group-hover:opacity-100 [&_svg]:h-3.5 [&_svg]:w-3.5"
+                size="icon"
+                type="button"
+                variant="ghost"
+                disabled={runState === "running"}
+                onClick={() => setDeleteCandidate(session)}
+              >
+                <Trash2 aria-hidden="true" />
+              </Button>
+            </div>
           ))}
         </nav>
-        <div className="mt-auto border-t border-sidebar-border p-4">
-          <span className="flex min-w-0 items-center gap-2 truncate font-mono text-[11px] font-semibold text-primary">
-            <span className="relative flex h-2 w-2 shrink-0" aria-hidden="true">
-              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-55" />
-              <span className="relative inline-flex h-2 w-2 rounded-full bg-primary" />
-            </span>
+        <div className="mt-auto">
+          <span className="sr-only" aria-live="polite">
             {status}
           </span>
         </div>
       </aside>
 
-      <main className="grid h-screen min-w-0 grid-rows-[42px_minmax(0,1fr)] overflow-hidden bg-background">
-        <header className="grid min-h-10 border-b border-border bg-background">
-          <div className="grid min-h-10 grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-5">
+      <main className="grid h-[100dvh] min-w-0 grid-rows-[52px_minmax(0,1fr)] overflow-hidden bg-background/80">
+        <header className="grid min-h-13 border-b border-border/80 bg-background/88 backdrop-blur">
+          <div className="grid min-h-13 grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-6">
             <div className="flex min-w-0 items-center gap-2 text-sm font-medium">
               <span className="text-primary">
                 {activePage === "playground" ? "Agents" : "Studio"}
@@ -1292,15 +1312,7 @@ export function StudioConsole() {
             </div>
             <div className="flex items-center gap-1">
               <Button
-                className="h-7 min-h-7 border-transparent bg-transparent px-3 font-mono text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
-                type="button"
-                variant="secondary"
-                onClick={() => navigatePage("agents")}
-              >
-                See config
-              </Button>
-              <Button
-                className="h-7 min-h-7 border-transparent bg-transparent px-3 font-mono text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+                className="h-8 min-h-8 border-transparent bg-transparent px-3 font-mono text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
                 type="button"
                 variant="secondary"
                 onClick={() => navigatePage("sessions")}
@@ -1308,7 +1320,7 @@ export function StudioConsole() {
                 Sessions
               </Button>
               <Button
-                className="h-7 min-h-7 gap-1.5 rounded-sm border-0 bg-primary px-3 font-mono text-xs text-primary-foreground hover:bg-primary/90"
+                className="h-8 min-h-8 gap-1.5 rounded-sm border-0 bg-primary px-3 font-mono text-xs text-primary-foreground hover:bg-primary/90"
                 type="button"
                 onClick={() => startNewChat()}
               >
@@ -1320,13 +1332,22 @@ export function StudioConsole() {
         </header>
 
         {activePage === "playground" ? (
-          <section className="grid min-h-0 grid-cols-[minmax(0,1fr)_310px] overflow-hidden bg-background max-xl:grid-cols-1">
-            <div className="grid min-h-0 grid-rows-[minmax(0,1fr)_auto] overflow-hidden">
-              <section className="min-h-0 overflow-auto px-6 py-5">
-                <div className="mx-auto grid min-h-full w-full max-w-210 content-start items-start gap-5 pb-6">
+          <section className="grid min-h-0 min-w-0 max-w-full grid-cols-[minmax(0,1fr)_minmax(0,460px)] overflow-hidden bg-background/45 max-xl:grid-cols-1">
+            <div className="grid min-h-0 min-w-0 grid-rows-[minmax(0,1fr)_auto] overflow-hidden">
+              <section className="min-h-0 overflow-auto px-6 py-6">
+                <div className="mx-auto grid min-h-full w-full max-w-235 content-start items-start gap-6 pb-8">
                   {!hasMessages ? (
-                    <div className="grid min-h-80 place-items-center text-sm font-medium text-muted-foreground">
-                      No messages
+                    <div className="grid min-h-96 place-items-center text-sm font-medium text-muted-foreground">
+                      <div className="grid max-w-xl gap-4 text-center">
+                        <div className="mx-auto h-px w-28 bg-primary/45" />
+                        <h1 className="m-0 text-4xl font-semibold leading-tight text-foreground text-balance">
+                          What should this agent work on?
+                        </h1>
+                        <p className="m-0 text-base leading-7 text-muted-foreground text-pretty">
+                          Choose a prompt below or write a task. Studio will stream the response,
+                          tool calls, approvals, and trace data here.
+                        </p>
+                      </div>
                     </div>
                   ) : null}
                   {messages.map((message) => (
@@ -1347,17 +1368,17 @@ export function StudioConsole() {
                 </div>
               </section>
               <form
-                className="grid gap-2 bg-background px-6 pb-5"
+                className="grid gap-3 bg-gradient-to-t from-background via-background/95 to-background/0 px-6 pb-6 pt-2"
                 onSubmit={(event) => {
                   event.preventDefault();
                   void runPrompt(prompt);
                 }}
               >
                 {hasMessages || selectedAgentQuickPrompts.length === 0 ? null : (
-                  <div className="mx-auto grid w-full max-w-210 grid-cols-3 gap-2 max-md:grid-cols-1">
+                  <div className="mx-auto grid w-full max-w-235 grid-cols-3 gap-2 max-md:grid-cols-1">
                     {selectedAgentQuickPrompts.map((quickPrompt) => (
                       <Button
-                        className="h-auto min-h-14 justify-start whitespace-normal rounded-sm border border-border bg-card px-3 py-2 text-left text-sm font-medium leading-5 text-foreground hover:border-primary/45 hover:bg-primary/10 hover:text-primary"
+                        className="h-auto min-h-16 justify-start whitespace-normal rounded-sm border border-border/80 bg-card/85 px-3 py-2.5 text-left text-sm font-medium leading-5 text-foreground shadow-sm hover:border-primary/45 hover:bg-primary/10 hover:text-primary"
                         type="button"
                         variant="ghost"
                         disabled={runState === "running" || selectedAgentId.length === 0}
@@ -1371,9 +1392,9 @@ export function StudioConsole() {
                     ))}
                   </div>
                 )}
-                <div className="mx-auto grid w-full max-w-210 gap-2 rounded-lg border border-border bg-card p-2.5 shadow-xl focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/25">
+                <div className="mx-auto grid w-full max-w-235 gap-2 rounded-md border border-border/80 bg-card/95 p-2.5 shadow-xl shadow-black/35 backdrop-blur focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/25">
                   <Textarea
-                    className="min-h-14 min-w-0 resize-none rounded-md border-0 bg-transparent px-3 py-3 text-sm text-foreground shadow-none outline-none ring-0 placeholder:text-muted-foreground/70 focus:border-transparent focus:ring-0"
+                    className="min-h-16 min-w-0 resize-none rounded-sm border-0 bg-transparent px-3 py-3 text-[15px] leading-7 text-foreground shadow-none outline-none ring-0 placeholder:text-muted-foreground/70 focus:border-transparent focus:ring-0"
                     ref={promptRef}
                     rows={1}
                     value={prompt}
@@ -1385,7 +1406,7 @@ export function StudioConsole() {
                     <div className="flex min-w-0 items-center gap-2">
                       <Button
                         aria-label="Attach context"
-                        className="h-8 min-h-8 w-8 rounded-full border-border bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                        className="h-8 min-h-8 w-8 rounded-sm border-border bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground"
                         size="icon"
                         type="button"
                         variant="secondary"
@@ -1402,7 +1423,7 @@ export function StudioConsole() {
                         >
                           <SelectTrigger
                             aria-label="Select agent"
-                            className="hidden h-8 min-h-8 w-auto max-w-64 gap-2 border-0 bg-transparent px-2 py-1 font-mono text-xs font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground sm:flex"
+                            className="hidden h-8 min-h-8 w-auto max-w-64 gap-2 border-0 bg-transparent px-2 py-1 font-mono text-xs font-medium text-muted-foreground shadow-none hover:bg-accent hover:text-accent-foreground sm:flex"
                           >
                             <SelectValue placeholder="Agent" />
                           </SelectTrigger>
@@ -1421,7 +1442,7 @@ export function StudioConsole() {
                       )}
                       <Button
                         aria-label={runState === "running" ? "Running" : "Send message"}
-                        className="h-9 min-h-9 w-9 rounded-sm border-primary bg-primary text-primary-foreground hover:bg-primary/90 dark:hover:bg-[#eaff73]"
+                        className="h-9 min-h-9 w-9 rounded-sm border-primary bg-primary text-primary-foreground hover:bg-primary/90"
                         size="icon"
                         type="submit"
                         disabled={runState === "running" || selectedAgentId.length === 0}

--- a/packages/tools/studio/src/ui/app/app.tsx
+++ b/packages/tools/studio/src/ui/app/app.tsx
@@ -1,4 +1,4 @@
-import { ArrowUp, Plus, Trash2 } from "lucide-react";
+import { ArrowUp, Plus } from "lucide-react";
 import {
   type ChangeEvent,
   type KeyboardEvent,
@@ -12,6 +12,7 @@ import type {
   StudioConfig,
   StudioKnowledgeSummary,
   StudioSession,
+  StudioSessionLogEntry,
   StudioSessionSummary,
   StudioTrace,
   StudioTraceSummary,
@@ -30,6 +31,7 @@ import { cn } from "./lib/utils";
 import { AgentsPage } from "./modules/agents/agents-page";
 import { KnowledgePage } from "./modules/knowledge/knowledge-page";
 import { TranscriptItem } from "./modules/playground/transcript-item";
+import { SessionLogsPanel } from "./modules/session-logs/session-logs-panel";
 import { DeleteSessionDialog, SessionsPage } from "./modules/sessions/sessions-page";
 import {
   errorMessage,
@@ -102,6 +104,7 @@ export function StudioConsole() {
   const [selectedSessionId, setSelectedSessionId] = useState("");
   const [allSessions, setAllSessions] = useState<StudioSessionSummary[]>([]);
   const [traces, setTraces] = useState<StudioTrace[]>([]);
+  const [sessionLogs, setSessionLogs] = useState<StudioSessionLogEntry[]>([]);
   const [messages, setMessages] = useState<TranscriptEntry[]>([]);
   const [prompt, setPrompt] = useState("");
   const [activePage, setActivePage] = useState<ActivePage>(() => initialLocation.page);
@@ -116,6 +119,7 @@ export function StudioConsole() {
   const [decidingApprovals, setDecidingApprovals] = useState<Set<string>>(() => new Set());
   const [answeringQuestions, setAnsweringQuestions] = useState<Set<string>>(() => new Set());
   const [sessionLoadState, setSessionLoadState] = useState<SessionLoadState>("idle");
+  const [sessionLogLoadState, setSessionLogLoadState] = useState<SessionLoadState>("idle");
   const [traceLoadState, setTraceLoadState] = useState<TraceLoadState>("idle");
   const [knowledge, setKnowledge] = useState<StudioKnowledgeSummary | undefined>();
   const [knowledgeLoadState, setKnowledgeLoadState] = useState<"idle" | "loading">("idle");
@@ -178,6 +182,34 @@ export function StudioConsole() {
     void loadAllSessions();
   }, [loadAllSessions]);
 
+  const loadSessionLogs = useCallback(
+    async (sessionId: string): Promise<StudioSessionLogEntry[]> => {
+      if (!sessionsEnabled) {
+        setSessionLogs([]);
+        return [];
+      }
+
+      setSessionLogLoadState("loading");
+      try {
+        const params = new URLSearchParams({ limit: "1000" });
+        const response = await fetch(`/sessions/${encodeURIComponent(sessionId)}/logs?${params}`);
+        if (!response.ok) {
+          throw new Error(`Session logs failed with HTTP ${response.status}`);
+        }
+        const body = (await response.json()) as { logs: StudioSessionLogEntry[] };
+        setSessionLogs(body.logs);
+        return body.logs;
+      } catch (loadError) {
+        setError(errorMessage(loadError));
+        setSessionLogs([]);
+        return [];
+      } finally {
+        setSessionLogLoadState("idle");
+      }
+    },
+    [sessionsEnabled],
+  );
+
   async function createSession(title: string): Promise<StudioSessionSummary> {
     const agentId = selectedAgent?.id ?? selectedAgentId;
     const response = await fetch("/sessions", {
@@ -200,6 +232,7 @@ export function StudioConsole() {
     setSelectedSessionId(session.id);
     setAllSessions((current) => [session, ...current.filter((item) => item.id !== session.id)]);
     updateSessionPath(session.id);
+    await loadSessionLogs(session.id);
     return session;
   }
 
@@ -356,7 +389,10 @@ export function StudioConsole() {
           throw new Error(`Session load failed with HTTP ${response.status}`);
         }
         const session = (await response.json()) as StudioSession;
-        const traceSummaries = await loadSessionTraceSummaries(session.id);
+        const [traceSummaries] = await Promise.all([
+          loadSessionTraceSummaries(session.id),
+          loadSessionLogs(session.id),
+        ]);
         setTranscriptSequence(nextSequence(session.transcript));
         setSelectedAgentId(session.agentId);
         setSelectedSessionId(session.id);
@@ -372,7 +408,7 @@ export function StudioConsole() {
         setSessionLoadState("idle");
       }
     },
-    [runState, loadSessionTraceSummaries],
+    [runState, loadSessionTraceSummaries, loadSessionLogs],
   );
 
   const startNewChat = useCallback(
@@ -382,6 +418,7 @@ export function StudioConsole() {
       }
       resetTranscriptSequence();
       setSelectedSessionId("");
+      setSessionLogs([]);
       setMessages([]);
       setPrompt("");
       setActivePage("playground");
@@ -403,6 +440,7 @@ export function StudioConsole() {
       setSelectedAgentId(agentId);
       resetTranscriptSequence();
       setSelectedSessionId("");
+      setSessionLogs([]);
       setMessages([]);
       setPrompt("");
       setActivePage("playground");
@@ -432,6 +470,7 @@ export function StudioConsole() {
       if (selectedSessionId === session.id) {
         resetTranscriptSequence();
         setSelectedSessionId("");
+        setSessionLogs([]);
         setMessages([]);
         setPrompt("");
         if (activePage === "playground") {
@@ -548,7 +587,10 @@ export function StudioConsole() {
       await loadAllSessions();
       if (sessionId.length > 0) {
         setSelectedSessionId(sessionId);
-        const traceSummaries = await loadSessionTraceSummaries(sessionId);
+        const [traceSummaries] = await Promise.all([
+          loadSessionTraceSummaries(sessionId),
+          loadSessionLogs(sessionId),
+        ]);
         setMessages((current) => enrichTranscriptWithTraceIds(current, traceSummaries));
       }
       setStatus("Connected");
@@ -607,6 +649,10 @@ export function StudioConsole() {
       updateToolQuestion(event.question);
       return true;
     }
+    if (event.type === "session_log") {
+      appendSessionLogEntry(event.log);
+      return true;
+    }
     if (event.type === "final" && event.trace?.traceId !== undefined) {
       assignAssistantTraceId(event.trace.traceId);
       return true;
@@ -615,6 +661,15 @@ export function StudioConsole() {
       setError(JSON.stringify(event.error));
     }
     return false;
+  }
+
+  function appendSessionLogEntry(log: StudioSessionLogEntry) {
+    setSessionLogs((current) => {
+      if (current.some((item) => item.id === log.id)) {
+        return current;
+      }
+      return [...current, log].sort((left, right) => left.sequence - right.sequence);
+    });
   }
 
   function appendAssistantText(delta: string) {
@@ -1099,6 +1154,33 @@ export function StudioConsole() {
             onClick={() => navigatePage("knowledge")}
           />
         </nav>
+        <nav
+          className="grid min-h-0 gap-1 overflow-auto border-b border-sidebar-border px-3 py-3"
+          aria-label="Recent sessions"
+        >
+          <div className="px-2 pb-1 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Recent
+          </div>
+          {allSessions.slice(0, 8).map((session) => (
+            <Button
+              className={cn(
+                "grid h-auto min-h-9 min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 rounded-sm border-0 bg-transparent px-2 py-1 text-left text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+                session.id === selectedSessionId && "bg-sidebar-accent text-primary",
+              )}
+              type="button"
+              variant="ghost"
+              onClick={() => void loadSession(session.id)}
+              key={session.id}
+            >
+              <span className="min-w-0 truncate text-xs font-medium">
+                {session.title ?? "Untitled chat"}
+              </span>
+              <time className="font-mono text-[10px] font-medium tabular-nums text-muted-foreground">
+                {formatRelativeTime(session.updatedAt)}
+              </time>
+            </Button>
+          ))}
+        </nav>
         <div className="mt-auto border-t border-sidebar-border p-4">
           <span className="flex min-w-0 items-center gap-2 truncate font-mono text-[11px] font-semibold text-primary">
             <span className="relative flex h-2 w-2 shrink-0" aria-hidden="true">
@@ -1265,47 +1347,11 @@ export function StudioConsole() {
                 </div>
               </form>
             </div>
-            <aside className="min-h-0 overflow-auto border-l border-border px-3 py-5 max-xl:hidden">
-              <div className="grid gap-1">
-                {allSessions.slice(0, 12).map((session) => (
-                  <div
-                    className={cn(
-                      "group grid min-h-10 grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-2 border-l border-transparent bg-transparent px-3 py-1 text-left hover:bg-accent",
-                      session.id === selectedSessionId &&
-                        "border-primary bg-accent text-accent-foreground",
-                    )}
-                    key={session.id}
-                  >
-                    <Button
-                      className="h-auto min-h-0 min-w-0 justify-start rounded-none border-0 bg-transparent p-0 text-left text-inherit hover:bg-transparent hover:text-inherit"
-                      type="button"
-                      variant="ghost"
-                      onClick={() => void loadSession(session.id)}
-                    >
-                      <span className="min-w-0 truncate text-sm font-medium">
-                        {session.title ?? "Untitled chat"}
-                      </span>
-                    </Button>
-                    <time className="self-center justify-self-end font-mono text-xs font-medium tabular-nums text-muted-foreground">
-                      {formatRelativeTime(session.updatedAt)}
-                    </time>
-                    <Button
-                      aria-label={`Delete ${session.title ?? "Untitled chat"}`}
-                      className="h-7 min-h-7 w-7 border-0 bg-transparent p-0 text-muted-foreground opacity-70 hover:bg-transparent hover:text-destructive hover:opacity-100 focus-visible:opacity-100 [&_svg]:h-3.5 [&_svg]:w-3.5"
-                      size="icon"
-                      type="button"
-                      variant="ghost"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        setDeleteCandidate(session);
-                      }}
-                    >
-                      <Trash2 aria-hidden="true" />
-                    </Button>
-                  </div>
-                ))}
-              </div>
-            </aside>
+            <SessionLogsPanel
+              logs={sessionLogs}
+              selectedSessionId={selectedSessionId}
+              loading={sessionLogLoadState === "loading"}
+            />
           </section>
         ) : null}
 

--- a/packages/tools/studio/src/ui/app/app.tsx
+++ b/packages/tools/studio/src/ui/app/app.tsx
@@ -74,6 +74,27 @@ function applyDarkTheme(): void {
   document.documentElement.classList.add("dark");
 }
 
+async function responseErrorMessage(response: Response, label: string): Promise<string> {
+  let detail = "";
+  try {
+    const body = (await response.json()) as unknown;
+    if (
+      typeof body === "object" &&
+      body !== null &&
+      "error" in body &&
+      typeof body.error === "object" &&
+      body.error !== null &&
+      "message" in body.error &&
+      typeof body.error.message === "string"
+    ) {
+      detail = `: ${body.error.message}`;
+    }
+  } catch {
+    // Ignore non-JSON error bodies.
+  }
+  return `${label} with HTTP ${response.status}${detail}`;
+}
+
 export function StudioConsole() {
   const initialLocation = pageLocationFromLocation();
   const [config, setConfig] = useState<StudioConfig | undefined>();
@@ -158,13 +179,14 @@ export function StudioConsole() {
   }, [loadAllSessions]);
 
   async function createSession(title: string): Promise<StudioSessionSummary> {
+    const agentId = selectedAgent?.id ?? selectedAgentId;
     const response = await fetch("/sessions", {
       method: "POST",
       headers: {
         "content-type": "application/json",
       },
       body: JSON.stringify({
-        agentId: selectedAgentId,
+        agentId,
         title,
         metadata: {
           source: "anvia-studio",
@@ -172,7 +194,7 @@ export function StudioConsole() {
       }),
     });
     if (!response.ok) {
-      throw new Error(`Session create failed with HTTP ${response.status}`);
+      throw new Error(await responseErrorMessage(response, "Session create failed"));
     }
     const session = (await response.json()) as StudioSessionSummary;
     setSelectedSessionId(session.id);
@@ -473,7 +495,8 @@ export function StudioConsole() {
 
   async function runPrompt(text: string) {
     const trimmed = text.trim();
-    if (trimmed.length === 0 || selectedAgentId.length === 0 || runState === "running") {
+    const agentId = selectedAgent?.id ?? selectedAgentId;
+    if (trimmed.length === 0 || agentId.length === 0 || runState === "running") {
       return;
     }
 
@@ -493,7 +516,7 @@ export function StudioConsole() {
           ? (await createSession(titleFromText(trimmed))).id
           : selectedSessionId;
       const history = sessionsEnabled ? undefined : toHistory(messages);
-      const response = await fetch(`/agents/${encodeURIComponent(selectedAgentId)}/runs`, {
+      const response = await fetch(`/agents/${encodeURIComponent(agentId)}/runs`, {
         method: "POST",
         headers: {
           "content-type": "application/json",

--- a/packages/tools/studio/src/ui/app/components/ui/badge.tsx
+++ b/packages/tools/studio/src/ui/app/components/ui/badge.tsx
@@ -3,11 +3,11 @@ import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-sm border px-2 py-1 text-xs font-semibold",
+  "inline-flex items-center rounded-sm border px-2 py-1 font-mono text-[11px] font-semibold uppercase tracking-[0.12em]",
   {
     variants: {
       variant: {
-        default: "border-border bg-muted text-foreground",
+        default: "border-border/80 bg-muted/70 text-muted-foreground",
         success: "border-primary/40 bg-primary/15 text-primary",
         destructive: "border-destructive/40 bg-destructive/15 text-destructive",
       },

--- a/packages/tools/studio/src/ui/app/components/ui/button.tsx
+++ b/packages/tools/studio/src/ui/app/components/ui/button.tsx
@@ -4,18 +4,18 @@ import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-sm text-sm font-semibold transition disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-sm text-sm font-semibold shadow-none transition duration-200 ease-out active:translate-y-px disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-ring/35 focus-visible:ring-offset-0 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
         default:
-          "border border-primary bg-primary text-primary-foreground hover:bg-primary/90 dark:hover:bg-[#eaff73]",
+          "border border-primary/80 bg-primary text-primary-foreground shadow-sm shadow-primary/15 hover:border-primary hover:bg-primary/90",
         ghost:
           "border border-transparent bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground",
         destructive:
           "border border-destructive bg-destructive text-destructive-foreground hover:bg-destructive/90",
         secondary:
-          "border border-border bg-secondary text-secondary-foreground hover:bg-accent hover:text-accent-foreground",
+          "border border-border/80 bg-secondary text-secondary-foreground shadow-xs hover:border-primary/35 hover:bg-accent hover:text-accent-foreground",
       },
       size: {
         default: "h-9 px-3",

--- a/packages/tools/studio/src/ui/app/components/ui/card.tsx
+++ b/packages/tools/studio/src/ui/app/components/ui/card.tsx
@@ -4,7 +4,10 @@ import { cn } from "@/lib/utils";
 export function Card({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
-      className={cn("rounded-sm border border-border bg-card text-card-foreground", className)}
+      className={cn(
+        "rounded-sm border border-border/80 bg-card/95 text-card-foreground shadow-sm shadow-black/20",
+        className,
+      )}
       {...props}
     />
   );

--- a/packages/tools/studio/src/ui/app/components/ui/input.tsx
+++ b/packages/tools/studio/src/ui/app/components/ui/input.tsx
@@ -6,7 +6,7 @@ export function Input({ className, type, ...props }: React.ComponentProps<"input
     <input
       type={type}
       className={cn(
-        "h-9 w-full rounded-sm border border-input bg-card px-3 text-foreground outline-none transition focus:border-ring focus:ring-2 focus:ring-ring/20",
+        "h-9 w-full rounded-sm border border-input bg-card/90 px-3 text-foreground outline-none shadow-inner shadow-black/10 transition duration-200 placeholder:text-muted-foreground/65 focus:border-ring focus:ring-2 focus:ring-ring/20",
         className,
       )}
       {...props}

--- a/packages/tools/studio/src/ui/app/components/ui/select.tsx
+++ b/packages/tools/studio/src/ui/app/components/ui/select.tsx
@@ -14,7 +14,7 @@ export function SelectTrigger({
   return (
     <SelectPrimitive.Trigger
       className={cn(
-        "flex h-9 w-full items-center justify-between rounded-sm border border-input bg-card px-3 text-sm text-foreground outline-none transition focus:border-ring focus:ring-2 focus:ring-ring/20 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-9 w-full items-center justify-between rounded-sm border border-input bg-card/90 px-3 text-sm text-foreground outline-none shadow-inner shadow-black/10 transition duration-200 hover:border-primary/35 focus:border-ring focus:ring-2 focus:ring-ring/20 disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       {...props}
@@ -38,7 +38,7 @@ export function SelectContent({
       <SelectPrimitive.Content
         position={position}
         className={cn(
-          "z-50 max-h-80 min-w-[8rem] overflow-hidden rounded-sm border border-border bg-popover text-popover-foreground shadow-xl shadow-black/30",
+          "z-50 max-h-80 min-w-[8rem] overflow-hidden rounded-sm border border-border/90 bg-popover/98 text-popover-foreground shadow-xl shadow-black/45 backdrop-blur",
           className,
         )}
         {...props}
@@ -57,7 +57,7 @@ export function SelectItem({
   return (
     <SelectPrimitive.Item
       className={cn(
-        "relative flex min-h-8 cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:opacity-50",
+        "relative flex min-h-8 cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition data-[disabled]:pointer-events-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:opacity-50",
         className,
       )}
       {...props}

--- a/packages/tools/studio/src/ui/app/components/ui/textarea.tsx
+++ b/packages/tools/studio/src/ui/app/components/ui/textarea.tsx
@@ -5,7 +5,7 @@ export function Textarea({ className, ...props }: React.ComponentProps<"textarea
   return (
     <textarea
       className={cn(
-        "min-h-9 w-full resize-none rounded-sm border border-input bg-card px-3 py-2.5 leading-6 text-foreground outline-none transition focus:border-ring focus:ring-2 focus:ring-ring/20",
+        "min-h-9 w-full resize-none rounded-sm border border-input bg-card/90 px-3 py-2.5 leading-6 text-foreground outline-none shadow-inner shadow-black/10 transition duration-200 placeholder:text-muted-foreground/65 focus:border-ring focus:ring-2 focus:ring-ring/20",
         className,
       )}
       {...props}

--- a/packages/tools/studio/src/ui/app/index.html
+++ b/packages/tools/studio/src/ui/app/index.html
@@ -4,6 +4,10 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Anvia Studio</title>
+    <meta
+      name="description"
+      content="Professional Studio interface for Anvia agents, sessions, tools, knowledge, and traces."
+    />
     <link rel="icon" type="image/png" href="/ui/assets/logo.png" />
   </head>
   <body>

--- a/packages/tools/studio/src/ui/app/modules/agents/agents-page.tsx
+++ b/packages/tools/studio/src/ui/app/modules/agents/agents-page.tsx
@@ -3,58 +3,50 @@ import { Badge } from "../../components/ui/badge";
 import { cn } from "../../lib/utils";
 
 export function AgentsPage(props: { agents: StudioConfig["agents"]; selectedAgentId: string }) {
-  const quickPromptCount = props.agents.reduce(
-    (total, agent) => total + agent.quickPrompts.length,
-    0,
-  );
-  const selectedAgent =
-    props.agents.find((agent) => agent.id === props.selectedAgentId) ?? props.agents[0];
-
   return (
-    <section className="min-h-0 overflow-auto bg-background/45" aria-label="Agents">
-      <div className="mx-auto grid max-w-[1500px] gap-6 px-6 py-6">
-        <header className="grid grid-cols-[minmax(0,1fr)_auto] items-end gap-6 border-b border-border/80 pb-6 max-lg:grid-cols-1">
-          <div className="grid min-w-0 gap-3">
+    <section
+      className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden bg-background/55"
+      aria-label="Agents"
+    >
+      <header className="border-b border-border/80 bg-background/70 px-6 py-5 backdrop-blur">
+        <div className="mx-auto grid max-w-[1500px] grid-cols-[minmax(0,1fr)_auto] items-end gap-4 max-md:grid-cols-1">
+          <div className="grid min-w-0 gap-2">
             <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.24em] text-primary">
               Studio registry
             </div>
-            <div className="grid gap-2">
-              <h1 className="m-0 text-3xl font-semibold leading-none tracking-tight text-foreground">
-                Agent control surface
-              </h1>
-              <p className="m-0 max-w-[68ch] text-sm leading-6 text-muted-foreground">
-                Review registered agents, operational prompts, and runtime metadata without the
-                table squeeze.
-              </p>
-            </div>
+            <h1 className="m-0 text-2xl font-semibold leading-none tracking-tight text-foreground">
+              Studio
+            </h1>
+            <p className="m-0 max-w-[62ch] text-sm leading-6 text-muted-foreground">
+              Registered agents, operational prompts, and runtime metadata for Studio agents.
+            </p>
           </div>
-          <div className="grid grid-cols-3 border border-border/80 bg-card/45 max-sm:grid-cols-1">
-            <Metric label="agents" value={props.agents.length} />
-            <Metric label="prompts" value={quickPromptCount} />
-            <Metric label="selected" value={selectedAgent?.name ?? selectedAgent?.id ?? "none"} />
-          </div>
-        </header>
+        </div>
+      </header>
 
-        {props.agents.length === 0 ? (
-          <div className="grid min-h-80 place-items-center border border-dashed border-border/80 bg-card/35 px-6 text-center">
-            <div className="grid max-w-md gap-2">
-              <h2 className="m-0 text-base font-semibold text-foreground">No agents</h2>
-              <p className="m-0 text-sm leading-6 text-muted-foreground">
-                Studio has no registered agents to inspect.
-              </p>
+      <div className="min-h-0 overflow-auto px-6 py-6">
+        <div className="mx-auto grid max-w-[1500px] gap-4">
+          {props.agents.length === 0 ? (
+            <div className="grid min-h-80 place-items-center border border-dashed border-border/80 bg-card/35 px-6 text-center">
+              <div className="grid max-w-md gap-2">
+                <h2 className="m-0 text-base font-semibold text-foreground">No agents</h2>
+                <p className="m-0 text-sm leading-6 text-muted-foreground">
+                  Studio has no registered agents to inspect.
+                </p>
+              </div>
             </div>
-          </div>
-        ) : (
-          <div className="grid gap-4">
-            {props.agents.map((agent) => (
-              <AgentDossier
-                agent={agent}
-                active={agent.id === props.selectedAgentId}
-                key={agent.id}
-              />
-            ))}
-          </div>
-        )}
+          ) : (
+            <div className="grid gap-4">
+              {props.agents.map((agent) => (
+                <AgentDossier
+                  agent={agent}
+                  active={agent.id === props.selectedAgentId}
+                  key={agent.id}
+                />
+              ))}
+            </div>
+          )}
+        </div>
       </div>
     </section>
   );
@@ -158,17 +150,6 @@ function AgentDossier(props: { agent: StudioConfig["agents"][number]; active: bo
         </section>
       </div>
     </article>
-  );
-}
-
-function Metric(props: { label: string; value: string | number }) {
-  return (
-    <div className="grid min-w-0 gap-1 border-r border-border/80 px-4 py-3 last:border-r-0 max-sm:border-b max-sm:border-r-0 max-sm:last:border-b-0">
-      <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-        {props.label}
-      </span>
-      <span className="min-w-0 truncate text-sm font-semibold text-foreground">{props.value}</span>
-    </div>
   );
 }
 

--- a/packages/tools/studio/src/ui/app/modules/agents/agents-page.tsx
+++ b/packages/tools/studio/src/ui/app/modules/agents/agents-page.tsx
@@ -1,53 +1,204 @@
 import type { StudioConfig } from "../../../../types";
 import { Badge } from "../../components/ui/badge";
 import { cn } from "../../lib/utils";
-import { JsonValueView } from "../shared/renderers";
 
 export function AgentsPage(props: { agents: StudioConfig["agents"]; selectedAgentId: string }) {
+  const quickPromptCount = props.agents.reduce(
+    (total, agent) => total + agent.quickPrompts.length,
+    0,
+  );
+  const selectedAgent =
+    props.agents.find((agent) => agent.id === props.selectedAgentId) ?? props.agents[0];
+
   return (
-    <section className="grid min-h-0 w-full overflow-auto" aria-label="Agents">
-      <div className="min-w-260 border-b border-border bg-card">
-        <div className="grid min-h-10 grid-cols-[minmax(220px,1.1fr)_minmax(280px,1.4fr)_160px_minmax(220px,0.9fr)] items-center gap-4 border-b border-border px-5 font-mono text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-          <span>Agent</span>
-          <span>Description</span>
-          <span>Quick prompts</span>
-          <span>Metadata</span>
-        </div>
-        {props.agents.length === 0 ? (
-          <div className="px-5 py-4 text-sm font-medium text-muted-foreground">No agents</div>
-        ) : null}
-        {props.agents.map((agent) => (
-          <div
-            className={cn(
-              "grid min-h-16 grid-cols-[minmax(220px,1.1fr)_minmax(280px,1.4fr)_160px_minmax(220px,0.9fr)] items-start gap-4 border-b border-border px-5 py-3 text-left text-muted-foreground",
-              agent.id === props.selectedAgentId && "bg-primary/10 text-primary",
-            )}
-            key={agent.id}
-          >
-            <span className="grid min-w-0 gap-0.5">
-              <strong className="min-w-0 truncate text-sm font-medium text-foreground">
-                {agent.name ?? agent.id}
-              </strong>
-              <span className="min-w-0 truncate font-mono text-xs font-medium text-muted-foreground">
-                {agent.id}
-              </span>
-            </span>
-            <p className="m-0 min-w-0 text-sm leading-6 text-muted-foreground">
-              {agent.description ?? "No description"}
-            </p>
-            <span className="flex min-w-0 flex-wrap gap-1.5">
-              {agent.quickPrompts.length === 0 ? (
-                <span className="text-xs font-medium text-muted-foreground">None</span>
-              ) : (
-                agent.quickPrompts.map((prompt) => <Badge key={prompt}>{prompt}</Badge>)
-              )}
-            </span>
-            <span className="min-w-0 overflow-hidden text-xs text-muted-foreground">
-              {agent.metadata === undefined ? "None" : <JsonValueView value={agent.metadata} />}
-            </span>
+    <section className="min-h-0 overflow-auto bg-background/45" aria-label="Agents">
+      <div className="mx-auto grid max-w-[1500px] gap-6 px-6 py-6">
+        <header className="grid grid-cols-[minmax(0,1fr)_auto] items-end gap-6 border-b border-border/80 pb-6 max-lg:grid-cols-1">
+          <div className="grid min-w-0 gap-3">
+            <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.24em] text-primary">
+              Studio registry
+            </div>
+            <div className="grid gap-2">
+              <h1 className="m-0 text-3xl font-semibold leading-none tracking-tight text-foreground">
+                Agent control surface
+              </h1>
+              <p className="m-0 max-w-[68ch] text-sm leading-6 text-muted-foreground">
+                Review registered agents, operational prompts, and runtime metadata without the
+                table squeeze.
+              </p>
+            </div>
           </div>
-        ))}
+          <div className="grid grid-cols-3 border border-border/80 bg-card/45 max-sm:grid-cols-1">
+            <Metric label="agents" value={props.agents.length} />
+            <Metric label="prompts" value={quickPromptCount} />
+            <Metric label="selected" value={selectedAgent?.name ?? selectedAgent?.id ?? "none"} />
+          </div>
+        </header>
+
+        {props.agents.length === 0 ? (
+          <div className="grid min-h-80 place-items-center border border-dashed border-border/80 bg-card/35 px-6 text-center">
+            <div className="grid max-w-md gap-2">
+              <h2 className="m-0 text-base font-semibold text-foreground">No agents</h2>
+              <p className="m-0 text-sm leading-6 text-muted-foreground">
+                Studio has no registered agents to inspect.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="grid gap-4">
+            {props.agents.map((agent) => (
+              <AgentDossier
+                agent={agent}
+                active={agent.id === props.selectedAgentId}
+                key={agent.id}
+              />
+            ))}
+          </div>
+        )}
       </div>
     </section>
   );
+}
+
+function AgentDossier(props: { agent: StudioConfig["agents"][number]; active: boolean }) {
+  const metadata = metadataEntries(props.agent.metadata);
+
+  return (
+    <article
+      className={cn(
+        "grid overflow-hidden border border-border/80 bg-card/45 shadow-sm transition duration-200 hover:border-border hover:bg-card/60",
+        props.active && "border-primary/35 bg-card/70 shadow-[inset_0_1px_0_hsl(0_0%_100%_/_0.08)]",
+      )}
+    >
+      <div className="grid gap-0 xl:grid-cols-[minmax(280px,0.72fr)_minmax(0,1fr)_minmax(280px,0.7fr)]">
+        <section className="grid content-between gap-8 border-b border-border/70 p-5 xl:border-b-0 xl:border-r">
+          <div className="grid gap-3">
+            <div className="flex min-w-0 items-center justify-between gap-3">
+              <Badge
+                className={cn(
+                  "border-border/80 bg-muted/45 text-muted-foreground",
+                  props.active && "border-primary/35 bg-primary/10 text-primary",
+                )}
+              >
+                {props.active ? "selected" : "agent"}
+              </Badge>
+              <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                {props.agent.quickPrompts.length} prompts
+              </span>
+            </div>
+            <div className="grid gap-2">
+              <h2 className="m-0 text-xl font-semibold leading-tight tracking-tight text-foreground text-balance">
+                {props.agent.name ?? props.agent.id}
+              </h2>
+              <span className="min-w-0 break-all font-mono text-xs font-medium leading-5 text-muted-foreground">
+                {props.agent.id}
+              </span>
+            </div>
+          </div>
+          <div className="h-px w-20 bg-primary/55" />
+        </section>
+
+        <section className="grid content-start gap-5 border-b border-border/70 p-5 xl:border-b-0 xl:border-r">
+          <div className="grid gap-2">
+            <SectionLabel>description</SectionLabel>
+            <p className="m-0 max-w-[72ch] text-sm leading-6 text-muted-foreground">
+              {props.agent.description ?? "No description"}
+            </p>
+          </div>
+          <div className="grid gap-2">
+            <SectionLabel>quick prompts</SectionLabel>
+            {props.agent.quickPrompts.length === 0 ? (
+              <div className="border border-dashed border-border/80 bg-background/35 px-3 py-2 text-sm text-muted-foreground">
+                None configured
+              </div>
+            ) : (
+              <div className="grid gap-2">
+                {props.agent.quickPrompts.map((prompt, index) => (
+                  <div
+                    className="grid grid-cols-[28px_minmax(0,1fr)] gap-3 border border-border/70 bg-background/35 px-3 py-2 text-sm leading-6 text-foreground"
+                    key={prompt}
+                  >
+                    <span className="font-mono text-[11px] font-semibold text-muted-foreground">
+                      {String(index + 1).padStart(2, "0")}
+                    </span>
+                    <span className="min-w-0 [overflow-wrap:anywhere]">{prompt}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </section>
+
+        <section className="grid content-start gap-3 p-5">
+          <SectionLabel>metadata</SectionLabel>
+          {metadata.length === 0 ? (
+            <div className="border border-dashed border-border/80 bg-background/35 px-3 py-2 text-sm text-muted-foreground">
+              None
+            </div>
+          ) : (
+            <div className="grid divide-y divide-border/70 border border-border/70 bg-background/35">
+              {metadata.map(([key, value]) => (
+                <div
+                  className="grid min-w-0 grid-cols-[minmax(110px,0.75fr)_minmax(0,1fr)] gap-3 px-3 py-2 text-sm"
+                  key={key}
+                >
+                  <span className="min-w-0 truncate font-medium text-muted-foreground" title={key}>
+                    {key}
+                  </span>
+                  <span
+                    className="min-w-0 truncate font-mono text-xs text-foreground"
+                    title={formatMetadataValue(value)}
+                  >
+                    {formatMetadataValue(value)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </article>
+  );
+}
+
+function Metric(props: { label: string; value: string | number }) {
+  return (
+    <div className="grid min-w-0 gap-1 border-r border-border/80 px-4 py-3 last:border-r-0 max-sm:border-b max-sm:border-r-0 max-sm:last:border-b-0">
+      <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+        {props.label}
+      </span>
+      <span className="min-w-0 truncate text-sm font-semibold text-foreground">{props.value}</span>
+    </div>
+  );
+}
+
+function SectionLabel(props: { children: string }) {
+  return (
+    <h3 className="m-0 font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+      {props.children}
+    </h3>
+  );
+}
+
+function metadataEntries(metadata: StudioConfig["agents"][number]["metadata"]) {
+  if (metadata === undefined) {
+    return [];
+  }
+  return Object.entries(metadata);
+}
+
+function formatMetadataValue(value: unknown): string {
+  if (value === null) {
+    return "null";
+  }
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.length}]`;
+  }
+  if (typeof value === "object") {
+    return "{...}";
+  }
+  return "";
 }

--- a/packages/tools/studio/src/ui/app/modules/knowledge/knowledge-page.tsx
+++ b/packages/tools/studio/src/ui/app/modules/knowledge/knowledge-page.tsx
@@ -25,8 +25,8 @@ export function KnowledgePage(props: {
   const evidence = props.summary?.evidence ?? [];
 
   return (
-    <section className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden bg-background">
-      <header className="flex min-h-12 items-center justify-between gap-3 border-b border-border px-5">
+    <section className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden bg-background/45">
+      <header className="flex min-h-16 items-center justify-between gap-3 border-b border-border/80 bg-card/70 px-6 shadow-sm">
         <div className="min-w-0">
           <h1 className="m-0 text-sm font-semibold text-foreground">Knowledge</h1>
           <p className="m-0 text-xs font-medium text-muted-foreground">
@@ -43,16 +43,16 @@ export function KnowledgePage(props: {
           Refresh
         </Button>
       </header>
-      <div className="min-h-0 overflow-auto p-5">
-        <div className="grid min-w-0 gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(360px,0.8fr)]">
+      <div className="min-h-0 overflow-auto p-6">
+        <div className="grid min-w-0 gap-5 xl:grid-cols-[minmax(0,1fr)_minmax(380px,0.8fr)]">
           <section className="grid min-w-0 content-start gap-3" aria-label="Agent knowledge">
             {props.loading && agents.length === 0 ? <MutedRow text="Loading knowledge" /> : null}
             {!props.loading && agents.length === 0 ? (
               <MutedRow text="No knowledge sources" />
             ) : null}
             {agents.map((agent) => (
-              <Card className="overflow-hidden rounded-sm" key={agent.agentId}>
-                <div className="grid gap-1 border-b border-border px-4 py-3">
+              <Card className="overflow-hidden rounded-sm bg-card/90" key={agent.agentId}>
+                <div className="grid gap-1 border-b border-border/80 px-4 py-3">
                   <strong className="truncate text-sm font-semibold text-foreground">
                     {agent.agentName ?? agent.agentId}
                   </strong>
@@ -60,7 +60,7 @@ export function KnowledgePage(props: {
                     {agent.agentId}
                   </span>
                 </div>
-                <div className="flex flex-wrap gap-2 border-b border-border px-4 py-3">
+                <div className="flex flex-wrap gap-2 border-b border-border/80 bg-muted/20 px-4 py-3">
                   {agent.sources.map((source) => (
                     <Badge className="rounded-sm" key={source.kind}>
                       {source.kind.replaceAll("_", " ")}: {source.count}
@@ -73,7 +73,7 @@ export function KnowledgePage(props: {
                   ) : (
                     agent.staticContext.map((document) => (
                       <div
-                        className="grid gap-2 border-b border-border px-4 py-3 last:border-b-0"
+                        className="grid gap-2 border-b border-border/75 px-4 py-3.5 last:border-b-0"
                         key={document.id}
                       >
                         <span className="font-mono text-xs font-semibold text-muted-foreground">
@@ -99,10 +99,10 @@ export function KnowledgePage(props: {
             {evidence.length === 0 ? <MutedRow text="No retrieved context captured yet" /> : null}
             {evidence.map((item) => (
               <Card
-                className="overflow-hidden rounded-sm"
+                className="overflow-hidden rounded-sm bg-card/90"
                 key={`${item.traceId}:${item.observationId}`}
               >
-                <div className="grid gap-1 border-b border-border px-4 py-3">
+                <div className="grid gap-1 border-b border-border/80 px-4 py-3">
                   <strong className="truncate text-sm font-semibold text-foreground">
                     {item.observationName}
                   </strong>
@@ -115,7 +115,7 @@ export function KnowledgePage(props: {
                     {item.traceId}
                   </Button>
                 </div>
-                <div className="flex flex-wrap gap-2 border-b border-border px-4 py-3">
+                <div className="flex flex-wrap gap-2 border-b border-border/80 bg-muted/20 px-4 py-3">
                   <Badge>Turn {item.turn}</Badge>
                   <Badge>{item.documentCount} docs</Badge>
                   <Badge>{item.toolCount} tools</Badge>

--- a/packages/tools/studio/src/ui/app/modules/mcps/mcps-page.tsx
+++ b/packages/tools/studio/src/ui/app/modules/mcps/mcps-page.tsx
@@ -1,4 +1,9 @@
-import type { StudioAgentMcpsSummary, StudioConfig } from "../../../../types";
+import type {
+  StudioAgentMcpServerMetadata,
+  StudioAgentMcpsSummary,
+  StudioAgentMcpToolMetadata,
+  StudioConfig,
+} from "../../../../types";
 import { Badge } from "../../components/ui/badge";
 import {
   Select,
@@ -7,7 +12,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "../../components/ui/select";
-import { JsonValueView } from "../shared/renderers";
 
 export function McpsPage(props: {
   agents: StudioConfig["agents"];
@@ -20,95 +24,135 @@ export function McpsPage(props: {
   const selectedAgent =
     props.agents.find((agent) => agent.id === props.selectedAgentId) ?? props.agents[0];
   const servers = props.summary?.servers ?? [];
+  const toolCount = servers.reduce((total, server) => total + server.toolCount, 0);
 
   return (
     <section
-      className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden"
+      className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden bg-background/55"
       aria-label="MCPs"
     >
-      <header className="grid min-h-18 border-b border-border bg-card px-5 py-4">
-        <div className="flex min-w-0 flex-wrap items-center justify-between gap-3">
-          <div className="grid min-w-0 gap-1">
-            <h1 className="m-0 text-sm font-semibold text-foreground">MCPs</h1>
-            <p className="m-0 text-xs font-medium text-muted-foreground">
-              MCP servers and tools registered on Studio agents
+      <header className="border-b border-border/80 bg-background/70 px-6 py-5 backdrop-blur">
+        <div className="mx-auto grid max-w-[1500px] grid-cols-[minmax(0,1fr)_auto] items-end gap-4 max-md:grid-cols-1">
+          <div className="grid min-w-0 gap-2">
+            <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.24em] text-primary">
+              External context
+            </div>
+            <h1 className="m-0 text-2xl font-semibold leading-none tracking-tight text-foreground">
+              MCPs
+            </h1>
+            <p className="m-0 max-w-[62ch] text-sm leading-6 text-muted-foreground">
+              MCP servers and remote tools registered on Studio agents, grouped by server.
             </p>
           </div>
-          {props.agents.length > 1 ? (
-            <Select value={selectedAgent?.id ?? ""} onValueChange={props.onSelectAgent}>
-              <SelectTrigger className="h-8 min-h-8 w-56 rounded-sm border-border bg-background font-mono text-xs">
-                <SelectValue placeholder="Agent" />
-              </SelectTrigger>
-              <SelectContent align="end">
-                {props.agents.map((agent) => (
-                  <SelectItem value={agent.id} key={agent.id}>
-                    {agent.name ?? agent.id}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          ) : null}
+          <div className="flex min-w-0 items-center gap-3 max-md:grid max-md:grid-cols-1">
+            <Badge className="h-9 justify-center border-border/80 bg-card/70 text-muted-foreground">
+              {servers.length} servers / {toolCount} tools
+            </Badge>
+            {props.agents.length > 1 ? (
+              <Select value={selectedAgent?.id ?? ""} onValueChange={props.onSelectAgent}>
+                <SelectTrigger className="h-9 min-h-9 w-64 rounded-sm border-border bg-card/80 font-mono text-xs max-md:w-full">
+                  <SelectValue placeholder="Agent" />
+                </SelectTrigger>
+                <SelectContent align="end">
+                  {props.agents.map((agent) => (
+                    <SelectItem value={agent.id} key={agent.id}>
+                      {agent.name ?? agent.id}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : null}
+          </div>
         </div>
       </header>
 
-      <div className="min-h-0 overflow-auto">
-        {!props.enabled ? (
-          <EmptyState
-            title="MCPs unavailable"
-            message="No registered Studio agent exposes MCP tools."
-          />
-        ) : props.loading ? (
-          <EmptyState title="Loading MCPs" message="Reading registered MCP metadata." />
-        ) : servers.length === 0 ? (
-          <EmptyState title="No MCPs" message="The selected agent has no registered MCP tools." />
-        ) : (
-          <div className="min-w-260 border-b border-border bg-card">
-            <div className="grid min-h-10 grid-cols-[minmax(220px,0.8fr)_120px_minmax(220px,0.8fr)_minmax(320px,1.1fr)_140px_minmax(360px,1.3fr)] items-center gap-4 border-b border-border px-5 font-mono text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-              <span>Server</span>
-              <span>Tools</span>
-              <span>Tool</span>
-              <span>Description</span>
-              <span>Source</span>
-              <span>Parameters</span>
-            </div>
-            {servers.flatMap((server) =>
-              server.tools.map((tool, index) => (
-                <div
-                  className="grid min-h-18 grid-cols-[minmax(220px,0.8fr)_120px_minmax(220px,0.8fr)_minmax(320px,1.1fr)_140px_minmax(360px,1.3fr)] items-start gap-4 border-b border-border px-5 py-3 text-muted-foreground"
-                  key={`${server.name}:${tool.source}:${tool.name}`}
-                >
-                  <span className="grid min-w-0 gap-0.5">
-                    {index === 0 ? (
-                      <>
-                        <strong className="min-w-0 truncate text-sm font-medium text-foreground">
-                          {server.name}
-                        </strong>
-                        <span className="min-w-0 truncate font-mono text-xs font-medium text-muted-foreground">
-                          {server.agentId}
-                        </span>
-                      </>
-                    ) : null}
-                  </span>
-                  <span className="font-mono text-xs font-medium tabular-nums text-muted-foreground">
-                    {index === 0 ? server.toolCount : ""}
-                  </span>
-                  <span className="min-w-0 truncate text-sm font-medium text-foreground">
-                    {tool.name}
-                  </span>
-                  <p className="m-0 min-w-0 text-sm leading-6 text-muted-foreground">
-                    {tool.description}
-                  </p>
-                  <span className="flex min-w-0 flex-wrap gap-1.5">
-                    <Badge className={sourceBadgeClass(tool.source)}>{tool.source}</Badge>
-                  </span>
-                  <span className="min-w-0 overflow-hidden text-xs text-muted-foreground">
-                    <JsonValueView value={tool.parameters} />
-                  </span>
-                </div>
-              )),
-            )}
-          </div>
-        )}
+      <div className="min-h-0 overflow-auto px-6 py-6">
+        <div className="mx-auto grid max-w-[1500px] gap-5">
+          {!props.enabled ? (
+            <EmptyState
+              title="MCPs unavailable"
+              message="No registered Studio agent exposes MCP tools."
+            />
+          ) : props.loading ? (
+            <EmptyState title="Loading MCPs" message="Reading registered MCP metadata." />
+          ) : servers.length === 0 ? (
+            <EmptyState title="No MCPs" message="The selected agent has no registered MCP tools." />
+          ) : (
+            servers.map((server) => <McpServerSection server={server} key={server.name} />)
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function McpServerSection(props: { server: StudioAgentMcpServerMetadata }) {
+  return (
+    <section className="overflow-hidden border border-border/80 bg-card/55 shadow-sm">
+      <header className="grid min-h-14 grid-cols-[minmax(0,1fr)_auto] items-center gap-4 border-b border-border/80 bg-muted/20 px-4">
+        <div className="grid min-w-0 gap-1">
+          <h2 className="m-0 truncate font-mono text-[15px] font-semibold text-foreground">
+            {props.server.name}
+          </h2>
+          <span className="truncate font-mono text-[11px] font-medium text-muted-foreground">
+            {props.server.agentId}
+          </span>
+        </div>
+        <Badge className="border-border/80 bg-background/50 text-muted-foreground">
+          {props.server.toolCount} tools
+        </Badge>
+      </header>
+      <div className="grid divide-y divide-border/70">
+        {props.server.tools.map((tool) => (
+          <McpToolRow tool={tool} key={`${tool.source}:${tool.name}`} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function McpToolRow(props: { tool: StudioAgentMcpToolMetadata }) {
+  return (
+    <article className="grid grid-cols-[minmax(300px,0.75fr)_minmax(0,1fr)] max-lg:grid-cols-1">
+      <div className="grid content-start gap-4 border-r border-border/70 p-4 max-lg:border-b max-lg:border-r-0">
+        <div className="grid gap-1">
+          <h3 className="m-0 truncate font-mono text-[15px] font-semibold text-foreground">
+            {props.tool.name}
+          </h3>
+          <span className="font-mono text-[11px] font-medium text-muted-foreground">
+            {props.tool.source}
+          </span>
+        </div>
+        <p className="m-0 max-w-[62ch] text-sm leading-6 text-muted-foreground">
+          {props.tool.description}
+        </p>
+        <div className="flex min-w-0 flex-wrap gap-2">
+          <Badge className={sourceBadgeClass(props.tool.source)}>{props.tool.source}</Badge>
+          <Badge className="border-border/80 bg-transparent text-muted-foreground">
+            {schemaPropertyCount(props.tool.parameters)} fields
+          </Badge>
+        </div>
+      </div>
+      <SchemaBlock value={props.tool.parameters} />
+    </article>
+  );
+}
+
+function SchemaBlock(props: { value: unknown }) {
+  return (
+    <section className="grid min-w-0 content-start bg-background/35">
+      <div className="flex min-h-9 items-center justify-between gap-3 border-b border-border/70 px-4">
+        <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+          Parameter schema
+        </span>
+        <span className="font-mono text-[10px] text-muted-foreground">
+          {schemaType(props.value)}
+        </span>
+      </div>
+      <div className="min-w-0 overflow-x-auto">
+        <pre className="m-0 max-h-80 min-w-max p-4 font-mono text-[12px] leading-5 text-foreground">
+          <code>{formatSchema(props.value)}</code>
+        </pre>
       </div>
     </section>
   );
@@ -116,9 +160,9 @@ export function McpsPage(props: {
 
 function EmptyState(props: { title: string; message: string }) {
   return (
-    <div className="grid min-h-80 place-items-center px-6 text-center">
+    <div className="grid min-h-80 place-items-center border border-dashed border-border/80 bg-card/35 px-6 text-center">
       <div className="grid max-w-md gap-2">
-        <h2 className="m-0 text-sm font-semibold text-foreground">{props.title}</h2>
+        <h2 className="m-0 text-base font-semibold text-foreground">{props.title}</h2>
         <p className="m-0 text-sm leading-6 text-muted-foreground">{props.message}</p>
       </div>
     </div>
@@ -127,6 +171,32 @@ function EmptyState(props: { title: string; message: string }) {
 
 function sourceBadgeClass(source: "static" | "dynamic"): string {
   return source === "dynamic"
-    ? "border-primary/30 bg-primary/10 text-primary"
-    : "border-border bg-muted text-muted-foreground";
+    ? "border-primary/35 bg-primary/10 text-primary"
+    : "border-border/80 bg-muted/55 text-muted-foreground";
+}
+
+function schemaType(value: unknown): string {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return "value";
+  }
+  const type = (value as { type?: unknown }).type;
+  return typeof type === "string" ? type : "object";
+}
+
+function schemaPropertyCount(value: unknown): number {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return 0;
+  }
+  const properties = (value as { properties?: unknown }).properties;
+  return typeof properties === "object" && properties !== null && !Array.isArray(properties)
+    ? Object.keys(properties).length
+    : 0;
+}
+
+function formatSchema(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
 }

--- a/packages/tools/studio/src/ui/app/modules/mcps/mcps-page.tsx
+++ b/packages/tools/studio/src/ui/app/modules/mcps/mcps-page.tsx
@@ -1,0 +1,132 @@
+import type { StudioAgentMcpsSummary, StudioConfig } from "../../../../types";
+import { Badge } from "../../components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../../components/ui/select";
+import { JsonValueView } from "../shared/renderers";
+
+export function McpsPage(props: {
+  agents: StudioConfig["agents"];
+  selectedAgentId: string;
+  summary: StudioAgentMcpsSummary | undefined;
+  enabled: boolean;
+  loading: boolean;
+  onSelectAgent: (agentId: string) => void;
+}) {
+  const selectedAgent =
+    props.agents.find((agent) => agent.id === props.selectedAgentId) ?? props.agents[0];
+  const servers = props.summary?.servers ?? [];
+
+  return (
+    <section
+      className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden"
+      aria-label="MCPs"
+    >
+      <header className="grid min-h-18 border-b border-border bg-card px-5 py-4">
+        <div className="flex min-w-0 flex-wrap items-center justify-between gap-3">
+          <div className="grid min-w-0 gap-1">
+            <h1 className="m-0 text-sm font-semibold text-foreground">MCPs</h1>
+            <p className="m-0 text-xs font-medium text-muted-foreground">
+              MCP servers and tools registered on Studio agents
+            </p>
+          </div>
+          {props.agents.length > 1 ? (
+            <Select value={selectedAgent?.id ?? ""} onValueChange={props.onSelectAgent}>
+              <SelectTrigger className="h-8 min-h-8 w-56 rounded-sm border-border bg-background font-mono text-xs">
+                <SelectValue placeholder="Agent" />
+              </SelectTrigger>
+              <SelectContent align="end">
+                {props.agents.map((agent) => (
+                  <SelectItem value={agent.id} key={agent.id}>
+                    {agent.name ?? agent.id}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : null}
+        </div>
+      </header>
+
+      <div className="min-h-0 overflow-auto">
+        {!props.enabled ? (
+          <EmptyState
+            title="MCPs unavailable"
+            message="No registered Studio agent exposes MCP tools."
+          />
+        ) : props.loading ? (
+          <EmptyState title="Loading MCPs" message="Reading registered MCP metadata." />
+        ) : servers.length === 0 ? (
+          <EmptyState title="No MCPs" message="The selected agent has no registered MCP tools." />
+        ) : (
+          <div className="min-w-260 border-b border-border bg-card">
+            <div className="grid min-h-10 grid-cols-[minmax(220px,0.8fr)_120px_minmax(220px,0.8fr)_minmax(320px,1.1fr)_140px_minmax(360px,1.3fr)] items-center gap-4 border-b border-border px-5 font-mono text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+              <span>Server</span>
+              <span>Tools</span>
+              <span>Tool</span>
+              <span>Description</span>
+              <span>Source</span>
+              <span>Parameters</span>
+            </div>
+            {servers.flatMap((server) =>
+              server.tools.map((tool, index) => (
+                <div
+                  className="grid min-h-18 grid-cols-[minmax(220px,0.8fr)_120px_minmax(220px,0.8fr)_minmax(320px,1.1fr)_140px_minmax(360px,1.3fr)] items-start gap-4 border-b border-border px-5 py-3 text-muted-foreground"
+                  key={`${server.name}:${tool.source}:${tool.name}`}
+                >
+                  <span className="grid min-w-0 gap-0.5">
+                    {index === 0 ? (
+                      <>
+                        <strong className="min-w-0 truncate text-sm font-medium text-foreground">
+                          {server.name}
+                        </strong>
+                        <span className="min-w-0 truncate font-mono text-xs font-medium text-muted-foreground">
+                          {server.agentId}
+                        </span>
+                      </>
+                    ) : null}
+                  </span>
+                  <span className="font-mono text-xs font-medium tabular-nums text-muted-foreground">
+                    {index === 0 ? server.toolCount : ""}
+                  </span>
+                  <span className="min-w-0 truncate text-sm font-medium text-foreground">
+                    {tool.name}
+                  </span>
+                  <p className="m-0 min-w-0 text-sm leading-6 text-muted-foreground">
+                    {tool.description}
+                  </p>
+                  <span className="flex min-w-0 flex-wrap gap-1.5">
+                    <Badge className={sourceBadgeClass(tool.source)}>{tool.source}</Badge>
+                  </span>
+                  <span className="min-w-0 overflow-hidden text-xs text-muted-foreground">
+                    <JsonValueView value={tool.parameters} />
+                  </span>
+                </div>
+              )),
+            )}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function EmptyState(props: { title: string; message: string }) {
+  return (
+    <div className="grid min-h-80 place-items-center px-6 text-center">
+      <div className="grid max-w-md gap-2">
+        <h2 className="m-0 text-sm font-semibold text-foreground">{props.title}</h2>
+        <p className="m-0 text-sm leading-6 text-muted-foreground">{props.message}</p>
+      </div>
+    </div>
+  );
+}
+
+function sourceBadgeClass(source: "static" | "dynamic"): string {
+  return source === "dynamic"
+    ? "border-primary/30 bg-primary/10 text-primary"
+    : "border-border bg-muted text-muted-foreground";
+}

--- a/packages/tools/studio/src/ui/app/modules/pipelines/pipeline-logs-panel.tsx
+++ b/packages/tools/studio/src/ui/app/modules/pipelines/pipeline-logs-panel.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useRef } from "react";
+import type { StudioPipelineLogEntry } from "../../../../types";
+import { cn } from "../../lib/utils";
+
+export function PipelineLogsPanel(props: {
+  logs: StudioPipelineLogEntry[];
+  selectedPipelineId: string;
+  loading: boolean;
+}) {
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+  const stickToBottomRef = useRef(true);
+
+  useEffect(() => {
+    const node = scrollerRef.current;
+    if (node === null || !stickToBottomRef.current) {
+      return;
+    }
+    node.scrollTop = node.scrollHeight;
+  });
+
+  function updateStickiness() {
+    const node = scrollerRef.current;
+    if (node === null) {
+      return;
+    }
+    stickToBottomRef.current = node.scrollHeight - node.scrollTop - node.clientHeight < 24;
+  }
+
+  return (
+    <aside className="grid min-h-0 min-w-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden border-l border-border/80 bg-background/70 max-xl:hidden">
+      <header className="grid min-h-12 min-w-0 gap-1 border-b border-border/80 bg-card/35 px-5 py-4">
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="m-0 text-sm font-semibold leading-tight text-foreground">Pipeline logs</h2>
+          <span className="font-mono text-[10px] font-semibold tabular-nums text-muted-foreground">
+            {props.logs.length}
+          </span>
+        </div>
+        <p className="m-0 truncate font-mono text-[11px] font-medium text-muted-foreground">
+          {props.selectedPipelineId.length === 0 ? "No active pipeline" : props.selectedPipelineId}
+        </p>
+      </header>
+      <div
+        className="min-h-0 min-w-0 overflow-x-auto overflow-y-auto"
+        ref={scrollerRef}
+        onScroll={updateStickiness}
+      >
+        {props.selectedPipelineId.length === 0 ? (
+          <div className="grid h-full min-h-80 place-items-center p-8 text-center">
+            <div className="max-w-xs">
+              <p className="m-0 text-sm font-semibold text-foreground">No pipeline selected</p>
+              <p className="m-0 mt-2 text-sm leading-6 text-muted-foreground">
+                Register a pipeline to view runtime logs.
+              </p>
+            </div>
+          </div>
+        ) : null}
+        {props.selectedPipelineId.length > 0 && props.loading && props.logs.length === 0 ? (
+          <div className="grid gap-2 px-4 py-4">
+            <div className="h-4 w-32 animate-pulse rounded-sm bg-muted" />
+            <div className="h-4 w-64 animate-pulse rounded-sm bg-muted/60" />
+            <div className="h-4 w-52 animate-pulse rounded-sm bg-muted/60" />
+          </div>
+        ) : null}
+        {props.selectedPipelineId.length > 0 && !props.loading && props.logs.length === 0 ? (
+          <div className="border-b border-border/70 px-5 py-5 text-sm font-medium text-muted-foreground">
+            No logs yet. Run the pipeline to populate this console.
+          </div>
+        ) : null}
+        <div className="grid min-w-full border-t border-border/65 font-mono">
+          {props.logs.map((log) => (
+            <LogRow log={log} key={log.id} />
+          ))}
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+function LogRow(props: { log: StudioPipelineLogEntry }) {
+  const metadata = Object.entries(props.log.metadata ?? {}).slice(0, 6);
+  const metadataText = metadata.map(([key, value]) => `${key}=${formatMetadata(value)}`).join(" ");
+  const line = [
+    formatLogTime(props.log.timestamp),
+    props.log.level.toUpperCase().padEnd(5, " "),
+    `${props.log.category}/${props.log.event}`,
+    props.log.message,
+    metadataText,
+  ]
+    .filter((item) => item.trim().length > 0)
+    .join("  ");
+  return (
+    <article
+      className={cn(
+        "w-max min-w-full whitespace-nowrap border-l-2 px-4 py-1.5 text-[11px] leading-5 transition duration-200 hover:bg-accent/45",
+        levelBorderClass(props.log.level),
+      )}
+      title={line}
+    >
+      <time className="text-muted-foreground">{formatLogTime(props.log.timestamp)}</time>
+      <span className={cn("ml-3 font-semibold", levelTextClass(props.log.level))}>
+        {props.log.level.toUpperCase().padEnd(5, " ")}
+      </span>
+      <span className="ml-3 text-muted-foreground">
+        {props.log.category}/{props.log.event}
+      </span>
+      <span className="ml-3 font-medium text-foreground">{props.log.message}</span>
+      <span className="ml-3 text-muted-foreground/85">{metadataText}</span>
+      <span className="sr-only">{line}</span>
+    </article>
+  );
+}
+
+function formatLogTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+  return date.toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+function formatMetadata(value: unknown): string {
+  if (value === null) {
+    return "null";
+  }
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.length}]`;
+  }
+  if (typeof value === "object" && value !== null) {
+    return "{...}";
+  }
+  return "";
+}
+
+function levelBorderClass(level: StudioPipelineLogEntry["level"]): string {
+  switch (level) {
+    case "error":
+      return "border-destructive";
+    case "warn":
+      return "border-yellow-500";
+    case "debug":
+      return "border-muted-foreground/45";
+    case "info":
+      return "border-primary/70";
+  }
+}
+
+function levelTextClass(level: StudioPipelineLogEntry["level"]): string {
+  switch (level) {
+    case "error":
+      return "text-destructive";
+    case "warn":
+      return "text-yellow-500";
+    case "debug":
+      return "text-muted-foreground";
+    case "info":
+      return "text-primary";
+  }
+}

--- a/packages/tools/studio/src/ui/app/modules/pipelines/pipelines-page.tsx
+++ b/packages/tools/studio/src/ui/app/modules/pipelines/pipelines-page.tsx
@@ -1,0 +1,831 @@
+import {
+  Background,
+  BackgroundVariant,
+  Controls,
+  type Edge,
+  Handle,
+  MarkerType,
+  type Node,
+  type NodeProps,
+  Position,
+  ReactFlow,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { Play } from "lucide-react";
+import { type CSSProperties, useEffect, useMemo, useRef, useState } from "react";
+import type { StudioConfig, StudioPipelineDetail, StudioPipelineLogEntry } from "../../../../types";
+import { Button } from "../../components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../../components/ui/select";
+import { Textarea } from "../../components/ui/textarea";
+
+const nodeTypes = {
+  pipelineStage: PipelineStageNode,
+};
+
+const flowPrimaryColor = "var(--primary)";
+const flowBackgroundColor = "var(--background)";
+const flowMutedForegroundColor = "var(--muted-foreground)";
+const flowDestructiveColor = "var(--destructive)";
+
+export function PipelinesPage(props: {
+  pipelines: StudioConfig["pipelines"];
+  selectedPipelineId: string;
+  detail: StudioPipelineDetail | undefined;
+  logs: StudioPipelineLogEntry[];
+  enabled: boolean;
+  detailLoading: boolean;
+  logsLoading: boolean;
+  runState: "idle" | "running";
+  runInput: string;
+  runOutput: string;
+  onSelectPipeline: (pipelineId: string) => void;
+  onRunInputChange: (value: string) => void;
+  onRun: () => void;
+}) {
+  const [selectedNodeId, setSelectedNodeId] = useState<string | undefined>();
+  const graph = props.detail?.graph;
+  const selectedNode =
+    graph?.nodes.find((node) => node.id === selectedNodeId) ?? graph?.nodes[0] ?? undefined;
+  const nodeStatuses = useMemo(() => nodeStatusFromLogs(props.logs), [props.logs]);
+  const flow = useMemo(() => {
+    if (graph === undefined) {
+      return { nodes: [] as Node[], edges: [] as Edge[] };
+    }
+    return toFlow(graph, nodeStatuses);
+  }, [graph, nodeStatuses]);
+
+  if (!props.enabled) {
+    return (
+      <section className="grid min-h-0 place-items-center p-8 text-center">
+        <div className="grid max-w-lg gap-3">
+          <h1 className="m-0 text-2xl font-semibold text-foreground">Pipelines unavailable</h1>
+          <p className="m-0 text-sm leading-6 text-muted-foreground">
+            This Studio runner has no registered pipelines.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="grid min-h-0 min-w-0 grid-cols-[minmax(0,2fr)_minmax(0,1fr)] overflow-hidden bg-background/45 max-lg:grid-cols-1">
+      <div className="relative min-h-0 min-w-0 overflow-hidden bg-card/25">
+        {props.detailLoading && graph === undefined ? (
+          <div className="grid h-full min-h-96 place-items-center p-6">
+            <div className="grid w-full max-w-lg gap-3">
+              <div className="h-4 w-40 animate-pulse rounded-sm bg-muted" />
+              <div className="h-16 animate-pulse rounded-sm bg-muted/60" />
+              <div className="h-16 w-4/5 animate-pulse rounded-sm bg-muted/60" />
+            </div>
+          </div>
+        ) : null}
+        {!props.detailLoading && graph === undefined ? (
+          <div className="grid h-full min-h-96 place-items-center p-8 text-center">
+            <div className="max-w-sm">
+              <p className="m-0 text-sm font-semibold text-foreground">No pipeline selected</p>
+              <p className="m-0 mt-2 text-sm leading-6 text-muted-foreground">
+                Choose a registered pipeline to inspect its graph and runtime logs.
+              </p>
+            </div>
+          </div>
+        ) : null}
+        {graph !== undefined ? (
+          <ReactFlow
+            nodes={flow.nodes}
+            edges={flow.edges}
+            className="pipeline-flow"
+            style={
+              {
+                "--xy-edge-stroke": "var(--primary)",
+                "--xy-edge-stroke-width": "1.6",
+                "--xy-edge-stroke-selected": "var(--primary)",
+              } as CSSProperties
+            }
+            fitView
+            fitViewOptions={{ padding: 0.18, maxZoom: 0.96 }}
+            minZoom={0.48}
+            maxZoom={1.35}
+            colorMode="dark"
+            nodeTypes={nodeTypes}
+            proOptions={{ hideAttribution: true }}
+            defaultEdgeOptions={{
+              type: "smoothstep",
+              focusable: true,
+            }}
+            onNodeClick={(_, node) => setSelectedNodeId(node.id)}
+          >
+            <Background
+              variant={BackgroundVariant.Dots}
+              gap={14}
+              size={1.8}
+              color={flowMutedForegroundColor}
+              className="opacity-35"
+            />
+            <Controls showInteractive={false} />
+          </ReactFlow>
+        ) : null}
+      </div>
+      <PipelineInspectorSidebar
+        pipelines={props.pipelines}
+        selectedPipelineId={props.selectedPipelineId}
+        detail={props.detail}
+        logs={props.logs}
+        logsLoading={props.logsLoading}
+        runState={props.runState}
+        runInput={props.runInput}
+        runOutput={props.runOutput}
+        selectedNode={selectedNode}
+        selectedNodeStatus={
+          selectedNode?.id === undefined ? undefined : nodeStatuses.get(selectedNode.id)
+        }
+        onSelectPipeline={(pipelineId) => {
+          setSelectedNodeId(undefined);
+          props.onSelectPipeline(pipelineId);
+        }}
+        onRunInputChange={props.onRunInputChange}
+        onRun={props.onRun}
+      />
+    </section>
+  );
+}
+
+function PipelineInspectorSidebar(props: {
+  pipelines: StudioConfig["pipelines"];
+  selectedPipelineId: string;
+  detail: StudioPipelineDetail | undefined;
+  logs: StudioPipelineLogEntry[];
+  logsLoading: boolean;
+  runState: "idle" | "running";
+  runInput: string;
+  runOutput: string;
+  selectedNode: NonNullable<StudioPipelineDetail["graph"]["nodes"][number]> | undefined;
+  selectedNodeStatus: NodeStatus | undefined;
+  onSelectPipeline: (pipelineId: string) => void;
+  onRunInputChange: (value: string) => void;
+  onRun: () => void;
+}) {
+  const [activeTab, setActiveTab] = useState<PipelineSidebarTab>("input");
+  const graph = props.detail?.graph;
+  const graphStats =
+    graph === undefined
+      ? undefined
+      : {
+          nodes: graph.nodes.length,
+          edges: graph.edges.length,
+          agents: graph.nodes.filter((node) => node.kind === "agent").length,
+          extractors: graph.nodes.filter((node) => node.kind === "extractor").length,
+          parallel: graph.nodes.some((node) => node.kind === "parallel") ? "yes" : "no",
+        };
+
+  return (
+    <aside className="grid min-h-0 min-w-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden border-l border-border/80 bg-background/70 max-lg:border-l-0 max-lg:border-t">
+      <header className="grid gap-3 border-b border-border/80 bg-card/35 px-4 py-4">
+        <div className="grid gap-3">
+          <div className="flex min-w-0 items-start justify-between gap-4">
+            <div className="min-w-0">
+              <h1 className="m-0 truncate text-base font-semibold tracking-tight text-foreground">
+                {props.detail?.name ?? "Pipeline"}
+              </h1>
+              {props.detail?.description === undefined ? null : (
+                <p className="m-0 mt-1 line-clamp-2 text-xs leading-5 text-muted-foreground">
+                  {props.detail.description}
+                </p>
+              )}
+            </div>
+            <span className="shrink-0 font-mono text-[10px] font-semibold tabular-nums text-muted-foreground">
+              {props.logs.length}
+            </span>
+          </div>
+          <Select value={props.selectedPipelineId} onValueChange={props.onSelectPipeline}>
+            <SelectTrigger className="h-8 w-full rounded-sm border-border bg-background font-mono text-[11px]">
+              <SelectValue placeholder="Select pipeline" />
+            </SelectTrigger>
+            <SelectContent>
+              {props.pipelines.map((pipeline) => (
+                <SelectItem key={pipeline.id} value={pipeline.id}>
+                  {pipeline.name ?? pipeline.id}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <PipelineSidebarTabs activeTab={activeTab} onChange={setActiveTab} />
+      </header>
+      <div
+        className={[
+          "min-h-0 min-w-0 px-5 py-5",
+          activeTab === "logs" ? "grid overflow-hidden" : "overflow-auto",
+        ].join(" ")}
+      >
+        {activeTab === "input" ? (
+          <PipelineInputPanel
+            runInput={props.runInput}
+            runState={props.runState}
+            disabled={props.detail === undefined}
+            onRunInputChange={props.onRunInputChange}
+            onRun={props.onRun}
+          />
+        ) : null}
+        {activeTab === "metadata" ? (
+          <PipelineMetadataPanel
+            graphStats={graphStats}
+            selectedNode={props.selectedNode}
+            selectedNodeStatus={props.selectedNodeStatus}
+          />
+        ) : null}
+        {activeTab === "runs" ? (
+          <PipelineRunsPanel runOutput={props.runOutput} runState={props.runState} />
+        ) : null}
+        {activeTab === "logs" ? (
+          <PipelineLogsSection
+            logs={props.logs}
+            selectedPipelineId={props.selectedPipelineId}
+            loading={props.logsLoading}
+          />
+        ) : null}
+      </div>
+    </aside>
+  );
+}
+
+type PipelineSidebarTab = "input" | "metadata" | "runs" | "logs";
+
+const pipelineSidebarTabs: Array<{ id: PipelineSidebarTab; label: string }> = [
+  { id: "input", label: "Input" },
+  { id: "metadata", label: "Metadata" },
+  { id: "runs", label: "Runs" },
+  { id: "logs", label: "Logs" },
+];
+
+function PipelineSidebarTabs(props: {
+  activeTab: PipelineSidebarTab;
+  onChange: (tab: PipelineSidebarTab) => void;
+}) {
+  return (
+    <div
+      className="grid grid-cols-4 border border-border/80 bg-background"
+      role="tablist"
+      aria-label="Pipeline sidebar"
+    >
+      {pipelineSidebarTabs.map((tab) => (
+        <button
+          aria-selected={props.activeTab === tab.id}
+          className={[
+            "h-8 border-r border-border/80 px-2 font-mono text-[10px] font-semibold uppercase tracking-[0.1em] transition duration-200 last:border-r-0",
+            props.activeTab === tab.id
+              ? "bg-primary text-primary-foreground"
+              : "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
+          ].join(" ")}
+          key={tab.id}
+          onClick={() => props.onChange(tab.id)}
+          role="tab"
+          type="button"
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function Metric(props: { label: string; value: string }) {
+  return (
+    <div className="min-w-0 border-r border-border/80 px-2.5 py-2.5 last:border-r-0">
+      <div className="truncate font-mono text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+        {props.label}
+      </div>
+      <div className="mt-1 truncate font-mono text-base font-semibold tabular-nums text-foreground">
+        {props.value}
+      </div>
+    </div>
+  );
+}
+
+function PipelineInputPanel(props: {
+  runInput: string;
+  runState: "idle" | "running";
+  disabled: boolean;
+  onRunInputChange: (value: string) => void;
+  onRun: () => void;
+}) {
+  return (
+    <section className="grid gap-4">
+      <div className="flex min-w-0 items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+            Pipeline input
+          </div>
+          <p className="m-0 mt-1 text-xs leading-5 text-muted-foreground">
+            Provide JSON-compatible input for this pipeline run.
+          </p>
+        </div>
+        <Button
+          className="h-8 shrink-0 rounded-sm px-3 text-xs font-semibold"
+          disabled={props.runState === "running" || props.disabled}
+          onClick={props.onRun}
+        >
+          <Play className="mr-1.5 h-3.5 w-3.5" />
+          {props.runState === "running" ? "Running" : "Run"}
+        </Button>
+      </div>
+      <label className="grid gap-2" htmlFor="pipeline-run-input">
+        <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+          JSON
+        </span>
+        <Textarea
+          id="pipeline-run-input"
+          value={props.runInput}
+          onChange={(event) => props.onRunInputChange(event.target.value)}
+          className="min-h-44 resize-y rounded-sm border-border bg-card/30 font-mono text-xs leading-5 text-foreground"
+          spellCheck={false}
+        />
+      </label>
+    </section>
+  );
+}
+
+function PipelineMetadataPanel(props: {
+  graphStats:
+    | {
+        nodes: number;
+        edges: number;
+        agents: number;
+        extractors: number;
+        parallel: string;
+      }
+    | undefined;
+  selectedNode: NonNullable<StudioPipelineDetail["graph"]["nodes"][number]> | undefined;
+  selectedNodeStatus: NodeStatus | undefined;
+}) {
+  return (
+    <section className="grid gap-5">
+      {props.graphStats === undefined ? null : (
+        <div className="grid grid-cols-5 border-y border-border/80">
+          <Metric label="Nodes" value={String(props.graphStats.nodes)} />
+          <Metric label="Edges" value={String(props.graphStats.edges)} />
+          <Metric label="Agents" value={String(props.graphStats.agents)} />
+          <Metric label="Extractors" value={String(props.graphStats.extractors)} />
+          <Metric label="Parallel" value={props.graphStats.parallel} />
+        </div>
+      )}
+      <NodeInspector node={props.selectedNode} status={props.selectedNodeStatus} />
+    </section>
+  );
+}
+
+function PipelineRunsPanel(props: { runOutput: string; runState: "idle" | "running" }) {
+  return (
+    <section className="grid gap-3">
+      <div className="flex min-w-0 items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+            Latest run
+          </div>
+          <p className="m-0 mt-1 text-xs leading-5 text-muted-foreground">
+            Most recent HTTP pipeline output.
+          </p>
+        </div>
+        <Badge>{props.runState}</Badge>
+      </div>
+      <div className="grid gap-2">
+        <div className="flex items-center justify-between gap-3">
+          <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+            Output
+          </span>
+          <span className="font-mono text-[9px] font-medium tabular-nums text-muted-foreground">
+            {props.runOutput.length} bytes
+          </span>
+        </div>
+        <pre className="min-h-52 max-h-[32rem] overflow-auto whitespace-pre-wrap break-words rounded-sm border border-border/80 bg-card/30 p-3 font-mono text-xs leading-5 text-foreground">
+          {props.runOutput.length > 0 ? props.runOutput : "Run the pipeline to inspect output."}
+        </pre>
+      </div>
+    </section>
+  );
+}
+
+function NodeInspector(props: {
+  node: NonNullable<StudioPipelineDetail["graph"]["nodes"][number]> | undefined;
+  status: NodeStatus | undefined;
+}) {
+  if (props.node === undefined) {
+    return (
+      <section className="text-sm font-medium text-muted-foreground">
+        Select a node for details.
+      </section>
+    );
+  }
+
+  const metadata = Object.entries(props.node.metadata ?? {});
+  return (
+    <section className="grid content-start gap-5">
+      <div>
+        <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+          Selected node
+        </div>
+        <h2 className="m-0 mt-2 text-lg font-semibold tracking-tight text-foreground">
+          {props.node.label}
+        </h2>
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          <Badge>{props.node.kind}</Badge>
+          {props.status === undefined ? null : <Badge>{props.status}</Badge>}
+          {props.node.branchKey === undefined ? null : <Badge>{props.node.branchKey}</Badge>}
+        </div>
+      </div>
+      {props.node.description === undefined ? null : (
+        <p className="m-0 border-l border-primary/45 pl-3 text-sm leading-6 text-muted-foreground">
+          {props.node.description}
+        </p>
+      )}
+      <DetailList
+        items={[
+          ["ID", props.node.id],
+          ["Agent", props.node.agentId],
+          ["Pipeline", props.node.pipelineId],
+        ]}
+      />
+      {metadata.length > 0 ? (
+        <div className="grid gap-2">
+          <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+            Metadata
+          </div>
+          <div className="grid gap-1">
+            {metadata.map(([key, value]) => (
+              <div className="grid grid-cols-[82px_minmax(0,1fr)] gap-2 text-xs" key={key}>
+                <span className="truncate font-mono text-muted-foreground">{key}</span>
+                <span className="truncate font-medium text-foreground">
+                  {formatMetadataValue(value)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function PipelineLogsSection(props: {
+  logs: StudioPipelineLogEntry[];
+  selectedPipelineId: string;
+  loading: boolean;
+}) {
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+  const stickToBottomRef = useRef(true);
+
+  useEffect(() => {
+    const node = scrollerRef.current;
+    if (node === null || !stickToBottomRef.current) {
+      return;
+    }
+    node.scrollTop = node.scrollHeight;
+  });
+
+  function updateStickiness() {
+    const node = scrollerRef.current;
+    if (node === null) {
+      return;
+    }
+    stickToBottomRef.current = node.scrollHeight - node.scrollTop - node.clientHeight < 24;
+  }
+
+  return (
+    <section className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-3">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+            Pipeline logs
+          </div>
+          <div className="mt-1 truncate font-mono text-[11px] font-medium text-muted-foreground">
+            {props.selectedPipelineId.length === 0
+              ? "No active pipeline"
+              : props.selectedPipelineId}
+          </div>
+        </div>
+        <span className="font-mono text-[10px] font-semibold tabular-nums text-muted-foreground">
+          {props.logs.length}
+        </span>
+      </div>
+      <div
+        className="min-h-0 overflow-auto border-y border-border/65 font-mono"
+        ref={scrollerRef}
+        onScroll={updateStickiness}
+      >
+        {props.selectedPipelineId.length === 0 ? (
+          <div className="px-0 py-4 text-sm font-medium text-muted-foreground">
+            No pipeline selected.
+          </div>
+        ) : null}
+        {props.selectedPipelineId.length > 0 && props.loading && props.logs.length === 0 ? (
+          <div className="grid gap-2 py-4">
+            <div className="h-4 w-32 animate-pulse rounded-sm bg-muted" />
+            <div className="h-4 w-64 max-w-full animate-pulse rounded-sm bg-muted/60" />
+            <div className="h-4 w-52 max-w-full animate-pulse rounded-sm bg-muted/60" />
+          </div>
+        ) : null}
+        {props.selectedPipelineId.length > 0 && !props.loading && props.logs.length === 0 ? (
+          <div className="py-4 text-sm font-medium text-muted-foreground">
+            No logs yet. Run the pipeline to populate this console.
+          </div>
+        ) : null}
+        {props.logs.map((log) => (
+          <PipelineLogRow log={log} key={log.id} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function PipelineLogRow(props: { log: StudioPipelineLogEntry }) {
+  const metadata = Object.entries(props.log.metadata ?? {}).slice(0, 4);
+  const metadataText = metadata
+    .map(([key, value]) => `${key}=${formatMetadataValue(value)}`)
+    .join(" ");
+  return (
+    <article
+      className={[
+        "w-max min-w-full whitespace-nowrap border-l-2 px-3 py-1.5 text-[11px] leading-5 transition duration-200 hover:bg-accent/45",
+        logLevelBorderClass(props.log.level),
+      ].join(" ")}
+    >
+      <time className="text-muted-foreground">{formatLogTime(props.log.timestamp)}</time>
+      <span className={["ml-3 font-semibold", logLevelTextClass(props.log.level)].join(" ")}>
+        {props.log.level.toUpperCase().padEnd(5, " ")}
+      </span>
+      <span className="ml-3 text-muted-foreground">
+        {props.log.category}/{props.log.event}
+      </span>
+      <span className="ml-3 font-medium text-foreground">{props.log.message}</span>
+      <span className="ml-3 text-muted-foreground/85">{metadataText}</span>
+    </article>
+  );
+}
+
+function DetailList(props: { items: Array<[string, string | undefined]> }) {
+  const items = props.items.filter(([, value]) => value !== undefined && value.length > 0);
+  if (items.length === 0) {
+    return null;
+  }
+  return (
+    <div className="grid gap-2 border-y border-border/80 py-4">
+      {items.map(([label, value]) => (
+        <div className="grid grid-cols-[82px_minmax(0,1fr)] gap-2 text-xs" key={label}>
+          <span className="truncate font-mono text-muted-foreground">{label}</span>
+          <span className="truncate font-medium text-foreground">{value}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function Badge(props: { children: string }) {
+  return (
+    <span className="rounded-sm border border-border/70 bg-background/70 px-2 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+      {props.children}
+    </span>
+  );
+}
+
+type PipelineNodeData = {
+  label: string;
+  kind: StudioPipelineDetail["graph"]["nodes"][number]["kind"];
+  status: NodeStatus | undefined;
+  statusColor: string;
+  branchKey: string | undefined;
+};
+
+function PipelineStageNode(props: NodeProps<Node<PipelineNodeData>>) {
+  const status = props.data.status;
+  return (
+    <article
+      className={[
+        "group relative min-h-[74px] w-[210px] rounded-md border bg-card px-4 py-3 text-left shadow-[inset_0_1px_0_hsl(var(--foreground)/0.06)] transition duration-200",
+        props.selected ? "border-primary" : "border-border/80",
+        status === "running" ? "translate-y-[-1px] border-primary" : "",
+        status === "completed" ? "border-primary/70" : "",
+        status === "failed" ? "border-destructive" : "",
+      ].join(" ")}
+    >
+      <Handle
+        type="target"
+        position={Position.Top}
+        className="!h-0 !w-0 !border-0 !bg-transparent !opacity-0"
+      />
+      <div className="flex min-w-0 items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="truncate text-[13px] font-semibold leading-5 tracking-tight text-foreground">
+            {props.data.label}
+          </div>
+          <div className="mt-1 flex items-center gap-1.5">
+            <span className="h-1.5 w-1.5 rounded-full bg-primary" />
+            <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+              {props.data.kind}
+            </span>
+          </div>
+        </div>
+        {status === undefined ? null : (
+          <span className="rounded-sm border border-border/70 bg-background/70 px-1.5 py-0.5 font-mono text-[9px] font-semibold uppercase tracking-[0.08em] text-primary">
+            {status}
+          </span>
+        )}
+      </div>
+      {props.data.branchKey === undefined ? null : (
+        <div className="mt-2 truncate font-mono text-[10px] text-muted-foreground">
+          branch: {props.data.branchKey}
+        </div>
+      )}
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        className="!h-0 !w-0 !border-0 !bg-transparent !opacity-0"
+      />
+    </article>
+  );
+}
+
+type NodeStatus = "running" | "completed" | "failed";
+
+function nodeStatusFromLogs(logs: StudioPipelineLogEntry[]): Map<string, NodeStatus> {
+  const statuses = new Map<string, NodeStatus>();
+  for (const log of logs) {
+    const nodeId = metadataString(log.metadata, "nodeId");
+    if (nodeId === undefined) {
+      continue;
+    }
+    if (log.event.endsWith(".started")) {
+      statuses.set(nodeId, "running");
+    }
+    if (log.event.endsWith(".completed")) {
+      statuses.set(nodeId, "completed");
+    }
+    if (log.event.endsWith(".failed")) {
+      statuses.set(nodeId, "failed");
+    }
+  }
+  return statuses;
+}
+
+function toFlow(
+  graph: StudioPipelineDetail["graph"],
+  statuses: Map<string, NodeStatus>,
+): { nodes: Node[]; edges: Edge[] } {
+  const depths = nodeDepths(graph);
+  const depthSlots = new Map<number, number>();
+  const depthCounts = new Map<number, number>();
+  for (const depth of depths.values()) {
+    depthCounts.set(depth, (depthCounts.get(depth) ?? 0) + 1);
+  }
+
+  const nodes: Node[] = graph.nodes.map((node) => {
+    const depth = depths.get(node.id) ?? 0;
+    const slot = depthSlots.get(depth) ?? 0;
+    depthSlots.set(depth, slot + 1);
+    const count = depthCounts.get(depth) ?? 1;
+    const status = statuses.get(node.id);
+    return {
+      id: node.id,
+      type: "pipelineStage",
+      position: {
+        x: (slot - (count - 1) / 2) * 280,
+        y: depth * 170,
+      },
+      sourcePosition: Position.Bottom,
+      targetPosition: Position.Top,
+      data: {
+        label: node.label,
+        kind: node.kind,
+        status,
+        statusColor: statusColor(status),
+        branchKey: node.branchKey,
+      },
+    };
+  });
+
+  const edges: Edge[] = graph.edges.map((edge) => ({
+    id: edge.id,
+    source: edge.source,
+    target: edge.target,
+    type: "smoothstep",
+    className: "pipeline-flow-edge",
+    label: edge.label,
+    markerEnd: {
+      type: MarkerType.ArrowClosed,
+      width: 10,
+      height: 10,
+      color: flowPrimaryColor,
+    },
+    style: {
+      stroke: flowPrimaryColor,
+      strokeWidth: 1.6,
+      opacity: 0.78,
+    },
+    labelShowBg: true,
+    labelStyle: {
+      fill: flowMutedForegroundColor,
+      fontSize: 11,
+      fontWeight: 700,
+    },
+    labelBgStyle: {
+      fill: flowBackgroundColor,
+      fillOpacity: 0.92,
+    },
+    labelBgPadding: [6, 4],
+    labelBgBorderRadius: 2,
+  }));
+
+  return { nodes, edges };
+}
+
+function nodeDepths(graph: StudioPipelineDetail["graph"]): Map<string, number> {
+  const depths = new Map<string, number>();
+  for (const node of graph.nodes) {
+    const incoming = graph.edges.filter((edge) => edge.target === node.id);
+    const depth =
+      incoming.length === 0
+        ? 0
+        : Math.max(...incoming.map((edge) => (depths.get(edge.source) ?? 0) + 1));
+    depths.set(node.id, depth);
+  }
+  return depths;
+}
+
+function statusColor(status: NodeStatus | undefined): string {
+  switch (status) {
+    case "running":
+      return flowPrimaryColor;
+    case "completed":
+      return flowPrimaryColor;
+    case "failed":
+      return flowDestructiveColor;
+    default:
+      return flowPrimaryColor;
+  }
+}
+
+function metadataString(
+  metadata: StudioPipelineLogEntry["metadata"],
+  key: string,
+): string | undefined {
+  const value = metadata?.[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function formatLogTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+  return date.toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+function formatMetadataValue(value: unknown): string {
+  if (value === null) {
+    return "null";
+  }
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.length}]`;
+  }
+  if (typeof value === "object" && value !== null) {
+    return "{...}";
+  }
+  return "";
+}
+
+function logLevelBorderClass(level: StudioPipelineLogEntry["level"]): string {
+  switch (level) {
+    case "error":
+      return "border-destructive";
+    case "warn":
+      return "border-muted-foreground";
+    case "debug":
+      return "border-muted-foreground/45";
+    case "info":
+      return "border-primary/70";
+  }
+}
+
+function logLevelTextClass(level: StudioPipelineLogEntry["level"]): string {
+  switch (level) {
+    case "error":
+      return "text-destructive";
+    case "warn":
+      return "text-muted-foreground";
+    case "debug":
+      return "text-muted-foreground";
+    case "info":
+      return "text-primary";
+  }
+}

--- a/packages/tools/studio/src/ui/app/modules/playground/transcript-item.tsx
+++ b/packages/tools/studio/src/ui/app/modules/playground/transcript-item.tsx
@@ -1,4 +1,4 @@
-import { Wrench } from "lucide-react";
+import { Route, Wrench } from "lucide-react";
 import { useState } from "react";
 import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
@@ -58,13 +58,20 @@ export function TranscriptItem(props: {
       <MarkdownText text={props.entry.text} />
       {traceId !== undefined ? (
         <Button
-          className="mt-3 h-auto min-h-0 max-w-full rounded-sm border border-border bg-muted px-2 py-1 font-mono text-xs font-semibold text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+          className="group mt-3 h-auto min-h-0 max-w-full gap-2 rounded-sm border-0 bg-transparent px-0 py-1 font-mono text-xs font-semibold text-muted-foreground shadow-none transition duration-200 hover:bg-transparent hover:text-primary"
           type="button"
           variant="ghost"
           onClick={() => props.onOpenTrace(traceId)}
         >
-          <span className="font-sans">TraceID:</span>
-          <span className="min-w-0 truncate">{traceId}</span>
+          <span className="grid h-5 w-5 shrink-0 place-items-center bg-primary text-background [&_svg]:h-3 [&_svg]:w-3">
+            <Route aria-hidden="true" />
+          </span>
+          <span className="font-sans text-[11px] font-semibold uppercase tracking-[0.16em] text-primary">
+            Trace
+          </span>
+          <span className="min-w-0 truncate border-l border-border/80 pl-2 text-muted-foreground transition-colors group-hover:text-primary">
+            {traceId}
+          </span>
         </Button>
       ) : null}
     </article>

--- a/packages/tools/studio/src/ui/app/modules/playground/transcript-item.tsx
+++ b/packages/tools/studio/src/ui/app/modules/playground/transcript-item.tsx
@@ -48,10 +48,10 @@ export function TranscriptItem(props: {
   return (
     <article
       className={cn(
-        "max-w-[min(78ch,100%)] self-start",
+        "max-w-[min(82ch,100%)] self-start",
         props.entry.role === "assistant" && "justify-self-start text-foreground",
         props.entry.role === "user" &&
-          "w-fit max-w-[min(64ch,82%)] justify-self-end rounded-sm border border-primary/20 bg-primary/10 px-3 py-2 text-foreground",
+          "w-fit max-w-[min(64ch,82%)] justify-self-end rounded-sm bg-primary/10 px-4 py-2.5 text-foreground shadow-sm shadow-primary/10",
       )}
       data-entry-id={String(props.entry.entryId)}
     >
@@ -100,18 +100,18 @@ function ToolEntry(props: {
 
   return (
     <article
-      className="w-full justify-self-start overflow-hidden rounded-sm border border-border bg-card text-foreground"
+      className="w-full justify-self-start overflow-hidden rounded-sm border border-border/80 bg-card/90 text-foreground shadow-sm shadow-black/20"
       data-entry-id={String(props.entry.entryId)}
     >
       <div
         className={cn(
-          "flex min-w-0 items-center gap-2 px-3 py-2",
-          !collapsed && hasPayload && "border-b border-border",
+          "flex min-w-0 items-center gap-2 px-3 py-2.5",
+          !collapsed && hasPayload && "border-b border-border/80",
         )}
       >
         <Button
           aria-expanded={!collapsed}
-          className="h-auto min-h-0 min-w-0 flex-1 justify-between rounded-none border-0 bg-transparent p-0 text-left text-inherit hover:bg-transparent hover:text-inherit"
+          className="h-auto min-h-0 min-w-0 flex-1 justify-between rounded-none border-0 bg-transparent p-0 text-left text-inherit shadow-none hover:bg-transparent hover:text-inherit"
           type="button"
           variant="ghost"
           onClick={() => setCollapsed((current) => !current)}
@@ -186,8 +186,8 @@ function ToolEntry(props: {
 
 function ChildAgentActivity(props: { events: NonNullable<ToolMessage["childEvents"]> }) {
   return (
-    <div className="rounded-sm border border-border bg-background">
-      <div className="border-b border-border px-3 py-2 font-mono text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+    <div className="rounded-sm border border-border/80 bg-background/65">
+      <div className="border-b border-border/80 bg-muted/20 px-3 py-2 font-mono text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
         Subagent activity
       </div>
       <div className="grid gap-3 p-3">
@@ -196,7 +196,7 @@ function ChildAgentActivity(props: { events: NonNullable<ToolMessage["childEvent
           if (event.kind === "message" || event.kind === "reasoning") {
             return (
               <div
-                className="grid gap-1 rounded-sm border border-border bg-card p-3"
+                className="grid gap-1 rounded-sm border border-border/80 bg-card/90 p-3"
                 key={`${event.kind}-${event.agentId}-${event.text}`}
               >
                 <div className="flex min-w-0 items-center gap-2">
@@ -213,7 +213,7 @@ function ChildAgentActivity(props: { events: NonNullable<ToolMessage["childEvent
           }
           return (
             <div
-              className="grid gap-2 rounded-sm border border-border bg-card p-3"
+              className="grid gap-2 rounded-sm border border-border/80 bg-card/90 p-3"
               key={`${event.kind}-${event.agentId}-${event.toolName}-${event.callId ?? event.args ?? event.result ?? ""}`}
             >
               <div className="flex min-w-0 items-center gap-2">
@@ -371,7 +371,7 @@ function QuestionPromptControl(props: {
     submittedAnswer !== undefined ? "Answered" : draftAnswer.length > 0 ? "Ready" : "Waiting";
 
   return (
-    <section className="grid gap-4 rounded-sm border border-border bg-background p-4">
+    <section className="grid gap-4 rounded-sm border border-border/80 bg-background/70 p-4">
       <div className="flex min-w-0 items-start justify-between gap-4">
         <div className="grid min-w-0 gap-2">
           <div className="font-mono text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
@@ -455,7 +455,7 @@ function ToolApprovalPanel(props: {
 }) {
   const pending = props.approval.status === "pending";
   return (
-    <div className="grid gap-3 rounded-sm border border-border bg-muted/40 p-3">
+    <div className="grid gap-3 rounded-sm border border-border/80 bg-muted/35 p-3">
       <div className="flex min-w-0 items-center justify-between gap-3">
         <div className="min-w-0">
           <div className="text-xs font-semibold uppercase text-muted-foreground">Approval</div>

--- a/packages/tools/studio/src/ui/app/modules/session-logs/session-logs-panel.tsx
+++ b/packages/tools/studio/src/ui/app/modules/session-logs/session-logs-panel.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useRef } from "react";
+import type { StudioSessionLogEntry } from "../../../../types";
+import { Badge } from "../../components/ui/badge";
+import { cn } from "../../lib/utils";
+
+export function SessionLogsPanel(props: {
+  logs: StudioSessionLogEntry[];
+  selectedSessionId: string;
+  loading: boolean;
+}) {
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+  const stickToBottomRef = useRef(true);
+
+  useEffect(() => {
+    const node = scrollerRef.current;
+    if (node === null || !stickToBottomRef.current) {
+      return;
+    }
+    node.scrollTop = node.scrollHeight;
+  });
+
+  function updateStickiness() {
+    const node = scrollerRef.current;
+    if (node === null) {
+      return;
+    }
+    stickToBottomRef.current = node.scrollHeight - node.scrollTop - node.clientHeight < 24;
+  }
+
+  return (
+    <aside className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] border-l border-border bg-background max-xl:hidden">
+      <header className="grid min-h-12 gap-1 border-b border-border px-4 py-3">
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="m-0 text-sm font-semibold leading-tight text-foreground">Session logs</h2>
+          <Badge className="font-mono text-[10px] uppercase">{props.logs.length}</Badge>
+        </div>
+        <p className="m-0 truncate font-mono text-[11px] font-medium text-muted-foreground">
+          {props.selectedSessionId.length === 0 ? "No active session" : props.selectedSessionId}
+        </p>
+      </header>
+      <div
+        className="min-h-0 overflow-auto px-3 py-3"
+        ref={scrollerRef}
+        onScroll={updateStickiness}
+      >
+        {props.selectedSessionId.length === 0 ? (
+          <div className="grid h-full min-h-80 place-items-center text-center text-sm font-medium text-muted-foreground">
+            Start or open a session to view runtime logs.
+          </div>
+        ) : null}
+        {props.selectedSessionId.length > 0 && props.loading && props.logs.length === 0 ? (
+          <div className="px-2 py-3 text-sm font-medium text-muted-foreground">Loading logs</div>
+        ) : null}
+        {props.selectedSessionId.length > 0 && !props.loading && props.logs.length === 0 ? (
+          <div className="px-2 py-3 text-sm font-medium text-muted-foreground">No logs yet</div>
+        ) : null}
+        <div className="grid gap-2">
+          {props.logs.map((log) => (
+            <LogRow log={log} key={log.id} />
+          ))}
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+function LogRow(props: { log: StudioSessionLogEntry }) {
+  const metadata = Object.entries(props.log.metadata ?? {}).slice(0, 6);
+  return (
+    <article
+      className={cn(
+        "grid gap-2 border-l-2 bg-card px-3 py-2 text-xs shadow-sm",
+        levelBorderClass(props.log.level),
+      )}
+    >
+      <div className="flex min-w-0 items-start justify-between gap-2">
+        <div className="grid min-w-0 gap-1">
+          <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+            <Badge
+              className={cn("font-mono text-[10px] uppercase", levelBadgeClass(props.log.level))}
+            >
+              {props.log.level}
+            </Badge>
+            <span className="min-w-0 truncate font-mono text-[11px] font-semibold text-muted-foreground">
+              {props.log.category}/{props.log.event}
+            </span>
+          </div>
+          <p className="m-0 text-sm font-medium leading-5 text-foreground">{props.log.message}</p>
+        </div>
+        <time className="shrink-0 font-mono text-[10px] font-medium tabular-nums text-muted-foreground">
+          {formatLogTime(props.log.timestamp)}
+        </time>
+      </div>
+      {metadata.length === 0 ? null : (
+        <div className="flex min-w-0 flex-wrap gap-1">
+          {metadata.map(([key, value]) => (
+            <span
+              className="max-w-full truncate rounded-sm border border-border bg-muted px-1.5 py-0.5 font-mono text-[10px] font-medium text-muted-foreground"
+              key={key}
+              title={`${key}: ${formatMetadata(value)}`}
+            >
+              {key}={formatMetadata(value)}
+            </span>
+          ))}
+        </div>
+      )}
+    </article>
+  );
+}
+
+function formatLogTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+  return date.toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+function formatMetadata(value: unknown): string {
+  if (value === null) {
+    return "null";
+  }
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.length}]`;
+  }
+  if (typeof value === "object" && value !== null) {
+    return "{...}";
+  }
+  return "";
+}
+
+function levelBorderClass(level: StudioSessionLogEntry["level"]): string {
+  switch (level) {
+    case "error":
+      return "border-destructive";
+    case "warn":
+      return "border-yellow-500";
+    case "debug":
+      return "border-muted-foreground/45";
+    case "info":
+      return "border-primary/70";
+  }
+}
+
+function levelBadgeClass(level: StudioSessionLogEntry["level"]): string {
+  switch (level) {
+    case "error":
+      return "border-destructive/40 bg-destructive/15 text-destructive";
+    case "warn":
+      return "border-yellow-500/40 bg-yellow-500/15 text-yellow-500";
+    case "debug":
+      return "border-border bg-muted text-muted-foreground";
+    case "info":
+      return "border-primary/40 bg-primary/15 text-primary";
+  }
+}

--- a/packages/tools/studio/src/ui/app/modules/session-logs/session-logs-panel.tsx
+++ b/packages/tools/studio/src/ui/app/modules/session-logs/session-logs-panel.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef } from "react";
 import type { StudioSessionLogEntry } from "../../../../types";
-import { Badge } from "../../components/ui/badge";
 import { cn } from "../../lib/utils";
 
 export function SessionLogsPanel(props: {
@@ -28,18 +27,20 @@ export function SessionLogsPanel(props: {
   }
 
   return (
-    <aside className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] border-l border-border bg-background max-xl:hidden">
-      <header className="grid min-h-12 gap-1 border-b border-border px-4 py-3">
+    <aside className="grid min-h-0 min-w-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden border-l border-border/80 bg-background/70 max-xl:hidden">
+      <header className="grid min-h-12 min-w-0 gap-1 border-b border-border/80 bg-card/35 px-4 py-3">
         <div className="flex items-center justify-between gap-3">
           <h2 className="m-0 text-sm font-semibold leading-tight text-foreground">Session logs</h2>
-          <Badge className="font-mono text-[10px] uppercase">{props.logs.length}</Badge>
+          <span className="font-mono text-[10px] font-semibold tabular-nums text-muted-foreground">
+            {props.logs.length}
+          </span>
         </div>
         <p className="m-0 truncate font-mono text-[11px] font-medium text-muted-foreground">
           {props.selectedSessionId.length === 0 ? "No active session" : props.selectedSessionId}
         </p>
       </header>
       <div
-        className="min-h-0 overflow-auto px-3 py-3"
+        className="min-h-0 min-w-0 overflow-x-auto overflow-y-auto"
         ref={scrollerRef}
         onScroll={updateStickiness}
       >
@@ -54,7 +55,7 @@ export function SessionLogsPanel(props: {
         {props.selectedSessionId.length > 0 && !props.loading && props.logs.length === 0 ? (
           <div className="px-2 py-3 text-sm font-medium text-muted-foreground">No logs yet</div>
         ) : null}
-        <div className="grid gap-2">
+        <div className="grid min-w-full border-t border-border/65 font-mono">
           {props.logs.map((log) => (
             <LogRow log={log} key={log.id} />
           ))}
@@ -66,44 +67,34 @@ export function SessionLogsPanel(props: {
 
 function LogRow(props: { log: StudioSessionLogEntry }) {
   const metadata = Object.entries(props.log.metadata ?? {}).slice(0, 6);
+  const metadataText = metadata.map(([key, value]) => `${key}=${formatMetadata(value)}`).join(" ");
+  const line = [
+    formatLogTime(props.log.timestamp),
+    props.log.level.toUpperCase().padEnd(5, " "),
+    `${props.log.category}/${props.log.event}`,
+    props.log.message,
+    metadataText,
+  ]
+    .filter((item) => item.trim().length > 0)
+    .join("  ");
   return (
     <article
       className={cn(
-        "grid gap-2 border-l-2 bg-card px-3 py-2 text-xs shadow-sm",
+        "w-max min-w-full whitespace-nowrap border-l-2 px-3 py-1 text-[11px] leading-5 transition duration-200 hover:bg-accent/45",
         levelBorderClass(props.log.level),
       )}
+      title={line}
     >
-      <div className="flex min-w-0 items-start justify-between gap-2">
-        <div className="grid min-w-0 gap-1">
-          <div className="flex min-w-0 flex-wrap items-center gap-1.5">
-            <Badge
-              className={cn("font-mono text-[10px] uppercase", levelBadgeClass(props.log.level))}
-            >
-              {props.log.level}
-            </Badge>
-            <span className="min-w-0 truncate font-mono text-[11px] font-semibold text-muted-foreground">
-              {props.log.category}/{props.log.event}
-            </span>
-          </div>
-          <p className="m-0 text-sm font-medium leading-5 text-foreground">{props.log.message}</p>
-        </div>
-        <time className="shrink-0 font-mono text-[10px] font-medium tabular-nums text-muted-foreground">
-          {formatLogTime(props.log.timestamp)}
-        </time>
-      </div>
-      {metadata.length === 0 ? null : (
-        <div className="flex min-w-0 flex-wrap gap-1">
-          {metadata.map(([key, value]) => (
-            <span
-              className="max-w-full truncate rounded-sm border border-border bg-muted px-1.5 py-0.5 font-mono text-[10px] font-medium text-muted-foreground"
-              key={key}
-              title={`${key}: ${formatMetadata(value)}`}
-            >
-              {key}={formatMetadata(value)}
-            </span>
-          ))}
-        </div>
-      )}
+      <time className="text-muted-foreground">{formatLogTime(props.log.timestamp)}</time>
+      <span className={cn("ml-3 font-semibold", levelTextClass(props.log.level))}>
+        {props.log.level.toUpperCase().padEnd(5, " ")}
+      </span>
+      <span className="ml-3 text-muted-foreground">
+        {props.log.category}/{props.log.event}
+      </span>
+      <span className="ml-3 font-medium text-foreground">{props.log.message}</span>
+      <span className="ml-3 text-muted-foreground/85">{metadataText}</span>
+      <span className="sr-only">{line}</span>
     </article>
   );
 }
@@ -149,15 +140,15 @@ function levelBorderClass(level: StudioSessionLogEntry["level"]): string {
   }
 }
 
-function levelBadgeClass(level: StudioSessionLogEntry["level"]): string {
+function levelTextClass(level: StudioSessionLogEntry["level"]): string {
   switch (level) {
     case "error":
-      return "border-destructive/40 bg-destructive/15 text-destructive";
+      return "text-destructive";
     case "warn":
-      return "border-yellow-500/40 bg-yellow-500/15 text-yellow-500";
+      return "text-yellow-500";
     case "debug":
-      return "border-border bg-muted text-muted-foreground";
+      return "text-muted-foreground";
     case "info":
-      return "border-primary/40 bg-primary/15 text-primary";
+      return "text-primary";
   }
 }

--- a/packages/tools/studio/src/ui/app/modules/sessions/sessions-page.tsx
+++ b/packages/tools/studio/src/ui/app/modules/sessions/sessions-page.tsx
@@ -33,8 +33,8 @@ export function SessionsPage(props: {
 
   return (
     <section className="grid min-h-0 w-full overflow-auto" aria-label="Sessions">
-      <div className="min-w-225 border-b border-border bg-card">
-        <div className="grid min-h-10 grid-cols-[minmax(220px,1.3fr)_180px_120px_120px_72px] items-center gap-4 border-b border-border px-5 font-mono text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+      <div className="min-w-225 border-b border-border/80 bg-card/80 shadow-sm">
+        <div className="sticky top-0 z-10 grid min-h-11 grid-cols-[minmax(220px,1.3fr)_180px_120px_120px_72px] items-center gap-4 border-b border-border/80 bg-card/95 px-6 font-mono text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground backdrop-blur">
           <span>Session</span>
           <span>Agent</span>
           <span>Messages</span>
@@ -52,13 +52,14 @@ export function SessionsPage(props: {
         {props.sessions.map((session) => (
           <div
             className={cn(
-              "grid min-h-14 w-full min-w-0 grid-cols-[minmax(220px,1.3fr)_180px_120px_120px_72px] items-center gap-4 border-b border-border px-5 text-left text-muted-foreground hover:bg-accent hover:text-accent-foreground",
-              session.id === props.selectedSessionId && "bg-primary/10 text-primary",
+              "grid min-h-14 w-full min-w-0 grid-cols-[minmax(220px,1.3fr)_180px_120px_120px_72px] items-center gap-4 border-b border-border/75 px-6 text-left text-muted-foreground transition duration-200 hover:border-primary/20 hover:bg-accent/80 hover:text-accent-foreground",
+              session.id === props.selectedSessionId &&
+                "border-l border-l-primary bg-primary/10 text-primary",
             )}
             key={session.id}
           >
             <Button
-              className="col-span-4 grid h-full min-h-14 min-w-0 grid-cols-[minmax(220px,1.3fr)_180px_120px_120px] items-center justify-start gap-4 rounded-none border-0 bg-transparent p-0 text-left text-inherit hover:bg-transparent hover:text-inherit"
+              className="col-span-4 grid h-full min-h-14 min-w-0 grid-cols-[minmax(220px,1.3fr)_180px_120px_120px] items-center justify-start gap-4 rounded-none border-0 bg-transparent p-0 text-left text-inherit shadow-none hover:bg-transparent hover:text-inherit"
               type="button"
               variant="ghost"
               onClick={() => props.onOpenSession(session.id)}

--- a/packages/tools/studio/src/ui/app/modules/shared/format.ts
+++ b/packages/tools/studio/src/ui/app/modules/shared/format.ts
@@ -81,6 +81,8 @@ export function pageTitle(page: ActivePage, agentName: string | undefined): stri
       return "Tools";
     case "mcps":
       return "MCPs";
+    case "pipelines":
+      return "Pipelines";
     case "knowledge":
       return "Knowledge";
     case "playground":

--- a/packages/tools/studio/src/ui/app/modules/shared/format.ts
+++ b/packages/tools/studio/src/ui/app/modules/shared/format.ts
@@ -77,6 +77,10 @@ export function pageTitle(page: ActivePage, agentName: string | undefined): stri
       return "Sessions";
     case "tracing":
       return "Traces";
+    case "tools":
+      return "Tools";
+    case "mcps":
+      return "MCPs";
     case "knowledge":
       return "Knowledge";
     case "playground":

--- a/packages/tools/studio/src/ui/app/modules/shared/path.ts
+++ b/packages/tools/studio/src/ui/app/modules/shared/path.ts
@@ -72,6 +72,12 @@ function pageLocationFromSegments(segments: string[]): PageLocation {
   if (first === "agents") {
     return { page: "agents" };
   }
+  if (first === "tools") {
+    return { page: "tools" };
+  }
+  if (first === "mcps") {
+    return { page: "mcps" };
+  }
   if (first === "knowledge") {
     return { page: "knowledge" };
   }
@@ -92,7 +98,11 @@ export function updatePagePath(page: ActivePage): void {
   const normalizedCompatUiPath = normalizePathPrefix(compatUiPath) || "/ui";
   if (
     normalizedUiPath.length === 0 &&
-    (page === "sessions" || page === "agents" || page === "knowledge")
+    (page === "sessions" ||
+      page === "agents" ||
+      page === "tools" ||
+      page === "mcps" ||
+      page === "knowledge")
   ) {
     updateLocationPath(`${normalizedCompatUiPath}/${page}`);
     return;

--- a/packages/tools/studio/src/ui/app/modules/shared/path.ts
+++ b/packages/tools/studio/src/ui/app/modules/shared/path.ts
@@ -78,6 +78,9 @@ function pageLocationFromSegments(segments: string[]): PageLocation {
   if (first === "mcps") {
     return { page: "mcps" };
   }
+  if (first === "pipelines") {
+    return { page: "pipelines" };
+  }
   if (first === "knowledge") {
     return { page: "knowledge" };
   }
@@ -102,6 +105,7 @@ export function updatePagePath(page: ActivePage): void {
       page === "agents" ||
       page === "tools" ||
       page === "mcps" ||
+      page === "pipelines" ||
       page === "knowledge")
   ) {
     updateLocationPath(`${normalizedCompatUiPath}/${page}`);

--- a/packages/tools/studio/src/ui/app/modules/shared/renderers.tsx
+++ b/packages/tools/studio/src/ui/app/modules/shared/renderers.tsx
@@ -7,12 +7,12 @@ import { isRecord } from "./object";
 
 export function MarkdownText(props: { text: string }) {
   return (
-    <div className="prose prose-sm max-w-none text-current [overflow-wrap:anywhere] prose-headings:text-current prose-headings:font-semibold prose-p:text-current prose-a:text-current prose-a:decoration-muted-foreground prose-a:underline-offset-2 prose-strong:text-current prose-code:rounded-sm prose-code:border prose-code:border-border prose-code:bg-muted prose-code:px-1 prose-code:py-0.5 prose-code:text-[0.92em] prose-code:font-semibold prose-code:text-current prose-code:before:content-none prose-code:after:content-none prose-pre:overflow-auto prose-pre:rounded-sm prose-pre:border prose-pre:border-border prose-pre:bg-card prose-pre:text-current prose-blockquote:border-border prose-blockquote:text-muted-foreground prose-li:marker:text-muted-foreground prose-hr:border-border prose-table:m-0 prose-thead:border-0 prose-tr:border-0 prose-th:p-0 prose-td:p-0 dark:prose-invert dark:prose-headings:text-current dark:prose-p:text-current dark:prose-strong:text-current dark:prose-code:text-current dark:prose-pre:bg-card dark:prose-pre:text-current">
+    <div className="prose prose-sm max-w-none text-current [overflow-wrap:anywhere] prose-headings:text-current prose-headings:font-semibold prose-p:text-current prose-p:leading-7 prose-a:text-current prose-a:decoration-muted-foreground prose-a:underline-offset-2 prose-strong:text-current prose-code:rounded-sm prose-code:border prose-code:border-border/80 prose-code:bg-muted/80 prose-code:px-1 prose-code:py-0.5 prose-code:text-[0.92em] prose-code:font-semibold prose-code:text-current prose-code:before:content-none prose-code:after:content-none prose-pre:overflow-auto prose-pre:rounded-sm prose-pre:border prose-pre:border-border/80 prose-pre:bg-card/90 prose-pre:text-current prose-blockquote:border-border prose-blockquote:text-muted-foreground prose-li:marker:text-muted-foreground prose-hr:border-border prose-table:m-0 prose-thead:border-0 prose-tr:border-0 prose-th:p-0 prose-td:p-0 dark:prose-invert dark:prose-headings:text-current dark:prose-p:text-current dark:prose-strong:text-current dark:prose-code:text-current dark:prose-pre:bg-card dark:prose-pre:text-current">
       <ReactMarkdown
         components={{
           table({ children }) {
             return (
-              <div className="my-4 min-w-0 overflow-hidden rounded-sm border border-border bg-card">
+              <div className="my-4 min-w-0 overflow-hidden rounded-sm border border-border/80 bg-card/90 shadow-sm">
                 <div className="min-w-0 overflow-x-auto">
                   <table className="m-0 w-full min-w-130 border-separate border-spacing-0 text-left text-sm">
                     {children}
@@ -63,9 +63,9 @@ export function ToolPayload(props: { title: string; value: string }) {
   const display = toolPayloadDisplay(props.value);
 
   return (
-    <section className="overflow-hidden rounded-sm border border-border bg-background">
-      <div className="flex min-h-9 items-center gap-3 border-b border-border px-3">
-        <div className="font-mono text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+    <section className="overflow-hidden rounded-sm border border-border/80 bg-background/70">
+      <div className="flex min-h-9 items-center gap-3 border-b border-border/80 bg-muted/20 px-3">
+        <div className="font-mono text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
           {props.title}
         </div>
       </div>

--- a/packages/tools/studio/src/ui/app/modules/shared/types.ts
+++ b/packages/tools/studio/src/ui/app/modules/shared/types.ts
@@ -24,6 +24,7 @@ export type ActivePage =
   | "agents"
   | "tools"
   | "mcps"
+  | "pipelines"
   | "knowledge";
 export type TraceStatusFilter = "all" | StudioTrace["status"];
 export type TraceInspectorKey = "trace" | "agent" | `turn:${number}` | `observation:${string}`;

--- a/packages/tools/studio/src/ui/app/modules/shared/types.ts
+++ b/packages/tools/studio/src/ui/app/modules/shared/types.ts
@@ -17,7 +17,14 @@ export type TraceObservationItem = StudioTrace["observations"][number];
 export type RunState = "idle" | "running";
 export type SessionLoadState = "idle" | "loading";
 export type TraceLoadState = "idle" | "loading";
-export type ActivePage = "playground" | "tracing" | "sessions" | "agents" | "knowledge";
+export type ActivePage =
+  | "playground"
+  | "tracing"
+  | "sessions"
+  | "agents"
+  | "tools"
+  | "mcps"
+  | "knowledge";
 export type TraceStatusFilter = "all" | StudioTrace["status"];
 export type TraceInspectorKey = "trace" | "agent" | `turn:${number}` | `observation:${string}`;
 export type PageLocation = {

--- a/packages/tools/studio/src/ui/app/modules/shell/nav-button.tsx
+++ b/packages/tools/studio/src/ui/app/modules/shell/nav-button.tsx
@@ -5,7 +5,9 @@ import {
   List,
   type LucideIcon,
   MessageSquare,
+  Plug,
   ShieldCheck,
+  Wrench,
 } from "lucide-react";
 import { Button } from "../../components/ui/button";
 import { cn } from "../../lib/utils";
@@ -36,7 +38,7 @@ export function NavButton(props: {
   );
 }
 
-type IconName = "activity" | "bot" | "database" | "list" | "message" | "shield";
+type IconName = "activity" | "bot" | "database" | "list" | "message" | "plug" | "shield" | "wrench";
 
 function navIcon(name: IconName): LucideIcon {
   switch (name) {
@@ -50,7 +52,11 @@ function navIcon(name: IconName): LucideIcon {
       return List;
     case "message":
       return MessageSquare;
+    case "plug":
+      return Plug;
     case "shield":
       return ShieldCheck;
+    case "wrench":
+      return Wrench;
   }
 }

--- a/packages/tools/studio/src/ui/app/modules/shell/nav-button.tsx
+++ b/packages/tools/studio/src/ui/app/modules/shell/nav-button.tsx
@@ -23,9 +23,9 @@ export function NavButton(props: {
   return (
     <Button
       className={cn(
-        "h-8 min-h-8 w-full justify-start gap-3 rounded-sm border-0 bg-transparent px-2 text-sm font-medium text-sidebar-foreground/66 hover:bg-sidebar-accent hover:text-sidebar-foreground [&_svg]:h-3.5 [&_svg]:w-3.5",
+        "h-8 min-h-8 w-full justify-start gap-3 rounded-sm border border-transparent bg-transparent px-2 text-sm font-medium text-sidebar-foreground/62 shadow-none hover:border-sidebar-border hover:bg-sidebar-accent hover:text-sidebar-foreground [&_svg]:h-3.5 [&_svg]:w-3.5",
         props.active &&
-          "bg-sidebar-accent text-sidebar-accent-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+          "border-sidebar-border bg-sidebar-accent text-sidebar-accent-foreground hover:border-sidebar-border hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
       )}
       variant="ghost"
       type="button"

--- a/packages/tools/studio/src/ui/app/modules/shell/nav-button.tsx
+++ b/packages/tools/studio/src/ui/app/modules/shell/nav-button.tsx
@@ -7,6 +7,7 @@ import {
   MessageSquare,
   Plug,
   ShieldCheck,
+  Workflow,
   Wrench,
 } from "lucide-react";
 import { Button } from "../../components/ui/button";
@@ -38,7 +39,16 @@ export function NavButton(props: {
   );
 }
 
-type IconName = "activity" | "bot" | "database" | "list" | "message" | "plug" | "shield" | "wrench";
+type IconName =
+  | "activity"
+  | "bot"
+  | "database"
+  | "list"
+  | "message"
+  | "plug"
+  | "shield"
+  | "wrench"
+  | "workflow";
 
 function navIcon(name: IconName): LucideIcon {
   switch (name) {
@@ -58,5 +68,7 @@ function navIcon(name: IconName): LucideIcon {
       return ShieldCheck;
     case "wrench":
       return Wrench;
+    case "workflow":
+      return Workflow;
   }
 }

--- a/packages/tools/studio/src/ui/app/modules/tools/tools-page.tsx
+++ b/packages/tools/studio/src/ui/app/modules/tools/tools-page.tsx
@@ -1,0 +1,137 @@
+import type { StudioAgentToolsSummary, StudioConfig } from "../../../../types";
+import { Badge } from "../../components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../../components/ui/select";
+import { cn } from "../../lib/utils";
+import { JsonValueView } from "../shared/renderers";
+
+export function ToolsPage(props: {
+  agents: StudioConfig["agents"];
+  selectedAgentId: string;
+  summary: StudioAgentToolsSummary | undefined;
+  enabled: boolean;
+  loading: boolean;
+  onSelectAgent: (agentId: string) => void;
+}) {
+  const selectedAgent =
+    props.agents.find((agent) => agent.id === props.selectedAgentId) ?? props.agents[0];
+  const tools = props.summary?.tools ?? [];
+
+  return (
+    <section
+      className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden"
+      aria-label="Tools"
+    >
+      <header className="grid min-h-18 border-b border-border bg-card px-5 py-4">
+        <div className="flex min-w-0 flex-wrap items-center justify-between gap-3">
+          <div className="grid min-w-0 gap-1">
+            <h1 className="m-0 text-sm font-semibold text-foreground">Tools</h1>
+            <p className="m-0 text-xs font-medium text-muted-foreground">
+              Tool definitions registered on Studio agents
+            </p>
+          </div>
+          {props.agents.length > 1 ? (
+            <Select value={selectedAgent?.id ?? ""} onValueChange={props.onSelectAgent}>
+              <SelectTrigger className="h-8 min-h-8 w-56 rounded-sm border-border bg-background font-mono text-xs">
+                <SelectValue placeholder="Agent" />
+              </SelectTrigger>
+              <SelectContent align="end">
+                {props.agents.map((agent) => (
+                  <SelectItem value={agent.id} key={agent.id}>
+                    {agent.name ?? agent.id}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : null}
+        </div>
+      </header>
+
+      <div className="min-h-0 overflow-auto">
+        {!props.enabled ? (
+          <EmptyState
+            title="Tools unavailable"
+            message="No registered Studio agent exposes static or dynamic tools."
+          />
+        ) : props.loading ? (
+          <EmptyState title="Loading tools" message="Reading registered tool metadata." />
+        ) : tools.length === 0 ? (
+          <EmptyState title="No tools" message="The selected agent has no registered tools." />
+        ) : (
+          <div className="min-w-260 border-b border-border bg-card">
+            <div className="grid min-h-10 grid-cols-[minmax(220px,0.9fr)_minmax(300px,1.2fr)_150px_150px_minmax(360px,1.4fr)] items-center gap-4 border-b border-border px-5 font-mono text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+              <span>Tool</span>
+              <span>Description</span>
+              <span>Source</span>
+              <span>Approval</span>
+              <span>Parameters</span>
+            </div>
+            {tools.map((tool) => (
+              <div
+                className="grid min-h-18 grid-cols-[minmax(220px,0.9fr)_minmax(300px,1.2fr)_150px_150px_minmax(360px,1.4fr)] items-start gap-4 border-b border-border px-5 py-3 text-muted-foreground"
+                key={`${tool.source}:${tool.name}`}
+              >
+                <span className="grid min-w-0 gap-0.5">
+                  <strong className="min-w-0 truncate text-sm font-medium text-foreground">
+                    {tool.name}
+                  </strong>
+                  <span className="min-w-0 truncate font-mono text-xs font-medium text-muted-foreground">
+                    {tool.agentId}
+                  </span>
+                </span>
+                <p className="m-0 min-w-0 text-sm leading-6 text-muted-foreground">
+                  {tool.description}
+                </p>
+                <span className="flex min-w-0 flex-wrap gap-1.5">
+                  <Badge className={sourceBadgeClass(tool.source)}>{tool.source}</Badge>
+                </span>
+                <span className="grid min-w-0 gap-1.5">
+                  <Badge
+                    className={cn(
+                      "w-fit",
+                      tool.approval.required
+                        ? "border-primary/30 bg-primary/10 text-primary"
+                        : "border-border bg-muted text-muted-foreground",
+                    )}
+                  >
+                    {tool.approval.required ? "required" : "none"}
+                  </Badge>
+                  {tool.approval.reason === undefined ? null : (
+                    <span className="text-xs leading-5 text-muted-foreground">
+                      {tool.approval.reason}
+                    </span>
+                  )}
+                </span>
+                <span className="min-w-0 overflow-hidden text-xs text-muted-foreground">
+                  <JsonValueView value={tool.parameters} />
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function EmptyState(props: { title: string; message: string }) {
+  return (
+    <div className="grid min-h-80 place-items-center px-6 text-center">
+      <div className="grid max-w-md gap-2">
+        <h2 className="m-0 text-sm font-semibold text-foreground">{props.title}</h2>
+        <p className="m-0 text-sm leading-6 text-muted-foreground">{props.message}</p>
+      </div>
+    </div>
+  );
+}
+
+function sourceBadgeClass(source: "static" | "dynamic"): string {
+  return source === "dynamic"
+    ? "border-primary/30 bg-primary/10 text-primary"
+    : "border-border bg-muted text-muted-foreground";
+}

--- a/packages/tools/studio/src/ui/app/modules/tools/tools-page.tsx
+++ b/packages/tools/studio/src/ui/app/modules/tools/tools-page.tsx
@@ -1,4 +1,8 @@
-import type { StudioAgentToolsSummary, StudioConfig } from "../../../../types";
+import type {
+  StudioAgentToolMetadata,
+  StudioAgentToolsSummary,
+  StudioConfig,
+} from "../../../../types";
 import { Badge } from "../../components/ui/badge";
 import {
   Select,
@@ -8,7 +12,6 @@ import {
   SelectValue,
 } from "../../components/ui/select";
 import { cn } from "../../lib/utils";
-import { JsonValueView } from "../shared/renderers";
 
 export function ToolsPage(props: {
   agents: StudioConfig["agents"];
@@ -24,20 +27,26 @@ export function ToolsPage(props: {
 
   return (
     <section
-      className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden"
+      className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden bg-background/55"
       aria-label="Tools"
     >
-      <header className="grid min-h-18 border-b border-border bg-card px-5 py-4">
-        <div className="flex min-w-0 flex-wrap items-center justify-between gap-3">
-          <div className="grid min-w-0 gap-1">
-            <h1 className="m-0 text-sm font-semibold text-foreground">Tools</h1>
-            <p className="m-0 text-xs font-medium text-muted-foreground">
-              Tool definitions registered on Studio agents
+      <header className="border-b border-border/80 bg-background/70 px-6 py-5 backdrop-blur">
+        <div className="mx-auto grid max-w-[1500px] grid-cols-[minmax(0,1fr)_auto] items-end gap-4 max-md:grid-cols-1">
+          <div className="grid min-w-0 gap-2">
+            <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.24em] text-primary">
+              Agent capabilities
+            </div>
+            <h1 className="m-0 text-2xl font-semibold leading-none tracking-tight text-foreground">
+              Tools
+            </h1>
+            <p className="m-0 max-w-[62ch] text-sm leading-6 text-muted-foreground">
+              Tool definitions registered on Studio agents, including approval policy and input
+              schema.
             </p>
           </div>
           {props.agents.length > 1 ? (
             <Select value={selectedAgent?.id ?? ""} onValueChange={props.onSelectAgent}>
-              <SelectTrigger className="h-8 min-h-8 w-56 rounded-sm border-border bg-background font-mono text-xs">
+              <SelectTrigger className="h-9 min-h-9 w-64 rounded-sm border-border bg-card/80 font-mono text-xs max-md:w-full">
                 <SelectValue placeholder="Agent" />
               </SelectTrigger>
               <SelectContent align="end">
@@ -52,68 +61,91 @@ export function ToolsPage(props: {
         </div>
       </header>
 
-      <div className="min-h-0 overflow-auto">
-        {!props.enabled ? (
-          <EmptyState
-            title="Tools unavailable"
-            message="No registered Studio agent exposes static or dynamic tools."
-          />
-        ) : props.loading ? (
-          <EmptyState title="Loading tools" message="Reading registered tool metadata." />
-        ) : tools.length === 0 ? (
-          <EmptyState title="No tools" message="The selected agent has no registered tools." />
-        ) : (
-          <div className="min-w-260 border-b border-border bg-card">
-            <div className="grid min-h-10 grid-cols-[minmax(220px,0.9fr)_minmax(300px,1.2fr)_150px_150px_minmax(360px,1.4fr)] items-center gap-4 border-b border-border px-5 font-mono text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-              <span>Tool</span>
-              <span>Description</span>
-              <span>Source</span>
-              <span>Approval</span>
-              <span>Parameters</span>
-            </div>
-            {tools.map((tool) => (
-              <div
-                className="grid min-h-18 grid-cols-[minmax(220px,0.9fr)_minmax(300px,1.2fr)_150px_150px_minmax(360px,1.4fr)] items-start gap-4 border-b border-border px-5 py-3 text-muted-foreground"
-                key={`${tool.source}:${tool.name}`}
-              >
-                <span className="grid min-w-0 gap-0.5">
-                  <strong className="min-w-0 truncate text-sm font-medium text-foreground">
-                    {tool.name}
-                  </strong>
-                  <span className="min-w-0 truncate font-mono text-xs font-medium text-muted-foreground">
-                    {tool.agentId}
-                  </span>
-                </span>
-                <p className="m-0 min-w-0 text-sm leading-6 text-muted-foreground">
-                  {tool.description}
-                </p>
-                <span className="flex min-w-0 flex-wrap gap-1.5">
-                  <Badge className={sourceBadgeClass(tool.source)}>{tool.source}</Badge>
-                </span>
-                <span className="grid min-w-0 gap-1.5">
-                  <Badge
-                    className={cn(
-                      "w-fit",
-                      tool.approval.required
-                        ? "border-primary/30 bg-primary/10 text-primary"
-                        : "border-border bg-muted text-muted-foreground",
-                    )}
-                  >
-                    {tool.approval.required ? "required" : "none"}
-                  </Badge>
-                  {tool.approval.reason === undefined ? null : (
-                    <span className="text-xs leading-5 text-muted-foreground">
-                      {tool.approval.reason}
-                    </span>
-                  )}
-                </span>
-                <span className="min-w-0 overflow-hidden text-xs text-muted-foreground">
-                  <JsonValueView value={tool.parameters} />
-                </span>
+      <div className="min-h-0 overflow-auto px-6 py-6">
+        <div className="mx-auto grid max-w-[1500px] gap-4">
+          {!props.enabled ? (
+            <EmptyState
+              title="Tools unavailable"
+              message="No registered Studio agent exposes static or dynamic tools."
+            />
+          ) : props.loading ? (
+            <EmptyState title="Loading tools" message="Reading registered tool metadata." />
+          ) : tools.length === 0 ? (
+            <EmptyState title="No tools" message="The selected agent has no registered tools." />
+          ) : (
+            <div className="grid overflow-hidden border border-border/80 bg-card/55 shadow-sm">
+              <div className="grid min-h-10 grid-cols-[minmax(260px,0.75fr)_minmax(0,1fr)] items-center border-b border-border/80 bg-muted/20 px-4 font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground max-lg:hidden">
+                <span>Definition</span>
+                <span>Parameter schema</span>
               </div>
-            ))}
-          </div>
+              {tools.map((tool) => (
+                <ToolDefinitionRow tool={tool} key={`${tool.source}:${tool.name}`} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ToolDefinitionRow(props: { tool: StudioAgentToolMetadata }) {
+  const propertyCount = schemaPropertyCount(props.tool.parameters);
+  return (
+    <article className="grid grid-cols-[minmax(300px,0.75fr)_minmax(0,1fr)] border-b border-border/70 last:border-b-0 max-lg:grid-cols-1">
+      <div className="grid content-start gap-4 border-r border-border/70 p-4 max-lg:border-b max-lg:border-r-0">
+        <div className="grid gap-1">
+          <h2 className="m-0 truncate font-mono text-[15px] font-semibold text-foreground">
+            {props.tool.name}
+          </h2>
+          <span className="truncate font-mono text-[11px] font-medium text-muted-foreground">
+            {props.tool.agentId}
+          </span>
+        </div>
+        <p className="m-0 max-w-[62ch] text-sm leading-6 text-muted-foreground">
+          {props.tool.description}
+        </p>
+        <div className="flex min-w-0 flex-wrap gap-2">
+          <Badge className={sourceBadgeClass(props.tool.source)}>{props.tool.source}</Badge>
+          <Badge
+            className={cn(
+              props.tool.approval.required
+                ? "border-primary/35 bg-primary/10 text-primary"
+                : "border-border/80 bg-muted/55 text-muted-foreground",
+            )}
+          >
+            approval {props.tool.approval.required ? "required" : "none"}
+          </Badge>
+          <Badge className="border-border/80 bg-transparent text-muted-foreground">
+            {propertyCount} {propertyCount === 1 ? "field" : "fields"}
+          </Badge>
+        </div>
+        {props.tool.approval.reason === undefined ? null : (
+          <p className="m-0 border-l border-primary/40 pl-3 text-xs leading-5 text-muted-foreground">
+            {props.tool.approval.reason}
+          </p>
         )}
+      </div>
+      <SchemaBlock value={props.tool.parameters} />
+    </article>
+  );
+}
+
+function SchemaBlock(props: { value: unknown }) {
+  return (
+    <section className="grid min-w-0 content-start bg-background/35">
+      <div className="flex min-h-9 items-center justify-between gap-3 border-b border-border/70 px-4">
+        <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+          JSON schema
+        </span>
+        <span className="font-mono text-[10px] text-muted-foreground">
+          {schemaType(props.value)}
+        </span>
+      </div>
+      <div className="min-w-0 overflow-x-auto">
+        <pre className="m-0 max-h-96 min-w-max p-4 font-mono text-[12px] leading-5 text-foreground">
+          <code>{formatSchema(props.value)}</code>
+        </pre>
       </div>
     </section>
   );
@@ -121,9 +153,9 @@ export function ToolsPage(props: {
 
 function EmptyState(props: { title: string; message: string }) {
   return (
-    <div className="grid min-h-80 place-items-center px-6 text-center">
+    <div className="grid min-h-80 place-items-center border border-dashed border-border/80 bg-card/35 px-6 text-center">
       <div className="grid max-w-md gap-2">
-        <h2 className="m-0 text-sm font-semibold text-foreground">{props.title}</h2>
+        <h2 className="m-0 text-base font-semibold text-foreground">{props.title}</h2>
         <p className="m-0 text-sm leading-6 text-muted-foreground">{props.message}</p>
       </div>
     </div>
@@ -132,6 +164,32 @@ function EmptyState(props: { title: string; message: string }) {
 
 function sourceBadgeClass(source: "static" | "dynamic"): string {
   return source === "dynamic"
-    ? "border-primary/30 bg-primary/10 text-primary"
-    : "border-border bg-muted text-muted-foreground";
+    ? "border-primary/35 bg-primary/10 text-primary"
+    : "border-border/80 bg-muted/55 text-muted-foreground";
+}
+
+function schemaType(value: unknown): string {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return "value";
+  }
+  const type = (value as { type?: unknown }).type;
+  return typeof type === "string" ? type : "object";
+}
+
+function schemaPropertyCount(value: unknown): number {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return 0;
+  }
+  const properties = (value as { properties?: unknown }).properties;
+  return typeof properties === "object" && properties !== null && !Array.isArray(properties)
+    ? Object.keys(properties).length
+    : 0;
+}
+
+function formatSchema(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
 }

--- a/packages/tools/studio/src/ui/app/modules/tracing/trace-browser.tsx
+++ b/packages/tools/studio/src/ui/app/modules/tracing/trace-browser.tsx
@@ -78,12 +78,12 @@ function TraceTable(props: {
 }) {
   return (
     <Card
-      className="min-h-0 overflow-hidden rounded-none border-x-0 border-t-0 border-border bg-card"
+      className="min-h-0 overflow-hidden rounded-none border-x-0 border-t-0 border-border/80 bg-card/80"
       aria-label="Traces"
     >
       <ScrollArea className="h-full min-h-0">
         <div className="min-w-280">
-          <div className="grid min-h-10 grid-cols-[minmax(220px,1.3fr)_150px_120px_120px_120px_120px_110px_90px] items-center gap-4 border-b border-border px-5 font-mono text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+          <div className="sticky top-0 z-10 grid min-h-11 grid-cols-[minmax(220px,1.3fr)_150px_120px_120px_120px_120px_110px_90px] items-center gap-4 border-b border-border/80 bg-card/95 px-6 font-mono text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground backdrop-blur">
             <span>Trace</span>
             <span>Session</span>
             <span>Agent</span>
@@ -105,7 +105,7 @@ function TraceTable(props: {
           ) : null}
           {props.traces.map((trace) => (
             <Button
-              className="grid h-auto min-h-14 w-full grid-cols-[minmax(220px,1.3fr)_150px_120px_120px_120px_120px_110px_90px] items-center justify-start gap-4 whitespace-normal rounded-none border-0 border-b border-border bg-transparent px-5 py-2.5 text-left text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+              className="grid h-auto min-h-14 w-full grid-cols-[minmax(220px,1.3fr)_150px_120px_120px_120px_120px_110px_90px] items-center justify-start gap-4 whitespace-normal rounded-none border-0 border-b border-border/75 bg-transparent px-6 py-2.5 text-left text-muted-foreground shadow-none transition duration-200 hover:bg-accent/70 hover:text-accent-foreground"
               type="button"
               variant="ghost"
               key={trace.id}
@@ -156,7 +156,7 @@ function TraceDetailRoute(props: {
 }) {
   return (
     <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden">
-      <header className="grid min-h-14 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 overflow-hidden border-b border-border bg-background px-5 py-3">
+      <header className="grid min-h-16 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 overflow-hidden border-b border-border/80 bg-card/70 px-6 py-3 shadow-sm">
         <Button
           aria-label="Back to traces"
           className="h-8 min-h-8 w-8 text-muted-foreground hover:text-foreground"
@@ -266,10 +266,10 @@ function TracePanel(props: {
     >
       <div className="grid h-full min-h-0 grid-cols-[320px_minmax(0,1fr)] overflow-hidden max-md:grid-cols-1">
         <nav
-          className="grid min-h-0 auto-rows-min content-start overflow-auto border-r border-border bg-background max-md:max-h-80 max-md:border-b max-md:border-r-0"
+          className="grid min-h-0 auto-rows-min content-start overflow-auto border-r border-border/80 bg-card/35 max-md:max-h-80 max-md:border-b max-md:border-r-0"
           aria-label="Trace timeline"
         >
-          <div className="sticky top-0 z-30 flex min-h-11 items-center justify-between border-b border-border bg-background px-5 text-xs font-medium text-muted-foreground">
+          <div className="sticky top-0 z-30 flex min-h-11 items-center justify-between border-b border-border/80 bg-card/90 px-5 text-xs font-medium text-muted-foreground backdrop-blur">
             <span>Search</span>
             <strong className="text-foreground">Timeline</strong>
           </div>
@@ -360,7 +360,7 @@ function TraceTreeRow(props: {
   return (
     <Button
       className={cn(
-        "relative grid h-auto min-h-0 w-full min-w-0 grid-cols-[20px_minmax(0,1fr)] items-start justify-start gap-2 whitespace-normal rounded-none border-0 bg-transparent px-3 py-2 text-left text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+        "relative grid h-auto min-h-0 w-full min-w-0 grid-cols-[20px_minmax(0,1fr)] items-start justify-start gap-2 whitespace-normal rounded-none border-0 bg-transparent px-3 py-2.5 text-left text-muted-foreground shadow-none transition duration-200 hover:bg-accent/70 hover:text-accent-foreground",
         props.active && "bg-primary/10 text-primary hover:bg-primary/10 hover:text-primary",
       )}
       type="button"
@@ -518,10 +518,10 @@ function TraceDetailPane(props: {
   const selected = selectedTraceDetail(props.trace, props.turns, props.activeKey);
   return (
     <section
-      className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-auto bg-background"
+      className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-auto bg-background/45"
       aria-label="Trace detail"
     >
-      <header className="grid gap-3 border-b border-border px-4 py-4">
+      <header className="grid gap-3 border-b border-border/80 bg-card/55 px-5 py-5">
         <div className="flex min-w-0 items-center gap-3">
           <span
             className={cn(
@@ -576,7 +576,7 @@ function TraceDataSection(props: { title: string; value: unknown; tone?: "succes
       <h3 className="m-0 text-base font-semibold leading-tight text-foreground">{props.title}</h3>
       <div
         className={cn(
-          "overflow-hidden rounded-sm border border-border bg-card",
+          "overflow-hidden rounded-sm border border-border/80 bg-card/90 shadow-sm",
           props.tone === "success" && "border-primary/40 bg-primary/10",
           props.tone === "error" && "border-destructive/40 bg-destructive/10",
         )}

--- a/packages/tools/studio/src/ui/app/modules/tracing/trace-browser.tsx
+++ b/packages/tools/studio/src/ui/app/modules/tracing/trace-browser.tsx
@@ -1,7 +1,6 @@
 import { ArrowLeft, Bot, Cpu, GitBranch, Route, Wrench } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import type { StudioConfig, StudioTrace } from "../../../../types";
-import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
 import { Card } from "../../components/ui/card";
 import { ScrollArea } from "../../components/ui/scroll-area";
@@ -518,87 +517,127 @@ function TraceDetailPane(props: {
   const selected = selectedTraceDetail(props.trace, props.turns, props.activeKey);
   return (
     <section
-      className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-auto bg-background/45"
+      className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden bg-background"
       aria-label="Trace detail"
     >
-      <header className="grid gap-3 border-b border-border/80 bg-card/55 px-5 py-5">
-        <div className="flex min-w-0 items-center gap-3">
-          <span
-            className={cn(
-              "grid h-6 w-6 shrink-0 place-items-center rounded-sm bg-transparent [&_svg]:h-3.5 [&_svg]:w-3.5 [&_svg]:opacity-100",
-              traceToneIconClass(selected.tone),
+      <header className="border-b border-border/80 bg-card/45 px-6 py-5">
+        <div className="grid min-w-0 gap-5">
+          <div className="flex min-w-0 items-start justify-between gap-4">
+            <div className="flex min-w-0 items-center gap-3">
+              <span
+                className={cn(
+                  "grid h-8 w-8 shrink-0 place-items-center bg-primary text-primary-foreground [&_svg]:h-4 [&_svg]:w-4 [&_svg]:opacity-100",
+                  selected.tone !== "trace" && "bg-muted text-foreground",
+                  traceToneIconClass(selected.tone),
+                )}
+              >
+                <TraceToneIcon tone={selected.tone} />
+              </span>
+              <div className="grid min-w-0 gap-1">
+                <h2 className="m-0 min-w-0 truncate text-2xl font-semibold leading-none tracking-[-0.01em] text-foreground">
+                  {selected.title}
+                </h2>
+                <div className="font-mono text-xs font-medium text-muted-foreground">
+                  {selected.startedAt}
+                </div>
+              </div>
+            </div>
+            {selected.usage.length > 0 ? (
+              <div className="shrink-0 font-mono text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                {selected.usage}
+              </div>
+            ) : null}
+          </div>
+          <div className="grid min-w-0 grid-cols-[repeat(auto-fit,minmax(150px,1fr))] gap-px overflow-hidden border border-border/80 bg-border/80">
+            <TraceMetric label="Duration" value={formatDuration(selected.durationMs)} />
+            {selected.firstDeltaMs === undefined ? null : (
+              <TraceMetric label="First delta" value={formatDuration(selected.firstDeltaMs)} />
             )}
-          >
-            <TraceToneIcon tone={selected.tone} />
-          </span>
-          <h2 className="m-0 min-w-0 truncate text-xl font-semibold leading-tight text-foreground">
-            {selected.title}
-          </h2>
-        </div>
-        <div className="text-sm font-medium text-muted-foreground">{selected.startedAt}</div>
-        <div className="flex flex-wrap gap-2">
-          <Badge>Duration: {formatDuration(selected.durationMs)}</Badge>
-          {selected.firstDeltaMs === undefined ? null : (
-            <Badge>First delta: {formatDuration(selected.firstDeltaMs)}</Badge>
-          )}
-          <Button
-            className="h-auto min-h-0 max-w-full rounded-sm border border-border bg-muted px-2 py-1 font-mono text-xs font-semibold text-foreground hover:bg-accent hover:text-accent-foreground"
-            type="button"
-            variant="ghost"
-            onClick={() => props.onShowSessionTraces(props.trace.sessionId)}
-          >
-            <span className="font-sans">SessionID:</span>
-            <span className="min-w-0 truncate">{props.trace.sessionId}</span>
-          </Button>
-          {selected.usage.length > 0 ? <Badge>{selected.usage}</Badge> : null}
+            <button
+              className="grid min-w-0 gap-1 bg-background px-4 py-3 text-left transition duration-200 hover:bg-accent hover:text-accent-foreground"
+              type="button"
+              onClick={() => props.onShowSessionTraces(props.trace.sessionId)}
+            >
+              <span className="font-mono text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                Session
+              </span>
+              <span className="min-w-0 truncate font-mono text-sm font-semibold text-current">
+                {props.trace.sessionId}
+              </span>
+            </button>
+          </div>
         </div>
       </header>
-      <div className="grid min-w-0 content-start gap-4 p-4">
-        {selected.input === undefined ? null : (
-          <TraceDataSection title="Input" value={selected.input} />
-        )}
-        {selected.output === undefined ? null : (
-          <TraceDataSection title="Output" value={selected.output} tone="success" />
-        )}
-        {selected.error === undefined ? null : (
-          <TraceDataSection title="Error" value={selected.error} tone="error" />
-        )}
-        <TraceDataSection title="Metadata" value={selected.metadata} />
+      <div className="min-w-0 overflow-auto">
+        <div className="grid min-w-0 max-w-6xl content-start gap-6 p-6">
+          {selected.input === undefined ? null : (
+            <TraceDataSection title="Input" value={selected.input} />
+          )}
+          {selected.output === undefined ? null : (
+            <TraceDataSection title="Output" value={selected.output} tone="success" />
+          )}
+          {selected.error === undefined ? null : (
+            <TraceDataSection title="Error" value={selected.error} tone="error" />
+          )}
+          <TraceDataSection title="Metadata" value={selected.metadata} compact />
+        </div>
       </div>
     </section>
   );
 }
 
-function TraceDataSection(props: { title: string; value: unknown; tone?: "success" | "error" }) {
+function TraceMetric(props: { label: string; value: string }) {
+  return (
+    <div className="grid min-w-0 gap-1 bg-background px-4 py-3">
+      <span className="font-mono text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+        {props.label}
+      </span>
+      <span className="min-w-0 truncate font-mono text-sm font-semibold text-foreground">
+        {props.value}
+      </span>
+    </div>
+  );
+}
+
+function TraceDataSection(props: {
+  title: string;
+  value: unknown;
+  tone?: "success" | "error";
+  compact?: boolean;
+}) {
   const rows = plainTraceValue(props.title, props.value);
   return (
-    <section className="grid min-w-0 gap-2">
-      <h3 className="m-0 text-base font-semibold leading-tight text-foreground">{props.title}</h3>
-      <div
-        className={cn(
-          "overflow-hidden rounded-sm border border-border/80 bg-card/90 shadow-sm",
-          props.tone === "success" && "border-primary/40 bg-primary/10",
-          props.tone === "error" && "border-destructive/40 bg-destructive/10",
-        )}
-      >
+    <section className="grid min-w-0 gap-3">
+      <div className="flex items-center gap-3">
+        <h3 className="m-0 text-lg font-semibold leading-tight text-foreground">{props.title}</h3>
+        <span className="h-px flex-1 bg-border/80" aria-hidden="true" />
+      </div>
+      <div className="grid min-w-0 gap-3">
         {rows.map((item) => (
-          <div
-            className="grid gap-2 border-b border-border px-3 py-3 last:border-b-0"
+          <article
+            className={cn(
+              "grid min-w-0 gap-3 bg-card/65 px-4 py-4",
+              props.compact &&
+                "grid-cols-[150px_minmax(0,1fr)] items-start gap-4 max-lg:grid-cols-1",
+              props.tone === "success" && "bg-primary/[0.08]",
+              props.tone === "error" && "bg-destructive/10",
+            )}
             key={`${item.label}-${item.text}`}
           >
-            <span className="text-xs font-semibold uppercase text-muted-foreground">
+            <span className="font-mono text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
               {item.label}
             </span>
             <p
               className={cn(
-                "m-0 whitespace-pre-wrap text-sm leading-6 text-foreground [overflow-wrap:anywhere]",
+                "m-0 whitespace-pre-wrap text-[15px] leading-7 text-foreground [overflow-wrap:anywhere]",
+                props.compact && "font-mono text-[13px] leading-6",
                 props.tone === "success" && "text-primary",
                 props.tone === "error" && "text-destructive",
               )}
             >
               {item.text}
             </p>
-          </div>
+          </article>
         ))}
       </div>
     </section>

--- a/packages/tools/studio/src/ui/app/modules/tracing/trace-browser.tsx
+++ b/packages/tools/studio/src/ui/app/modules/tracing/trace-browser.tsx
@@ -569,7 +569,7 @@ function TraceDetailPane(props: {
         </div>
       </header>
       <div className="min-w-0 overflow-auto">
-        <div className="grid min-w-0 max-w-6xl content-start gap-6 p-6">
+        <div className="grid min-w-0 content-start gap-6 p-6">
           {selected.input === undefined ? null : (
             <TraceDataSection title="Input" value={selected.input} />
           )}

--- a/packages/tools/studio/src/ui/app/styles.css
+++ b/packages/tools/studio/src/ui/app/styles.css
@@ -6,39 +6,39 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --background: hsl(0 0% 99%);
-  --foreground: hsl(0 0% 4%);
-  --card: hsl(0 0% 100%);
-  --card-foreground: hsl(0 0% 4%);
-  --popover: hsl(0 0% 100%);
-  --popover-foreground: hsl(0 0% 4%);
-  --primary: hsl(72 72% 28%);
-  --primary-foreground: hsl(0 0% 100%);
-  --secondary: hsl(0 0% 95%);
-  --secondary-foreground: hsl(0 0% 7%);
-  --muted: hsl(0 0% 96%);
-  --muted-foreground: hsl(0 0% 34%);
-  --accent: hsl(68 100% 56% / 26%);
-  --accent-foreground: hsl(0 0% 4%);
-  --destructive: hsl(0 74% 47%);
-  --destructive-foreground: hsl(0 0% 100%);
-  --border: hsl(0 0% 0% / 12%);
-  --input: hsl(0 0% 0% / 16%);
+  --background: hsl(0 0% 2%);
+  --foreground: hsl(0 0% 91%);
+  --card: hsl(0 0% 4.5%);
+  --card-foreground: hsl(0 0% 92%);
+  --popover: hsl(0 0% 5%);
+  --popover-foreground: hsl(0 0% 88%);
+  --primary: hsl(68 100% 56%);
+  --primary-foreground: hsl(0 0% 4%);
+  --secondary: hsl(0 0% 6.5%);
+  --secondary-foreground: hsl(0 0% 88%);
+  --muted: hsl(0 0% 7%);
+  --muted-foreground: hsl(0 0% 58%);
+  --accent: hsl(0 0% 100% / 5%);
+  --accent-foreground: hsl(0 0% 92%);
+  --destructive: hsl(4 70% 62%);
+  --destructive-foreground: hsl(0 0% 4%);
+  --border: hsl(0 0% 100% / 5%);
+  --input: hsl(0 0% 100% / 10%);
   --ring: hsl(162 52% 58%);
-  --chart-1: hsl(72 72% 28%);
-  --chart-2: hsl(199 74% 60%);
-  --chart-3: hsl(267 72% 68%);
-  --chart-4: hsl(36 84% 62%);
-  --chart-5: hsl(0 74% 65%);
-  --sidebar: hsl(0 0% 97%);
-  --sidebar-foreground: hsl(0 0% 4%);
+  --chart-1: hsl(68 100% 56%);
+  --chart-2: hsl(162 52% 58%);
+  --chart-3: hsl(0 0% 58%);
+  --chart-4: hsl(0 0% 88%);
+  --chart-5: hsl(4 70% 62%);
+  --sidebar: hsl(0 0% 2%);
+  --sidebar-foreground: hsl(0 0% 91%);
   --sidebar-primary: var(--primary);
   --sidebar-primary-foreground: var(--primary-foreground);
-  --sidebar-accent: hsl(68 100% 56% / 30%);
-  --sidebar-accent-foreground: hsl(72 72% 22%);
+  --sidebar-accent: hsl(0 0% 100% / 5%);
+  --sidebar-accent-foreground: hsl(68 100% 56%);
   --sidebar-border: var(--border);
   --sidebar-ring: var(--ring);
-  --font-sans: -apple-system, BlinkMacSystemFont, Inter, ui-sans-serif, sans-serif, system-ui;
+  --font-sans: Inter, -apple-system, BlinkMacSystemFont, ui-sans-serif, sans-serif, system-ui;
   --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
   --font-mono: Geist Mono, ui-monospace, monospace;
   --radius: 0.25rem;
@@ -47,15 +47,15 @@
   --shadow-blur: 3px;
   --shadow-spread: 0px;
   --shadow-opacity: 0.1;
-  --shadow-color: hsl(0 0% 0%);
-  --shadow-2xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
-  --shadow-xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
-  --shadow-sm: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 1px 2px -1px hsl(0 0% 0% / 0.1);
-  --shadow: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 1px 2px -1px hsl(0 0% 0% / 0.1);
-  --shadow-md: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 2px 4px -1px hsl(0 0% 0% / 0.1);
-  --shadow-lg: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 4px 6px -1px hsl(0 0% 0% / 0.1);
-  --shadow-xl: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 8px 10px -1px hsl(0 0% 0% / 0.1);
-  --shadow-2xl: 0 1px 3px 0px hsl(0 0% 0% / 0.25);
+  --shadow-color: hsl(216 20% 15%);
+  --shadow-2xs: 0 1px 2px 0px hsl(216 20% 15% / 0.05);
+  --shadow-xs: 0 1px 3px 0px hsl(216 20% 15% / 0.06);
+  --shadow-sm: 0 1px 2px hsl(216 20% 15% / 0.08), 0 8px 18px -18px hsl(216 20% 15% / 0.26);
+  --shadow: 0 1px 2px hsl(216 20% 15% / 0.1), 0 14px 34px -26px hsl(216 20% 15% / 0.34);
+  --shadow-md: 0 2px 4px hsl(216 20% 15% / 0.12), 0 20px 44px -30px hsl(216 20% 15% / 0.42);
+  --shadow-lg: 0 3px 8px hsl(216 20% 15% / 0.16), 0 28px 64px -38px hsl(216 20% 15% / 0.5);
+  --shadow-xl: 0 4px 12px hsl(216 20% 15% / 0.2), 0 34px 86px -44px hsl(216 20% 15% / 0.56);
+  --shadow-2xl: 0 10px 32px hsl(216 20% 15% / 0.28), 0 48px 120px -56px hsl(216 20% 15% / 0.68);
   --tracking-normal: 0em;
   --spacing: 0.25rem;
 }
@@ -75,25 +75,25 @@
   --muted-foreground: hsl(0 0% 58%);
   --accent: hsl(0 0% 100% / 5%);
   --accent-foreground: hsl(0 0% 92%);
-  --destructive: hsl(0 74% 65%);
+  --destructive: hsl(4 70% 62%);
   --destructive-foreground: hsl(0 0% 4%);
   --border: hsl(0 0% 100% / 5%);
   --input: hsl(0 0% 100% / 10%);
   --ring: hsl(162 52% 58%);
   --chart-1: hsl(68 100% 56%);
-  --chart-2: hsl(199 74% 60%);
-  --chart-3: hsl(267 72% 68%);
-  --chart-4: hsl(36 84% 62%);
-  --chart-5: hsl(0 74% 65%);
+  --chart-2: hsl(162 52% 58%);
+  --chart-3: hsl(0 0% 58%);
+  --chart-4: hsl(0 0% 88%);
+  --chart-5: hsl(4 70% 62%);
   --sidebar: hsl(0 0% 2%);
   --sidebar-foreground: hsl(0 0% 91%);
   --sidebar-primary: var(--primary);
   --sidebar-primary-foreground: var(--primary-foreground);
-  --sidebar-accent: hsl(68 100% 56% / 11%);
+  --sidebar-accent: hsl(0 0% 100% / 5%);
   --sidebar-accent-foreground: hsl(68 100% 56%);
   --sidebar-border: var(--border);
   --sidebar-ring: var(--ring);
-  --font-sans: -apple-system, BlinkMacSystemFont, Inter, ui-sans-serif, sans-serif, system-ui;
+  --font-sans: Inter, -apple-system, BlinkMacSystemFont, ui-sans-serif, sans-serif, system-ui;
   --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
   --font-mono: Geist Mono, ui-monospace, monospace;
   --radius: 0.25rem;
@@ -102,15 +102,15 @@
   --shadow-blur: 3px;
   --shadow-spread: 0px;
   --shadow-opacity: 0.1;
-  --shadow-color: hsl(0 0% 0%);
-  --shadow-2xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
-  --shadow-xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
-  --shadow-sm: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 1px 2px -1px hsl(0 0% 0% / 0.1);
-  --shadow: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 1px 2px -1px hsl(0 0% 0% / 0.1);
-  --shadow-md: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 2px 4px -1px hsl(0 0% 0% / 0.1);
-  --shadow-lg: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 4px 6px -1px hsl(0 0% 0% / 0.1);
-  --shadow-xl: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 8px 10px -1px hsl(0 0% 0% / 0.1);
-  --shadow-2xl: 0 1px 3px 0px hsl(0 0% 0% / 0.25);
+  --shadow-color: hsl(216 30% 3%);
+  --shadow-2xs: 0 1px 2px 0px hsl(216 30% 3% / 0.25);
+  --shadow-xs: 0 1px 3px 0px hsl(216 30% 3% / 0.28);
+  --shadow-sm: 0 1px 2px hsl(216 30% 3% / 0.36), 0 10px 24px -20px hsl(216 30% 3% / 0.7);
+  --shadow: 0 1px 2px hsl(216 30% 3% / 0.42), 0 20px 54px -34px hsl(216 30% 3% / 0.86);
+  --shadow-md: 0 2px 6px hsl(216 30% 3% / 0.48), 0 28px 70px -42px hsl(216 30% 3% / 0.9);
+  --shadow-lg: 0 4px 10px hsl(216 30% 3% / 0.54), 0 36px 90px -48px hsl(216 30% 3% / 0.94);
+  --shadow-xl: 0 8px 18px hsl(216 30% 3% / 0.62), 0 44px 110px -54px hsl(216 30% 3% / 0.98);
+  --shadow-2xl: 0 14px 44px hsl(216 30% 3% / 0.72), 0 60px 140px -64px hsl(216 30% 3% / 1);
 }
 
 @theme inline {
@@ -175,6 +175,8 @@
     font-size: 16px;
     color-scheme: light;
     background: var(--background);
+    max-width: 100%;
+    overflow-x: hidden;
   }
 
   html.dark {
@@ -183,9 +185,46 @@
 
   body {
     @apply bg-background text-foreground;
+    width: 100%;
+    max-width: 100%;
+    overflow-x: hidden;
     min-width: 320px;
     margin: 0;
+    background:
+      radial-gradient(circle at 20% -10%, hsl(68 100% 56% / 7%), transparent 30rem),
+      radial-gradient(circle at 88% 8%, hsl(204 46% 61% / 5%), transparent 28rem), var(--background);
+    font-family: var(--font-sans);
     font-feature-settings: "cv02", "cv03", "cv04", "cv11";
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0;
+    text-rendering: geometricPrecision;
+  }
+
+  body::before {
+    position: fixed;
+    inset: 0;
+    z-index: 0;
+    pointer-events: none;
+    content: "";
+    opacity: 0.22;
+    background-image:
+      linear-gradient(hsl(210 18% 91% / 0.032) 1px, transparent 1px),
+      linear-gradient(90deg, hsl(210 18% 91% / 0.024) 1px, transparent 1px),
+      radial-gradient(circle at 25% 15%, hsl(68 100% 56% / 0.07), transparent 18rem);
+    background-size:
+      84px 84px,
+      84px 84px,
+      auto;
+    mask-image: linear-gradient(to bottom, black, transparent 88%);
+  }
+
+  #anvia-ui {
+    isolation: isolate;
+    position: relative;
+    z-index: 1;
+    width: 100%;
+    max-width: 100%;
+    overflow-x: hidden;
   }
 
   ::selection {
@@ -232,6 +271,11 @@
   .anvia-wordmark {
     font-family: "Krona One", var(--font-sans);
     letter-spacing: -0.04em;
+  }
+
+  :focus-visible {
+    outline: 2px solid var(--ring);
+    outline-offset: 2px;
   }
 
   *::-webkit-scrollbar {

--- a/packages/tools/studio/src/ui/app/styles.css
+++ b/packages/tools/studio/src/ui/app/styles.css
@@ -304,4 +304,15 @@
     width: 0;
     height: 0;
   }
+
+  .pipeline-flow .react-flow__edge.pipeline-flow-edge .react-flow__edge-path {
+    stroke: var(--primary);
+    stroke-width: 1.6;
+    opacity: 0.78;
+  }
+
+  .pipeline-flow .react-flow__edges marker path {
+    fill: var(--primary);
+    stroke: var(--primary);
+  }
 }

--- a/packages/tools/studio/test/runner.test.ts
+++ b/packages/tools/studio/test/runner.test.ts
@@ -1602,6 +1602,84 @@ describe("Anvia studio", () => {
     });
   });
 
+  it("streams and persists metadata-only session audit logs", async () => {
+    const model = new StreamingQueueModel([[{ type: "text_delta", delta: "safe answer" }]]);
+    const agent = new AgentBuilder("support", model).build();
+    const runner = new Studio([agent]);
+
+    const created = await runner.fetch(
+      new Request("http://runner.test/sessions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ agentId: "support", title: "secret title" }),
+      }),
+    );
+    const session = (await created.json()) as { id: string };
+
+    const run = await runner.fetch(
+      new Request("http://runner.test/agents/support/runs", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          message: "my raw secret prompt",
+          sessionId: session.id,
+          stream: true,
+        }),
+      }),
+    );
+
+    expect(run.status).toBe(200);
+    const events = await readJsonl(run);
+    const streamedLogs = events.filter(
+      (event): event is { type: "session_log"; log: { event: string; sequence: number } } =>
+        typeof event === "object" &&
+        event !== null &&
+        "type" in event &&
+        event.type === "session_log",
+    );
+    expect(streamedLogs).toContainEqual(
+      expect.objectContaining({ log: expect.objectContaining({ event: "run.started" }) }),
+    );
+    expect(streamedLogs).toContainEqual(
+      expect.objectContaining({ log: expect.objectContaining({ event: "memory.loaded" }) }),
+    );
+    expect(streamedLogs).toContainEqual(
+      expect.objectContaining({ log: expect.objectContaining({ event: "prompt.prepared" }) }),
+    );
+    expect(streamedLogs).toContainEqual(
+      expect.objectContaining({ log: expect.objectContaining({ event: "run.completed" }) }),
+    );
+    expect(streamedLogs).toContainEqual(
+      expect.objectContaining({ log: expect.objectContaining({ event: "memory.saved" }) }),
+    );
+
+    const firstPage = await runner.fetch(
+      new Request(`http://runner.test/sessions/${session.id}/logs?limit=2`),
+    );
+    expect(firstPage.status).toBe(200);
+    const firstBody = (await firstPage.json()) as {
+      logs: Array<{ event: string; sequence: number; metadata?: unknown }>;
+      nextCursor?: number;
+    };
+    expect(firstBody.logs).toHaveLength(2);
+    expect(firstBody.logs[0]).toMatchObject({ event: "session.created", sequence: 0 });
+    expect(firstBody.nextCursor).toBe(1);
+
+    const nextPage = await runner.fetch(
+      new Request(`http://runner.test/sessions/${session.id}/logs?after=${firstBody.nextCursor}`),
+    );
+    const nextBody = (await nextPage.json()) as {
+      logs: Array<{ event: string; sequence: number; metadata?: unknown }>;
+    };
+    expect(nextBody.logs[0]).toMatchObject({ event: "run.started", sequence: 2 });
+    expect(nextBody.logs.map((log) => log.event)).toContain("run.completed");
+
+    const serializedLogs = JSON.stringify([...firstBody.logs, ...nextBody.logs]);
+    expect(serializedLogs).not.toContain("my raw secret prompt");
+    expect(serializedLogs).not.toContain("secret title");
+    expect(serializedLogs).not.toContain("safe answer");
+  });
+
   it("persists streaming subagent activity in tool transcript entries", async () => {
     const parentModel = new StreamingQueueModel([
       [
@@ -2148,6 +2226,42 @@ describe("Anvia studio", () => {
       messageCount: 4,
       messages,
     });
+  });
+
+  it("persists session audit logs with monotonic sequence and deletes them with sessions", async () => {
+    const store = createSqliteSessionStore({ path: ":memory:" });
+    store.createSession({ id: "session_1", agentId: "support" });
+
+    const first = await store.appendSessionLog?.({
+      sessionId: "session_1",
+      level: "info",
+      category: "session",
+      event: "session.created",
+      message: "Session created",
+      metadata: { agentId: "support" },
+    });
+    const second = await store.appendSessionLog?.({
+      sessionId: "session_1",
+      runId: "run_1",
+      level: "debug",
+      category: "memory",
+      event: "memory.loaded",
+      message: "Session memory loaded",
+      metadata: { messageCount: 0 },
+    });
+
+    expect(first).toMatchObject({ sequence: 0, event: "session.created" });
+    expect(second).toMatchObject({ sequence: 1, event: "memory.loaded", runId: "run_1" });
+    expect(await store.listSessionLogs?.({ sessionId: "session_1", limit: 10 })).toEqual([
+      expect.objectContaining({ sequence: 0 }),
+      expect.objectContaining({ sequence: 1 }),
+    ]);
+    expect(await store.listSessionLogs?.({ sessionId: "session_1", limit: 10, after: 0 })).toEqual([
+      expect.objectContaining({ sequence: 1 }),
+    ]);
+
+    expect(await store.deleteSession?.("session_1")).toBe(true);
+    expect(await store.listSessionLogs?.({ sessionId: "session_1", limit: 10 })).toEqual([]);
   });
 
   it("rejects legacy SQLite session schemas with messages_json", () => {

--- a/packages/tools/studio/test/runner.test.ts
+++ b/packages/tools/studio/test/runner.test.ts
@@ -11,12 +11,14 @@ import {
   type CompletionRequest,
   type CompletionResponse,
   type CompletionStreamEvent,
+  connectMcp,
   createHook,
   createToolIndex,
   type Embedding,
   type EmbeddingModel,
   embedDocuments,
   InMemoryVectorStore,
+  type McpClient,
   Message,
   type StreamingCompletionModel,
   skipTool,
@@ -516,6 +518,110 @@ describe("Anvia studio", () => {
         name: "lookup_policy",
       }),
     ]);
+  });
+
+  it("exposes tool metadata for registered agents", async () => {
+    const embeddings = new KeywordEmbeddingModel();
+    const index = await createToolIndex(embeddings, [lookupPolicyTool]);
+    const refundTool = createRefundTool(() => "ok");
+    const agent = new AgentBuilder("support", new QueueModel([]))
+      .tool(addTool)
+      .tool(refundTool)
+      .dynamicTools(index, { topK: 1 })
+      .build();
+    const runner = new Studio([agent]);
+
+    expect(runner.config().capabilities.tools).toEqual({ enabled: true });
+
+    const res = await runner.fetch(new Request("http://runner.test/agents/support/tools"));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      agentId: "support",
+      tools: [
+        expect.objectContaining({
+          agentId: "support",
+          name: "add",
+          description: "Add numbers",
+          source: "static",
+          approval: { required: false },
+          parameters: expect.objectContaining({ type: "object" }),
+        }),
+        expect.objectContaining({
+          agentId: "support",
+          name: "issue_refund",
+          source: "static",
+          approval: { required: true, rejectMessage: "Rejected by test." },
+        }),
+        expect.objectContaining({
+          agentId: "support",
+          name: "lookup_policy",
+          description: "Look up policy documents",
+          source: "dynamic",
+          approval: { required: false },
+        }),
+      ],
+    });
+  });
+
+  it("exposes MCP server metadata for registered agents", async () => {
+    const mcpClient: McpClient = {
+      async listTools() {
+        return {
+          tools: [
+            {
+              name: "lookup_policy",
+              description: "Look up policy documents",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  query: { type: "string" },
+                },
+                required: ["query"],
+              },
+            },
+          ],
+        };
+      },
+      async callTool() {
+        return { content: [{ type: "text", text: "policy" }] };
+      },
+      async close() {},
+    };
+    const mcpServer = await connectMcp({
+      name: "policies",
+      connect: async () => mcpClient,
+    });
+    const agent = new AgentBuilder("support", new QueueModel([])).mcp([mcpServer]).build();
+    const runner = new Studio([agent]);
+
+    expect(runner.config().capabilities.mcps).toEqual({ enabled: true });
+
+    const res = await runner.fetch(new Request("http://runner.test/agents/support/mcps"));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      agentId: "support",
+      servers: [
+        {
+          agentId: "support",
+          name: "policies",
+          toolCount: 1,
+          tools: [
+            {
+              name: "lookup_policy",
+              description: "Look up policy documents",
+              source: "static",
+              parameters: {
+                type: "object",
+                properties: {
+                  query: { type: "string" },
+                },
+                required: ["query"],
+              },
+            },
+          ],
+        },
+      ],
+    });
   });
 
   it("reports knowledge capability and exposes the knowledge inspector route", async () => {
@@ -1469,6 +1575,8 @@ describe("Anvia studio", () => {
       "/ui/tracing/sessions/session_1",
       "/ui/sessions",
       "/ui/agents",
+      "/ui/tools",
+      "/ui/mcps",
       "/ui/knowledge",
     ]) {
       const routeShell = await runner.fetch(new Request(`http://runner.test${path}`));

--- a/packages/tools/studio/test/runner.test.ts
+++ b/packages/tools/studio/test/runner.test.ts
@@ -20,6 +20,7 @@ import {
   InMemoryVectorStore,
   type McpClient,
   Message,
+  PipelineBuilder,
   type StreamingCompletionModel,
   skipTool,
   type Tool,
@@ -366,6 +367,129 @@ describe("Anvia studio", () => {
       "support-triage-2": ["second"],
       "agent-3": ["fallback"],
     });
+  });
+
+  it("registers pipelines separately from agents", async () => {
+    const agent = new AgentBuilder("support", new QueueModel([])).name("Support").build();
+    const pipeline = new PipelineBuilder<string>({
+      id: "ticket-pipeline",
+      name: "Ticket Pipeline",
+      description: "Prepare support tickets",
+      metadata: { owner: "support" },
+    })
+      .step((input) => input.trim(), { id: "normalize", name: "Normalize" })
+      .step((input) => input.toUpperCase(), { id: "classify", name: "Classify" })
+      .build();
+    const runner = new Studio([agent, pipeline]);
+
+    expect(runner.config()).toMatchObject({
+      agents: [{ id: "support" }],
+      pipelines: [
+        {
+          id: "ticket-pipeline",
+          name: "Ticket Pipeline",
+          description: "Prepare support tickets",
+          metadata: { owner: "support" },
+          stageCount: 2,
+          edgeCount: 3,
+          hasParallelStages: false,
+        },
+      ],
+      capabilities: {
+        pipelines: { enabled: true },
+      },
+    });
+
+    const list = await runner.fetch(new Request("http://runner.test/pipelines"));
+    expect(list.status).toBe(200);
+    await expect(list.json()).resolves.toMatchObject({
+      pipelines: [{ id: "ticket-pipeline", stageCount: 2 }],
+    });
+
+    const detail = await runner.fetch(new Request("http://runner.test/pipelines/ticket-pipeline"));
+    expect(detail.status).toBe(200);
+    await expect(detail.json()).resolves.toMatchObject({
+      id: "ticket-pipeline",
+      graph: {
+        id: "ticket-pipeline",
+        nodes: [
+          { id: "input", kind: "input" },
+          { id: "normalize", kind: "step", label: "Normalize" },
+          { id: "classify", kind: "step", label: "Classify" },
+          { id: "output", kind: "output" },
+        ],
+      },
+    });
+  });
+
+  it("runs pipelines over HTTP and persists metadata-only pipeline logs", async () => {
+    const pipeline = new PipelineBuilder<string>({ id: "audit-pipeline" })
+      .step((input) => input.trim(), { id: "normalize", name: "Normalize" })
+      .step((input) => ({ reply: input.toUpperCase() }), { id: "shape", name: "Shape" })
+      .build();
+    const runner = new Studio([pipeline]);
+
+    const run = await runner.fetch(
+      new Request("http://runner.test/pipelines/audit-pipeline/runs", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ input: " raw secret payload ", stream: true }),
+      }),
+    );
+
+    expect(run.status).toBe(200);
+    const events = await readJsonl(run);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "pipeline_log",
+        log: expect.objectContaining({ event: "pipeline.run_started" }),
+      }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "pipeline_log",
+        log: expect.objectContaining({ event: "step.started" }),
+      }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "pipeline_final",
+        output: { reply: "RAW SECRET PAYLOAD" },
+      }),
+    );
+
+    const firstPage = await runner.fetch(
+      new Request("http://runner.test/pipelines/audit-pipeline/logs?limit=2"),
+    );
+    expect(firstPage.status).toBe(200);
+    const firstBody = (await firstPage.json()) as {
+      logs: Array<{ event: string; sequence: number; metadata?: unknown }>;
+      nextCursor?: number;
+    };
+    expect(firstBody.logs).toHaveLength(2);
+    expect(firstBody.logs[0]).toMatchObject({
+      event: "pipeline.run_received",
+      sequence: 0,
+    });
+    expect(firstBody.logs[1]).toMatchObject({
+      event: "pipeline.run_started",
+      sequence: 1,
+    });
+    expect(firstBody.nextCursor).toBe(1);
+
+    const nextPage = await runner.fetch(
+      new Request(`http://runner.test/pipelines/audit-pipeline/logs?after=${firstBody.nextCursor}`),
+    );
+    expect(nextPage.status).toBe(200);
+    const nextBody = (await nextPage.json()) as {
+      logs: Array<{ event: string; sequence: number; metadata?: unknown }>;
+    };
+    expect(nextBody.logs[0]).toMatchObject({ event: "step.started", sequence: 2 });
+    expect(nextBody.logs.map((log) => log.event)).toContain("pipeline.run_completed");
+
+    const serializedLogs = JSON.stringify([...firstBody.logs, ...nextBody.logs]);
+    expect(serializedLogs).not.toContain("raw secret payload");
+    expect(serializedLogs).not.toContain("RAW SECRET PAYLOAD");
   });
 
   it("starts a served single-agent runner from a built agent", async () => {
@@ -1576,6 +1700,7 @@ describe("Anvia studio", () => {
       "/ui/sessions",
       "/ui/agents",
       "/ui/tools",
+      "/ui/pipelines",
       "/ui/mcps",
       "/ui/knowledge",
     ]) {

--- a/packages/tools/studio/test/runner.test.ts
+++ b/packages/tools/studio/test/runner.test.ts
@@ -850,6 +850,192 @@ describe("Anvia studio", () => {
     });
   });
 
+  it("handles hook-based approval requests in streaming runs", async () => {
+    let executed = false;
+    const refundTool = {
+      name: "issue_refund",
+      definition() {
+        return {
+          name: "issue_refund",
+          description: "Issue a customer refund",
+          parameters: {
+            type: "object",
+            properties: {
+              orderId: { type: "string" },
+              amount: { type: "number" },
+            },
+            required: ["orderId", "amount"],
+          },
+        };
+      },
+      call(args) {
+        executed = true;
+        return `Refunded ${args.amount} for ${args.orderId}`;
+      },
+    } satisfies Tool<{ orderId: string; amount: number }, string>;
+    const model = new StreamingQueueModel([
+      [
+        {
+          type: "tool_call_delta",
+          id: "call_1",
+          name: "issue_refund",
+          argumentsDelta: '{"orderId":"ORD-1","amount":25}',
+        },
+      ],
+      [{ type: "text_delta", delta: "Refund complete" }],
+    ]);
+    const agent = new AgentBuilder("support", model)
+      .tool(refundTool)
+      .hook(
+        createHook({
+          onToolCall({ toolName, tool }) {
+            if (toolName === "issue_refund") {
+              return tool.requestApproval({
+                reason: "Review refund before issuing it.",
+                rejectMessage: "Rejected by hook.",
+              });
+            }
+            return tool.run();
+          },
+        }),
+      )
+      .defaultMaxTurns(2)
+      .build();
+    const runner = new Studio([agent]);
+
+    const res = await runner.fetch(
+      new Request("http://runner.test/agents/support/runs", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ message: "refund", stream: true }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const reader = createJsonlReader(res);
+    let approvalId = "";
+    while (approvalId.length === 0) {
+      const event = await withTimeout(reader.read(), 1_000);
+      if ((event as { type?: string }).type === "tool_approval_request") {
+        const approval = (event as { approval: { id: string; reason?: string } }).approval;
+        approvalId = approval.id;
+        expect(approval.reason).toBe("Review refund before issuing it.");
+      }
+    }
+    expect(executed).toBe(false);
+
+    const decision = await runner.fetch(
+      new Request(`http://runner.test/approvals/${approvalId}/decision`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ approved: true }),
+      }),
+    );
+    expect(decision.status).toBe(200);
+
+    const remaining = await readRemainingJsonl(reader);
+    expect(executed).toBe(true);
+    expect(remaining).toContainEqual(
+      expect.objectContaining({
+        type: "tool_approval_result",
+        approval: expect.objectContaining({ id: approvalId, status: "approved" }),
+      }),
+    );
+    expect(remaining).toContainEqual(
+      expect.objectContaining({
+        type: "tool_result",
+        result: "Refunded 25 for ORD-1",
+      }),
+    );
+  });
+
+  it("skips rejected hook-based approval requests with the reject message", async () => {
+    let executed = false;
+    const refundTool = {
+      name: "issue_refund",
+      definition() {
+        return {
+          name: "issue_refund",
+          description: "Issue a customer refund",
+          parameters: {
+            type: "object",
+            properties: {
+              orderId: { type: "string" },
+              amount: { type: "number" },
+            },
+            required: ["orderId", "amount"],
+          },
+        };
+      },
+      call() {
+        executed = true;
+        return "should not run";
+      },
+    } satisfies Tool<{ orderId: string; amount: number }, string>;
+    const model = new StreamingQueueModel([
+      [
+        {
+          type: "tool_call_delta",
+          id: "call_1",
+          name: "issue_refund",
+          argumentsDelta: '{"orderId":"ORD-1","amount":25}',
+        },
+      ],
+      [{ type: "text_delta", delta: "Refund denied" }],
+    ]);
+    const agent = new AgentBuilder("support", model)
+      .tool(refundTool)
+      .hook(
+        createHook({
+          onToolCall({ tool }) {
+            return tool.requestApproval({
+              reason: "Review refund before issuing it.",
+              rejectMessage: "Rejected by hook.",
+            });
+          },
+        }),
+      )
+      .defaultMaxTurns(2)
+      .build();
+    const runner = new Studio([agent]);
+
+    const res = await runner.fetch(
+      new Request("http://runner.test/agents/support/runs", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ message: "refund", stream: true }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const reader = createJsonlReader(res);
+    let approvalId = "";
+    while (approvalId.length === 0) {
+      const event = await withTimeout(reader.read(), 1_000);
+      if ((event as { type?: string }).type === "tool_approval_request") {
+        approvalId = (event as { approval: { id: string } }).approval.id;
+      }
+    }
+
+    const decision = await runner.fetch(
+      new Request(`http://runner.test/approvals/${approvalId}/decision`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ approved: false }),
+      }),
+    );
+    expect(decision.status).toBe(200);
+
+    const remaining = await readRemainingJsonl(reader);
+    expect(executed).toBe(false);
+    expect(remaining).toContainEqual(
+      expect.objectContaining({
+        type: "tool_result",
+        result: "Rejected by hook.",
+      }),
+    );
+  });
+
   it("pauses ask_question tool calls until Studio receives answers", async () => {
     const model = new StreamingQueueModel([
       [
@@ -1239,6 +1425,15 @@ describe("Anvia studio", () => {
   it("marks approvals enabled when a registered agent protects tools", () => {
     const agent = new AgentBuilder("support", new QueueModel([]))
       .tool(createRefundTool(() => "ok"))
+      .build();
+    const runner = new Studio([agent]);
+
+    expect(runner.config().capabilities.approvals).toEqual({ enabled: true });
+  });
+
+  it("marks approvals enabled when a registered agent has hooks", () => {
+    const agent = new AgentBuilder("support", new QueueModel([]))
+      .hook(createHook({ onToolCall: ({ tool }) => tool.requestApproval() }))
       .build();
     const runner = new Studio([agent]);
 

--- a/packages/tools/studio/test/runner.test.ts
+++ b/packages/tools/studio/test/runner.test.ts
@@ -1,4 +1,5 @@
 import { mkdtempSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -20,11 +21,17 @@ import {
   type StreamingCompletionModel,
   skipTool,
   type Tool,
+  ToolContent,
   Usage,
+  UserContent,
 } from "@anvia/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { Studio } from "../src/index";
 import { createSqliteSessionStore } from "../src/sqlite";
+
+const { DatabaseSync } = createRequire(import.meta.url)(
+  "node:sqlite",
+) as typeof import("node:sqlite");
 
 class QueueModel {
   readonly provider = "test";
@@ -1878,6 +1885,97 @@ describe("Anvia studio", () => {
       messages: [],
       transcript: [],
     });
+  });
+
+  it("persists session messages and parts in normalized SQLite tables", async () => {
+    const path = join(studioDbDir ?? tmpdir(), "normalized.sqlite");
+    const store = createSqliteSessionStore({ path });
+    store.createSession({ id: "session_1", agentId: "support" });
+
+    const messages = [
+      Message.system("Use project policy."),
+      Message.user([
+        UserContent.text("hi"),
+        UserContent.imageUrl("https://example.test/image.png", { detail: "high" }),
+        UserContent.documentUrl("https://example.test/file.pdf", "application/pdf", {
+          filename: "file.pdf",
+        }),
+      ]),
+      Message.assistant(
+        [
+          AssistantContent.text("hello"),
+          AssistantContent.reasoning("thinking", "reasoning_1"),
+          AssistantContent.toolCall("tool_1", "lookup", { query: "x" }, "call_1"),
+          AssistantContent.imageBase64("abc123", "image/png"),
+        ],
+        "assistant_message_1",
+      ),
+      Message.tool(
+        ToolContent.toolResult(
+          "tool_1",
+          [
+            { type: "text", text: "lookup result" },
+            { type: "image", data: "abc123", mediaType: "image/png" },
+          ],
+          "call_1",
+        ),
+      ),
+    ];
+
+    await store.append({
+      context: { sessionId: "session_1" },
+      runId: "run_1",
+      turn: 1,
+      messages: messages.slice(0, 2),
+    });
+    await store.append({
+      context: { sessionId: "session_1" },
+      runId: "run_1",
+      turn: 2,
+      messages: messages.slice(2),
+    });
+
+    const db = new DatabaseSync(path);
+    const messageCount = db
+      .prepare("SELECT COUNT(*) AS count FROM runner_session_messages")
+      .get() as { count: number };
+    const partCount = db
+      .prepare("SELECT COUNT(*) AS count FROM runner_session_message_parts")
+      .get() as { count: number };
+    expect(messageCount.count).toBe(4);
+    expect(partCount.count).toBe(9);
+    db.close();
+
+    const reloaded = createSqliteSessionStore({ path });
+    await expect(reloaded.load({ sessionId: "session_1" })).resolves.toEqual(messages);
+    expect(await reloaded.getSession("session_1")).toMatchObject({
+      id: "session_1",
+      messageCount: 4,
+      messages,
+    });
+  });
+
+  it("rejects legacy SQLite session schemas with messages_json", () => {
+    const path = join(studioDbDir ?? tmpdir(), "legacy.sqlite");
+    const db = new DatabaseSync(path);
+    db.exec(`
+      CREATE TABLE runner_sessions (
+        id TEXT PRIMARY KEY,
+        agent_id TEXT NOT NULL,
+        title TEXT,
+        metadata_json TEXT,
+        messages_json TEXT NOT NULL,
+        transcript_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      ) STRICT;
+    `);
+    db.close();
+
+    const store = createSqliteSessionStore({ path });
+    expect(() => store.createSession({ id: "session_1", agentId: "support" })).toThrow(
+      "legacy messages_json schema",
+    );
   });
 
   it("lists global runner traces with filters", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,8 +121,8 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5
       zod:
-        specifier: ^4.4.2
-        version: 4.4.2
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.13
@@ -183,7 +183,7 @@ importers:
         version: link:../../packages/embeddings/transformers
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0(zod@4.4.2)
+        version: 1.29.0(zod@4.4.3)
       '@opentelemetry/exporter-trace-otlp-http':
         specifier: ^0.216.0
         version: 0.216.0(@opentelemetry/api@1.9.1)
@@ -194,8 +194,8 @@ importers:
         specifier: ^17.4.2
         version: 17.4.2
       zod:
-        specifier: ^4.4.2
-        version: 4.4.2
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: ^24.9.1
@@ -6532,33 +6532,11 @@ snapshots:
   '@mistralai/mistralai@2.2.1':
     dependencies:
       ws: 8.20.0
-      zod: 4.4.2
-      zod-to-json-schema: 3.25.2(zod@4.4.2)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.2)':
-    dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.15)
-      ajv: 8.20.0
-      ajv-formats: 3.0.1(ajv@8.20.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.0.8
-      express: 5.2.1
-      express-rate-limit: 8.4.1(express@5.2.1)
-      hono: 4.12.15
-      jose: 6.2.3
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 4.4.2
-      zod-to-json-schema: 3.25.2(zod@4.4.2)
-    transitivePeerDependencies:
-      - supports-color
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
@@ -11487,10 +11465,6 @@ snapshots:
       '@speed-highlight/core': 1.2.15
       cookie: 1.1.1
       youch-core: 0.3.3
-
-  zod-to-json-schema@3.25.2(zod@4.4.2):
-    dependencies:
-      zod: 4.4.2
 
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
 
   apps/docs:
     dependencies:
@@ -446,6 +446,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.14)(react@19.2.6)
+      '@xyflow/react':
+        specifier: ^12.10.2
+        version: 12.10.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -476,7 +479,7 @@ importers:
         version: 0.5.19(tailwindcss@4.2.4)
       '@tailwindcss/vite':
         specifier: ^4.2.4
-        version: 4.2.4(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
+        version: 4.2.4(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
       '@types/node':
         specifier: ^24.9.1
         version: 24.12.2
@@ -488,7 +491,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
+        version: 6.0.1(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -503,10 +506,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.10
-        version: 8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4)
+        version: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4)
       vitest:
         specifier: ^4.0.8
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
 
   packages/vector-stores/chroma:
     dependencies:
@@ -3028,6 +3031,24 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -3122,6 +3143,15 @@ packages:
 
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+
+  '@xyflow/react@12.10.2':
+    resolution: {integrity: sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@xyflow/system@0.0.76':
+    resolution: {integrity: sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -3403,6 +3433,9 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
   cli-boxes@4.0.1:
     resolution: {integrity: sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==}
     engines: {node: '>=18.20 <19 || >=20.10'}
@@ -3528,6 +3561,44 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -5759,6 +5830,21 @@ packages:
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -8000,6 +8086,13 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.2.4
 
+  '@tailwindcss/vite@4.2.4(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))':
+    dependencies:
+      '@tailwindcss/node': 4.2.4
+      '@tailwindcss/oxide': 4.2.4
+      tailwindcss: 4.2.4
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4)
+
   '@tailwindcss/vite@4.2.4(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@tailwindcss/node': 4.2.4
@@ -8225,6 +8318,27 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -8280,6 +8394,11 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.7
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4)
+
   '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
@@ -8333,6 +8452,29 @@ snapshots:
       '@vitest/pretty-format': 4.1.5
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
+
+  '@xyflow/react@12.10.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@xyflow/system': 0.0.76
+      classcat: 5.0.5
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      zustand: 4.5.7(@types/react@19.2.14)(react@19.2.6)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@xyflow/system@0.0.76':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
 
   accepts@2.0.0:
     dependencies:
@@ -8591,6 +8733,8 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  classcat@5.0.5: {}
+
   cli-boxes@4.0.1: {}
 
   cli-cursor@4.0.0:
@@ -8704,6 +8848,42 @@ snapshots:
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
+
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   data-uri-to-buffer@4.0.1: {}
 
@@ -11232,6 +11412,10 @@ snapshots:
     dependencies:
       react: 19.2.5
 
+  use-sync-external-store@1.6.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+
   util-deprecate@1.0.2: {}
 
   vary@1.1.2: {}
@@ -11475,5 +11659,12 @@ snapshots:
   zod@4.4.2: {}
 
   zod@4.4.3: {}
+
+  zustand@4.5.7(@types/react@19.2.14)(react@19.2.6):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.6
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary
- add Studio persistence/session and pipeline inspection improvements
- add pipeline runtime APIs and docs for the new Studio workflows
- add @xyflow/react for the Studio pipeline UI
- bump @anvia/core and @anvia/studio to 0.2.0

## Verification
- pnpm --filter @anvia/core --filter @anvia/studio typecheck
- pnpm --filter @anvia/core --filter @anvia/studio test
- pnpm --filter @anvia/core --filter @anvia/studio build
- pnpm deploy in apps/docs

## Published
- @anvia/core@0.2.0
- @anvia/studio@0.2.0

Docs deploy: https://anvia-docs.me-063.workers.dev
Version ID: d345c59a-ea17-417f-ba1e-2ae5a05d1dbb