### PR TITLE
fix: persist Studio pipeline runs

### DIFF
--- a/packages/tools/studio/package.json
+++ b/packages/tools/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/studio",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Studio UI and HTTP runtime for Anvia agents.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/tools/studio/src/runtime/pipelines.ts
+++ b/packages/tools/studio/src/runtime/pipelines.ts
@@ -1,4 +1,4 @@
-import type { JsonValue, PipelineRunEvent } from "@anvia/core";
+import type { JsonObject, JsonValue, PipelineRunEvent } from "@anvia/core";
 import type { Context, Hono } from "hono";
 import { stream as streamResponse } from "hono/streaming";
 import type {
@@ -8,6 +8,8 @@ import type {
   StudioPipelineLogStore,
   StudioPipelineRunRequest,
   StudioPipelineRunResponse,
+  StudioPipelineRunSaveInput,
+  StudioPipelineRunStore,
 } from "../types";
 import {
   appendPipelineLog,
@@ -26,7 +28,8 @@ export function registerPipelineRoutes(
   props: {
     pipelines: StudioPipeline[];
     pipelineMap: Map<string, StudioPipeline>;
-    store?: StudioPipelineLogStore;
+    logStore?: StudioPipelineLogStore;
+    runStore?: StudioPipelineRunStore;
   },
 ): void {
   app.get("/pipelines", (c) =>
@@ -48,7 +51,7 @@ export function registerPipelineRoutes(
     if (!props.pipelineMap.has(pipelineId)) {
       return errorResponse(c, 404, "not_found", "Pipeline not found");
     }
-    if (props.store === undefined) {
+    if (props.logStore === undefined) {
       return errorResponse(
         c,
         501,
@@ -67,7 +70,7 @@ export function registerPipelineRoutes(
       return errorResponse(c, 400, "bad_request", "after must be a non-negative integer");
     }
 
-    const logs = await props.store.listPipelineLogs({
+    const logs = await props.logStore.listPipelineLogs({
       pipelineId,
       limit,
       ...(after === undefined ? {} : { after }),
@@ -77,6 +80,30 @@ export function registerPipelineRoutes(
       logs,
       ...(logs.length === limit && last !== undefined ? { nextCursor: last.sequence } : {}),
     });
+  });
+
+  app.get("/pipelines/:pipelineId/runs", async (c) => {
+    const pipelineId = c.req.param("pipelineId");
+    if (!props.pipelineMap.has(pipelineId)) {
+      return errorResponse(c, 404, "not_found", "Pipeline not found");
+    }
+    if (props.runStore === undefined) {
+      return errorResponse(
+        c,
+        501,
+        "unsupported_capability",
+        'Capability "pipelines.runs" is not implemented by this runner',
+        { capability: "pipelines", operation: "runs" },
+      );
+    }
+
+    const limit = parsePipelineLogLimit(c.req.query("limit"));
+    if (limit === undefined) {
+      return errorResponse(c, 400, "bad_request", "limit must be a positive integer");
+    }
+
+    const runs = await props.runStore.listPipelineRuns({ pipelineId, limit });
+    return c.json({ runs });
   });
 
   app.post("/pipelines/:pipelineId/runs", async (c) => {
@@ -92,8 +119,9 @@ export function registerPipelineRoutes(
 
     const runId = globalThis.crypto.randomUUID();
     const startedAt = Date.now();
+    const startedAtIso = new Date(startedAt).toISOString();
     await appendPipelineLog(
-      props.store,
+      props.logStore,
       pipelineRunReceivedLog({
         pipeline,
         runId,
@@ -102,6 +130,14 @@ export function registerPipelineRoutes(
         ...(body.metadata === undefined ? {} : { metadata: body.metadata }),
       }),
     );
+    await savePipelineRun(props.runStore, {
+      runId,
+      pipelineId: pipeline.id,
+      status: "running",
+      input: body.input,
+      ...(body.metadata === undefined ? {} : { metadata: body.metadata }),
+      startedAt: startedAtIso,
+    });
 
     if (body.stream === true) {
       return streamPipelineRun(c, {
@@ -109,26 +145,41 @@ export function registerPipelineRoutes(
         runId,
         input: body.input,
         startedAt,
-        ...(props.store === undefined ? {} : { store: props.store }),
+        startedAtIso,
+        ...(body.metadata === undefined ? {} : { metadata: body.metadata }),
+        ...(props.logStore === undefined ? {} : { logStore: props.logStore }),
+        ...(props.runStore === undefined ? {} : { runStore: props.runStore }),
       });
     }
 
     try {
-      await appendPipelineLog(props.store, pipelineRunStartedLog(pipeline, runId));
+      await appendPipelineLog(props.logStore, pipelineRunStartedLog(pipeline, runId));
       const output = await pipeline.pipeline.run(body.input, {
         observer: {
           async onEvent(event) {
-            await appendPipelineLog(props.store, pipelineStageLog(pipeline.id, runId, event));
+            await appendPipelineLog(props.logStore, pipelineStageLog(pipeline.id, runId, event));
           },
         },
       });
       const jsonOutput = toJsonValue(output);
+      const endedAt = Date.now();
+      await savePipelineRun(props.runStore, {
+        runId,
+        pipelineId: pipeline.id,
+        status: "success",
+        input: body.input,
+        output: jsonOutput,
+        ...(body.metadata === undefined ? {} : { metadata: body.metadata }),
+        startedAt: startedAtIso,
+        endedAt: new Date(endedAt).toISOString(),
+        durationMs: endedAt - startedAt,
+      });
       await appendPipelineLog(
-        props.store,
+        props.logStore,
         pipelineRunCompletedLog({
           pipelineId: pipeline.id,
           runId,
-          durationMs: Date.now() - startedAt,
+          durationMs: endedAt - startedAt,
           output: jsonOutput,
         }),
       );
@@ -139,8 +190,20 @@ export function registerPipelineRoutes(
       };
       return c.json(response);
     } catch (error) {
+      const endedAt = Date.now();
+      await savePipelineRun(props.runStore, {
+        runId,
+        pipelineId: pipeline.id,
+        status: "error",
+        input: body.input,
+        error: serializeError(error),
+        ...(body.metadata === undefined ? {} : { metadata: body.metadata }),
+        startedAt: startedAtIso,
+        endedAt: new Date(endedAt).toISOString(),
+        durationMs: endedAt - startedAt,
+      });
       await appendPipelineLog(
-        props.store,
+        props.logStore,
         pipelineRunFailedLog(pipeline.id, runId, error, startedAt),
       );
       return errorResponse(c, 500, "internal_error", "Pipeline run failed", serializeError(error));
@@ -164,7 +227,10 @@ function streamPipelineRun(
     runId: string;
     input: JsonValue;
     startedAt: number;
-    store?: StudioPipelineLogStore;
+    startedAtIso: string;
+    metadata?: JsonObject;
+    logStore?: StudioPipelineLogStore;
+    runStore?: StudioPipelineRunStore;
   },
 ): Response {
   c.header("content-type", "application/x-ndjson; charset=utf-8");
@@ -191,9 +257,12 @@ async function* pipelineRunEvents(props: {
   runId: string;
   input: JsonValue;
   startedAt: number;
-  store?: StudioPipelineLogStore;
+  startedAtIso: string;
+  metadata?: JsonObject;
+  logStore?: StudioPipelineLogStore;
+  runStore?: StudioPipelineRunStore;
 }): AsyncIterable<AgentRunStreamEvent> {
-  yield* emitPipelineLog(props.store, pipelineRunStartedLog(props.pipeline, props.runId));
+  yield* emitPipelineLog(props.logStore, pipelineRunStartedLog(props.pipeline, props.runId));
 
   const events = new AsyncEventQueue<AgentRunStreamEvent>();
   const run = props.pipeline.pipeline
@@ -201,7 +270,7 @@ async function* pipelineRunEvents(props: {
       observer: {
         async onEvent(event: PipelineRunEvent) {
           const log = await appendPipelineLog(
-            props.store,
+            props.logStore,
             pipelineStageLog(props.pipeline.id, props.runId, event),
           );
           if (log !== undefined) {
@@ -212,12 +281,24 @@ async function* pipelineRunEvents(props: {
     })
     .then(async (output) => {
       const jsonOutput = toJsonValue(output);
+      const endedAt = Date.now();
+      await savePipelineRun(props.runStore, {
+        runId: props.runId,
+        pipelineId: props.pipeline.id,
+        status: "success",
+        input: props.input,
+        output: jsonOutput,
+        ...(props.metadata === undefined ? {} : { metadata: props.metadata }),
+        startedAt: props.startedAtIso,
+        endedAt: new Date(endedAt).toISOString(),
+        durationMs: endedAt - props.startedAt,
+      });
       const log = await appendPipelineLog(
-        props.store,
+        props.logStore,
         pipelineRunCompletedLog({
           pipelineId: props.pipeline.id,
           runId: props.runId,
-          durationMs: Date.now() - props.startedAt,
+          durationMs: endedAt - props.startedAt,
           output: jsonOutput,
         }),
       );
@@ -232,8 +313,20 @@ async function* pipelineRunEvents(props: {
       });
     })
     .catch(async (error) => {
+      const endedAt = Date.now();
+      await savePipelineRun(props.runStore, {
+        runId: props.runId,
+        pipelineId: props.pipeline.id,
+        status: "error",
+        input: props.input,
+        error: serializeError(error),
+        ...(props.metadata === undefined ? {} : { metadata: props.metadata }),
+        startedAt: props.startedAtIso,
+        endedAt: new Date(endedAt).toISOString(),
+        durationMs: endedAt - props.startedAt,
+      });
       const log = await appendPipelineLog(
-        props.store,
+        props.logStore,
         pipelineRunFailedLog(props.pipeline.id, props.runId, error, props.startedAt),
       );
       if (log !== undefined) {
@@ -254,6 +347,13 @@ async function* pipelineRunEvents(props: {
   } finally {
     await run;
   }
+}
+
+async function savePipelineRun(
+  store: StudioPipelineRunStore | undefined,
+  input: StudioPipelineRunSaveInput,
+) {
+  return store?.savePipelineRun(input);
 }
 
 async function parsePipelineRunRequest(

--- a/packages/tools/studio/src/runtime/shared.ts
+++ b/packages/tools/studio/src/runtime/shared.ts
@@ -13,6 +13,7 @@ import type {
   StudioPipeline,
   StudioPipelineConfig,
   StudioPipelineLogStore,
+  StudioPipelineRunStore,
   StudioSessionStore,
   StudioStores,
   StudioTraceStatus,
@@ -25,6 +26,7 @@ export type ResolvedStores = {
   sessions?: StudioSessionStore;
   traces?: StudioTraceStore;
   pipelineLogs?: StudioPipelineLogStore;
+  pipelineRuns?: StudioPipelineRunStore;
 };
 
 export type StudioRuntimeOptions = {
@@ -47,10 +49,12 @@ export function resolveStores(options: StudioRuntimeOptions): ResolvedStores {
   const sessions = resolveSessionStore(options, defaultStore);
   const traces = resolveTraceStore(options, sessions, defaultStore);
   const pipelineLogs = resolvePipelineLogStore(options, sessions, defaultStore);
+  const pipelineRuns = resolvePipelineRunStore(options, sessions, pipelineLogs, defaultStore);
   return {
     ...(sessions === undefined ? {} : { sessions }),
     ...(traces === undefined ? {} : { traces }),
     ...(pipelineLogs === undefined ? {} : { pipelineLogs }),
+    ...(pipelineRuns === undefined ? {} : { pipelineRuns }),
   };
 }
 
@@ -102,6 +106,27 @@ function resolvePipelineLogStore(
   return defaultStore;
 }
 
+function resolvePipelineRunStore(
+  options: StudioRuntimeOptions,
+  sessionStore: StudioSessionStore | undefined,
+  pipelineLogStore: StudioPipelineLogStore | undefined,
+  defaultStore: StudioPipelineRunStore,
+): StudioPipelineRunStore | undefined {
+  if (options.stores?.pipelineRuns === false) {
+    return undefined;
+  }
+  if (options.stores?.pipelineRuns !== undefined) {
+    return options.stores.pipelineRuns;
+  }
+  if (sessionStore !== undefined && isPipelineRunStore(sessionStore)) {
+    return sessionStore;
+  }
+  if (pipelineLogStore !== undefined && isPipelineRunStore(pipelineLogStore)) {
+    return pipelineLogStore;
+  }
+  return defaultStore;
+}
+
 function isTraceStore(store: StudioSessionStore): store is StudioSessionStore & StudioTraceStore {
   const candidate = store as Partial<StudioTraceStore>;
   return (
@@ -118,6 +143,14 @@ function isPipelineLogStore(
   return (
     typeof candidate.appendPipelineLog === "function" &&
     typeof candidate.listPipelineLogs === "function"
+  );
+}
+
+function isPipelineRunStore(store: object): store is object & StudioPipelineRunStore {
+  const candidate = store as Partial<StudioPipelineRunStore>;
+  return (
+    typeof candidate.savePipelineRun === "function" &&
+    typeof candidate.listPipelineRuns === "function"
   );
 }
 

--- a/packages/tools/studio/src/runtime/studio.ts
+++ b/packages/tools/studio/src/runtime/studio.ts
@@ -275,7 +275,8 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
   registerPipelineRoutes(app, {
     pipelines,
     pipelineMap,
-    ...(stores.pipelineLogs === undefined ? {} : { store: stores.pipelineLogs }),
+    ...(stores.pipelineLogs === undefined ? {} : { logStore: stores.pipelineLogs }),
+    ...(stores.pipelineRuns === undefined ? {} : { runStore: stores.pipelineRuns }),
   });
 
   app.post("/agents/:agentId/runs", async (c) => {

--- a/packages/tools/studio/src/storage/sqlite-store.ts
+++ b/packages/tools/studio/src/storage/sqlite-store.ts
@@ -15,6 +15,10 @@ import type {
   StudioPipelineLogEntry,
   StudioPipelineLogListOptions,
   StudioPipelineLogStore,
+  StudioPipelineRunListOptions,
+  StudioPipelineRunRecord,
+  StudioPipelineRunSaveInput,
+  StudioPipelineRunStore,
   StudioSession,
   StudioSessionCreateInput,
   StudioSessionListOptions,
@@ -133,13 +137,28 @@ type PipelineLogRow = {
   metadata_json: string | null;
 };
 
+type PipelineRunRow = {
+  run_id: string;
+  pipeline_id: string;
+  status: StudioPipelineRunRecord["status"];
+  input_json: string;
+  output_json: string | null;
+  error_json: string | null;
+  metadata_json: string | null;
+  started_at: string;
+  ended_at: string | null;
+  duration_ms: number | null;
+};
+
 export function createSqliteSessionStore(
   options: SqliteSessionStoreOptions = {},
-): StudioSessionStore & StudioTraceStore & StudioPipelineLogStore {
+): StudioSessionStore & StudioTraceStore & StudioPipelineLogStore & StudioPipelineRunStore {
   return new SqliteSessionStore(options.path ?? ":memory:");
 }
 
-class SqliteSessionStore implements StudioSessionStore, StudioTraceStore, StudioPipelineLogStore {
+class SqliteSessionStore
+  implements StudioSessionStore, StudioTraceStore, StudioPipelineLogStore, StudioPipelineRunStore
+{
   readonly kind = "sqlite";
   private db: DatabaseSyncType | undefined;
 
@@ -556,6 +575,88 @@ class SqliteSessionStore implements StudioSessionStore, StudioTraceStore, Studio
     return rows.map(toPipelineLog);
   }
 
+  savePipelineRun(input: StudioPipelineRunSaveInput): StudioPipelineRunRecord {
+    const db = this.database();
+    db.prepare(
+      `INSERT INTO runner_pipeline_runs (
+        run_id,
+        pipeline_id,
+        status,
+        input_json,
+        output_json,
+        error_json,
+        metadata_json,
+        started_at,
+        ended_at,
+        duration_ms
+      ) VALUES (
+        $runId,
+        $pipelineId,
+        $status,
+        $input,
+        $output,
+        $error,
+        $metadata,
+        $startedAt,
+        $endedAt,
+        $durationMs
+      )
+      ON CONFLICT(run_id) DO UPDATE SET
+        pipeline_id = excluded.pipeline_id,
+        status = excluded.status,
+        input_json = excluded.input_json,
+        output_json = excluded.output_json,
+        error_json = excluded.error_json,
+        metadata_json = excluded.metadata_json,
+        started_at = excluded.started_at,
+        ended_at = excluded.ended_at,
+        duration_ms = excluded.duration_ms`,
+    ).run({
+      $runId: input.runId,
+      $pipelineId: input.pipelineId,
+      $status: input.status,
+      $input: JSON.stringify(input.input),
+      $output: input.output === undefined ? null : JSON.stringify(input.output),
+      $error: input.error === undefined ? null : JSON.stringify(input.error),
+      $metadata: input.metadata === undefined ? null : JSON.stringify(input.metadata),
+      $startedAt: input.startedAt,
+      $endedAt: input.endedAt ?? null,
+      $durationMs: input.durationMs ?? null,
+    });
+
+    return {
+      runId: input.runId,
+      pipelineId: input.pipelineId,
+      status: input.status,
+      input: input.input,
+      ...(input.output === undefined ? {} : { output: input.output }),
+      ...(input.error === undefined ? {} : { error: input.error }),
+      ...(input.metadata === undefined ? {} : { metadata: input.metadata }),
+      startedAt: input.startedAt,
+      ...(input.endedAt === undefined ? {} : { endedAt: input.endedAt }),
+      ...(input.durationMs === undefined ? {} : { durationMs: input.durationMs }),
+    };
+  }
+
+  listPipelineRuns(options: StudioPipelineRunListOptions): StudioPipelineRunRecord[] {
+    const db = this.database();
+    const rows = db
+      .prepare(
+        `SELECT run_id, pipeline_id, status, input_json, output_json, error_json,
+                metadata_json, started_at, ended_at, duration_ms
+         FROM runner_pipeline_runs
+         WHERE pipeline_id = $pipelineId
+         ORDER BY started_at DESC
+         LIMIT $limit`,
+      )
+      .all({
+        $pipelineId: options.pipelineId,
+        $limit: options.limit,
+      }) as PipelineRunRow[];
+
+    return rows.map(toPipelineRun);
+  }
+
   deleteSession(id: string): boolean {
     const db = this.database();
 
@@ -812,6 +913,20 @@ class SqliteSessionStore implements StudioSessionStore, StudioTraceStore, Studio
       ) STRICT;
       CREATE INDEX IF NOT EXISTS runner_pipeline_logs_pipeline_sequence_idx
         ON runner_pipeline_logs(pipeline_id, sequence ASC);
+      CREATE TABLE IF NOT EXISTS runner_pipeline_runs (
+        run_id TEXT PRIMARY KEY,
+        pipeline_id TEXT NOT NULL,
+        status TEXT NOT NULL,
+        input_json TEXT NOT NULL,
+        output_json TEXT,
+        error_json TEXT,
+        metadata_json TEXT,
+        started_at TEXT NOT NULL,
+        ended_at TEXT,
+        duration_ms INTEGER
+      ) STRICT;
+      CREATE INDEX IF NOT EXISTS runner_pipeline_runs_pipeline_started_idx
+        ON runner_pipeline_runs(pipeline_id, started_at DESC);
       CREATE TABLE IF NOT EXISTS runner_traces (
         id TEXT PRIMARY KEY,
         session_id TEXT NOT NULL,
@@ -1042,6 +1157,24 @@ function toPipelineLog(row: PipelineLogRow): StudioPipelineLogEntry {
     event: row.event,
     message: row.message,
     ...(metadata === undefined ? {} : { metadata }),
+  };
+}
+
+function toPipelineRun(row: PipelineRunRow): StudioPipelineRunRecord {
+  const output = parseJsonValue<JsonValue>(row.output_json);
+  const error = parseJsonValue<JsonValue>(row.error_json);
+  const metadata = parseJsonValue<JsonObject>(row.metadata_json);
+  return {
+    runId: row.run_id,
+    pipelineId: row.pipeline_id,
+    status: row.status,
+    input: JSON.parse(row.input_json) as JsonValue,
+    ...(output === undefined ? {} : { output }),
+    ...(error === undefined ? {} : { error }),
+    ...(metadata === undefined ? {} : { metadata }),
+    startedAt: row.started_at,
+    ...(row.ended_at === null ? {} : { endedAt: row.ended_at }),
+    ...(row.duration_ms === null ? {} : { durationMs: row.duration_ms }),
   };
 }
 

--- a/packages/tools/studio/src/types.ts
+++ b/packages/tools/studio/src/types.ts
@@ -399,6 +399,7 @@ export type StudioStores = {
   sessions?: StudioSessionStore | false;
   traces?: StudioTraceStore;
   pipelineLogs?: StudioPipelineLogStore | false;
+  pipelineRuns?: StudioPipelineRunStore | false;
 };
 
 export type StudioUiOptions = {
@@ -579,6 +580,48 @@ export type StudioPipelineFinalEvent = {
   runId: string;
   pipelineId: string;
   output: JsonValue;
+};
+
+export type StudioPipelineRunStatus = "running" | "success" | "error";
+
+export type StudioPipelineRunRecord = {
+  runId: string;
+  pipelineId: string;
+  status: StudioPipelineRunStatus;
+  input: JsonValue;
+  output?: JsonValue;
+  error?: JsonValue;
+  metadata?: JsonObject;
+  startedAt: string;
+  endedAt?: string;
+  durationMs?: number;
+};
+
+export type StudioPipelineRunSaveInput = {
+  runId: string;
+  pipelineId: string;
+  status: StudioPipelineRunStatus;
+  input: JsonValue;
+  output?: JsonValue;
+  error?: JsonValue;
+  metadata?: JsonObject;
+  startedAt: string;
+  endedAt?: string;
+  durationMs?: number;
+};
+
+export type StudioPipelineRunListOptions = {
+  pipelineId: string;
+  limit: number;
+};
+
+export type StudioPipelineRunStore = {
+  savePipelineRun(
+    input: StudioPipelineRunSaveInput,
+  ): StudioPipelineRunRecord | Promise<StudioPipelineRunRecord>;
+  listPipelineRuns(
+    options: StudioPipelineRunListOptions,
+  ): StudioPipelineRunRecord[] | Promise<StudioPipelineRunRecord[]>;
 };
 
 export type StudioPipelineRunRequest = {

--- a/packages/tools/studio/src/ui/app/app.tsx
+++ b/packages/tools/studio/src/ui/app/app.tsx
@@ -15,6 +15,7 @@ import type {
   StudioKnowledgeSummary,
   StudioPipelineDetail,
   StudioPipelineLogEntry,
+  StudioPipelineRunRecord,
   StudioSession,
   StudioSessionLogEntry,
   StudioSessionSummary,
@@ -117,10 +118,12 @@ export function StudioConsole() {
   const [sessionLogs, setSessionLogs] = useState<StudioSessionLogEntry[]>([]);
   const [pipelineDetail, setPipelineDetail] = useState<StudioPipelineDetail | undefined>();
   const [pipelineLogs, setPipelineLogs] = useState<StudioPipelineLogEntry[]>([]);
+  const [pipelineRuns, setPipelineRuns] = useState<StudioPipelineRunRecord[]>([]);
   const [messages, setMessages] = useState<TranscriptEntry[]>([]);
   const [prompt, setPrompt] = useState("");
   const [pipelineRunInput, setPipelineRunInput] = useState('"Hello from Studio"');
   const [pipelineRunOutput, setPipelineRunOutput] = useState("");
+  const [activePipelineRunId, setActivePipelineRunId] = useState("");
   const [activePage, setActivePage] = useState<ActivePage>(() => initialLocation.page);
   const [selectedTraceId, setSelectedTraceId] = useState(() => initialLocation.traceId ?? "");
   const [traceSessionDetailId, setTraceSessionDetailId] = useState<string | undefined>(
@@ -145,6 +148,7 @@ export function StudioConsole() {
     "idle",
   );
   const [pipelineLogLoadState, setPipelineLogLoadState] = useState<"idle" | "loading">("idle");
+  const [pipelineRunLoadState, setPipelineRunLoadState] = useState<"idle" | "loading">("idle");
   const [pipelineRunState, setPipelineRunState] = useState<RunState>("idle");
   const promptRef = useRef<HTMLTextAreaElement | null>(null);
 
@@ -492,11 +496,40 @@ export function StudioConsole() {
     [pipelinesEnabled],
   );
 
+  const loadPipelineRuns = useCallback(
+    async (pipelineId: string): Promise<StudioPipelineRunRecord[]> => {
+      if (!pipelinesEnabled || pipelineId.length === 0) {
+        setPipelineRuns([]);
+        return [];
+      }
+
+      setPipelineRunLoadState("loading");
+      try {
+        const params = new URLSearchParams({ limit: "50" });
+        const response = await fetch(`/pipelines/${encodeURIComponent(pipelineId)}/runs?${params}`);
+        if (!response.ok) {
+          throw new Error(`Pipeline runs failed with HTTP ${response.status}`);
+        }
+        const body = (await response.json()) as { runs: StudioPipelineRunRecord[] };
+        setPipelineRuns(body.runs);
+        return body.runs;
+      } catch (loadError) {
+        setError(errorMessage(loadError));
+        setPipelineRuns([]);
+        return [];
+      } finally {
+        setPipelineRunLoadState("idle");
+      }
+    },
+    [pipelinesEnabled],
+  );
+
   const loadPipeline = useCallback(
     async (pipelineId: string) => {
       if (!pipelinesEnabled || pipelineId.length === 0) {
         setPipelineDetail(undefined);
         setPipelineLogs([]);
+        setPipelineRuns([]);
         return;
       }
 
@@ -509,7 +542,7 @@ export function StudioConsole() {
         }
         setSelectedPipelineId(pipelineId);
         setPipelineDetail((await response.json()) as StudioPipelineDetail);
-        await loadPipelineLogs(pipelineId);
+        await Promise.all([loadPipelineLogs(pipelineId), loadPipelineRuns(pipelineId)]);
       } catch (loadError) {
         setError(errorMessage(loadError));
         setPipelineDetail(undefined);
@@ -517,7 +550,7 @@ export function StudioConsole() {
         setPipelineDetailLoadState("idle");
       }
     },
-    [loadPipelineLogs, pipelinesEnabled],
+    [loadPipelineLogs, loadPipelineRuns, pipelinesEnabled],
   );
 
   useEffect(() => {
@@ -774,6 +807,7 @@ export function StudioConsole() {
 
     setPipelineRunState("running");
     setPipelineRunOutput("");
+    setActivePipelineRunId("");
     setError("");
     try {
       const response = await fetch(`/pipelines/${encodeURIComponent(pipelineId)}/runs`, {
@@ -796,6 +830,9 @@ export function StudioConsole() {
 
       await readJsonl(response.body, async (event) => {
         if (isPipelineLogEvent(event)) {
+          if (event.log.runId !== undefined) {
+            setActivePipelineRunId((current) => current || event.log.runId || "");
+          }
           appendPipelineLogEntry(event.log);
           await nextPaint();
           return;
@@ -809,7 +846,7 @@ export function StudioConsole() {
           throw new Error(JSON.stringify(event.error));
         }
       });
-      await loadPipelineLogs(pipelineId);
+      await Promise.all([loadPipelineLogs(pipelineId), loadPipelineRuns(pipelineId)]);
       setStatus("Connected");
     } catch (runError) {
       setError(errorMessage(runError));
@@ -1682,15 +1719,19 @@ export function StudioConsole() {
             selectedPipelineId={selectedPipelineId}
             detail={pipelineDetail}
             logs={pipelineLogs}
+            activeRunId={activePipelineRunId}
+            runs={pipelineRuns}
             enabled={pipelinesEnabled}
             detailLoading={pipelineDetailLoadState === "loading"}
             logsLoading={pipelineLogLoadState === "loading"}
+            runsLoading={pipelineRunLoadState === "loading"}
             runState={pipelineRunState}
             runInput={pipelineRunInput}
             runOutput={pipelineRunOutput}
             onSelectPipeline={(pipelineId) => {
               setSelectedPipelineId(pipelineId);
               setPipelineRunOutput("");
+              setActivePipelineRunId("");
               void loadPipeline(pipelineId);
             }}
             onRunInputChange={setPipelineRunInput}

--- a/packages/tools/studio/src/ui/app/modules/pipelines/pipelines-page.tsx
+++ b/packages/tools/studio/src/ui/app/modules/pipelines/pipelines-page.tsx
@@ -13,7 +13,12 @@ import {
 import "@xyflow/react/dist/style.css";
 import { Play } from "lucide-react";
 import { type CSSProperties, useEffect, useMemo, useRef, useState } from "react";
-import type { StudioConfig, StudioPipelineDetail, StudioPipelineLogEntry } from "../../../../types";
+import type {
+  StudioConfig,
+  StudioPipelineDetail,
+  StudioPipelineLogEntry,
+  StudioPipelineRunRecord,
+} from "../../../../types";
 import { Button } from "../../components/ui/button";
 import {
   Select,
@@ -32,15 +37,19 @@ const flowPrimaryColor = "var(--primary)";
 const flowBackgroundColor = "var(--background)";
 const flowMutedForegroundColor = "var(--muted-foreground)";
 const flowDestructiveColor = "var(--destructive)";
+const flowRunningColor = "hsl(38 96% 56%)";
 
 export function PipelinesPage(props: {
   pipelines: StudioConfig["pipelines"];
   selectedPipelineId: string;
   detail: StudioPipelineDetail | undefined;
   logs: StudioPipelineLogEntry[];
+  activeRunId: string;
+  runs: StudioPipelineRunRecord[];
   enabled: boolean;
   detailLoading: boolean;
   logsLoading: boolean;
+  runsLoading: boolean;
   runState: "idle" | "running";
   runInput: string;
   runOutput: string;
@@ -52,7 +61,10 @@ export function PipelinesPage(props: {
   const graph = props.detail?.graph;
   const selectedNode =
     graph?.nodes.find((node) => node.id === selectedNodeId) ?? graph?.nodes[0] ?? undefined;
-  const nodeStatuses = useMemo(() => nodeStatusFromLogs(props.logs), [props.logs]);
+  const nodeStatuses = useMemo(
+    () => nodeStatusFromLogs(props.logs, props.activeRunId),
+    [props.logs, props.activeRunId],
+  );
   const flow = useMemo(() => {
     if (graph === undefined) {
       return { nodes: [] as Node[], edges: [] as Edge[] };
@@ -136,7 +148,9 @@ export function PipelinesPage(props: {
         selectedPipelineId={props.selectedPipelineId}
         detail={props.detail}
         logs={props.logs}
+        runs={props.runs}
         logsLoading={props.logsLoading}
+        runsLoading={props.runsLoading}
         runState={props.runState}
         runInput={props.runInput}
         runOutput={props.runOutput}
@@ -160,7 +174,9 @@ function PipelineInspectorSidebar(props: {
   selectedPipelineId: string;
   detail: StudioPipelineDetail | undefined;
   logs: StudioPipelineLogEntry[];
+  runs: StudioPipelineRunRecord[];
   logsLoading: boolean;
+  runsLoading: boolean;
   runState: "idle" | "running";
   runInput: string;
   runOutput: string;
@@ -240,7 +256,12 @@ function PipelineInspectorSidebar(props: {
           />
         ) : null}
         {activeTab === "runs" ? (
-          <PipelineRunsPanel runOutput={props.runOutput} runState={props.runState} />
+          <PipelineRunsPanel
+            runs={props.runs}
+            runOutput={props.runOutput}
+            runState={props.runState}
+            loading={props.runsLoading}
+          />
         ) : null}
         {activeTab === "logs" ? (
           <PipelineLogsSection
@@ -379,35 +400,113 @@ function PipelineMetadataPanel(props: {
   );
 }
 
-function PipelineRunsPanel(props: { runOutput: string; runState: "idle" | "running" }) {
+function PipelineRunsPanel(props: {
+  runs: StudioPipelineRunRecord[];
+  runOutput: string;
+  runState: "idle" | "running";
+  loading: boolean;
+}) {
   return (
     <section className="grid gap-3">
       <div className="flex min-w-0 items-center justify-between gap-3">
         <div className="min-w-0">
           <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-            Latest run
+            Runs
           </div>
           <p className="m-0 mt-1 text-xs leading-5 text-muted-foreground">
-            Most recent HTTP pipeline output.
+            Persisted pipeline executions.
           </p>
         </div>
         <Badge>{props.runState}</Badge>
       </div>
+      {props.runOutput.length > 0 && props.runs.length === 0 ? (
+        <PipelineRunOutputBlock title="Latest output" output={props.runOutput} />
+      ) : null}
       <div className="grid gap-2">
-        <div className="flex items-center justify-between gap-3">
-          <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-            Output
-          </span>
-          <span className="font-mono text-[9px] font-medium tabular-nums text-muted-foreground">
-            {props.runOutput.length} bytes
-          </span>
-        </div>
-        <pre className="min-h-52 max-h-[32rem] overflow-auto whitespace-pre-wrap break-words rounded-sm border border-border/80 bg-card/30 p-3 font-mono text-xs leading-5 text-foreground">
-          {props.runOutput.length > 0 ? props.runOutput : "Run the pipeline to inspect output."}
-        </pre>
+        {props.loading && props.runs.length === 0 ? (
+          <div className="grid gap-2 py-3">
+            <div className="h-4 w-32 animate-pulse rounded-sm bg-muted" />
+            <div className="h-4 w-56 max-w-full animate-pulse rounded-sm bg-muted/60" />
+          </div>
+        ) : null}
+        {!props.loading && props.runs.length === 0 ? (
+          <div className="py-3 text-sm font-medium text-muted-foreground">
+            No saved pipeline runs yet.
+          </div>
+        ) : null}
+        {props.runs.map((run) => (
+          <PipelineRunRow run={run} key={run.runId} />
+        ))}
       </div>
     </section>
   );
+}
+
+function PipelineRunRow(props: { run: StudioPipelineRunRecord }) {
+  const output = pipelineRunOutputText(props.run);
+  return (
+    <article className="grid gap-3 rounded-sm border border-border/80 bg-card/25 p-3">
+      <div className="flex min-w-0 items-center justify-between gap-3">
+        <span className="truncate font-mono text-[11px] font-semibold text-foreground">
+          {props.run.runId}
+        </span>
+        <span
+          className={[
+            "shrink-0 font-mono text-[10px] font-semibold uppercase tracking-[0.08em]",
+            pipelineRunStatusClass(props.run.status),
+          ].join(" ")}
+        >
+          {props.run.status}
+        </span>
+      </div>
+      <div className="grid grid-cols-2 gap-2 text-[11px] text-muted-foreground">
+        <span className="truncate">{formatLogTime(props.run.startedAt)}</span>
+        <span className="truncate text-right tabular-nums">
+          {props.run.durationMs === undefined ? "" : `${props.run.durationMs}ms`}
+        </span>
+      </div>
+      <PipelineRunOutputBlock title="Output" output={output} />
+    </article>
+  );
+}
+
+function PipelineRunOutputBlock(props: { title: string; output: string }) {
+  return (
+    <div className="grid gap-2">
+      <div className="flex min-w-0 items-center justify-between gap-3">
+        <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+          {props.title}
+        </span>
+        <span className="font-mono text-[9px] font-medium tabular-nums text-muted-foreground">
+          {props.output.length} bytes
+        </span>
+      </div>
+      <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-words rounded-sm border border-border/80 bg-background/55 p-3 font-mono text-xs leading-5 text-foreground">
+        {props.output.length > 0 ? props.output : "No output saved."}
+      </pre>
+    </div>
+  );
+}
+
+function pipelineRunOutputText(run: StudioPipelineRunRecord): string {
+  if (run.output !== undefined) {
+    return JSON.stringify(run.output, null, 2);
+  }
+  if (run.error !== undefined) {
+    return JSON.stringify(run.error, null, 2);
+  }
+  return "";
+}
+
+function pipelineRunStatusClass(status: StudioPipelineRunRecord["status"]): string {
+  switch (status) {
+    case "success":
+      return "text-primary";
+    case "error":
+      return "text-destructive";
+    case "running":
+      return "text-muted-foreground";
+  }
 }
 
 function NodeInspector(props: {
@@ -607,7 +706,7 @@ function PipelineStageNode(props: NodeProps<Node<PipelineNodeData>>) {
       className={[
         "group relative min-h-[74px] w-[210px] rounded-md border bg-card px-4 py-3 text-left shadow-[inset_0_1px_0_hsl(var(--foreground)/0.06)] transition duration-200",
         props.selected ? "border-primary" : "border-border/80",
-        status === "running" ? "translate-y-[-1px] border-primary" : "",
+        status === "running" ? "translate-y-[-1px] border-amber-400" : "",
         status === "completed" ? "border-primary/70" : "",
         status === "failed" ? "border-destructive" : "",
       ].join(" ")}
@@ -623,14 +722,20 @@ function PipelineStageNode(props: NodeProps<Node<PipelineNodeData>>) {
             {props.data.label}
           </div>
           <div className="mt-1 flex items-center gap-1.5">
-            <span className="h-1.5 w-1.5 rounded-full bg-primary" />
+            <span
+              className="h-1.5 w-1.5 rounded-full"
+              style={{ backgroundColor: props.data.statusColor }}
+            />
             <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
               {props.data.kind}
             </span>
           </div>
         </div>
         {status === undefined ? null : (
-          <span className="rounded-sm border border-border/70 bg-background/70 px-1.5 py-0.5 font-mono text-[9px] font-semibold uppercase tracking-[0.08em] text-primary">
+          <span
+            className="rounded-sm border border-border/70 bg-background/70 px-1.5 py-0.5 font-mono text-[9px] font-semibold uppercase tracking-[0.08em]"
+            style={{ color: props.data.statusColor }}
+          >
             {status}
           </span>
         )}
@@ -651,9 +756,18 @@ function PipelineStageNode(props: NodeProps<Node<PipelineNodeData>>) {
 
 type NodeStatus = "running" | "completed" | "failed";
 
-function nodeStatusFromLogs(logs: StudioPipelineLogEntry[]): Map<string, NodeStatus> {
+function nodeStatusFromLogs(
+  logs: StudioPipelineLogEntry[],
+  activeRunId: string,
+): Map<string, NodeStatus> {
   const statuses = new Map<string, NodeStatus>();
+  if (activeRunId.length === 0) {
+    return statuses;
+  }
   for (const log of logs) {
+    if (log.runId !== activeRunId) {
+      continue;
+    }
     const nodeId = metadataString(log.metadata, "nodeId");
     if (nodeId === undefined) {
       continue;
@@ -758,7 +872,7 @@ function nodeDepths(graph: StudioPipelineDetail["graph"]): Map<string, number> {
 function statusColor(status: NodeStatus | undefined): string {
   switch (status) {
     case "running":
-      return flowPrimaryColor;
+      return flowRunningColor;
     case "completed":
       return flowPrimaryColor;
     case "failed":

--- a/packages/tools/studio/test/runner.test.ts
+++ b/packages/tools/studio/test/runner.test.ts
@@ -422,7 +422,7 @@ describe("Anvia studio", () => {
     });
   });
 
-  it("runs pipelines over HTTP and persists metadata-only pipeline logs", async () => {
+  it("runs pipelines over HTTP and persists runs plus metadata-only pipeline logs", async () => {
     const pipeline = new PipelineBuilder<string>({ id: "audit-pipeline" })
       .step((input) => input.trim(), { id: "normalize", name: "Normalize" })
       .step((input) => ({ reply: input.toUpperCase() }), { id: "shape", name: "Shape" })
@@ -490,6 +490,50 @@ describe("Anvia studio", () => {
     const serializedLogs = JSON.stringify([...firstBody.logs, ...nextBody.logs]);
     expect(serializedLogs).not.toContain("raw secret payload");
     expect(serializedLogs).not.toContain("RAW SECRET PAYLOAD");
+
+    const runsPage = await runner.fetch(
+      new Request("http://runner.test/pipelines/audit-pipeline/runs?limit=10"),
+    );
+    expect(runsPage.status).toBe(200);
+    const runsBody = (await runsPage.json()) as {
+      runs: Array<{
+        runId: string;
+        pipelineId: string;
+        status: string;
+        input: unknown;
+        output?: unknown;
+        metadata?: unknown;
+      }>;
+    };
+    expect(runsBody.runs).toHaveLength(1);
+    const savedRun = runsBody.runs[0]!;
+    expect(savedRun).toMatchObject({
+      pipelineId: "audit-pipeline",
+      status: "success",
+      input: " raw secret payload ",
+      output: { reply: "RAW SECRET PAYLOAD" },
+    });
+
+    const db = new DatabaseSync(process.env.ANVIA_STUDIO_DB!);
+    try {
+      const row = db
+        .prepare(
+          `SELECT pipeline_id, status, input_json, output_json
+           FROM runner_pipeline_runs
+           WHERE run_id = $runId`,
+        )
+        .get({ $runId: savedRun.runId }) as
+        | { pipeline_id: string; status: string; input_json: string; output_json: string }
+        | undefined;
+      expect(row).toMatchObject({
+        pipeline_id: "audit-pipeline",
+        status: "success",
+        input_json: JSON.stringify(" raw secret payload "),
+        output_json: JSON.stringify({ reply: "RAW SECRET PAYLOAD" }),
+      });
+    } finally {
+      db.close();
+    }
   });
 
   it("starts a served single-agent runner from a built agent", async () => {


### PR DESCRIPTION
## Summary
- persist Studio pipeline run records for streamed and non-streamed executions
- add pipeline run listing support and UI run history in the pipeline inspector
- bump @anvia/studio to 0.2.1

## Verification
- pnpm --filter @anvia/studio typecheck
- pnpm --filter @anvia/studio test
- pnpm --filter @anvia/studio build

## Published
- @anvia/studio@0.2.1