### PR TITLE
Fix published package dependency ranges

### DIFF
--- a/packages/observability/langfuse/package.json
+++ b/packages/observability/langfuse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/langfuse",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Langfuse tracing adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",
@@ -23,7 +23,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
+    "@anvia/core": "^0.2.0",
     "@langfuse/otel": "^5.3.0",
     "@langfuse/tracing": "^5.3.0",
     "@opentelemetry/sdk-node": "^0.217.0"

--- a/packages/providers/anthropic/package.json
+++ b/packages/providers/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/anthropic",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Anthropic provider adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.95.1",
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "^0.2.0"
   },
   "devDependencies": {
     "@types/node": "^24.9.1",

--- a/packages/providers/gemini/package.json
+++ b/packages/providers/gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/gemini",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Gemini provider adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",
@@ -23,7 +23,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
+    "@anvia/core": "^0.2.0",
     "@google/genai": "^2.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@anvia/core': workspace:*
+
 importers:
 
   .:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,8 @@ packages:
   - "packages/*/*"
   - "apps/*"
   - "examples/*"
+overrides:
+  '@anvia/core': "workspace:*"
 allowBuilds:
   '@google/genai': true
   esbuild: true


### PR DESCRIPTION
## Summary
- bump @anvia/langfuse, @anvia/anthropic, and @anvia/gemini patch versions
- replace leaked @anvia/core workspace ranges with ^0.2.0 for publish-safe package metadata
- add a pnpm workspace override so local installs still link the in-repo @anvia/core

## Verification
- pnpm --filter @anvia/langfuse typecheck
- pnpm --filter @anvia/langfuse test
- pnpm --filter @anvia/langfuse build
- pnpm --filter @anvia/anthropic typecheck
- pnpm --filter @anvia/anthropic test
- pnpm --filter @anvia/anthropic build
- pnpm --filter @anvia/gemini typecheck
- pnpm --filter @anvia/gemini test
- pnpm --filter @anvia/gemini build
- npm publish succeeded for @anvia/langfuse@0.1.4, @anvia/anthropic@0.1.5, @anvia/gemini@0.1.4
- clean temp pnpm install succeeded for all three packages