### PR TITLE
fix(openai): preserve Kimi reasoning tool-call history

### DIFF
--- a/packages/providers/openai/README.md
+++ b/packages/providers/openai/README.md
@@ -54,6 +54,41 @@ const model = client.completionModel("openai/gpt-5.2");
 
 You can also force a specific completion API with `completionApi: "responses"` or `completionApi: "chat"`.
 
+### Reasoning tool-call providers
+
+Some OpenAI-compatible chat-completions providers return reasoning in provider-specific
+fields while using normal tool calls. For example, Moonshot Kimi K2.6 returns
+`reasoning_content` when thinking is enabled.
+
+The chat-completions adapter preserves this reasoning in assistant history and sends it
+back as `reasoning_content` on later turns. This matters after tool calls: providers
+such as Moonshot can reject the next request if an assistant `tool_calls` message is
+missing its prior `reasoning_content`.
+
+For Moonshot Kimi K2.6 thinking mode:
+
+```ts
+const client = new OpenAIClient({
+  apiKey: process.env.OPENAI_API_KEY,
+  baseUrl: "https://api.moonshot.ai/v1",
+});
+
+const model = client.completionModel("kimi-k2.6");
+
+const response = await model.completion({
+  chatHistory,
+  documents: [],
+  tools,
+  maxTokens: 16_000,
+  additionalParams: {
+    thinking: { type: "enabled", keep: "all" },
+  },
+});
+```
+
+Provider caveat: Moonshot rejects forced/specified `tool_choice` while thinking is
+enabled. Let the model choose tools naturally when using Kimi thinking mode.
+
 ## Other Models
 
 ```ts

--- a/packages/providers/openai/package.json
+++ b/packages/providers/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/openai",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "OpenAI provider adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/providers/openai/src/openai/chat-completion.ts
+++ b/packages/providers/openai/src/openai/chat-completion.ts
@@ -122,6 +122,11 @@ export function fromOpenAIChatCompletionResponse(response: unknown): CompletionR
     choice.push(AssistantContent.text(message.content));
   }
 
+  const reasoning = stringFrom(message.reasoning) ?? stringFrom(message.reasoning_content);
+  if (reasoning !== undefined && reasoning.length > 0) {
+    choice.push(AssistantContent.reasoning(reasoning));
+  }
+
   const toolCalls = Array.isArray(message.tool_calls) ? message.tool_calls : [];
   for (const toolCall of toolCalls) {
     if (!isPlainObject(toolCall)) {
@@ -250,13 +255,17 @@ function messageToChatMessages(message: MessageType): ChatMessage[] {
   const text = message.content
     .flatMap((content) => (content.type === "text" ? [content.text] : []))
     .join("\n");
+  const reasoning = message.content
+    .flatMap((content) => (content.type === "reasoning" ? [content.text] : []))
+    .filter((text) => text.length > 0)
+    .join("\n");
   if (message.content.some((content) => content.type === "image")) {
     throw new Error("OpenAI chat completions does not support image content in assistant history");
   }
   const toolCalls = message.content
     .filter((content) => content.type === "tool_call")
     .map((content) => ({
-      id: content.id,
+      id: content.callId ?? content.id,
       type: "function",
       function: {
         name: content.function.name,
@@ -269,6 +278,9 @@ function messageToChatMessages(message: MessageType): ChatMessage[] {
   };
   if (text.length > 0) {
     chatMessage.content = text;
+  }
+  if (reasoning.length > 0) {
+    chatMessage.reasoning_content = reasoning;
   }
   if (toolCalls.length > 0) {
     chatMessage.tool_calls = toolCalls;

--- a/packages/providers/openai/test/openai-chat-completion.test.ts
+++ b/packages/providers/openai/test/openai-chat-completion.test.ts
@@ -1,6 +1,10 @@
-import { Message, UserContent } from "@anvia/core";
+import { AssistantContent, Message, ToolContent, UserContent } from "@anvia/core";
 import { describe, expect, it } from "vitest";
 import { OpenAIChatCompletionModel, OpenAIClient } from "../src/index";
+import {
+  fromOpenAIChatCompletionResponse,
+  toOpenAIChatCompletionParams,
+} from "../src/openai/chat-completion";
 
 describe("OpenAI chat-completions client path", () => {
   it("exposes OpenAI chat-completions capability metadata", () => {
@@ -62,6 +66,57 @@ describe("OpenAI chat-completions client path", () => {
     });
 
     expect(openai.completionModel("custom-chat-model")).toBeInstanceOf(OpenAIChatCompletionModel);
+  });
+
+  it("preserves assistant reasoning and provider tool call ids across tool turns", () => {
+    const params = toOpenAIChatCompletionParams("kimi-k2.6", {
+      chatHistory: [
+        Message.assistant([
+          AssistantContent.reasoning("provider reasoning text"),
+          AssistantContent.toolCall("tool_0", "create_task", { title: "A" }, "call_abc"),
+        ]),
+        Message.tool(ToolContent.toolResult("tool_0", '{"id":"task_1"}', "call_abc")),
+        Message.user("continue"),
+      ],
+      documents: [],
+      tools: [],
+    });
+
+    expect(params.messages).toEqual([
+      {
+        role: "assistant",
+        reasoning_content: "provider reasoning text",
+        tool_calls: [
+          {
+            id: "call_abc",
+            type: "function",
+            function: { name: "create_task", arguments: '{"title":"A"}' },
+          },
+        ],
+      },
+      { role: "tool", tool_call_id: "call_abc", content: '{"id":"task_1"}' },
+      { role: "user", content: "continue" },
+    ]);
+  });
+
+  it("maps non-streaming reasoning_content responses to assistant reasoning", () => {
+    const response = fromOpenAIChatCompletionResponse({
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: "created",
+            reasoning_content: "provider reasoning text",
+          },
+        },
+      ],
+      usage: {},
+    });
+
+    expect(response.choice).toEqual([
+      AssistantContent.text("created"),
+      AssistantContent.reasoning("provider reasoning text"),
+    ]);
   });
 
   it("rejects unsupported document file input before provider calls", async () => {


### PR DESCRIPTION
## Summary
- Preserve non-streaming chat-completions reasoning from `reasoning` / `reasoning_content` as Anvia reasoning content
- Serialize assistant reasoning history back to chat completions as `reasoning_content`
- Use provider-facing `callId ?? id` for outbound chat-completions tool call ids
- Document Moonshot Kimi K2.6 thinking/tool-choice behavior
- Bump `@anvia/openai` to `0.1.5` after publishing

## Verification
- `pnpm --filter @anvia/openai test`
- `pnpm --filter @anvia/openai typecheck`
- `pnpm --filter @anvia/openai build`
- Live Moonshot Kimi K2.6 reasoning/tool-call continuity test passed
- Published `@anvia/openai@0.1.5` to npm