### PR TITLE
Improve Studio knowledge UI

### DIFF
--- a/bin/check-upstream-deps.sh
+++ b/bin/check-upstream-deps.sh
@@ -18,7 +18,7 @@ const options = {
 };
 
 function usage() {
-  console.log(`Usage: bin/dependency-report.sh [options]
+  console.log(`Usage: bin/check-upstream-deps.sh [options]
 
 Reports npm updates for external runtime dependencies declared by packages/* wrappers.
 
@@ -164,14 +164,14 @@ function updateKind(current, latest) {
   return "patch";
 }
 
-async function fetchLatestVersion(packageName) {
+async function fetchLatestPackageInfo(packageName) {
   const packageUrlName = packageName
     .split("/")
     .map((part) => encodeURIComponent(part))
     .join("/");
   const registryUrl = `https://registry.npmjs.org/${packageUrlName}`;
   const response = await fetch(registryUrl, {
-    headers: { accept: "application/vnd.npm.install-v1+json" },
+    headers: { accept: "application/json" },
   });
 
   if (!response.ok) {
@@ -185,7 +185,10 @@ async function fetchLatestVersion(packageName) {
     throw new Error(`No latest dist-tag found for ${packageName}`);
   }
 
-  return latest;
+  return {
+    latest,
+    latestPublishedAt: metadata?.time?.[latest] ?? null,
+  };
 }
 
 function uniqueDependencies(records) {
@@ -196,6 +199,53 @@ function pad(value, width) {
   return value.padEnd(width, " ");
 }
 
+function formatRelativeTime(dateString, now) {
+  if (!dateString) {
+    return "-";
+  }
+
+  const date = new Date(dateString);
+  const timestamp = date.getTime();
+
+  if (Number.isNaN(timestamp)) {
+    return "-";
+  }
+
+  const diffMs = now.getTime() - timestamp;
+  const tense = diffMs < 0 ? "from now" : "ago";
+  let remainingSeconds = Math.floor(Math.abs(diffMs) / 1000);
+
+  if (remainingSeconds < 60) {
+    return "just now";
+  }
+
+  const units = [
+    ["y", 365 * 24 * 60 * 60],
+    ["mo", 30 * 24 * 60 * 60],
+    ["d", 24 * 60 * 60],
+    ["h", 60 * 60],
+    ["m", 60],
+  ];
+  const parts = [];
+
+  for (const [label, seconds] of units) {
+    const value = Math.floor(remainingSeconds / seconds);
+
+    if (value === 0) {
+      continue;
+    }
+
+    parts.push(`${value}${label}`);
+    remainingSeconds -= value * seconds;
+
+    if (parts.length === 2) {
+      break;
+    }
+  }
+
+  return `${parts.join(" ")} ${tense}`;
+}
+
 function formatTable(records) {
   const columns = [
     ["Wrapper", (record) => record.wrapper],
@@ -203,6 +253,7 @@ function formatTable(records) {
     ["Field", (record) => record.field],
     ["Declared", (record) => record.declared],
     ["Latest", (record) => record.latest ?? "-"],
+    ["Published", (record) => record.latestPublishedAge ?? "-"],
     ["Status", (record) => record.status],
   ];
 
@@ -266,13 +317,14 @@ for (const packageJsonFile of packageJsonFiles) {
   }
 }
 
-const latestByDependency = new Map();
+const latestInfoByDependency = new Map();
 const errors = [];
+const now = new Date();
 
 await Promise.all(
   uniqueDependencies(records).map(async (dependency) => {
     try {
-      latestByDependency.set(dependency, await fetchLatestVersion(dependency));
+      latestInfoByDependency.set(dependency, await fetchLatestPackageInfo(dependency));
     } catch (error) {
       errors.push({ dependency, message: error.message });
     }
@@ -280,7 +332,10 @@ await Promise.all(
 );
 
 for (const record of records) {
-  record.latest = latestByDependency.get(record.dependency) ?? null;
+  const latestInfo = latestInfoByDependency.get(record.dependency);
+  record.latest = latestInfo?.latest ?? null;
+  record.latestPublishedAt = latestInfo?.latestPublishedAt ?? null;
+  record.latestPublishedAge = formatRelativeTime(record.latestPublishedAt, now);
   record.status = "unknown";
 
   if (record.latest && record.declaredVersion) {

--- a/examples/cookbook/09_studio/08-multiple-pipelines.ts
+++ b/examples/cookbook/09_studio/08-multiple-pipelines.ts
@@ -1,0 +1,140 @@
+import { PipelineBuilder } from "@anvia/core/pipeline";
+import { Studio } from "@anvia/studio";
+
+type OrderSnapshot = {
+  id: string;
+  status: "processing" | "blocked" | "shipped" | "unknown";
+  customer: string;
+  notes: string;
+};
+
+const orders: Record<string, OrderSnapshot> = {
+  "11001": {
+    id: "11001",
+    status: "blocked",
+    customer: "Delta Kit Labs",
+    notes: "Payment review is complete, but warehouse allocation has not been confirmed.",
+  },
+  "11002": {
+    id: "11002",
+    status: "processing",
+    customer: "Northwind Labs",
+    notes: "Picking is queued for the next warehouse wave.",
+  },
+  "11003": {
+    id: "11003",
+    status: "shipped",
+    customer: "Aster Supply",
+    notes: "Carrier pickup completed and tracking is active.",
+  },
+};
+
+const orderStatusPipeline = new PipelineBuilder<string>({
+  id: "order-status-pipeline",
+  name: "Order Status Pipeline",
+  description:
+    "Normalizes an order lookup, reads local order state, and returns an operator summary.",
+  metadata: {
+    owner: "support-operations",
+    sampleInput: "ORDER 11001",
+  },
+})
+  .step((raw) => raw.trim().replace(/^order\s+/i, ""), {
+    name: "Normalize Order Id",
+    description: "Accept either a bare order id or input like ORDER 11001.",
+  })
+  .step(
+    (orderId): OrderSnapshot =>
+      orders[orderId] ?? {
+        id: orderId,
+        status: "unknown",
+        customer: "Unknown",
+        notes: "No local order snapshot was found for this id.",
+      },
+    {
+      name: "Read Order Snapshot",
+      description: "Look up the order in local application state.",
+    },
+  )
+  .step(
+    (order) => ({
+      title: `Order ${order.id}`,
+      status: order.status,
+      customer: order.customer,
+      nextAction:
+        order.status === "blocked"
+          ? "Ask warehouse operations to confirm allocation."
+          : order.status === "processing"
+            ? "Monitor the next warehouse wave."
+            : order.status === "shipped"
+              ? "Share the active tracking status with the customer."
+              : "Ask the customer to verify the order id.",
+      notes: order.notes,
+    }),
+    {
+      name: "Build Operator Summary",
+      description: "Return a compact result object for Studio inspection.",
+    },
+  )
+  .build();
+
+const ticketRoutingPipeline = new PipelineBuilder<string>({
+  id: "ticket-routing-pipeline",
+  name: "Ticket Routing Pipeline",
+  description: "Classifies a pasted support ticket and recommends an operational route.",
+  metadata: {
+    owner: "support-operations",
+    sampleInput: "Enterprise customer reports checkout outage after payment retries failed.",
+  },
+})
+  .step((ticket) => ticket.trim(), {
+    name: "Normalize Ticket",
+    description: "Trim pasted ticket text before deterministic branch analysis.",
+  })
+  .parallel(
+    {
+      classification: new PipelineBuilder<string>()
+        .step((ticket) => ({
+          topic: ticket.toLowerCase().includes("payment") ? "billing" : "operations",
+        }))
+        .build(),
+      priority: new PipelineBuilder<string>()
+        .step((ticket) => ({
+          priority:
+            ticket.toLowerCase().includes("outage") ||
+            ticket.toLowerCase().includes("enterprise") ||
+            ticket.toLowerCase().includes("blocked")
+              ? "high"
+              : "normal",
+        }))
+        .build(),
+      routing: new PipelineBuilder<string>()
+        .step((ticket) => ({
+          team: ticket.toLowerCase().includes("payment") ? "billing-ops" : "support-ops",
+        }))
+        .build(),
+    },
+    {
+      name: "Analyze Ticket",
+      description: "Run independent deterministic classifiers in parallel.",
+    },
+  )
+  .step(
+    ({ classification, priority, routing }) => ({
+      topic: classification.topic,
+      priority: priority.priority,
+      team: routing.team,
+      handoffRequired: priority.priority === "high",
+      nextAction:
+        priority.priority === "high"
+          ? `Escalate to ${routing.team} with the incident context.`
+          : `Queue for ${routing.team} review.`,
+    }),
+    {
+      name: "Build Routing Decision",
+      description: "Merge branch outputs into one routing object.",
+    },
+  )
+  .build();
+
+new Studio([orderStatusPipeline, ticketRoutingPipeline]).start();

--- a/examples/cookbook/README.md
+++ b/examples/cookbook/README.md
@@ -28,7 +28,7 @@ Legacy script names such as `cookbook:basic:01`, `cookbook:intermediate:14`, `co
 | `06_retrieval` | Embeddings, in-memory search, metadata filters, RAG context, document loaders, vector stores, and embedding provider variants. |
 | `07_multi_agent` | Basic agent-tools, pipeline-backed parallel specialists, streaming agent-tools, and event stores. |
 | `08_evals` | Deterministic metrics, semantic similarity, custom metrics, agent eval targets, and LLM judge/score. |
-| `09_studio` | Single-agent, multi-agent, and subagent Studio runners, tool approvals, human feedback, and Knowledge inspection. |
+| `09_studio` | Single-agent, multi-agent, pipeline, and subagent Studio runners, tool approvals, human feedback, and Knowledge inspection. |
 | `10_integrations` | MCP tools, local skills, Langfuse tracing, and Langfuse eval reporting. |
 
 ## Environment

--- a/examples/cookbook/package.json
+++ b/examples/cookbook/package.json
@@ -80,6 +80,7 @@
     "studio:05": "tsx -r dotenv/config 09_studio/05-knowledge-inspector.ts dotenv_config_path=../../.env",
     "studio:06": "tsx -r dotenv/config 09_studio/06-subagents.ts dotenv_config_path=../../.env",
     "studio:07": "tsx -r dotenv/config 09_studio/07-pipeline-inspector.ts dotenv_config_path=../../.env",
+    "studio:08": "tsx -r dotenv/config 09_studio/08-multiple-pipelines.ts dotenv_config_path=../../.env",
     "integrations": "tsx -r dotenv/config 10_integrations/01-mcp-tools.ts dotenv_config_path=../../.env",
     "integrations:01": "tsx -r dotenv/config 10_integrations/01-mcp-tools.ts dotenv_config_path=../../.env",
     "integrations:02": "tsx -r dotenv/config 10_integrations/02-local-skills.ts dotenv_config_path=../../.env",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "cookbook:studio:05": "pnpm --filter cookbook studio:05",
     "cookbook:studio:06": "pnpm --filter cookbook studio:06",
     "cookbook:studio:07": "pnpm --filter cookbook studio:07",
+    "cookbook:studio:08": "pnpm --filter cookbook studio:08",
     "cookbook:integrations": "pnpm --filter cookbook integrations",
     "cookbook:integrations:01": "pnpm --filter cookbook integrations:01",
     "cookbook:integrations:02": "pnpm --filter cookbook integrations:02",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Core runtime primitives for context-aware Anvia agents.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/core/src/agent/request.ts
+++ b/packages/core/src/agent/request.ts
@@ -4,6 +4,7 @@ import {
   CompletionRequestBuilder,
   type CompletionResponse,
   type Document,
+  type JsonObject,
   Message,
   type Message as MessageType,
   type ReasoningContentType,
@@ -22,7 +23,7 @@ import {
 } from "../observability/group";
 import type { AgentTraceInfo, AgentTraceOptions } from "../observability/types";
 import { toReadableStream } from "../streaming";
-import type { ToolCallStreamEvent } from "../tool";
+import type { AnyTool, ToolCallStreamEvent } from "../tool";
 import type { ToolMiddleware, ToolResultMiddlewareArgs } from "../tool/middleware";
 import type { Agent } from "./agent";
 import { MaxTurnsError, PromptCancelledError } from "./errors";
@@ -30,6 +31,8 @@ import type { PromptHook, ToolHookArgs } from "./hooks";
 import { runControl, toolCallControl } from "./hooks";
 import { type AgentDeltaEvent, CompletionStreamAccumulator } from "./stream-accumulator";
 import { extractRagText, isStreamingCompletionModel, mapWithConcurrency } from "./utils";
+
+const MCP_TOOL_METADATA_KEY = Symbol.for("anvia.mcp.tool.metadata");
 
 export type PromptResponse = {
   output: string;
@@ -239,6 +242,7 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
           {
             turn: currentTurns,
             runObservers,
+            toolDefinitions: request.tools,
           },
         );
         const toolMessage = Message.tool(toolResults);
@@ -308,12 +312,15 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
           .build();
 
         assertCompletionRequestSupported(this.agent.model, request, { streaming: true });
+        const providerRequest = this.providerTraceRequest(request, { stream: true });
         const generationObservers = await runObservers.startGeneration({
           turn: currentTurns,
           request,
+          ...(providerRequest === undefined ? {} : { providerRequest }),
           modelInfo: {
             provider: this.agent.model.provider,
             defaultModel: this.agent.model.defaultModel,
+            capabilities: this.agent.model.capabilities,
           },
         });
         const accumulator = new CompletionStreamAccumulator();
@@ -395,6 +402,7 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
           {
             turn: currentTurns,
             runObservers,
+            toolDefinitions: request.tools,
           },
         );
         toolResultsPromise.then(
@@ -430,12 +438,15 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
     runObservers: ActiveAgentRunObservers,
   ): Promise<CompletionResponse> {
     assertCompletionRequestSupported(this.agent.model, request);
+    const providerRequest = this.providerTraceRequest(request);
     const generationObservers = await runObservers.startGeneration({
       turn,
       request,
+      ...(providerRequest === undefined ? {} : { providerRequest }),
       modelInfo: {
         provider: this.agent.model.provider,
         defaultModel: this.agent.model.defaultModel,
+        capabilities: this.agent.model.capabilities,
       },
     });
     try {
@@ -448,6 +459,36 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
     }
   }
 
+  private providerTraceRequest(
+    request: ReturnType<CompletionRequestBuilder["build"]>,
+    options: { stream?: boolean | undefined } = {},
+  ): JsonObject | undefined {
+    try {
+      return this.agent.model.traceRequest?.(request, options);
+    } catch (error) {
+      return {
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  private toolTraceMetadata(tool: AnyTool | undefined): JsonObject | undefined {
+    if (tool === undefined) {
+      return undefined;
+    }
+    const metadata = (tool as { [MCP_TOOL_METADATA_KEY]?: unknown })[MCP_TOOL_METADATA_KEY];
+    const mcpMetadata =
+      typeof metadata === "object" && metadata !== null
+        ? (metadata as { serverName?: unknown })
+        : undefined;
+    return {
+      approvalRequired: tool.approval !== undefined,
+      ...(typeof mcpMetadata?.serverName === "string" && mcpMetadata.serverName.length > 0
+        ? { mcpServerName: mcpMetadata.serverName }
+        : {}),
+    };
+  }
+
   private async executeToolCalls(
     toolCalls: ToolCall[],
     newMessages: MessageType[],
@@ -456,6 +497,7 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
     observation?: {
       turn: number;
       runObservers: ActiveAgentRunObservers;
+      toolDefinitions?: ToolDefinition[];
     },
   ): Promise<ToolResult[]> {
     return mapWithConcurrency(toolCalls, this.concurrency, async (toolCall) => {
@@ -469,6 +511,11 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
       if (toolCall.callId !== undefined) {
         hookArgs.toolCallId = toolCall.callId;
       }
+      const tool = this.agent.getTool(toolCall.function.name);
+      const toolDefinition = observation?.toolDefinitions?.find(
+        (definition) => definition.name === toolCall.function.name,
+      );
+      const toolMetadata = this.toolTraceMetadata(tool);
 
       const toolObservers = await observation?.runObservers.startTool({
         turn: observation.turn,
@@ -477,6 +524,8 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
         internalCallId,
         args,
         toolCallId: toolCall.callId,
+        ...(toolDefinition === undefined ? {} : { toolDefinition }),
+        ...(toolMetadata === undefined ? {} : { toolMetadata }),
       });
 
       const callAction = await this.activeHook?.onToolCall?.({

--- a/packages/core/src/agent/request.ts
+++ b/packages/core/src/agent/request.ts
@@ -311,6 +311,10 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
         const generationObservers = await runObservers.startGeneration({
           turn: currentTurns,
           request,
+          modelInfo: {
+            provider: this.agent.model.provider,
+            defaultModel: this.agent.model.defaultModel,
+          },
         });
         const accumulator = new CompletionStreamAccumulator();
         const generationStartedAt = Date.now();
@@ -426,7 +430,14 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
     runObservers: ActiveAgentRunObservers,
   ): Promise<CompletionResponse> {
     assertCompletionRequestSupported(this.agent.model, request);
-    const generationObservers = await runObservers.startGeneration({ turn, request });
+    const generationObservers = await runObservers.startGeneration({
+      turn,
+      request,
+      modelInfo: {
+        provider: this.agent.model.provider,
+        defaultModel: this.agent.model.defaultModel,
+      },
+    });
     try {
       const response = await this.agent.model.completion(request);
       await generationObservers.end({ turn, response });

--- a/packages/core/src/completion/types.ts
+++ b/packages/core/src/completion/types.ts
@@ -372,6 +372,10 @@ export interface CompletionModel<RawResponse = unknown> {
   readonly provider: string;
   readonly defaultModel: string;
   readonly capabilities: CompletionModelCapabilities;
+  traceRequest?(
+    request: CompletionRequest,
+    options?: { stream?: boolean | undefined },
+  ): JsonObject | undefined;
   completion(request: CompletionRequest): Promise<CompletionResponse<RawResponse>>;
 }
 

--- a/packages/core/src/observability/types.ts
+++ b/packages/core/src/observability/types.ts
@@ -48,6 +48,10 @@ export type AgentRunErrorArgs = {
 export type AgentGenerationStartArgs = {
   turn: number;
   request: CompletionRequest;
+  modelInfo?: {
+    provider: string;
+    defaultModel: string;
+  };
 };
 
 export type AgentGenerationEndArgs<RawResponse = unknown> = {

--- a/packages/core/src/observability/types.ts
+++ b/packages/core/src/observability/types.ts
@@ -1,8 +1,11 @@
 import type {
+  CompletionModelCapabilities,
   CompletionRequest,
   CompletionResponse,
+  JsonObject,
   Message,
   ToolCall,
+  ToolDefinition,
   Usage,
 } from "../completion";
 import type { ToolCallStreamEvent } from "../tool";
@@ -48,9 +51,11 @@ export type AgentRunErrorArgs = {
 export type AgentGenerationStartArgs = {
   turn: number;
   request: CompletionRequest;
+  providerRequest?: JsonObject | undefined;
   modelInfo?: {
     provider: string;
     defaultModel: string;
+    capabilities?: CompletionModelCapabilities | undefined;
   };
 };
 
@@ -72,6 +77,8 @@ export type AgentToolStartArgs = {
   args: string;
   internalCallId: string;
   toolCallId?: string | undefined;
+  toolDefinition?: ToolDefinition | undefined;
+  toolMetadata?: JsonObject | undefined;
 };
 
 export type AgentToolEndArgs = AgentToolStartArgs & {

--- a/packages/core/src/tool/dynamic-tools.ts
+++ b/packages/core/src/tool/dynamic-tools.ts
@@ -1,7 +1,12 @@
 import type { ToolDefinition } from "../completion";
 import type { EmbeddedDocument, EmbeddingModel, VectorMetadata } from "../embeddings";
 import { embedDocuments } from "../embeddings";
-import type { VectorSearchResult, VectorSearchToolOptions } from "../vector-store";
+import type {
+  VectorInspectPage,
+  VectorInspectRequest,
+  VectorSearchResult,
+  VectorSearchToolOptions,
+} from "../vector-store";
 import {
   InMemoryVectorStore,
   type VectorSearchIndex,
@@ -86,10 +91,21 @@ export function isDynamicToolIndex(value: unknown): value is DynamicToolIndex {
 class DynamicToolSearchIndex<Metadata extends VectorMetadata>
   implements DynamicToolIndex<Metadata>
 {
+  readonly inspect?: (
+    request: VectorInspectRequest,
+  ) => Promise<VectorInspectPage<ToolSearchDocument<Metadata>, Metadata>>;
+
   constructor(
     private readonly index: VectorSearchIndex<ToolSearchDocument<Metadata>, Metadata>,
     readonly toolSet: ToolSet,
-  ) {}
+  ) {
+    if (index.inspect !== undefined) {
+      this.inspect = (request) =>
+        index.inspect?.(request) as Promise<
+          VectorInspectPage<ToolSearchDocument<Metadata>, Metadata>
+        >;
+    }
+  }
 
   search(
     request: VectorSearchRequest,

--- a/packages/core/src/vector-store/index.ts
+++ b/packages/core/src/vector-store/index.ts
@@ -30,10 +30,29 @@ export type VectorSearchResult<T = unknown, Metadata extends VectorMetadata = Ve
   metadata?: Metadata | undefined;
 };
 
+export type VectorInspectRequest = {
+  limit: number;
+  cursor?: string | undefined;
+  filter?: VectorFilter | undefined;
+};
+
+export type VectorInspectItem<T = unknown, Metadata extends VectorMetadata = VectorMetadata> = {
+  id: string;
+  document: T;
+  metadata?: Metadata | undefined;
+};
+
+export type VectorInspectPage<T = unknown, Metadata extends VectorMetadata = VectorMetadata> = {
+  items: Array<VectorInspectItem<T, Metadata>>;
+  nextCursor?: string | undefined;
+  totalCount?: number | undefined;
+};
+
 export interface VectorSearchIndex<T = unknown, Metadata extends VectorMetadata = VectorMetadata> {
   search(request: VectorSearchRequest): Promise<Array<VectorSearchResult<T, Metadata>>>;
   searchIds(request: VectorSearchRequest): Promise<Array<{ score: number; id: string }>>;
   asTool(options: VectorSearchToolOptions): Tool<{ query: string; topK?: number }, unknown>;
+  inspect?(request: VectorInspectRequest): Promise<VectorInspectPage<T, Metadata>>;
 }
 
 export type VectorSearchToolOptions = {
@@ -166,6 +185,25 @@ export class InMemoryVectorIndex<T, Metadata extends VectorMetadata = VectorMeta
 
   async searchIds(request: VectorSearchRequest): Promise<Array<{ score: number; id: string }>> {
     return (await this.search(request)).map(({ score, id }) => ({ score, id }));
+  }
+
+  async inspect(request: VectorInspectRequest): Promise<VectorInspectPage<T, Metadata>> {
+    const limit = Math.max(0, Math.trunc(request.limit));
+    const start = Math.max(0, Math.trunc(Number(request.cursor ?? "0")));
+    const documents = this.store
+      .values()
+      .filter((document) => matchesVectorFilter(document.metadata, request.filter));
+    const page = documents.slice(start, start + limit);
+    const nextOffset = start + page.length;
+    return {
+      items: page.map((document) => ({
+        id: document.id,
+        document: document.document,
+        ...(document.metadata === undefined ? {} : { metadata: document.metadata }),
+      })),
+      ...(nextOffset < documents.length ? { nextCursor: String(nextOffset) } : {}),
+      totalCount: documents.length,
+    };
   }
 
   asTool(options: VectorSearchToolOptions): Tool<{ query: string; topK?: number }, unknown> {

--- a/packages/core/test/embeddings-vector-store.test.ts
+++ b/packages/core/test/embeddings-vector-store.test.ts
@@ -245,6 +245,44 @@ describe("in-memory vector store", () => {
     await expect(tool.call({ query: "cat" })).resolves.toMatchObject([{ id: "cat" }]);
     expect(await tool.definition("")).toMatchObject({ name: "search_docs" });
   });
+
+  it("inspects paginated documents without embeddings", async () => {
+    const model = new KeywordEmbeddingModel();
+    const index = InMemoryVectorStore.fromDocuments(await sampleEmbedded(model)).index(model);
+
+    await expect(index.inspect({ limit: 2 })).resolves.toEqual({
+      items: [
+        {
+          id: "cat",
+          document: { id: "cat", title: "Cat guide", texts: ["cat", "pet"] },
+          metadata: { category: "animal", rank: 3 },
+        },
+        {
+          id: "dog",
+          document: { id: "dog", title: "Dog guide", texts: ["dog"] },
+          metadata: { category: "animal", rank: 3 },
+        },
+      ],
+      nextCursor: "2",
+      totalCount: 3,
+    });
+    await expect(index.inspect({ limit: 2, cursor: "2" })).resolves.toEqual({
+      items: [
+        {
+          id: "risk",
+          document: { id: "risk", title: "Risk memo", texts: ["risk"] },
+          metadata: { category: "finance", rank: 1 },
+        },
+      ],
+      totalCount: 3,
+    });
+    await expect(
+      index.inspect({ limit: 5, filter: vectorFilter.eq("category", "animal") }),
+    ).resolves.toMatchObject({
+      items: [{ id: "cat" }, { id: "dog" }],
+      totalCount: 2,
+    });
+  });
 });
 
 describe("agent dynamic context", () => {
@@ -309,6 +347,25 @@ describe("agent dynamic tools", () => {
         metadata: { domain: "billing" },
       },
     ]);
+  });
+
+  it("passes dynamic tool inspection through to the wrapped index", async () => {
+    const embeddingModel = new KeywordEmbeddingModel();
+    const index = await createToolIndex(embeddingModel, [issueRefundTool, lookupDogTool]);
+
+    await expect(index.inspect?.({ limit: 1 })).resolves.toMatchObject({
+      items: [
+        {
+          id: "issue_refund",
+          document: {
+            toolName: "issue_refund",
+            definition: expect.objectContaining({ name: "issue_refund" }),
+          },
+        },
+      ],
+      nextCursor: "1",
+      totalCount: 2,
+    });
   });
 
   it("injects selected dynamic tools into send requests and executes them", async () => {

--- a/packages/core/test/observability.test.ts
+++ b/packages/core/test/observability.test.ts
@@ -17,6 +17,7 @@ import {
   type CompletionStreamEvent,
   createHook,
   createTool,
+  type JsonObject,
   type StreamingCompletionModel,
   skipTool,
   Usage,
@@ -41,6 +42,15 @@ class QueueModel implements CompletionModel {
   readonly requests: CompletionRequest[] = [];
 
   constructor(private readonly responses: CompletionResponse[]) {}
+
+  traceRequest(request: CompletionRequest): JsonObject {
+    return {
+      provider: this.provider,
+      stream: false,
+      model: request.model ?? this.defaultModel,
+      messageCount: request.chatHistory.length,
+    };
+  }
 
   async completion(request: CompletionRequest): Promise<CompletionResponse> {
     this.requests.push(request);
@@ -70,6 +80,15 @@ class StreamingQueueModel implements StreamingCompletionModel {
 
   async completion(): Promise<CompletionResponse> {
     throw new Error("completion should not be called");
+  }
+
+  traceRequest(request: CompletionRequest, options: { stream?: boolean } = {}): JsonObject {
+    return {
+      provider: this.provider,
+      stream: options.stream === true,
+      model: request.model ?? this.defaultModel,
+      messageCount: request.chatHistory.length,
+    };
   }
 
   async *streamCompletion(request: CompletionRequest): AsyncIterable<CompletionStreamEvent> {
@@ -166,7 +185,14 @@ describe("agent observability", () => {
           modelInfo: {
             provider: "test",
             defaultModel: "test",
+            capabilities: expect.objectContaining({ streaming: false }),
           },
+          providerRequest: expect.objectContaining({
+            provider: "test",
+            stream: false,
+            model: "test",
+            messageCount: 1,
+          }),
         }),
       }),
     );
@@ -192,6 +218,20 @@ describe("agent observability", () => {
       "generation_end",
       "run_end",
     ]);
+    expect(observer.events).toContainEqual(
+      expect.objectContaining({
+        type: "tool_start",
+        args: expect.objectContaining({
+          toolDefinition: expect.objectContaining({
+            name: "add",
+            description: "Add numbers",
+          }),
+          toolMetadata: expect.objectContaining({
+            approvalRequired: false,
+          }),
+        }),
+      }),
+    );
     expect(observer.events).toContainEqual(
       expect.objectContaining({
         type: "tool_end",
@@ -283,7 +323,13 @@ describe("agent observability", () => {
           modelInfo: {
             provider: "test",
             defaultModel: "test",
+            capabilities: expect.objectContaining({ streaming: true }),
           },
+          providerRequest: expect.objectContaining({
+            provider: "test",
+            stream: true,
+            model: "test",
+          }),
         }),
       }),
     );

--- a/packages/core/test/observability.test.ts
+++ b/packages/core/test/observability.test.ts
@@ -159,6 +159,17 @@ describe("agent observability", () => {
         },
       },
     });
+    expect(observer.events).toContainEqual(
+      expect.objectContaining({
+        type: "generation_start",
+        args: expect.objectContaining({
+          modelInfo: {
+            provider: "test",
+            defaultModel: "test",
+          },
+        }),
+      }),
+    );
   });
 
   it("records multiple turns and tool calls", async () => {
@@ -265,6 +276,17 @@ describe("agent observability", () => {
       "generation_end",
       "run_end",
     ]);
+    expect(observer.events).toContainEqual(
+      expect.objectContaining({
+        type: "generation_start",
+        args: expect.objectContaining({
+          modelInfo: {
+            provider: "test",
+            defaultModel: "test",
+          },
+        }),
+      }),
+    );
     expect(observer.events).toContainEqual(
       expect.objectContaining({
         type: "generation_end",

--- a/packages/providers/anthropic/package.json
+++ b/packages/providers/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/anthropic",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Anthropic provider adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.95.1",
-    "@anvia/core": "^0.2.0"
+    "@anvia/core": "^0.2.1"
   },
   "devDependencies": {
     "@types/node": "^24.9.1",

--- a/packages/providers/anthropic/src/anthropic/completion.ts
+++ b/packages/providers/anthropic/src/anthropic/completion.ts
@@ -9,6 +9,7 @@ import {
   type CompletionStreamEvent,
   type DocumentContent,
   type ImageContent,
+  type JsonObject,
   type JsonValue,
   type Message as MessageType,
   type ReasoningContent,
@@ -44,6 +45,17 @@ export class AnthropicCompletionModel implements StreamingCompletionModel {
     private readonly client: Anthropic,
     readonly defaultModel = "claude-sonnet-4-20250514",
   ) {}
+
+  traceRequest(
+    request: CompletionRequest,
+    options: { stream?: boolean | undefined } = {},
+  ): JsonObject {
+    const params = toAnthropicMessagesParams(this.defaultModel, request);
+    if (options.stream === true) {
+      params.stream = true;
+    }
+    return providerRequestSummary(params, request, options);
+  }
 
   async completion(request: CompletionRequest): Promise<CompletionResponse> {
     assertCompletionRequestSupported(this, request);
@@ -111,6 +123,48 @@ export function toAnthropicMessagesParams(
   }
 
   return params;
+}
+
+function providerRequestSummary(
+  params: AnthropicCreateParams,
+  request: CompletionRequest,
+  options: { stream?: boolean | undefined },
+): JsonObject {
+  return compactJsonObject({
+    provider: "anthropic",
+    api: "messages",
+    stream: options.stream === true,
+    model: stringFrom(params.model),
+    parameterKeys: Object.keys(params).sort(),
+    messageCount: Array.isArray(params.messages) ? params.messages.length : undefined,
+    toolCount: request.tools.length,
+    toolNames: request.tools.map((tool) => tool.name),
+    hasSystem: typeof params.system === "string" && params.system.length > 0,
+    temperature: request.temperature,
+    maxTokens: request.maxTokens ?? numberFrom(params.max_tokens),
+    toolChoice: toolChoiceSummary(request.toolChoice),
+    additionalParamKeys: isPlainObject(request.additionalParams)
+      ? Object.keys(request.additionalParams).sort()
+      : undefined,
+  });
+}
+
+function toolChoiceSummary(toolChoice: ToolChoice | undefined): JsonValue | undefined {
+  if (toolChoice === undefined || typeof toolChoice === "string") {
+    return toolChoice;
+  }
+  return { type: toolChoice.type, name: toolChoice.name };
+}
+
+function compactJsonObject(values: Record<string, unknown>): JsonObject {
+  return Object.fromEntries(
+    Object.entries(values).flatMap(([key, value]) => {
+      if (value === undefined) {
+        return [];
+      }
+      return [[key, toJsonValue(value)]];
+    }),
+  ) as JsonObject;
 }
 
 function requestMessages(request: CompletionRequest): MessageType[] {

--- a/packages/providers/anthropic/test/anthropic-completion.test.ts
+++ b/packages/providers/anthropic/test/anthropic-completion.test.ts
@@ -88,6 +88,30 @@ describe("Anthropic Messages mapping", () => {
     });
   });
 
+  it("summarizes provider request metadata for traces", () => {
+    const model = new AnthropicCompletionModel({} as never, "claude-test");
+    const request: CompletionRequest = {
+      instructions: "Be concise.",
+      chatHistory: [Message.user("What is 2+5?")],
+      documents: [],
+      tools: [{ name: "add", description: "Add numbers", parameters: { type: "object" } }],
+      maxTokens: 256,
+      toolChoice: "auto",
+    };
+
+    expect(model.traceRequest(request, { stream: true })).toMatchObject({
+      provider: "anthropic",
+      api: "messages",
+      stream: true,
+      model: "claude-test",
+      messageCount: 1,
+      toolCount: 1,
+      toolNames: ["add"],
+      hasSystem: true,
+      parameterKeys: expect.arrayContaining(["messages", "model", "stream", "system", "tools"]),
+    });
+  });
+
   it("prepends normalized static context before chat history and maps system messages", () => {
     const request: CompletionRequest = {
       chatHistory: [Message.system("Use context."), Message.user("What is the owner?")],

--- a/packages/providers/gemini/package.json
+++ b/packages/providers/gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/gemini",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Gemini provider adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",
@@ -23,7 +23,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "^0.2.0",
+    "@anvia/core": "^0.2.1",
     "@google/genai": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/providers/gemini/src/gemini/completion.ts
+++ b/packages/providers/gemini/src/gemini/completion.ts
@@ -6,6 +6,7 @@ import {
   type CompletionRequest,
   type CompletionResponse,
   type CompletionStreamEvent,
+  type JsonObject,
   type JsonValue,
   type Message as MessageType,
   type StreamingCompletionModel,
@@ -42,6 +43,14 @@ export class GeminiCompletionModel implements StreamingCompletionModel {
     private readonly client: GoogleGenAI,
     readonly defaultModel = "gemini-2.5-flash",
   ) {}
+
+  traceRequest(
+    request: CompletionRequest,
+    options: { stream?: boolean | undefined } = {},
+  ): JsonObject {
+    const params = toGeminiGenerateContentParams(this.defaultModel, request);
+    return providerRequestSummary(params, request, options);
+  }
 
   async completion(request: CompletionRequest): Promise<CompletionResponse> {
     assertCompletionRequestSupported(this, request);
@@ -83,6 +92,51 @@ export function toGeminiGenerateContentParams(
   }
 
   return params;
+}
+
+function providerRequestSummary(
+  params: GeminiGenerateParams,
+  request: CompletionRequest,
+  options: { stream?: boolean | undefined },
+): JsonObject {
+  const config = isPlainObject(params.config) ? params.config : {};
+  return compactJsonObject({
+    provider: "gemini",
+    api: options.stream === true ? "models.generateContentStream" : "models.generateContent",
+    stream: options.stream === true,
+    model: typeof params.model === "string" ? params.model : undefined,
+    parameterKeys: Object.keys(params).sort(),
+    contentCount: Array.isArray(params.contents) ? params.contents.length : undefined,
+    configKeys: Object.keys(config).sort(),
+    toolCount: request.tools.length,
+    toolNames: request.tools.map((tool) => tool.name),
+    hasSystemInstruction: config.systemInstruction !== undefined,
+    hasOutputSchema: request.outputSchema !== undefined,
+    temperature: request.temperature,
+    maxTokens: request.maxTokens,
+    toolChoice: toolChoiceSummary(request.toolChoice),
+    additionalParamKeys: isPlainObject(request.additionalParams)
+      ? Object.keys(request.additionalParams).sort()
+      : undefined,
+  });
+}
+
+function toolChoiceSummary(toolChoice: ToolChoice | undefined): JsonValue | undefined {
+  if (toolChoice === undefined || typeof toolChoice === "string") {
+    return toolChoice;
+  }
+  return { type: toolChoice.type, name: toolChoice.name };
+}
+
+function compactJsonObject(values: Record<string, unknown>): JsonObject {
+  return Object.fromEntries(
+    Object.entries(values).flatMap(([key, value]) => {
+      if (value === undefined) {
+        return [];
+      }
+      return [[key, toJsonValue(value)]];
+    }),
+  ) as JsonObject;
 }
 
 function requestMessages(request: CompletionRequest): MessageType[] {

--- a/packages/providers/gemini/test/completion.test.ts
+++ b/packages/providers/gemini/test/completion.test.ts
@@ -69,6 +69,30 @@ describe("Gemini completion mapping", () => {
     });
   });
 
+  it("summarizes provider request metadata for traces", () => {
+    const model = new GeminiCompletionModel({} as never, "gemini-test");
+    const request: CompletionRequest = {
+      instructions: "Be concise.",
+      chatHistory: [Message.user("What is 2+5?")],
+      documents: [],
+      tools: [{ name: "add", description: "Add numbers", parameters: { type: "object" } }],
+      maxTokens: 128,
+      toolChoice: "auto",
+    };
+
+    expect(model.traceRequest(request, { stream: true })).toMatchObject({
+      provider: "gemini",
+      api: "models.generateContentStream",
+      stream: true,
+      model: "gemini-test",
+      contentCount: 1,
+      toolCount: 1,
+      toolNames: ["add"],
+      hasSystemInstruction: true,
+      parameterKeys: expect.arrayContaining(["config", "contents", "model"]),
+    });
+  });
+
   it("maps normalized requests to Gemini generateContent params", () => {
     const request: CompletionRequest = {
       instructions: "Use the support policy.",

--- a/packages/providers/mistral/package.json
+++ b/packages/providers/mistral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/mistral",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Mistral provider adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/providers/mistral/src/mistral/completion.ts
+++ b/packages/providers/mistral/src/mistral/completion.ts
@@ -7,6 +7,7 @@ import {
   type CompletionResponse,
   type CompletionStreamEvent,
   type DocumentContent,
+  type JsonObject,
   type JsonValue,
   type Message as MessageType,
   type StreamingCompletionModel,
@@ -39,6 +40,14 @@ export class MistralCompletionModel implements StreamingCompletionModel {
     private readonly client: Mistral,
     readonly defaultModel = "mistral-large-latest",
   ) {}
+
+  traceRequest(
+    request: CompletionRequest,
+    options: { stream?: boolean | undefined } = {},
+  ): JsonObject {
+    const params = toMistralChatParams(this.defaultModel, request);
+    return providerRequestSummary(params, request, options);
+  }
 
   async completion(request: CompletionRequest): Promise<CompletionResponse> {
     assertCompletionRequestSupported(this, request);
@@ -100,6 +109,48 @@ export function toMistralChatParams(
   }
 
   return params;
+}
+
+function providerRequestSummary(
+  params: MistralChatParams,
+  request: CompletionRequest,
+  options: { stream?: boolean | undefined },
+): JsonObject {
+  return compactJsonObject({
+    provider: "mistral",
+    api: options.stream === true ? "chat.stream" : "chat.complete",
+    stream: options.stream === true,
+    model: stringFrom(params.model),
+    parameterKeys: Object.keys(params).sort(),
+    messageCount: Array.isArray(params.messages) ? params.messages.length : undefined,
+    toolCount: request.tools.length,
+    toolNames: request.tools.map((tool) => tool.name),
+    hasOutputSchema: request.outputSchema !== undefined,
+    temperature: request.temperature,
+    maxTokens: request.maxTokens,
+    toolChoice: toolChoiceSummary(request.toolChoice),
+    additionalParamKeys: isPlainObject(request.additionalParams)
+      ? Object.keys(request.additionalParams).sort()
+      : undefined,
+  });
+}
+
+function toolChoiceSummary(toolChoice: ToolChoice | undefined): JsonValue | undefined {
+  if (toolChoice === undefined || typeof toolChoice === "string") {
+    return toolChoice;
+  }
+  return { type: toolChoice.type, name: toolChoice.name };
+}
+
+function compactJsonObject(values: Record<string, unknown>): JsonObject {
+  return Object.fromEntries(
+    Object.entries(values).flatMap(([key, value]) => {
+      if (value === undefined) {
+        return [];
+      }
+      return [[key, toJsonValue(value)]];
+    }),
+  ) as JsonObject;
 }
 
 function requestMessages(request: CompletionRequest): MessageType[] {

--- a/packages/providers/mistral/test/completion.test.ts
+++ b/packages/providers/mistral/test/completion.test.ts
@@ -83,6 +83,28 @@ describe("Mistral completion mapping", () => {
     expect(calls).toHaveLength(0);
   });
 
+  it("summarizes provider request metadata for traces", () => {
+    const model = new MistralCompletionModel({} as never, "mistral-test");
+    const request: CompletionRequest = {
+      chatHistory: [Message.user("What is 2+5?")],
+      documents: [],
+      tools: [{ name: "add", description: "Add numbers", parameters: { type: "object" } }],
+      maxTokens: 128,
+      toolChoice: "auto",
+    };
+
+    expect(model.traceRequest(request, { stream: true })).toMatchObject({
+      provider: "mistral",
+      api: "chat.stream",
+      stream: true,
+      model: "mistral-test",
+      messageCount: 1,
+      toolCount: 1,
+      toolNames: ["add"],
+      parameterKeys: expect.arrayContaining(["messages", "model", "tools"]),
+    });
+  });
+
   it("maps normalized requests to Mistral chat params", () => {
     const request: CompletionRequest = {
       instructions: "Use the support policy.",

--- a/packages/providers/openai/package.json
+++ b/packages/providers/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/openai",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "OpenAI provider adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/providers/openai/src/openai/chat-completion.ts
+++ b/packages/providers/openai/src/openai/chat-completion.ts
@@ -8,6 +8,8 @@ import {
   type CompletionStreamEvent,
   type DocumentContent,
   type ImageContent,
+  type JsonObject,
+  type JsonValue,
   type Message as MessageType,
   type StreamingCompletionModel,
   type ToolChoice,
@@ -39,6 +41,19 @@ export class OpenAIChatCompletionModel implements StreamingCompletionModel {
     private readonly client: OpenAI,
     readonly defaultModel = "openai/gpt-5.2",
   ) {}
+
+  traceRequest(
+    request: CompletionRequest,
+    options: { stream?: boolean | undefined } = {},
+  ): JsonObject {
+    const params: ChatCompletionParams = toOpenAIChatCompletionParams(this.defaultModel, request);
+    if (options.stream === true) {
+      params.stream = true;
+      const streamOptions = isPlainObject(params.stream_options) ? params.stream_options : {};
+      params.stream_options = { ...streamOptions, include_usage: true };
+    }
+    return providerRequestSummary(params, request, options);
+  }
 
   async completion(request: CompletionRequest): Promise<CompletionResponse> {
     assertCompletionRequestSupported(this, request);
@@ -105,6 +120,66 @@ export function toOpenAIChatCompletionParams(
   }
 
   return params;
+}
+
+function providerRequestSummary(
+  params: ChatCompletionParams,
+  request: CompletionRequest,
+  options: { stream?: boolean | undefined },
+): JsonObject {
+  return compactJsonObject({
+    provider: "openai-chat",
+    api: "chat.completions",
+    stream: options.stream === true,
+    model: stringFrom(params.model),
+    parameterKeys: Object.keys(params).sort(),
+    messageCount: Array.isArray(params.messages) ? params.messages.length : undefined,
+    toolCount: request.tools.length,
+    toolNames: request.tools.map((tool) => tool.name),
+    hasOutputSchema: request.outputSchema !== undefined,
+    temperature: request.temperature,
+    maxTokens: request.maxTokens,
+    toolChoice: toolChoiceSummary(request.toolChoice),
+    additionalParamKeys: isPlainObject(request.additionalParams)
+      ? Object.keys(request.additionalParams).sort()
+      : undefined,
+  });
+}
+
+function toolChoiceSummary(toolChoice: ToolChoice | undefined): JsonValue | undefined {
+  if (toolChoice === undefined || typeof toolChoice === "string") {
+    return toolChoice;
+  }
+  return { type: toolChoice.type, name: toolChoice.name };
+}
+
+function compactJsonObject(values: Record<string, unknown>): JsonObject {
+  return Object.fromEntries(
+    Object.entries(values).flatMap(([key, value]) => {
+      if (value === undefined) {
+        return [];
+      }
+      return [[key, toJsonValue(value)]];
+    }),
+  ) as JsonObject;
+}
+
+function toJsonValue(value: unknown): JsonValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => toJsonValue(item));
+  }
+  if (isPlainObject(value)) {
+    return compactJsonObject(value);
+  }
+  return String(value);
 }
 
 function requestMessages(request: CompletionRequest): MessageType[] {

--- a/packages/providers/openai/src/openai/responses.ts
+++ b/packages/providers/openai/src/openai/responses.ts
@@ -8,6 +8,8 @@ import {
   type CompletionStreamEvent,
   type DocumentContent,
   type ImageContent,
+  type JsonObject,
+  type JsonValue,
   type Message as MessageType,
   type Reasoning,
   type ReasoningContent,
@@ -41,6 +43,17 @@ export class OpenAIResponsesCompletionModel implements StreamingCompletionModel 
     private readonly client: OpenAI,
     readonly defaultModel = "gpt-5",
   ) {}
+
+  traceRequest(
+    request: CompletionRequest,
+    options: { stream?: boolean | undefined } = {},
+  ): JsonObject {
+    const params = toOpenAIResponsesParams(this.defaultModel, request);
+    if (options.stream === true) {
+      params.stream = true;
+    }
+    return providerRequestSummary(params, request, options);
+  }
 
   async completion(request: CompletionRequest): Promise<CompletionResponse> {
     assertCompletionRequestSupported(this, request);
@@ -107,6 +120,67 @@ export function toOpenAIResponsesParams(
   }
 
   return params;
+}
+
+function providerRequestSummary(
+  params: ResponsesCreateParams,
+  request: CompletionRequest,
+  options: { stream?: boolean | undefined },
+): JsonObject {
+  return compactJsonObject({
+    provider: "openai",
+    api: "responses",
+    stream: options.stream === true,
+    model: stringFrom(params.model),
+    parameterKeys: Object.keys(params).sort(),
+    inputCount: Array.isArray(params.input) ? params.input.length : undefined,
+    toolCount: request.tools.length,
+    toolNames: request.tools.map((tool) => tool.name),
+    hasInstructions: typeof params.instructions === "string" && params.instructions.length > 0,
+    hasOutputSchema: request.outputSchema !== undefined,
+    temperature: request.temperature,
+    maxTokens: request.maxTokens,
+    toolChoice: toolChoiceSummary(request.toolChoice),
+    additionalParamKeys: isPlainObject(request.additionalParams)
+      ? Object.keys(request.additionalParams).sort()
+      : undefined,
+  });
+}
+
+function toolChoiceSummary(toolChoice: ToolChoice | undefined): JsonValue | undefined {
+  if (toolChoice === undefined || typeof toolChoice === "string") {
+    return toolChoice;
+  }
+  return { type: toolChoice.type, name: toolChoice.name };
+}
+
+function compactJsonObject(values: Record<string, unknown>): JsonObject {
+  return Object.fromEntries(
+    Object.entries(values).flatMap(([key, value]) => {
+      if (value === undefined) {
+        return [];
+      }
+      return [[key, toJsonValue(value)]];
+    }),
+  ) as JsonObject;
+}
+
+function toJsonValue(value: unknown): JsonValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => toJsonValue(item));
+  }
+  if (isPlainObject(value)) {
+    return compactJsonObject(value);
+  }
+  return String(value);
 }
 
 function requestMessages(request: CompletionRequest): MessageType[] {

--- a/packages/providers/openai/test/openai-chat-completion.test.ts
+++ b/packages/providers/openai/test/openai-chat-completion.test.ts
@@ -1,4 +1,10 @@
-import { AssistantContent, Message, ToolContent, UserContent } from "@anvia/core";
+import {
+  AssistantContent,
+  type CompletionRequest,
+  Message,
+  ToolContent,
+  UserContent,
+} from "@anvia/core";
 import { describe, expect, it } from "vitest";
 import { OpenAIChatCompletionModel, OpenAIClient } from "../src/index";
 import {
@@ -97,6 +103,28 @@ describe("OpenAI chat-completions client path", () => {
       { role: "tool", tool_call_id: "call_abc", content: '{"id":"task_1"}' },
       { role: "user", content: "continue" },
     ]);
+  });
+
+  it("summarizes provider request metadata for traces", () => {
+    const model = new OpenAIChatCompletionModel({} as never, "chat-test");
+    const request: CompletionRequest = {
+      chatHistory: [Message.user("What is 2+5?")],
+      documents: [],
+      tools: [{ name: "add", description: "Add numbers", parameters: { type: "object" } }],
+      maxTokens: 64,
+      toolChoice: { type: "function", name: "add" },
+    };
+
+    expect(model.traceRequest(request, { stream: true })).toMatchObject({
+      provider: "openai-chat",
+      api: "chat.completions",
+      stream: true,
+      model: "chat-test",
+      messageCount: 1,
+      toolCount: 1,
+      toolNames: ["add"],
+      parameterKeys: expect.arrayContaining(["messages", "model", "stream", "stream_options"]),
+    });
   });
 
   it("maps non-streaming reasoning_content responses to assistant reasoning", () => {

--- a/packages/providers/openai/test/openai-responses.test.ts
+++ b/packages/providers/openai/test/openai-responses.test.ts
@@ -70,6 +70,30 @@ describe("OpenAI Responses mapping", () => {
     });
   });
 
+  it("summarizes provider request metadata for traces", () => {
+    const model = new OpenAIResponsesCompletionModel({} as never, "gpt-test");
+    const request: CompletionRequest = {
+      instructions: "Be concise.",
+      chatHistory: [Message.user("What is 2+5?")],
+      documents: [],
+      tools: [{ name: "add", description: "Add numbers", parameters: { type: "object" } }],
+      temperature: 0.2,
+      maxTokens: 128,
+      toolChoice: "auto",
+    };
+
+    expect(model.traceRequest(request, { stream: true })).toMatchObject({
+      provider: "openai",
+      api: "responses",
+      stream: true,
+      model: "gpt-test",
+      inputCount: 1,
+      toolCount: 1,
+      toolNames: ["add"],
+      parameterKeys: expect.arrayContaining(["input", "model", "stream", "tools"]),
+    });
+  });
+
   it("prepends normalized static context before chat history", () => {
     const request: CompletionRequest = {
       chatHistory: [Message.system("Use context."), Message.user("What is the owner?")],

--- a/packages/tools/studio/package.json
+++ b/packages/tools/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/studio",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Studio UI and HTTP runtime for Anvia agents.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/tools/studio/src/runtime/knowledge.ts
+++ b/packages/tools/studio/src/runtime/knowledge.ts
@@ -5,12 +5,24 @@ import type {
   StudioAgentKnowledgeConfig,
   StudioKnowledgeEvidence,
   StudioKnowledgeEvidenceDocument,
+  StudioKnowledgeItem,
+  StudioKnowledgeItemsPage,
+  StudioKnowledgeSourceKind,
+  StudioKnowledgeSourceSummary,
   StudioKnowledgeSummary,
   StudioTrace,
   StudioTraceStore,
 } from "../types";
-import { compactJsonObject } from "./json";
-import { errorResponse, parseLimit } from "./shared";
+import { compactJsonObject, toJsonValue } from "./json";
+import { errorResponse, optionalQueryString, parseLimit } from "./shared";
+
+type InspectableIndex = {
+  inspect?: (request: { limit: number; cursor?: string | undefined; filter?: unknown }) => Promise<{
+    items: Array<{ id: string; document: unknown; metadata?: Record<string, unknown> }>;
+    nextCursor?: string | undefined;
+    totalCount?: number | undefined;
+  }>;
+};
 
 export function registerKnowledgeRoutes(
   app: Hono,
@@ -26,10 +38,38 @@ export function registerKnowledgeRoutes(
     }
 
     const summary: StudioKnowledgeSummary = {
-      agents: props.agents.map(agentKnowledgeConfig),
+      agents: await Promise.all(props.agents.map(agentKnowledgeConfig)),
       evidence: await recentKnowledgeEvidence(props.traceStore, limit),
     };
     return c.json(summary);
+  });
+
+  app.get("/knowledge/items", async (c) => {
+    const limit = parseLimit(c.req.query("limit"));
+    if (limit === undefined) {
+      return errorResponse(c, 400, "bad_request", "Invalid limit");
+    }
+
+    const agentId = optionalQueryString(c.req.query("agentId"));
+    const sourceId = optionalQueryString(c.req.query("sourceId"));
+    if (agentId === undefined || sourceId === undefined) {
+      return errorResponse(c, 400, "bad_request", "agentId and sourceId are required");
+    }
+
+    const agent = props.agents.find((item) => item.id === agentId);
+    if (agent === undefined) {
+      return errorResponse(c, 404, "not_found", "Agent not found");
+    }
+
+    const page = await knowledgeItemsPage(agent, sourceId, {
+      limit,
+      cursor: optionalQueryString(c.req.query("cursor")),
+    });
+    if (page === undefined) {
+      return errorResponse(c, 404, "not_found", "Knowledge source not found");
+    }
+
+    return c.json(page);
   });
 }
 
@@ -41,16 +81,12 @@ export function agentHasKnowledge(agent: StudioAgent): boolean {
   );
 }
 
-function agentKnowledgeConfig(agent: StudioAgent): StudioAgentKnowledgeConfig {
+async function agentKnowledgeConfig(agent: StudioAgent): Promise<StudioAgentKnowledgeConfig> {
   const agentName = agent.name ?? agent.agent.name;
   return {
     agentId: agent.id,
     ...(agentName === undefined ? {} : { agentName }),
-    sources: [
-      { kind: "static_context", count: agent.agent.staticContext.length },
-      { kind: "dynamic_context", count: agent.agent.dynamicContexts.length },
-      { kind: "dynamic_tools", count: agent.agent.dynamicTools.length },
-    ],
+    sources: await knowledgeSources(agent),
     staticContext: agent.agent.staticContext.map((document) => ({
       id: document.id,
       text: document.text,
@@ -59,6 +95,260 @@ function agentKnowledgeConfig(agent: StudioAgent): StudioAgentKnowledgeConfig {
         : { additionalProps: jsonObjectFromRecord(document.additionalProps) }),
     })),
   };
+}
+
+async function knowledgeSources(agent: StudioAgent): Promise<StudioKnowledgeSourceSummary[]> {
+  const sources: StudioKnowledgeSourceSummary[] = [
+    {
+      sourceId: staticSourceId(),
+      kind: "static_context",
+      label: "Static context",
+      count: agent.agent.staticContext.length,
+      inspectable: true,
+      itemCount: agent.agent.staticContext.length,
+    },
+  ];
+
+  const dynamicContextSources = await Promise.all(
+    agent.agent.dynamicContexts.map(async (registration, index) => {
+      const inspect = inspectFn(registration.index);
+      const count = await inspectableCount(inspect, registration.options.filter);
+      return {
+        sourceId: dynamicContextSourceId(index),
+        kind: "dynamic_context" as const,
+        label: `Dynamic context ${index + 1}`,
+        count: 1,
+        registrationIndex: index,
+        topK: registration.options.topK,
+        ...(registration.options.threshold === undefined
+          ? {}
+          : { threshold: registration.options.threshold }),
+        inspectable: inspect !== undefined,
+        ...(count === undefined ? {} : { itemCount: count }),
+      };
+    }),
+  );
+
+  const dynamicToolSources = await Promise.all(
+    agent.agent.dynamicTools.map(async (registration, index) => {
+      const inspect = inspectFn(registration.index);
+      const count = await inspectableCount(inspect, registration.options.filter);
+      return {
+        sourceId: dynamicToolsSourceId(index),
+        kind: "dynamic_tools" as const,
+        label: `Dynamic tools ${index + 1}`,
+        count: 1,
+        registrationIndex: index,
+        topK: registration.options.topK,
+        ...(registration.options.threshold === undefined
+          ? {}
+          : { threshold: registration.options.threshold }),
+        inspectable: inspect !== undefined,
+        ...(count === undefined ? {} : { itemCount: count }),
+      };
+    }),
+  );
+
+  return [...sources, ...dynamicContextSources, ...dynamicToolSources];
+}
+
+async function inspectableCount(
+  inspect: InspectableIndex["inspect"] | undefined,
+  filter?: unknown,
+): Promise<number | undefined> {
+  if (inspect === undefined) {
+    return undefined;
+  }
+  const page = await inspect({ limit: 1, filter });
+  return page.totalCount;
+}
+
+async function knowledgeItemsPage(
+  agent: StudioAgent,
+  sourceId: string,
+  request: { limit: number; cursor?: string | undefined },
+): Promise<StudioKnowledgeItemsPage | undefined> {
+  if (sourceId === staticSourceId()) {
+    return staticKnowledgeItemsPage(agent, request);
+  }
+
+  const dynamicContextIndex = dynamicSourceIndex(sourceId, "dynamic_context");
+  if (dynamicContextIndex !== undefined) {
+    const registration = agent.agent.dynamicContexts[dynamicContextIndex];
+    if (registration === undefined) {
+      return undefined;
+    }
+    const inspect = inspectFn(registration.index);
+    if (inspect === undefined) {
+      return nonInspectablePage(agent.id, sourceId, "dynamic_context");
+    }
+    const page = await inspect({
+      limit: request.limit,
+      cursor: request.cursor,
+      filter: registration.options.filter,
+    });
+    return {
+      agentId: agent.id,
+      sourceId,
+      kind: "dynamic_context",
+      inspectable: true,
+      items: page.items.map((item) => dynamicContextItem(item)),
+      ...(page.nextCursor === undefined ? {} : { nextCursor: page.nextCursor }),
+      ...(page.totalCount === undefined ? {} : { totalCount: page.totalCount }),
+    };
+  }
+
+  const dynamicToolsIndex = dynamicSourceIndex(sourceId, "dynamic_tools");
+  if (dynamicToolsIndex !== undefined) {
+    const registration = agent.agent.dynamicTools[dynamicToolsIndex];
+    if (registration === undefined) {
+      return undefined;
+    }
+    const inspect = inspectFn(registration.index);
+    if (inspect === undefined) {
+      return nonInspectablePage(agent.id, sourceId, "dynamic_tools");
+    }
+    const page = await inspect({
+      limit: request.limit,
+      cursor: request.cursor,
+      filter: registration.options.filter,
+    });
+    return {
+      agentId: agent.id,
+      sourceId,
+      kind: "dynamic_tools",
+      inspectable: true,
+      items: page.items.map((item) => dynamicToolItem(item)),
+      ...(page.nextCursor === undefined ? {} : { nextCursor: page.nextCursor }),
+      ...(page.totalCount === undefined ? {} : { totalCount: page.totalCount }),
+    };
+  }
+
+  return undefined;
+}
+
+function inspectFn(index: unknown): InspectableIndex["inspect"] | undefined {
+  if (!isRecord(index) || typeof index.inspect !== "function") {
+    return undefined;
+  }
+  const inspect = index.inspect;
+  return (request) =>
+    inspect.call(index, request) as ReturnType<NonNullable<InspectableIndex["inspect"]>>;
+}
+
+function staticKnowledgeItemsPage(
+  agent: StudioAgent,
+  request: { limit: number; cursor?: string | undefined },
+): StudioKnowledgeItemsPage {
+  const start = Math.max(0, Math.trunc(Number(request.cursor ?? "0")));
+  const page = agent.agent.staticContext.slice(start, start + request.limit);
+  const nextOffset = start + page.length;
+  return {
+    agentId: agent.id,
+    sourceId: staticSourceId(),
+    kind: "static_context",
+    inspectable: true,
+    items: page.map((document) => ({
+      id: document.id,
+      kind: "static_context",
+      text: document.text,
+      ...(document.additionalProps === undefined
+        ? {}
+        : { metadata: jsonObjectFromRecord(document.additionalProps) }),
+    })),
+    ...(nextOffset < agent.agent.staticContext.length ? { nextCursor: String(nextOffset) } : {}),
+    totalCount: agent.agent.staticContext.length,
+  };
+}
+
+function nonInspectablePage(
+  agentId: string,
+  sourceId: string,
+  kind: StudioKnowledgeSourceKind,
+): StudioKnowledgeItemsPage {
+  return {
+    agentId,
+    sourceId,
+    kind,
+    inspectable: false,
+    items: [],
+    message: "This source can be searched at runtime, but it does not expose browseable chunks.",
+  };
+}
+
+function dynamicContextItem(item: {
+  id: string;
+  document: unknown;
+  metadata?: Record<string, unknown> | undefined;
+}): StudioKnowledgeItem {
+  const text =
+    isRecord(item.document) && typeof item.document.text === "string"
+      ? item.document.text
+      : typeof item.document === "string"
+        ? item.document
+        : undefined;
+  return {
+    id: item.id,
+    kind: "dynamic_context",
+    ...(text === undefined ? { document: toJsonValue(item.document) } : { text }),
+    ...(item.metadata === undefined ? {} : { metadata: jsonObjectFromRecord(item.metadata) }),
+  };
+}
+
+function dynamicToolItem(item: {
+  id: string;
+  document: unknown;
+  metadata?: Record<string, unknown> | undefined;
+}): StudioKnowledgeItem {
+  const document = isRecord(item.document) ? item.document : {};
+  const definition = isRecord(document.definition) ? document.definition : {};
+  const toolName =
+    typeof document.toolName === "string"
+      ? document.toolName
+      : typeof definition.name === "string"
+        ? definition.name
+        : item.id;
+  const description = typeof definition.description === "string" ? definition.description : "";
+  return {
+    id: item.id,
+    kind: "dynamic_tool",
+    toolName,
+    description,
+    parameterKeys: parameterKeys(definition.parameters),
+    document: toJsonValue(item.document),
+    ...(item.metadata === undefined ? {} : { metadata: jsonObjectFromRecord(item.metadata) }),
+  };
+}
+
+function parameterKeys(parameters: unknown): string[] {
+  if (!isRecord(parameters) || !isRecord(parameters.properties)) {
+    return [];
+  }
+  return Object.keys(parameters.properties);
+}
+
+function staticSourceId(): string {
+  return "static-context";
+}
+
+function dynamicContextSourceId(index: number): string {
+  return `dynamic-context-${index}`;
+}
+
+function dynamicToolsSourceId(index: number): string {
+  return `dynamic-tools-${index}`;
+}
+
+function dynamicSourceIndex(
+  sourceId: string,
+  kind: "dynamic_context" | "dynamic_tools",
+): number | undefined {
+  const prefix = kind === "dynamic_context" ? "dynamic-context-" : "dynamic-tools-";
+  if (!sourceId.startsWith(prefix)) {
+    return undefined;
+  }
+  const index = Number(sourceId.slice(prefix.length));
+  return Number.isInteger(index) && index >= 0 ? index : undefined;
 }
 
 async function recentKnowledgeEvidence(

--- a/packages/tools/studio/src/traces/trace-observer.ts
+++ b/packages/tools/studio/src/traces/trace-observer.ts
@@ -75,11 +75,7 @@ class StudioRunTraceObserver implements AgentRunObserver {
             startedAt,
             input: toJsonValue(args.request),
             output: toJsonValue(endArgs.response),
-            metadata: {
-              model: args.request.model ?? "default",
-              toolCount: args.request.tools.length,
-              ...(endArgs.firstDeltaMs === undefined ? {} : { firstDeltaMs: endArgs.firstDeltaMs }),
-            },
+            metadata: generationMetadata(args, endArgs),
           }),
         );
       },
@@ -93,10 +89,7 @@ class StudioRunTraceObserver implements AgentRunObserver {
             startedAt,
             input: toJsonValue(args.request),
             error: serializeError(errorArgs.error),
-            metadata: {
-              model: args.request.model ?? "default",
-              toolCount: args.request.tools.length,
-            },
+            metadata: generationMetadata(args),
           }),
         );
       },
@@ -498,6 +491,61 @@ function traceMetadata(args: AgentRunStartArgs, messages: JsonValue): JsonObject
     metadata: toJsonValue(args.trace?.metadata ?? {}),
     messages,
   });
+}
+
+function generationMetadata(
+  args: AgentGenerationStartArgs,
+  endArgs?: AgentGenerationEndArgs,
+): JsonObject {
+  const request = args.request;
+  const response = endArgs?.response;
+  const rawResponse = isRecord(response?.rawResponse) ? response.rawResponse : undefined;
+  const effectiveModel =
+    request.model ?? stringValue(rawResponse?.model) ?? args.modelInfo?.defaultModel ?? "default";
+  const providerResponse = providerResponseSummary(rawResponse);
+
+  return compactJsonObject({
+    provider: args.modelInfo?.provider,
+    model: effectiveModel,
+    requestedModel: request.model,
+    defaultModel: args.modelInfo?.defaultModel,
+    messageId: response?.messageId,
+    toolCount: request.tools.length,
+    toolNames: request.tools.map((tool) => tool.name),
+    documentCount: request.documents.length,
+    historyCount: request.chatHistory.length,
+    temperature: request.temperature,
+    maxTokens: request.maxTokens,
+    toolChoice: request.toolChoice,
+    hasOutputSchema: request.outputSchema !== undefined,
+    firstDeltaMs: endArgs?.firstDeltaMs,
+    providerResponse,
+  });
+}
+
+function providerResponseSummary(
+  rawResponse: Record<string, unknown> | undefined,
+): JsonObject | undefined {
+  if (rawResponse === undefined) {
+    return undefined;
+  }
+  const reasoning = isRecord(rawResponse.reasoning) ? rawResponse.reasoning : undefined;
+  const text = isRecord(rawResponse.text) ? rawResponse.text : undefined;
+  const toolUsage = isRecord(rawResponse.tool_usage) ? rawResponse.tool_usage : undefined;
+  const webSearch = isRecord(toolUsage?.web_search) ? toolUsage.web_search : undefined;
+  const summary = compactJsonObject({
+    id: rawResponse.id,
+    status: rawResponse.status,
+    serviceTier: rawResponse.service_tier,
+    store: rawResponse.store,
+    parallelToolCalls: rawResponse.parallel_tool_calls,
+    promptCacheKey: rawResponse.prompt_cache_key,
+    promptCacheRetention: rawResponse.prompt_cache_retention,
+    reasoningEffort: reasoning?.effort,
+    textVerbosity: text?.verbosity,
+    webSearchRequestCount: webSearch?.num_requests,
+  });
+  return Object.keys(summary).length === 0 ? undefined : summary;
 }
 
 function toolMetadata(args: AgentToolStartArgs, skipped: boolean): JsonObject {

--- a/packages/tools/studio/src/traces/trace-observer.ts
+++ b/packages/tools/studio/src/traces/trace-observer.ts
@@ -112,7 +112,7 @@ class StudioRunTraceObserver implements AgentRunObserver {
           startedAt,
           input: parseOrString(args.args),
           output: parseOrString(endArgs.result),
-          metadata: toolMetadata(args, endArgs.skipped),
+          metadata: toolMetadata(args, endArgs.skipped, endArgs.result),
         });
         this.observations.push(parentObservation);
         this.observations.push(...childTrace.observations(parentObservation.id));
@@ -503,6 +503,7 @@ function generationMetadata(
   const effectiveModel =
     request.model ?? stringValue(rawResponse?.model) ?? args.modelInfo?.defaultModel ?? "default";
   const providerResponse = providerResponseSummary(rawResponse);
+  const usage = response?.usage;
 
   return compactJsonObject({
     provider: args.modelInfo?.provider,
@@ -510,6 +511,7 @@ function generationMetadata(
     requestedModel: request.model,
     defaultModel: args.modelInfo?.defaultModel,
     messageId: response?.messageId,
+    usage,
     toolCount: request.tools.length,
     toolNames: request.tools.map((tool) => tool.name),
     documentCount: request.documents.length,
@@ -517,9 +519,57 @@ function generationMetadata(
     temperature: request.temperature,
     maxTokens: request.maxTokens,
     toolChoice: request.toolChoice,
+    additionalParamKeys: isRecord(request.additionalParams)
+      ? Object.keys(request.additionalParams).sort()
+      : undefined,
     hasOutputSchema: request.outputSchema !== undefined,
     firstDeltaMs: endArgs?.firstDeltaMs,
     providerResponse,
+    modelInfo: compactJsonObject({
+      provider: args.modelInfo?.provider,
+      model: effectiveModel,
+      requestedModel: request.model,
+      defaultModel: args.modelInfo?.defaultModel,
+      capabilities: args.modelInfo?.capabilities,
+    }),
+    modelCall: compactJsonObject({
+      request: completionRequestSummary(request),
+      providerRequest: args.providerRequest,
+    }),
+    response: compactJsonObject({
+      messageId: response?.messageId,
+      usage,
+      contentTypes: response?.choice.map((item) => item.type),
+      providerResponse,
+    }),
+    tools: compactJsonObject({
+      count: request.tools.length,
+      names: request.tools.map((tool) => tool.name),
+      toolChoice: request.toolChoice,
+      hasOutputSchema: request.outputSchema !== undefined,
+    }),
+    timing: compactJsonObject({
+      firstDeltaMs: endArgs?.firstDeltaMs,
+    }),
+  });
+}
+
+function completionRequestSummary(request: AgentGenerationStartArgs["request"]): JsonObject {
+  return compactJsonObject({
+    model: request.model,
+    instructions: request.instructions === undefined ? undefined : { present: true },
+    messageCount: request.chatHistory.length,
+    documentCount: request.documents.length,
+    documentIds: request.documents.map((document) => document.id),
+    toolCount: request.tools.length,
+    toolNames: request.tools.map((tool) => tool.name),
+    temperature: request.temperature,
+    maxTokens: request.maxTokens,
+    toolChoice: request.toolChoice,
+    additionalParamKeys: isRecord(request.additionalParams)
+      ? Object.keys(request.additionalParams).sort()
+      : undefined,
+    hasOutputSchema: request.outputSchema !== undefined,
   });
 }
 
@@ -548,12 +598,45 @@ function providerResponseSummary(
   return Object.keys(summary).length === 0 ? undefined : summary;
 }
 
-function toolMetadata(args: AgentToolStartArgs, skipped: boolean): JsonObject {
+function toolMetadata(args: AgentToolStartArgs, skipped: boolean, result?: string): JsonObject {
+  const schema = isRecord(args.toolDefinition?.parameters) ? args.toolDefinition.parameters : {};
+  const properties = isRecord(schema.properties) ? schema.properties : {};
+  const required = Array.isArray(schema.required)
+    ? schema.required.filter((item): item is string => typeof item === "string")
+    : [];
   return compactJsonObject({
     internalCallId: args.internalCallId,
     toolCallId: args.toolCallId,
     skipped,
+    argumentBytes: byteLength(args.args),
+    resultBytes: result === undefined ? undefined : byteLength(result),
+    hasCallSignature: args.toolCall.signature !== undefined,
+    hasAdditionalParams: args.toolCall.additionalParams !== undefined,
+    toolDescription: args.toolDefinition?.description,
+    parameterKeys: Object.keys(properties).sort(),
+    requiredParameterKeys: required,
+    approvalRequired: args.toolMetadata?.approvalRequired,
+    mcpServerName: args.toolMetadata?.mcpServerName,
+    tools: compactJsonObject({
+      name: args.toolName,
+      internalCallId: args.internalCallId,
+      toolCallId: args.toolCallId,
+      skipped,
+      description: args.toolDefinition?.description,
+      parameterKeys: Object.keys(properties).sort(),
+      requiredParameterKeys: required,
+      approvalRequired: args.toolMetadata?.approvalRequired,
+      mcpServerName: args.toolMetadata?.mcpServerName,
+      argumentBytes: byteLength(args.args),
+      resultBytes: result === undefined ? undefined : byteLength(result),
+      hasCallSignature: args.toolCall.signature !== undefined,
+      hasAdditionalParams: args.toolCall.additionalParams !== undefined,
+    }),
   });
+}
+
+function byteLength(value: string): number {
+  return new TextEncoder().encode(value).length;
 }
 
 function compactJsonObject(values: Record<string, unknown>): JsonObject {

--- a/packages/tools/studio/src/types.ts
+++ b/packages/tools/studio/src/types.ts
@@ -353,8 +353,15 @@ export type StudioTraceStore = {
 export type StudioKnowledgeSourceKind = "static_context" | "dynamic_context" | "dynamic_tools";
 
 export type StudioKnowledgeSourceSummary = {
+  sourceId?: string;
   kind: StudioKnowledgeSourceKind;
+  label?: string;
   count: number;
+  registrationIndex?: number;
+  topK?: number;
+  threshold?: number;
+  inspectable?: boolean;
+  itemCount?: number;
 };
 
 export type StudioStaticKnowledgeDocument = {
@@ -388,6 +395,30 @@ export type StudioAgentKnowledgeConfig = {
   agentName?: string;
   sources: StudioKnowledgeSourceSummary[];
   staticContext: StudioStaticKnowledgeDocument[];
+};
+
+export type StudioKnowledgeItemKind = "static_context" | "dynamic_context" | "dynamic_tool";
+
+export type StudioKnowledgeItem = {
+  id: string;
+  kind: StudioKnowledgeItemKind;
+  text?: string;
+  document?: JsonValue;
+  toolName?: string;
+  description?: string;
+  parameterKeys?: string[];
+  metadata?: JsonObject;
+};
+
+export type StudioKnowledgeItemsPage = {
+  agentId: string;
+  sourceId: string;
+  kind: StudioKnowledgeSourceKind;
+  inspectable: boolean;
+  items: StudioKnowledgeItem[];
+  nextCursor?: string;
+  totalCount?: number;
+  message?: string;
 };
 
 export type StudioKnowledgeSummary = {

--- a/packages/tools/studio/src/ui/app/app.tsx
+++ b/packages/tools/studio/src/ui/app/app.tsx
@@ -188,6 +188,13 @@ export function StudioConsole() {
   const mcpsEnabled = config?.capabilities.mcps?.enabled === true;
   const toolsEnabled = config?.capabilities.tools?.enabled === true;
   const pipelinesEnabled = config?.capabilities.pipelines?.enabled === true;
+  const agents = config?.agents ?? [];
+  const pipelines = config?.pipelines ?? [];
+  const hasAgents = agents.length > 0;
+  const selectedAgent =
+    agents.find((agent) => agent.id === selectedAgentId) ?? agents[0] ?? undefined;
+  const selectedAgentQuickPrompts = selectedAgent?.quickPrompts ?? [];
+  const hasMessages = messages.length > 0;
 
   useEffect(() => {
     applyDarkTheme();
@@ -1334,14 +1341,11 @@ export function StudioConsole() {
     void runPrompt(prompt);
   }
 
-  const agents = config?.agents ?? [];
-  const pipelines = config?.pipelines ?? [];
-  const selectedAgent =
-    agents.find((agent) => agent.id === selectedAgentId) ?? agents[0] ?? undefined;
-  const selectedAgentQuickPrompts = selectedAgent?.quickPrompts ?? [];
-  const hasMessages = messages.length > 0;
-
   function navigatePage(page: ActivePage) {
+    if (page === "playground" && !hasAgents) {
+      return;
+    }
+
     setActivePage(page);
     if (page === "pipelines") {
       const pipelineId = selectedPipelineId || pipelines[0]?.id || "";
@@ -1364,6 +1368,46 @@ export function StudioConsole() {
     }
     updatePagePath(page);
   }
+
+  useEffect(() => {
+    if (config === undefined || hasAgents || activePage !== "playground") {
+      return;
+    }
+
+    const nextPage: ActivePage = pipelinesEnabled
+      ? "pipelines"
+      : sessionsEnabled
+        ? "sessions"
+        : tracesEnabled
+          ? "tracing"
+          : "agents";
+
+    resetTranscriptSequence();
+    setSelectedSessionId("");
+    setSessionLogs([]);
+    setMessages([]);
+    setPrompt("");
+    setActivePage(nextPage);
+    updatePagePath(nextPage);
+
+    if (nextPage === "pipelines") {
+      const pipelineId = selectedPipelineId || pipelines[0]?.id || "";
+      if (pipelineId.length > 0) {
+        setSelectedPipelineId(pipelineId);
+        void loadPipeline(pipelineId);
+      }
+    }
+  }, [
+    activePage,
+    config,
+    hasAgents,
+    loadPipeline,
+    pipelines,
+    pipelinesEnabled,
+    selectedPipelineId,
+    sessionsEnabled,
+    tracesEnabled,
+  ]);
 
   function selectTrace(traceId: string) {
     setActivePage("tracing");
@@ -1397,6 +1441,7 @@ export function StudioConsole() {
             active={activePage === "playground"}
             icon="message"
             label="Chat"
+            disabled={!hasAgents}
             onClick={() => navigatePage("playground")}
           />
           <NavButton

--- a/packages/tools/studio/src/ui/app/app.tsx
+++ b/packages/tools/studio/src/ui/app/app.tsx
@@ -47,8 +47,10 @@ import {
   titleFromText,
 } from "./modules/shared/format";
 import {
+  defaultKnowledgeTab,
   logoSrc,
   pageLocationFromLocation,
+  updateKnowledgePath,
   updatePagePath,
   updateSessionPath,
   updateTracePath,
@@ -69,6 +71,7 @@ import {
 } from "./modules/shared/transcript";
 import type {
   ActivePage,
+  KnowledgeTab,
   RunState,
   SessionLoadState,
   ToolApprovalUpdate,
@@ -125,6 +128,9 @@ export function StudioConsole() {
   const [pipelineRunOutput, setPipelineRunOutput] = useState("");
   const [activePipelineRunId, setActivePipelineRunId] = useState("");
   const [activePage, setActivePage] = useState<ActivePage>(() => initialLocation.page);
+  const [knowledgeTab, setKnowledgeTab] = useState<KnowledgeTab>(
+    () => initialLocation.knowledgeTab ?? defaultKnowledgeTab,
+  );
   const [selectedTraceId, setSelectedTraceId] = useState(() => initialLocation.traceId ?? "");
   const [traceSessionDetailId, setTraceSessionDetailId] = useState<string | undefined>(
     () => initialLocation.traceSessionId,
@@ -687,6 +693,7 @@ export function StudioConsole() {
 
     const location = pageLocationFromLocation();
     setActivePage(location.page);
+    setKnowledgeTab(location.knowledgeTab ?? defaultKnowledgeTab);
     setSelectedTraceId(location.traceId ?? "");
     setTraceSessionDetailId(location.traceSessionId);
     if (location.page === "tracing" && location.traceSessionId !== undefined) {
@@ -707,6 +714,7 @@ export function StudioConsole() {
     function handlePopState() {
       const location = pageLocationFromLocation();
       setActivePage(location.page);
+      setKnowledgeTab(location.knowledgeTab ?? defaultKnowledgeTab);
       setSelectedTraceId(location.traceId ?? "");
       setTraceSessionDetailId(location.traceSessionId);
       if (location.page === "tracing" && location.traceSessionId !== undefined) {
@@ -1360,6 +1368,12 @@ export function StudioConsole() {
       updatePagePath("tracing");
       return;
     }
+    if (page === "knowledge") {
+      setSelectedTraceId("");
+      setTraceSessionDetailId(undefined);
+      updateKnowledgePath(knowledgeTab);
+      return;
+    }
     setSelectedTraceId("");
     setTraceSessionDetailId(undefined);
     if (page === "playground" && selectedSessionId.length > 0) {
@@ -1367,6 +1381,14 @@ export function StudioConsole() {
       return;
     }
     updatePagePath(page);
+  }
+
+  function navigateKnowledgeTab(tab: KnowledgeTab) {
+    setActivePage("knowledge");
+    setKnowledgeTab(tab);
+    setSelectedTraceId("");
+    setTraceSessionDetailId(undefined);
+    updateKnowledgePath(tab);
   }
 
   useEffect(() => {
@@ -1792,11 +1814,13 @@ export function StudioConsole() {
 
         {activePage === "knowledge" ? (
           <KnowledgePage
+            activeTab={knowledgeTab}
             enabled={knowledgeEnabled}
             summary={knowledge}
             loading={knowledgeLoadState === "loading"}
             onOpenTrace={selectTrace}
             onRefresh={() => void loadKnowledge()}
+            onSelectTab={navigateKnowledgeTab}
           />
         ) : null}
       </main>

--- a/packages/tools/studio/src/ui/app/app.tsx
+++ b/packages/tools/studio/src/ui/app/app.tsx
@@ -1609,17 +1609,7 @@ export function StudioConsole() {
                     placeholder="Ask anything..."
                   />
                   <div className="flex min-w-0 items-center justify-between gap-2">
-                    <div className="flex min-w-0 items-center gap-2">
-                      <Button
-                        aria-label="Attach context"
-                        className="h-8 min-h-8 w-8 rounded-sm border-border bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                        size="icon"
-                        type="button"
-                        variant="secondary"
-                      >
-                        <Plus aria-hidden="true" />
-                      </Button>
-                    </div>
+                    <div />
                     <div className="flex min-w-0 items-center gap-2">
                       {agents.length > 1 ? (
                         <Select

--- a/packages/tools/studio/src/ui/app/app.tsx
+++ b/packages/tools/studio/src/ui/app/app.tsx
@@ -1458,14 +1458,14 @@ export function StudioConsole() {
           {allSessions.slice(0, 8).map((session) => (
             <div
               className={cn(
-                "group grid min-h-9 min-w-0 grid-cols-[minmax(0,1fr)_24px] items-center gap-1 rounded-sm border border-transparent pr-1 transition duration-200 hover:border-sidebar-border hover:bg-sidebar-accent",
+                "group grid min-h-9 min-w-0 grid-cols-[minmax(0,1fr)_44px] items-center gap-1 rounded-sm border border-transparent pr-1 transition duration-200 hover:border-sidebar-border hover:bg-sidebar-accent focus-within:border-sidebar-border focus-within:bg-sidebar-accent",
                 session.id === selectedSessionId && "border-sidebar-border bg-sidebar-accent",
               )}
               key={session.id}
             >
               <Button
                 className={cn(
-                  "grid h-auto min-h-8 min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 rounded-sm border-0 bg-transparent px-2 py-1 text-left text-sidebar-foreground/72 shadow-none hover:bg-transparent hover:text-sidebar-foreground",
+                  "grid h-auto min-h-8 min-w-0 justify-start rounded-sm border-0 bg-transparent px-2 py-1 text-left text-sidebar-foreground/72 shadow-none hover:bg-transparent hover:text-sidebar-foreground",
                   session.id === selectedSessionId && "text-sidebar-accent-foreground",
                 )}
                 type="button"
@@ -1475,21 +1475,23 @@ export function StudioConsole() {
                 <span className="min-w-0 truncate text-xs font-medium">
                   {session.title ?? "Untitled chat"}
                 </span>
-                <time className="font-mono text-[10px] font-medium tabular-nums text-muted-foreground">
+              </Button>
+              <div className="relative grid h-8 min-w-0 place-items-end">
+                <time className="self-center justify-self-end font-mono text-[10px] font-medium tabular-nums text-muted-foreground group-hover:opacity-0 group-focus-within:opacity-0">
                   {formatRelativeTime(session.updatedAt)}
                 </time>
-              </Button>
-              <Button
-                aria-label={`Delete ${session.title ?? "Untitled chat"}`}
-                className="h-6 min-h-6 w-6 border-0 bg-transparent p-0 text-muted-foreground opacity-55 shadow-none hover:bg-transparent hover:text-destructive hover:opacity-100 group-hover:opacity-100 [&_svg]:h-3.5 [&_svg]:w-3.5"
-                size="icon"
-                type="button"
-                variant="ghost"
-                disabled={runState === "running"}
-                onClick={() => setDeleteCandidate(session)}
-              >
-                <Trash2 aria-hidden="true" />
-              </Button>
+                <Button
+                  aria-label={`Delete ${session.title ?? "Untitled chat"}`}
+                  className="absolute right-0 top-1/2 hidden h-6 min-h-6 w-6 -translate-y-1/2 border-0 bg-transparent p-0 text-muted-foreground opacity-70 shadow-none hover:bg-transparent hover:text-destructive hover:opacity-100 group-hover:grid group-focus-within:grid [&_svg]:h-3.5 [&_svg]:w-3.5"
+                  size="icon"
+                  type="button"
+                  variant="ghost"
+                  disabled={runState === "running"}
+                  onClick={() => setDeleteCandidate(session)}
+                >
+                  <Trash2 aria-hidden="true" />
+                </Button>
+              </div>
             </div>
           ))}
         </nav>

--- a/packages/tools/studio/src/ui/app/modules/agents/agents-page.tsx
+++ b/packages/tools/studio/src/ui/app/modules/agents/agents-page.tsx
@@ -9,7 +9,7 @@ export function AgentsPage(props: { agents: StudioConfig["agents"]; selectedAgen
       aria-label="Agents"
     >
       <header className="border-b border-border/80 bg-background/70 px-6 py-5 backdrop-blur">
-        <div className="mx-auto grid max-w-[1500px] grid-cols-[minmax(0,1fr)_auto] items-end gap-4 max-md:grid-cols-1">
+        <div className="grid w-full grid-cols-[minmax(0,1fr)_auto] items-end gap-4 max-md:grid-cols-1">
           <div className="grid min-w-0 gap-2">
             <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.24em] text-primary">
               Studio registry
@@ -25,7 +25,7 @@ export function AgentsPage(props: { agents: StudioConfig["agents"]; selectedAgen
       </header>
 
       <div className="min-h-0 overflow-auto px-6 py-6">
-        <div className="mx-auto grid max-w-[1500px] gap-4">
+        <div className="grid w-full gap-4">
           {props.agents.length === 0 ? (
             <div className="grid min-h-80 place-items-center border border-dashed border-border/80 bg-card/35 px-6 text-center">
               <div className="grid max-w-md gap-2">

--- a/packages/tools/studio/src/ui/app/modules/knowledge/knowledge-page.tsx
+++ b/packages/tools/studio/src/ui/app/modules/knowledge/knowledge-page.tsx
@@ -1,5 +1,5 @@
 import { RefreshCw } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import type {
   StudioAgentKnowledgeConfig,
   StudioKnowledgeItem,
@@ -10,7 +10,9 @@ import type {
 } from "../../../../types";
 import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
-import { JsonValueView } from "../shared/renderers";
+import { isRecord } from "../shared/object";
+import { JsonSyntax, JsonValueView } from "../shared/renderers";
+import type { KnowledgeTab } from "../shared/types";
 
 const itemLimit = 50;
 
@@ -33,11 +35,13 @@ type ItemState = {
 };
 
 export function KnowledgePage(props: {
+  activeTab: KnowledgeTab;
   enabled: boolean;
   summary: StudioKnowledgeSummary | undefined;
   loading: boolean;
   onOpenTrace: (traceId: string) => void;
   onRefresh: () => void;
+  onSelectTab: (tab: KnowledgeTab) => void;
 }) {
   const [selectedKey, setSelectedKey] = useState("");
   const [itemState, setItemState] = useState<ItemState | undefined>();
@@ -45,28 +49,33 @@ export function KnowledgePage(props: {
   const agents = props.summary?.agents ?? [];
   const evidence = props.summary?.evidence ?? [];
   const sources = useMemo(() => flattenSources(agents), [agents]);
-  const selectedSource = sources.find((source) => source.key === selectedKey) ?? sources[0];
-  const metrics = useMemo(
-    () => knowledgeMetrics(agents, evidence.length),
-    [agents, evidence.length],
+  const activeSourceKind = sourceKindForTab(props.activeTab);
+  const visibleSources = useMemo(
+    () =>
+      activeSourceKind === undefined
+        ? []
+        : sources.filter((source) => source.source.kind === activeSourceKind),
+    [activeSourceKind, sources],
   );
+  const selectedSource =
+    visibleSources.find((source) => source.key === selectedKey) ?? visibleSources[0];
 
   useEffect(() => {
-    if (sources.length === 0) {
+    if (visibleSources.length === 0) {
       setSelectedKey("");
       return;
     }
-    if (sources.some((source) => source.key === selectedKey)) {
+    if (visibleSources.some((source) => source.key === selectedKey)) {
       return;
     }
     const next =
-      sources.find(
+      visibleSources.find(
         (source) => source.source.inspectable === true && (source.source.itemCount ?? 0) > 0,
       ) ??
-      sources.find((source) => source.source.inspectable === true) ??
-      sources[0];
+      visibleSources.find((source) => source.source.inspectable === true) ??
+      visibleSources[0];
     setSelectedKey(next?.key ?? "");
-  }, [selectedKey, sources]);
+  }, [selectedKey, visibleSources]);
 
   const loadItems = useCallback(
     async (source: KnowledgeSourceRef, options: { append: boolean; cursor?: string }) => {
@@ -146,7 +155,7 @@ export function KnowledgePage(props: {
         <div className="min-w-0">
           <h1 className="m-0 text-sm font-semibold text-foreground">Knowledge</h1>
           <p className="m-0 text-xs font-medium text-muted-foreground">
-            Browse configured context, dynamic chunks, tools, and retrieval evidence.
+            Browse configured context, dynamic chunks, dynamic tools, and retrieval evidence.
           </p>
         </div>
         <Button
@@ -160,151 +169,192 @@ export function KnowledgePage(props: {
         </Button>
       </header>
       <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-4 overflow-hidden p-6">
-        <MetricStrip metrics={metrics} />
-        <div className="grid min-h-0 gap-4 xl:grid-cols-[320px_minmax(0,1fr)_420px]">
-          <SourceList
-            sources={sources}
+        <KnowledgeTabs
+          activeTab={props.activeTab}
+          sources={sources}
+          evidenceCount={evidence.length}
+          onSelectTab={props.onSelectTab}
+        />
+        {props.activeTab === "retrieval-log" ? (
+          <RetrievalLogPanel evidence={evidence} onOpenTrace={props.onOpenTrace} />
+        ) : (
+          <SourceWorkspace
+            sources={visibleSources}
             selectedKey={selectedSource?.key ?? ""}
             loading={props.loading}
+            activeTab={props.activeTab}
             onSelect={setSelectedKey}
-          />
-          <ItemBrowser
-            source={selectedSource}
-            state={itemState}
-            onLoadMore={() => {
-              if (selectedSource === undefined) {
-                return;
-              }
-              void loadItems(
-                selectedSource,
-                itemState?.nextCursor === undefined
-                  ? { append: true }
-                  : { append: true, cursor: itemState.nextCursor },
-              );
-            }}
-          />
-          <EvidencePanel evidence={evidence} onOpenTrace={props.onOpenTrace} />
-        </div>
+          >
+            <ItemBrowser
+              activeTab={props.activeTab}
+              source={selectedSource}
+              state={itemState}
+              onLoadMore={() => {
+                if (selectedSource === undefined) {
+                  return;
+                }
+                void loadItems(
+                  selectedSource,
+                  itemState?.nextCursor === undefined
+                    ? { append: true }
+                    : { append: true, cursor: itemState.nextCursor },
+                );
+              }}
+            />
+          </SourceWorkspace>
+        )}
       </div>
     </section>
   );
 }
 
-function MetricStrip(props: { metrics: Array<[string, string]> }) {
+function KnowledgeTabs(props: {
+  activeTab: KnowledgeTab;
+  sources: KnowledgeSourceRef[];
+  evidenceCount: number;
+  onSelectTab: (tab: KnowledgeTab) => void;
+}) {
   return (
-    <div className="grid border-y border-border/80 sm:grid-cols-5">
-      {props.metrics.map(([label, value]) => (
-        <div
-          className="border-b border-border/80 px-4 py-3 last:border-b-0 sm:border-b-0 sm:border-r sm:last:border-r-0"
-          key={label}
-        >
-          <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-            {label}
+    <nav
+      className="flex min-w-0 gap-7 overflow-x-auto border-b border-border/80"
+      aria-label="Knowledge sections"
+    >
+      {knowledgeTabs.map((tab) => {
+        const active = props.activeTab === tab.id;
+        return (
+          <button
+            className={[
+              "flex min-h-10 shrink-0 items-center gap-2 border-b px-0 pb-2 pt-1 text-left transition duration-200 hover:text-foreground focus-visible:outline-none",
+              active
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:border-border",
+            ].join(" ")}
+            key={tab.id}
+            type="button"
+            aria-current={active ? "page" : undefined}
+            onClick={() => props.onSelectTab(tab.id)}
+          >
+            <span className="text-sm font-semibold">{tab.label}</span>
+            <span className="font-mono text-[10px] text-muted-foreground">
+              {tabCountLabel(tab.id, props.sources, props.evidenceCount)}
+            </span>
+          </button>
+        );
+      })}
+    </nav>
+  );
+}
+
+function SourceWorkspace(props: {
+  sources: KnowledgeSourceRef[];
+  selectedKey: string;
+  loading: boolean;
+  activeTab: KnowledgeTab;
+  onSelect: (key: string) => void;
+  children: ReactNode;
+}) {
+  const showSources = props.sources.length !== 1 || props.loading;
+  return (
+    <div
+      className={[
+        "grid min-h-0 gap-3 overflow-hidden",
+        showSources ? "grid-rows-[auto_minmax(0,1fr)]" : "grid-rows-[minmax(0,1fr)]",
+      ].join(" ")}
+    >
+      {showSources ? (
+        <div className="min-w-0 overflow-x-auto border border-border/80 bg-card/35">
+          <div className="flex min-h-11 min-w-max items-center gap-2 px-3">
+            <span className="mr-2 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              {tabLabel(props.activeTab)}
+            </span>
+            {props.loading && props.sources.length === 0 ? (
+              <span className="font-mono text-[11px] text-muted-foreground">Loading sources</span>
+            ) : null}
+            {!props.loading && props.sources.length === 0 ? (
+              <span className="font-mono text-[11px] text-muted-foreground">
+                No knowledge sources
+              </span>
+            ) : null}
+            {props.sources.map((source) => (
+              <button
+                className={[
+                  "flex h-7 items-center gap-2 border border-border/80 bg-background/45 px-2.5 font-mono text-[11px] font-semibold text-muted-foreground transition duration-200 hover:border-primary/45 hover:bg-primary/10 hover:text-foreground focus-visible:border-ring focus-visible:outline-none",
+                  props.selectedKey === source.key
+                    ? "border-primary/45 bg-primary/10 text-primary"
+                    : "",
+                ].join(" ")}
+                key={source.key}
+                type="button"
+                onClick={() => props.onSelect(source.key)}
+              >
+                <span>{source.source.label ?? sourceLabel(source.source.kind)}</span>
+                {source.source.itemCount === undefined ? null : (
+                  <span className="text-muted-foreground">{source.source.itemCount}</span>
+                )}
+              </button>
+            ))}
           </div>
-          <div className="mt-1 font-mono text-sm font-semibold text-foreground">{value}</div>
         </div>
-      ))}
+      ) : null}
+      {props.children}
     </div>
   );
 }
 
-function SourceList(props: {
-  sources: KnowledgeSourceRef[];
-  selectedKey: string;
-  loading: boolean;
-  onSelect: (key: string) => void;
-}) {
-  return (
-    <aside className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden border border-border/80 bg-card/45">
-      <div className="border-b border-border/80 px-4 py-3">
-        <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-          Sources
-        </div>
-        <p className="m-0 mt-1 text-xs leading-5 text-muted-foreground">
-          Browseable sources show chunks directly. Search-only sources still appear in evidence.
-        </p>
-      </div>
-      <div className="min-h-0 overflow-auto p-2">
-        {props.loading && props.sources.length === 0 ? <MutedRow text="Loading sources" /> : null}
-        {!props.loading && props.sources.length === 0 ? (
-          <MutedRow text="No knowledge sources" />
-        ) : null}
-        {props.sources.map((source) => (
-          <button
-            className={[
-              "grid w-full gap-2 border border-transparent px-3 py-3 text-left transition duration-200 hover:border-primary/35 hover:bg-primary/10",
-              props.selectedKey === source.key ? "border-primary/45 bg-primary/10" : "",
-            ].join(" ")}
-            key={source.key}
-            type="button"
-            onClick={() => props.onSelect(source.key)}
-          >
-            <div className="flex min-w-0 items-start justify-between gap-3">
-              <div className="min-w-0">
-                <div className="truncate text-sm font-semibold text-foreground">
-                  {source.source.label ?? sourceLabel(source.source.kind)}
-                </div>
-                <div className="truncate font-mono text-[11px] font-medium text-muted-foreground">
-                  {source.agentName}
-                </div>
-              </div>
-              <Badge variant={source.source.inspectable === true ? "success" : "default"}>
-                {source.source.inspectable === true ? "Browse" : "Search"}
-              </Badge>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              <Badge>{sourceLabel(source.source.kind)}</Badge>
-              {source.source.itemCount === undefined ? null : (
-                <Badge>{source.source.itemCount} items</Badge>
-              )}
-              {source.source.topK === undefined ? null : <Badge>Top {source.source.topK}</Badge>}
-            </div>
-          </button>
-        ))}
-      </div>
-    </aside>
-  );
-}
-
 function ItemBrowser(props: {
+  activeTab: KnowledgeTab;
   source: KnowledgeSourceRef | undefined;
   state: ItemState | undefined;
   onLoadMore: () => void;
 }) {
   const state = props.state;
+  const showHeader = props.activeTab !== "dynamic-tools";
   return (
-    <section className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden border border-border/80 bg-card/35">
-      <div className="border-b border-border/80 px-4 py-3">
-        <div className="flex min-w-0 items-start justify-between gap-3">
-          <div className="min-w-0">
-            <h2 className="m-0 truncate text-sm font-semibold text-foreground">
-              {props.source?.source.label ?? "Knowledge items"}
-            </h2>
-            <p className="m-0 mt-1 truncate font-mono text-xs text-muted-foreground">
-              {props.source === undefined
-                ? "No source selected"
-                : `${props.source.agentId} / ${sourceId(props.source.source)}`}
-            </p>
+    <section
+      className={[
+        "grid min-h-0 overflow-hidden border border-border/80 bg-card/20",
+        showHeader ? "grid-rows-[auto_minmax(0,1fr)_auto]" : "grid-rows-[minmax(0,1fr)_auto]",
+      ].join(" ")}
+    >
+      {showHeader ? (
+        <div className="border-b border-border/80 px-4 py-3">
+          <div className="flex min-w-0 items-start justify-between gap-3">
+            <div className="min-w-0">
+              <h2 className="m-0 truncate text-sm font-semibold text-foreground">
+                {props.source?.source.label ?? "Knowledge items"}
+              </h2>
+              <p className="m-0 mt-1 truncate font-mono text-xs text-muted-foreground">
+                {props.source === undefined
+                  ? "No source selected"
+                  : `${props.source.agentId} / ${sourceId(props.source.source)}`}
+              </p>
+            </div>
+            {state?.totalCount === undefined ? null : <Badge>{state.totalCount} total</Badge>}
           </div>
-          {state?.totalCount === undefined ? null : <Badge>{state.totalCount} total</Badge>}
         </div>
-      </div>
-      <div className="min-h-0 overflow-auto p-4">
-        {props.source === undefined ? <MutedRow text="No knowledge source selected" /> : null}
-        {state?.loading === true && state.items.length === 0 ? (
-          <MutedRow text="Loading items" />
-        ) : null}
-        {state?.error === undefined ? null : <MutedRow text={state.error} />}
-        {state?.inspectable === false ? (
-          <MutedRow text={state.message ?? "This source does not expose browseable chunks."} />
-        ) : null}
-        {state?.inspectable !== false && state?.loading === false && state.items.length === 0 ? (
-          <MutedRow text="No items in this source" />
-        ) : null}
-        <div className="grid gap-3">
-          {state?.items.map((item) => (
-            <KnowledgeItemCard item={item} key={`${item.kind}:${item.id}`} />
-          ))}
+      ) : null}
+      <div className="min-h-0 overflow-auto">
+        <div className={props.activeTab === "dynamic-tools" ? "" : "p-4"}>
+          {props.source === undefined ? <MutedRow text="No knowledge source selected" /> : null}
+          {state?.loading === true && state.items.length === 0 ? (
+            <MutedRow text="Loading items" />
+          ) : null}
+          {state?.error === undefined ? null : <MutedRow text={state.error} />}
+          {state?.inspectable === false ? (
+            <MutedRow text={state.message ?? "This source does not expose browseable chunks."} />
+          ) : null}
+          {state?.inspectable !== false && state?.loading === false && state.items.length === 0 ? (
+            <MutedRow text="No items in this source" />
+          ) : null}
+          {props.activeTab === "dynamic-tools" && state?.items.length ? (
+            <DynamicToolsTable items={state.items} source={props.source} />
+          ) : (
+            <div className="grid gap-3">
+              {state?.items.map((item) => (
+                <KnowledgeItemCard item={item} key={`${item.kind}:${item.id}`} />
+              ))}
+            </div>
+          )}
         </div>
       </div>
       <div className="flex min-h-12 items-center justify-between gap-3 border-t border-border/80 px-4 py-2">
@@ -322,6 +372,73 @@ function ItemBrowser(props: {
         </Button>
       </div>
     </section>
+  );
+}
+
+function DynamicToolsTable(props: {
+  items: StudioKnowledgeItem[];
+  source: KnowledgeSourceRef | undefined;
+}) {
+  return (
+    <div className="min-w-0 overflow-x-auto">
+      <div className="grid min-w-230 border-border/80 lg:grid-cols-[43%_57%]">
+        <div className="border-b border-r border-border/80 px-5 py-3 font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+          Definition
+        </div>
+        <div className="border-b border-border/80 px-5 py-3 font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+          Parameter schema
+        </div>
+        {props.items.map((item) => (
+          <DynamicToolRow item={item} key={`${item.kind}:${item.id}`} source={props.source} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function DynamicToolRow(props: {
+  item: StudioKnowledgeItem;
+  source: KnowledgeSourceRef | undefined;
+}) {
+  const schema = dynamicToolSchema(props.item);
+  return (
+    <>
+      <article className="grid content-start gap-5 border-b border-r border-border/80 px-5 py-6">
+        <div className="grid gap-2">
+          <h3 className="m-0 font-mono text-base font-semibold text-foreground">
+            {props.item.toolName ?? props.item.id}
+          </h3>
+          <p className="m-0 font-mono text-xs text-muted-foreground">
+            {props.source?.agentName ?? props.source?.agentId ?? "Agent"}
+          </p>
+        </div>
+        {props.item.description === undefined || props.item.description.length === 0 ? null : (
+          <p className="m-0 max-w-160 text-sm leading-7 text-muted-foreground [overflow-wrap:anywhere]">
+            {props.item.description}
+          </p>
+        )}
+        <div className="flex flex-wrap gap-2">
+          <Badge variant="success">Dynamic</Badge>
+          <Badge>Approval none</Badge>
+          <Badge>{props.item.parameterKeys?.length ?? 0} field</Badge>
+        </div>
+      </article>
+      <article className="grid content-start border-b border-border/80">
+        <div className="flex min-h-11 items-center justify-between gap-3 border-b border-border/80 px-5">
+          <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+            Json schema
+          </span>
+          <span className="font-mono text-xs text-muted-foreground">{schemaType(schema)}</span>
+        </div>
+        <div className="min-w-0 overflow-x-auto px-5 py-5">
+          <pre className="m-0 min-w-max font-mono text-[13px] leading-6 text-foreground">
+            <code>
+              <JsonSyntax text={jsonDisplay(schema)} />
+            </code>
+          </pre>
+        </div>
+      </article>
+    </>
   );
 }
 
@@ -368,15 +485,15 @@ function KnowledgeItemCard(props: { item: StudioKnowledgeItem }) {
   );
 }
 
-function EvidencePanel(props: {
+function RetrievalLogPanel(props: {
   evidence: NonNullable<StudioKnowledgeSummary["evidence"]>;
   onOpenTrace: (traceId: string) => void;
 }) {
   return (
-    <aside className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden border border-border/80 bg-card/35">
+    <section className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden border border-border/80 bg-card/35">
       <div className="border-b border-border/80 px-4 py-3">
         <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-          Recent evidence
+          Retrieval log
         </div>
         <p className="m-0 mt-1 text-xs leading-5 text-muted-foreground">
           Runtime retrieval and dynamic tool signals captured in traces.
@@ -440,7 +557,7 @@ function EvidencePanel(props: {
           ))}
         </div>
       </div>
-    </aside>
+    </section>
   );
 }
 
@@ -485,6 +602,13 @@ function flattenSources(agents: StudioAgentKnowledgeConfig[]): KnowledgeSourceRe
   );
 }
 
+const knowledgeTabs: Array<{ id: KnowledgeTab; label: string }> = [
+  { id: "static-context", label: "Static Context" },
+  { id: "dynamic-context", label: "Dynamic Context" },
+  { id: "dynamic-tools", label: "Dynamic Tools" },
+  { id: "retrieval-log", label: "Retrieval Log" },
+];
+
 function withSourceId(
   source: StudioKnowledgeSourceSummary,
   index: number,
@@ -509,23 +633,6 @@ function fallbackSourceId(source: StudioKnowledgeSourceSummary, index: number): 
   }
 }
 
-function knowledgeMetrics(
-  agents: StudioAgentKnowledgeConfig[],
-  evidenceCount: number,
-): Array<[string, string]> {
-  const sources = agents.flatMap((agent) => agent.sources);
-  return [
-    ["Agents", String(agents.length)],
-    ["Static docs", String(sumKind(sources, "static_context"))],
-    [
-      "Dynamic context",
-      String(sources.filter((source) => source.kind === "dynamic_context").length),
-    ],
-    ["Dynamic tools", String(sources.filter((source) => source.kind === "dynamic_tools").length)],
-    ["Evidence", String(evidenceCount)],
-  ];
-}
-
 function sumKind(sources: StudioKnowledgeSourceSummary[], kind: StudioKnowledgeSourceKind): number {
   return sources
     .filter((source) => source.kind === kind)
@@ -540,6 +647,66 @@ function sourceLabel(kind: StudioKnowledgeSourceKind): string {
       return "Dynamic context";
     case "dynamic_tools":
       return "Dynamic tools";
+  }
+}
+
+function sourceKindForTab(tab: KnowledgeTab): StudioKnowledgeSourceKind | undefined {
+  switch (tab) {
+    case "static-context":
+      return "static_context";
+    case "dynamic-context":
+      return "dynamic_context";
+    case "dynamic-tools":
+      return "dynamic_tools";
+    case "retrieval-log":
+      return undefined;
+  }
+}
+
+function tabLabel(tab: KnowledgeTab): string {
+  return knowledgeTabs.find((item) => item.id === tab)?.label ?? "Knowledge";
+}
+
+function tabCountLabel(
+  tab: KnowledgeTab,
+  sources: KnowledgeSourceRef[],
+  evidenceCount: number,
+): string {
+  const sourceKind = sourceKindForTab(tab);
+  if (sourceKind === undefined) {
+    return `${evidenceCount} entries`;
+  }
+  const tabSources = sources.filter((source) => source.source.kind === sourceKind);
+  const itemCount = sumKind(
+    tabSources.map((source) => source.source),
+    sourceKind,
+  );
+  return `${tabSources.length} sources / ${itemCount} items`;
+}
+
+function dynamicToolSchema(item: StudioKnowledgeItem): unknown {
+  if (!isRecord(item.document)) {
+    return {};
+  }
+  const definition = isRecord(item.document.definition) ? item.document.definition : {};
+  return definition.parameters ?? {};
+}
+
+function schemaType(schema: unknown): string {
+  if (isRecord(schema) && typeof schema.type === "string") {
+    return schema.type;
+  }
+  if (Array.isArray(schema)) {
+    return "array";
+  }
+  return typeof schema;
+}
+
+function jsonDisplay(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return JSON.stringify(String(value), null, 2);
   }
 }
 

--- a/packages/tools/studio/src/ui/app/modules/knowledge/knowledge-page.tsx
+++ b/packages/tools/studio/src/ui/app/modules/knowledge/knowledge-page.tsx
@@ -1,9 +1,36 @@
 import { RefreshCw } from "lucide-react";
-import type { StudioKnowledgeSummary } from "../../../../types";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type {
+  StudioAgentKnowledgeConfig,
+  StudioKnowledgeItem,
+  StudioKnowledgeItemsPage,
+  StudioKnowledgeSourceKind,
+  StudioKnowledgeSourceSummary,
+  StudioKnowledgeSummary,
+} from "../../../../types";
 import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
-import { Card } from "../../components/ui/card";
 import { JsonValueView } from "../shared/renderers";
+
+const itemLimit = 50;
+
+type KnowledgeSourceRef = {
+  key: string;
+  agentId: string;
+  agentName: string;
+  source: StudioKnowledgeSourceSummary;
+};
+
+type ItemState = {
+  key: string;
+  loading: boolean;
+  items: StudioKnowledgeItem[];
+  nextCursor?: string;
+  totalCount?: number;
+  inspectable: boolean;
+  message?: string;
+  error?: string;
+};
 
 export function KnowledgePage(props: {
   enabled: boolean;
@@ -12,6 +39,98 @@ export function KnowledgePage(props: {
   onOpenTrace: (traceId: string) => void;
   onRefresh: () => void;
 }) {
+  const [selectedKey, setSelectedKey] = useState("");
+  const [itemState, setItemState] = useState<ItemState | undefined>();
+
+  const agents = props.summary?.agents ?? [];
+  const evidence = props.summary?.evidence ?? [];
+  const sources = useMemo(() => flattenSources(agents), [agents]);
+  const selectedSource = sources.find((source) => source.key === selectedKey) ?? sources[0];
+  const metrics = useMemo(
+    () => knowledgeMetrics(agents, evidence.length),
+    [agents, evidence.length],
+  );
+
+  useEffect(() => {
+    if (sources.length === 0) {
+      setSelectedKey("");
+      return;
+    }
+    if (sources.some((source) => source.key === selectedKey)) {
+      return;
+    }
+    const next =
+      sources.find(
+        (source) => source.source.inspectable === true && (source.source.itemCount ?? 0) > 0,
+      ) ??
+      sources.find((source) => source.source.inspectable === true) ??
+      sources[0];
+    setSelectedKey(next?.key ?? "");
+  }, [selectedKey, sources]);
+
+  const loadItems = useCallback(
+    async (source: KnowledgeSourceRef, options: { append: boolean; cursor?: string }) => {
+      setItemState((current) => ({
+        key: source.key,
+        loading: true,
+        inspectable:
+          current?.key === source.key ? current.inspectable : source.source.inspectable === true,
+        items: options.append && current?.key === source.key ? current.items : [],
+        ...(options.append && current?.key === source.key && current.nextCursor !== undefined
+          ? { nextCursor: current.nextCursor }
+          : {}),
+        ...(current?.key === source.key && current.totalCount !== undefined
+          ? { totalCount: current.totalCount }
+          : {}),
+      }));
+
+      try {
+        const params = new URLSearchParams({
+          agentId: source.agentId,
+          sourceId: sourceId(source.source),
+          limit: String(itemLimit),
+        });
+        if (options.cursor !== undefined) {
+          params.set("cursor", options.cursor);
+        }
+        const response = await fetch(`/knowledge/items?${params.toString()}`);
+        if (!response.ok) {
+          throw new Error(`Knowledge items failed with HTTP ${response.status}`);
+        }
+        const page = (await response.json()) as StudioKnowledgeItemsPage;
+        setItemState((current) => ({
+          key: source.key,
+          loading: false,
+          inspectable: page.inspectable,
+          items:
+            options.append && current?.key === source.key
+              ? [...current.items, ...page.items]
+              : page.items,
+          ...(page.nextCursor === undefined ? {} : { nextCursor: page.nextCursor }),
+          ...(page.totalCount === undefined ? {} : { totalCount: page.totalCount }),
+          ...(page.message === undefined ? {} : { message: page.message }),
+        }));
+      } catch (error) {
+        setItemState((current) => ({
+          key: source.key,
+          loading: false,
+          inspectable: current?.inspectable ?? false,
+          items: current?.items ?? [],
+          error: error instanceof Error ? error.message : String(error),
+        }));
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (selectedSource === undefined) {
+      setItemState(undefined);
+      return;
+    }
+    void loadItems(selectedSource, { append: false });
+  }, [loadItems, selectedSource]);
+
   if (!props.enabled) {
     return (
       <EmptyState
@@ -21,16 +140,13 @@ export function KnowledgePage(props: {
     );
   }
 
-  const agents = props.summary?.agents ?? [];
-  const evidence = props.summary?.evidence ?? [];
-
   return (
     <section className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden bg-background/45">
       <header className="flex min-h-16 items-center justify-between gap-3 border-b border-border/80 bg-card/70 px-6 shadow-sm">
         <div className="min-w-0">
           <h1 className="m-0 text-sm font-semibold text-foreground">Knowledge</h1>
           <p className="m-0 text-xs font-medium text-muted-foreground">
-            Context and retrieval signals visible to Studio
+            Browse configured context, dynamic chunks, tools, and retrieval evidence.
           </p>
         </div>
         <Button
@@ -43,115 +159,299 @@ export function KnowledgePage(props: {
           Refresh
         </Button>
       </header>
-      <div className="min-h-0 overflow-auto p-6">
-        <div className="grid min-w-0 gap-5 xl:grid-cols-[minmax(0,1fr)_minmax(380px,0.8fr)]">
-          <section className="grid min-w-0 content-start gap-3" aria-label="Agent knowledge">
-            {props.loading && agents.length === 0 ? <MutedRow text="Loading knowledge" /> : null}
-            {!props.loading && agents.length === 0 ? (
-              <MutedRow text="No knowledge sources" />
-            ) : null}
-            {agents.map((agent) => (
-              <Card className="overflow-hidden rounded-sm bg-card/90" key={agent.agentId}>
-                <div className="grid gap-1 border-b border-border/80 px-4 py-3">
-                  <strong className="truncate text-sm font-semibold text-foreground">
-                    {agent.agentName ?? agent.agentId}
-                  </strong>
-                  <span className="truncate font-mono text-xs font-medium text-muted-foreground">
-                    {agent.agentId}
-                  </span>
-                </div>
-                <div className="flex flex-wrap gap-2 border-b border-border/80 bg-muted/20 px-4 py-3">
-                  {agent.sources.map((source) => (
-                    <Badge className="rounded-sm" key={source.kind}>
-                      {source.kind.replaceAll("_", " ")}: {source.count}
-                    </Badge>
-                  ))}
-                </div>
-                <div className="grid gap-0">
-                  {agent.staticContext.length === 0 ? (
-                    <MutedRow text="No static context" />
-                  ) : (
-                    agent.staticContext.map((document) => (
-                      <div
-                        className="grid gap-2 border-b border-border/75 px-4 py-3.5 last:border-b-0"
-                        key={document.id}
-                      >
-                        <span className="font-mono text-xs font-semibold text-muted-foreground">
-                          {document.id}
-                        </span>
-                        <p className="m-0 whitespace-pre-wrap text-sm leading-6 text-foreground [overflow-wrap:anywhere]">
-                          {document.text}
-                        </p>
-                        {document.additionalProps === undefined ? null : (
-                          <JsonValueView value={document.additionalProps} />
-                        )}
-                      </div>
-                    ))
-                  )}
-                </div>
-              </Card>
-            ))}
-          </section>
-          <section className="grid min-w-0 content-start gap-3" aria-label="Recent evidence">
-            <div className="font-mono text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-              Recent trace evidence
-            </div>
-            {evidence.length === 0 ? <MutedRow text="No retrieved context captured yet" /> : null}
-            {evidence.map((item) => (
-              <Card
-                className="overflow-hidden rounded-sm bg-card/90"
-                key={`${item.traceId}:${item.observationId}`}
-              >
-                <div className="grid gap-1 border-b border-border/80 px-4 py-3">
-                  <strong className="truncate text-sm font-semibold text-foreground">
-                    {item.observationName}
-                  </strong>
-                  <Button
-                    className="h-auto min-h-0 max-w-full justify-self-start rounded-sm border border-border bg-muted px-2 py-1 font-mono text-xs font-semibold text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                    type="button"
-                    variant="ghost"
-                    onClick={() => props.onOpenTrace(item.traceId)}
-                  >
-                    {item.traceId}
-                  </Button>
-                </div>
-                <div className="flex flex-wrap gap-2 border-b border-border/80 bg-muted/20 px-4 py-3">
-                  <Badge>Turn {item.turn}</Badge>
-                  <Badge>{item.documentCount} docs</Badge>
-                  <Badge>{item.toolCount} tools</Badge>
-                </div>
-                <div className="grid gap-2 px-4 py-3">
-                  {item.query === undefined ? null : (
-                    <p className="m-0 border-b border-border pb-3 text-sm leading-6 text-muted-foreground [overflow-wrap:anywhere]">
-                      <span className="font-mono text-xs font-semibold uppercase tracking-[0.16em] text-foreground">
-                        Query
-                      </span>{" "}
-                      {item.query}
-                    </p>
-                  )}
-                  {item.documents.slice(0, 4).map((document) => (
-                    <p
-                      className="m-0 text-sm leading-6 text-muted-foreground [overflow-wrap:anywhere]"
-                      key={`${document.id ?? "doc"}:${document.text ?? ""}`}
-                    >
-                      <span className="font-mono text-xs text-foreground">
-                        {document.id ?? "document"}
-                      </span>{" "}
-                      {document.text ?? ""}
-                    </p>
-                  ))}
-                  {item.tools.length === 0 ? null : (
-                    <p className="m-0 text-sm leading-6 text-muted-foreground">
-                      Tools: {item.tools.join(", ")}
-                    </p>
-                  )}
-                </div>
-              </Card>
-            ))}
-          </section>
+      <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-4 overflow-hidden p-6">
+        <MetricStrip metrics={metrics} />
+        <div className="grid min-h-0 gap-4 xl:grid-cols-[320px_minmax(0,1fr)_420px]">
+          <SourceList
+            sources={sources}
+            selectedKey={selectedSource?.key ?? ""}
+            loading={props.loading}
+            onSelect={setSelectedKey}
+          />
+          <ItemBrowser
+            source={selectedSource}
+            state={itemState}
+            onLoadMore={() => {
+              if (selectedSource === undefined) {
+                return;
+              }
+              void loadItems(
+                selectedSource,
+                itemState?.nextCursor === undefined
+                  ? { append: true }
+                  : { append: true, cursor: itemState.nextCursor },
+              );
+            }}
+          />
+          <EvidencePanel evidence={evidence} onOpenTrace={props.onOpenTrace} />
         </div>
       </div>
     </section>
+  );
+}
+
+function MetricStrip(props: { metrics: Array<[string, string]> }) {
+  return (
+    <div className="grid border-y border-border/80 sm:grid-cols-5">
+      {props.metrics.map(([label, value]) => (
+        <div
+          className="border-b border-border/80 px-4 py-3 last:border-b-0 sm:border-b-0 sm:border-r sm:last:border-r-0"
+          key={label}
+        >
+          <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+            {label}
+          </div>
+          <div className="mt-1 font-mono text-sm font-semibold text-foreground">{value}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SourceList(props: {
+  sources: KnowledgeSourceRef[];
+  selectedKey: string;
+  loading: boolean;
+  onSelect: (key: string) => void;
+}) {
+  return (
+    <aside className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden border border-border/80 bg-card/45">
+      <div className="border-b border-border/80 px-4 py-3">
+        <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+          Sources
+        </div>
+        <p className="m-0 mt-1 text-xs leading-5 text-muted-foreground">
+          Browseable sources show chunks directly. Search-only sources still appear in evidence.
+        </p>
+      </div>
+      <div className="min-h-0 overflow-auto p-2">
+        {props.loading && props.sources.length === 0 ? <MutedRow text="Loading sources" /> : null}
+        {!props.loading && props.sources.length === 0 ? (
+          <MutedRow text="No knowledge sources" />
+        ) : null}
+        {props.sources.map((source) => (
+          <button
+            className={[
+              "grid w-full gap-2 border border-transparent px-3 py-3 text-left transition duration-200 hover:border-primary/35 hover:bg-primary/10",
+              props.selectedKey === source.key ? "border-primary/45 bg-primary/10" : "",
+            ].join(" ")}
+            key={source.key}
+            type="button"
+            onClick={() => props.onSelect(source.key)}
+          >
+            <div className="flex min-w-0 items-start justify-between gap-3">
+              <div className="min-w-0">
+                <div className="truncate text-sm font-semibold text-foreground">
+                  {source.source.label ?? sourceLabel(source.source.kind)}
+                </div>
+                <div className="truncate font-mono text-[11px] font-medium text-muted-foreground">
+                  {source.agentName}
+                </div>
+              </div>
+              <Badge variant={source.source.inspectable === true ? "success" : "default"}>
+                {source.source.inspectable === true ? "Browse" : "Search"}
+              </Badge>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Badge>{sourceLabel(source.source.kind)}</Badge>
+              {source.source.itemCount === undefined ? null : (
+                <Badge>{source.source.itemCount} items</Badge>
+              )}
+              {source.source.topK === undefined ? null : <Badge>Top {source.source.topK}</Badge>}
+            </div>
+          </button>
+        ))}
+      </div>
+    </aside>
+  );
+}
+
+function ItemBrowser(props: {
+  source: KnowledgeSourceRef | undefined;
+  state: ItemState | undefined;
+  onLoadMore: () => void;
+}) {
+  const state = props.state;
+  return (
+    <section className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden border border-border/80 bg-card/35">
+      <div className="border-b border-border/80 px-4 py-3">
+        <div className="flex min-w-0 items-start justify-between gap-3">
+          <div className="min-w-0">
+            <h2 className="m-0 truncate text-sm font-semibold text-foreground">
+              {props.source?.source.label ?? "Knowledge items"}
+            </h2>
+            <p className="m-0 mt-1 truncate font-mono text-xs text-muted-foreground">
+              {props.source === undefined
+                ? "No source selected"
+                : `${props.source.agentId} / ${sourceId(props.source.source)}`}
+            </p>
+          </div>
+          {state?.totalCount === undefined ? null : <Badge>{state.totalCount} total</Badge>}
+        </div>
+      </div>
+      <div className="min-h-0 overflow-auto p-4">
+        {props.source === undefined ? <MutedRow text="No knowledge source selected" /> : null}
+        {state?.loading === true && state.items.length === 0 ? (
+          <MutedRow text="Loading items" />
+        ) : null}
+        {state?.error === undefined ? null : <MutedRow text={state.error} />}
+        {state?.inspectable === false ? (
+          <MutedRow text={state.message ?? "This source does not expose browseable chunks."} />
+        ) : null}
+        {state?.inspectable !== false && state?.loading === false && state.items.length === 0 ? (
+          <MutedRow text="No items in this source" />
+        ) : null}
+        <div className="grid gap-3">
+          {state?.items.map((item) => (
+            <KnowledgeItemCard item={item} key={`${item.kind}:${item.id}`} />
+          ))}
+        </div>
+      </div>
+      <div className="flex min-h-12 items-center justify-between gap-3 border-t border-border/80 px-4 py-2">
+        <span className="font-mono text-[11px] text-muted-foreground">
+          {state === undefined ? "0 loaded" : `${state.items.length} loaded`}
+        </span>
+        <Button
+          className="h-8 min-h-8"
+          type="button"
+          variant="secondary"
+          disabled={state?.loading === true || state?.nextCursor === undefined}
+          onClick={props.onLoadMore}
+        >
+          Load more
+        </Button>
+      </div>
+    </section>
+  );
+}
+
+function KnowledgeItemCard(props: { item: StudioKnowledgeItem }) {
+  return (
+    <article className="grid gap-3 border border-border/80 bg-background/55 p-4">
+      <div className="flex min-w-0 items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="truncate font-mono text-xs font-semibold text-primary">
+            {props.item.toolName ?? props.item.id}
+          </div>
+          <div className="mt-1 font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+            {itemKindLabel(props.item.kind)}
+          </div>
+        </div>
+        {props.item.parameterKeys === undefined || props.item.parameterKeys.length === 0 ? null : (
+          <Badge>{props.item.parameterKeys.length} params</Badge>
+        )}
+      </div>
+      {props.item.description === undefined || props.item.description.length === 0 ? null : (
+        <p className="m-0 text-sm leading-6 text-muted-foreground [overflow-wrap:anywhere]">
+          {props.item.description}
+        </p>
+      )}
+      {props.item.text === undefined ? null : (
+        <p className="m-0 whitespace-pre-wrap text-sm leading-6 text-foreground [overflow-wrap:anywhere]">
+          {props.item.text}
+        </p>
+      )}
+      {props.item.document === undefined ? null : (
+        <JsonBlock title="Document" value={props.item.document} />
+      )}
+      {props.item.metadata === undefined ? null : (
+        <JsonBlock title="Metadata" value={props.item.metadata} />
+      )}
+      {props.item.parameterKeys === undefined || props.item.parameterKeys.length === 0 ? null : (
+        <div className="flex flex-wrap gap-2">
+          {props.item.parameterKeys.map((key) => (
+            <Badge key={key}>{key}</Badge>
+          ))}
+        </div>
+      )}
+    </article>
+  );
+}
+
+function EvidencePanel(props: {
+  evidence: NonNullable<StudioKnowledgeSummary["evidence"]>;
+  onOpenTrace: (traceId: string) => void;
+}) {
+  return (
+    <aside className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden border border-border/80 bg-card/35">
+      <div className="border-b border-border/80 px-4 py-3">
+        <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+          Recent evidence
+        </div>
+        <p className="m-0 mt-1 text-xs leading-5 text-muted-foreground">
+          Runtime retrieval and dynamic tool signals captured in traces.
+        </p>
+      </div>
+      <div className="min-h-0 overflow-auto p-3">
+        {props.evidence.length === 0 ? (
+          <MutedRow text="No retrieval evidence captured yet" />
+        ) : null}
+        <div className="grid gap-3">
+          {props.evidence.map((item) => (
+            <article
+              className="grid gap-3 border border-border/80 bg-background/45 p-3"
+              key={`${item.traceId}:${item.observationId}`}
+            >
+              <div className="flex min-w-0 items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-semibold text-foreground">
+                    {item.observationName}
+                  </div>
+                  <div className="mt-1 font-mono text-[11px] text-muted-foreground">
+                    Turn {item.turn}
+                  </div>
+                </div>
+                <Button
+                  className="h-auto min-h-0 rounded-sm border border-border bg-muted px-2 py-1 font-mono text-[10px] text-muted-foreground"
+                  type="button"
+                  variant="ghost"
+                  onClick={() => props.onOpenTrace(item.traceId)}
+                >
+                  Trace
+                </Button>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Badge>{item.documentCount} docs</Badge>
+                <Badge>{item.toolCount} tools</Badge>
+              </div>
+              {item.query === undefined ? null : (
+                <p className="m-0 text-sm leading-6 text-muted-foreground [overflow-wrap:anywhere]">
+                  <span className="font-mono text-xs font-semibold uppercase tracking-[0.14em] text-foreground">
+                    Query
+                  </span>{" "}
+                  {item.query}
+                </p>
+              )}
+              {item.documents.slice(0, 2).map((document) => (
+                <p
+                  className="m-0 text-xs leading-5 text-muted-foreground [overflow-wrap:anywhere]"
+                  key={`${document.id ?? "doc"}:${document.text ?? ""}`}
+                >
+                  <span className="font-mono text-foreground">{document.id ?? "document"}</span>{" "}
+                  {document.text ?? ""}
+                </p>
+              ))}
+              {item.tools.length === 0 ? null : (
+                <p className="m-0 text-xs leading-5 text-muted-foreground">
+                  Tools: {item.tools.join(", ")}
+                </p>
+              )}
+            </article>
+          ))}
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+function JsonBlock(props: { title: string; value: unknown }) {
+  return (
+    <div className="grid gap-2 border-t border-border/70 pt-3">
+      <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+        {props.title}
+      </div>
+      <JsonValueView value={props.value} />
+    </div>
   );
 }
 
@@ -172,4 +472,84 @@ function MutedRow(props: { text: string }) {
       {props.text}
     </div>
   );
+}
+
+function flattenSources(agents: StudioAgentKnowledgeConfig[]): KnowledgeSourceRef[] {
+  return agents.flatMap((agent) =>
+    agent.sources.map((source, index) => ({
+      key: `${agent.agentId}:${sourceId(source, index)}`,
+      agentId: agent.agentId,
+      agentName: agent.agentName ?? agent.agentId,
+      source: withSourceId(source, index),
+    })),
+  );
+}
+
+function withSourceId(
+  source: StudioKnowledgeSourceSummary,
+  index: number,
+): StudioKnowledgeSourceSummary {
+  return source.sourceId === undefined
+    ? { ...source, sourceId: fallbackSourceId(source, index) }
+    : source;
+}
+
+function sourceId(source: StudioKnowledgeSourceSummary, index = 0): string {
+  return source.sourceId ?? fallbackSourceId(source, index);
+}
+
+function fallbackSourceId(source: StudioKnowledgeSourceSummary, index: number): string {
+  switch (source.kind) {
+    case "static_context":
+      return "static-context";
+    case "dynamic_context":
+      return `dynamic-context-${source.registrationIndex ?? index}`;
+    case "dynamic_tools":
+      return `dynamic-tools-${source.registrationIndex ?? index}`;
+  }
+}
+
+function knowledgeMetrics(
+  agents: StudioAgentKnowledgeConfig[],
+  evidenceCount: number,
+): Array<[string, string]> {
+  const sources = agents.flatMap((agent) => agent.sources);
+  return [
+    ["Agents", String(agents.length)],
+    ["Static docs", String(sumKind(sources, "static_context"))],
+    [
+      "Dynamic context",
+      String(sources.filter((source) => source.kind === "dynamic_context").length),
+    ],
+    ["Dynamic tools", String(sources.filter((source) => source.kind === "dynamic_tools").length)],
+    ["Evidence", String(evidenceCount)],
+  ];
+}
+
+function sumKind(sources: StudioKnowledgeSourceSummary[], kind: StudioKnowledgeSourceKind): number {
+  return sources
+    .filter((source) => source.kind === kind)
+    .reduce((total, source) => total + (source.itemCount ?? source.count), 0);
+}
+
+function sourceLabel(kind: StudioKnowledgeSourceKind): string {
+  switch (kind) {
+    case "static_context":
+      return "Static context";
+    case "dynamic_context":
+      return "Dynamic context";
+    case "dynamic_tools":
+      return "Dynamic tools";
+  }
+}
+
+function itemKindLabel(kind: StudioKnowledgeItem["kind"]): string {
+  switch (kind) {
+    case "static_context":
+      return "Static context";
+    case "dynamic_context":
+      return "Dynamic context";
+    case "dynamic_tool":
+      return "Dynamic tool";
+  }
 }

--- a/packages/tools/studio/src/ui/app/modules/mcps/mcps-page.tsx
+++ b/packages/tools/studio/src/ui/app/modules/mcps/mcps-page.tsx
@@ -32,7 +32,7 @@ export function McpsPage(props: {
       aria-label="MCPs"
     >
       <header className="border-b border-border/80 bg-background/70 px-6 py-5 backdrop-blur">
-        <div className="mx-auto grid max-w-[1500px] grid-cols-[minmax(0,1fr)_auto] items-end gap-4 max-md:grid-cols-1">
+        <div className="grid w-full grid-cols-[minmax(0,1fr)_auto] items-end gap-4 max-md:grid-cols-1">
           <div className="grid min-w-0 gap-2">
             <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.24em] text-primary">
               External context
@@ -67,7 +67,7 @@ export function McpsPage(props: {
       </header>
 
       <div className="min-h-0 overflow-auto px-6 py-6">
-        <div className="mx-auto grid max-w-[1500px] gap-5">
+        <div className="grid w-full gap-5">
           {!props.enabled ? (
             <EmptyState
               title="MCPs unavailable"

--- a/packages/tools/studio/src/ui/app/modules/pipelines/pipelines-page.tsx
+++ b/packages/tools/studio/src/ui/app/modules/pipelines/pipelines-page.tsx
@@ -28,6 +28,7 @@ import {
   SelectValue,
 } from "../../components/ui/select";
 import { Textarea } from "../../components/ui/textarea";
+import { JsonSyntax } from "../shared/renderers";
 
 const nodeTypes = {
   pipelineStage: PipelineStageNode,
@@ -219,7 +220,7 @@ function PipelineInspectorSidebar(props: {
             </span>
           </div>
           <Select value={props.selectedPipelineId} onValueChange={props.onSelectPipeline}>
-            <SelectTrigger className="h-8 w-full rounded-sm border-border bg-background font-mono text-[11px]">
+            <SelectTrigger className="h-8 w-full rounded-sm border-primary/55 bg-background font-mono text-[11px] hover:border-primary focus:border-primary focus:ring-primary/25">
               <SelectValue placeholder="Select pipeline" />
             </SelectTrigger>
             <SelectContent>
@@ -482,7 +483,7 @@ function PipelineRunOutputBlock(props: { title: string; output: string }) {
         </span>
       </div>
       <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-words rounded-sm border border-border/80 bg-background/55 p-3 font-mono text-xs leading-5 text-foreground">
-        {props.output.length > 0 ? props.output : "No output saved."}
+        {props.output.length > 0 ? <JsonSyntax text={props.output} /> : "No output saved."}
       </pre>
     </div>
   );

--- a/packages/tools/studio/src/ui/app/modules/shared/path.ts
+++ b/packages/tools/studio/src/ui/app/modules/shared/path.ts
@@ -1,4 +1,4 @@
-import type { ActivePage, PageLocation } from "./types";
+import type { ActivePage, KnowledgeTab, PageLocation } from "./types";
 
 const root = document.getElementById("anvia-ui");
 const uiPath = root?.dataset.uiPath ?? "/ui";
@@ -6,6 +6,7 @@ const compatUiPath = root?.dataset.uiCompatPath ?? "/ui";
 const assetPath = normalizePathPrefix(uiPath) || normalizePathPrefix(compatUiPath) || "/ui";
 
 export const logoSrc = `${assetPath}/assets/logo.png`;
+export const defaultKnowledgeTab: KnowledgeTab = "static-context";
 
 export function pageLocationFromLocation(): PageLocation {
   const normalizedUiPath = normalizePathPrefix(uiPath);
@@ -82,7 +83,7 @@ function pageLocationFromSegments(segments: string[]): PageLocation {
     return { page: "pipelines" };
   }
   if (first === "knowledge") {
-    return { page: "knowledge" };
+    return { page: "knowledge", knowledgeTab: knowledgeTabFromSegment(second) };
   }
   if (first === "playground") {
     return {
@@ -97,6 +98,10 @@ function pageLocationFromSegments(segments: string[]): PageLocation {
 }
 
 export function updatePagePath(page: ActivePage): void {
+  if (page === "knowledge") {
+    updateKnowledgePath(defaultKnowledgeTab);
+    return;
+  }
   const normalizedUiPath = normalizePathPrefix(uiPath);
   const normalizedCompatUiPath = normalizePathPrefix(compatUiPath) || "/ui";
   if (
@@ -105,8 +110,7 @@ export function updatePagePath(page: ActivePage): void {
       page === "agents" ||
       page === "tools" ||
       page === "mcps" ||
-      page === "pipelines" ||
-      page === "knowledge")
+      page === "pipelines")
   ) {
     updateLocationPath(`${normalizedCompatUiPath}/${page}`);
     return;
@@ -114,6 +118,13 @@ export function updatePagePath(page: ActivePage): void {
   const nextPath =
     page === "playground" ? `${normalizedUiPath}/playground` : `${normalizedUiPath}/${page}`;
   updateLocationPath(nextPath);
+}
+
+export function updateKnowledgePath(tab: KnowledgeTab): void {
+  const normalizedUiPath = normalizePathPrefix(uiPath);
+  const normalizedCompatUiPath = normalizePathPrefix(compatUiPath) || "/ui";
+  const basePath = normalizedUiPath.length === 0 ? normalizedCompatUiPath : normalizedUiPath;
+  updateLocationPath(`${basePath}/knowledge/${tab}`);
 }
 
 export function updateSessionPath(sessionId: string | undefined): void {
@@ -145,4 +156,16 @@ function updateLocationPath(nextPath: string): void {
     return;
   }
   window.history.pushState({}, "", nextUrl);
+}
+
+function knowledgeTabFromSegment(segment: string | undefined): KnowledgeTab {
+  switch (segment) {
+    case "dynamic-context":
+    case "dynamic-tools":
+    case "retrieval-log":
+    case "static-context":
+      return segment;
+    default:
+      return defaultKnowledgeTab;
+  }
 }

--- a/packages/tools/studio/src/ui/app/modules/shared/renderers.tsx
+++ b/packages/tools/studio/src/ui/app/modules/shared/renderers.tsx
@@ -91,7 +91,7 @@ function toolPayloadDisplay(value: string): string {
   }
 }
 
-function JsonSyntax(props: { text: string }) {
+export function JsonSyntax(props: { text: string }) {
   const tokenPattern =
     /"(?:\\.|[^"\\])*"|-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?|\btrue\b|\bfalse\b|\bnull\b|[{}[\],:]/g;
   const nodes: React.ReactNode[] = [];

--- a/packages/tools/studio/src/ui/app/modules/shared/types.ts
+++ b/packages/tools/studio/src/ui/app/modules/shared/types.ts
@@ -26,6 +26,7 @@ export type ActivePage =
   | "mcps"
   | "pipelines"
   | "knowledge";
+export type KnowledgeTab = "static-context" | "dynamic-context" | "dynamic-tools" | "retrieval-log";
 export type TraceStatusFilter = "all" | StudioTrace["status"];
 export type TraceInspectorKey = "trace" | "agent" | `turn:${number}` | `observation:${string}`;
 export type PageLocation = {
@@ -33,4 +34,5 @@ export type PageLocation = {
   sessionId?: string;
   traceId?: string;
   traceSessionId?: string;
+  knowledgeTab?: KnowledgeTab;
 };

--- a/packages/tools/studio/src/ui/app/modules/tools/tools-page.tsx
+++ b/packages/tools/studio/src/ui/app/modules/tools/tools-page.tsx
@@ -31,7 +31,7 @@ export function ToolsPage(props: {
       aria-label="Tools"
     >
       <header className="border-b border-border/80 bg-background/70 px-6 py-5 backdrop-blur">
-        <div className="mx-auto grid max-w-[1500px] grid-cols-[minmax(0,1fr)_auto] items-end gap-4 max-md:grid-cols-1">
+        <div className="grid w-full grid-cols-[minmax(0,1fr)_auto] items-end gap-4 max-md:grid-cols-1">
           <div className="grid min-w-0 gap-2">
             <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.24em] text-primary">
               Agent capabilities
@@ -62,7 +62,7 @@ export function ToolsPage(props: {
       </header>
 
       <div className="min-h-0 overflow-auto px-6 py-6">
-        <div className="mx-auto grid max-w-[1500px] gap-4">
+        <div className="grid w-full gap-4">
           {!props.enabled ? (
             <EmptyState
               title="Tools unavailable"

--- a/packages/tools/studio/src/ui/app/modules/tracing/trace-browser.tsx
+++ b/packages/tools/studio/src/ui/app/modules/tracing/trace-browser.tsx
@@ -284,7 +284,7 @@ function TracePanel(props: {
                   isLastSibling={true}
                   level={0}
                   tone="trace"
-                  title={trace.name ?? "support-ticket-summary"}
+                  title={trace.name ?? "Agent"}
                   subtitle={formatDuration(trace.durationMs)}
                   onSelect={() => selectTimelineItem(trace.id, "trace")}
                 />
@@ -897,7 +897,7 @@ function selectedTraceDetail(
     }
   }
   return {
-    title: trace.name ?? "support-ticket-summary",
+    title: trace.name ?? "Agent",
     tone: "trace",
     startedAt: formatTraceTime(trace.startedAt),
     durationMs: trace.durationMs,

--- a/packages/tools/studio/src/ui/app/modules/tracing/trace-browser.tsx
+++ b/packages/tools/studio/src/ui/app/modules/tracing/trace-browser.tsx
@@ -1,7 +1,18 @@
-import { ArrowLeft, Bot, Cpu, GitBranch, Route, Wrench } from "lucide-react";
+import {
+  ArrowLeft,
+  Bot,
+  Cpu,
+  GitBranch,
+  MessageSquareText,
+  Reply,
+  Route,
+  Settings2,
+  Wrench,
+} from "lucide-react";
 import type { ReactNode } from "react";
 import { useEffect, useMemo, useState } from "react";
 import type { StudioConfig, StudioTrace } from "../../../../types";
+import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
 import { Card } from "../../components/ui/card";
 import { ScrollArea } from "../../components/ui/scroll-area";
@@ -629,25 +640,91 @@ function TraceDataSection(props: {
               )}
               key={`${item.label}-${item.text}`}
             >
-              <span className="font-mono text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+              <span className="flex min-w-0 items-center gap-2 font-mono text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                <TraceRowIcon label={item.label} />
                 {item.label}
               </span>
-              <p
-                className={cn(
-                  "m-0 whitespace-pre-wrap text-[15px] leading-7 text-foreground [overflow-wrap:anywhere]",
-                  props.compact && "font-mono text-[13px] leading-6",
-                  props.tone === "success" && !isNeutralTraceRow(item) && "text-primary",
-                  props.tone === "error" && "text-destructive",
-                )}
-              >
-                {item.text}
-              </p>
+              <TraceRowContent compact={props.compact} item={item} tone={props.tone} />
             </article>
           ))}
         </div>
       )}
     </section>
   );
+}
+
+function TraceRowContent(props: {
+  compact?: boolean | undefined;
+  item: { label: string; text: string };
+  tone?: "success" | "error" | undefined;
+}) {
+  const historyItems = conversationHistoryItems(props.item);
+  if (historyItems.length > 0) {
+    return (
+      <div className="grid min-w-0 gap-5">
+        {historyItems.map((item) => (
+          <div className="grid min-w-0 gap-2" key={`${item.index}-${item.role}-${item.text}`}>
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="font-mono text-xs font-semibold tabular-nums text-muted-foreground">
+                {item.index}
+              </span>
+              <Badge
+                className={cn(
+                  "px-1.5 py-0.5",
+                  item.role === "User" && "border-chart-2/40 bg-chart-2/15 text-chart-2",
+                  item.role === "Assistant" && "border-chart-1/40 bg-chart-1/15 text-chart-1",
+                  item.role === "Tool" && "border-chart-5/40 bg-chart-5/15 text-chart-5",
+                )}
+              >
+                {item.role}
+              </Badge>
+            </div>
+            <p className="m-0 whitespace-pre-wrap text-[15px] leading-7 text-foreground [overflow-wrap:anywhere]">
+              {item.text}
+            </p>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <p
+      className={cn(
+        "m-0 whitespace-pre-wrap text-[15px] leading-7 text-foreground [overflow-wrap:anywhere]",
+        props.compact && "font-mono text-[13px] leading-6",
+        props.tone === "success" && !isNeutralTraceRow(props.item) && "text-primary",
+        props.tone === "error" && "text-destructive",
+      )}
+    >
+      {props.item.text}
+    </p>
+  );
+}
+
+function conversationHistoryItems(row: {
+  label: string;
+  text: string;
+}): Array<{ index: string; role: string; text: string }> {
+  if (!row.label.startsWith("Conversation history")) {
+    return [];
+  }
+  return row.text
+    .split("\n\n")
+    .flatMap((block): Array<{ index: string; role: string; text: string }> => {
+      const [heading, ...content] = block.split("\n");
+      const match = /^(\d+)\.\s+(.+)$/.exec(heading ?? "");
+      if (match === null) {
+        return [];
+      }
+      return [
+        {
+          index: match[1] ?? "",
+          role: match[2] ?? "Message",
+          text: content.join("\n"),
+        },
+      ];
+    });
 }
 
 export function rawTraceJson(value: unknown): string {
@@ -728,6 +805,21 @@ function isNeutralTraceRow(row: { label: string }): boolean {
   return row.label === "Message Id";
 }
 
+function TraceRowIcon(props: { label: string }) {
+  const className = "h-3.5 w-3.5 shrink-0";
+  switch (props.label) {
+    case "System prompt":
+      return <Settings2 aria-hidden="true" className={className} />;
+    case "Prompt":
+      return <MessageSquareText aria-hidden="true" className={className} />;
+    case "Output":
+    case "Assistant output":
+      return <Reply aria-hidden="true" className={className} />;
+    default:
+      return null;
+  }
+}
+
 export function plainTraceValue(
   title: string,
   value: unknown,
@@ -779,6 +871,12 @@ function plainTraceInput(
     return [{ label: "Value", text: value }];
   }
   if (Array.isArray(value)) {
+    if (parentKey === "chatHistory") {
+      return chatHistoryRows(value);
+    }
+    if (parentKey === "history") {
+      return conversationHistoryRows(value);
+    }
     return value
       .map((item, index) => ({
         label: traceArrayItemLabel(item, index, parentKey),
@@ -815,6 +913,49 @@ function plainTraceInput(
   }
 
   return rows;
+}
+
+function chatHistoryRows(value: unknown[]): Array<{ label: string; text: string }> {
+  const messages = value
+    .map((item, index) => ({
+      label: traceArrayItemLabel(item, index, "chatHistory"),
+      text: messageText(item) || formatToolValue(item),
+    }))
+    .filter((item) => item.text.length > 0);
+  const current = messages.at(-1);
+  const history = messages.slice(0, -1);
+  const rows: Array<{ label: string; text: string }> = [];
+  if (history.length > 0) {
+    rows.push({
+      label: `Conversation history (${history.length})`,
+      text: history.map((item, index) => `${index + 1}. ${item.label}\n${item.text}`).join("\n\n"),
+    });
+  }
+  if (current !== undefined) {
+    rows.push({
+      label: history.length > 0 ? "Current prompt" : "Prompt",
+      text: current.text,
+    });
+  }
+  return rows;
+}
+
+function conversationHistoryRows(value: unknown[]): Array<{ label: string; text: string }> {
+  const messages = value
+    .map((item, index) => ({
+      label: traceArrayItemLabel(item, index, "history"),
+      text: messageText(item) || formatToolValue(item),
+    }))
+    .filter((item) => item.text.length > 0);
+  if (messages.length === 0) {
+    return [];
+  }
+  return [
+    {
+      label: `Conversation history (${messages.length})`,
+      text: messages.map((item, index) => `${index + 1}. ${item.label}\n${item.text}`).join("\n\n"),
+    },
+  ];
 }
 
 function traceArrayItemLabel(item: unknown, index: number, parentKey: string | undefined): string {
@@ -1008,6 +1149,17 @@ function selectedTraceDetail(
 
 function traceDetailMetadata(trace: StudioTrace): Record<string, unknown> {
   const metadata = isRecord(trace.metadata) ? trace.metadata : {};
+  const traceGroup = compactTraceMetadata({
+    status: trace.status,
+    traceId: trace.trace?.traceId ?? trace.id,
+    observationId: trace.trace?.observationId,
+    sessionId: trace.sessionId,
+    observationCount: trace.observationCount,
+    messageCount: traceMessageCount(metadata.messages),
+    startedAt: trace.startedAt,
+    endedAt: trace.endedAt,
+    durationMs: trace.durationMs,
+  });
   return compactTraceMetadata({
     ...metadata,
     status: trace.status,
@@ -1019,6 +1171,7 @@ function traceDetailMetadata(trace: StudioTrace): Record<string, unknown> {
     startedAt: trace.startedAt,
     endedAt: trace.endedAt,
     durationMs: trace.durationMs,
+    trace: isRecord(metadata.trace) ? metadata.trace : traceGroup,
   });
 }
 
@@ -1041,7 +1194,7 @@ function turnDetailMetadata(
 
 function observationDetailMetadata(observation: TraceObservationItem): Record<string, unknown> {
   const metadata = isRecord(observation.metadata) ? observation.metadata : {};
-  return compactTraceMetadata({
+  const base = compactTraceMetadata({
     ...metadata,
     status: observation.status,
     kind: observation.kind,
@@ -1051,6 +1204,92 @@ function observationDetailMetadata(observation: TraceObservationItem): Record<st
     endedAt: observation.endedAt ?? null,
     durationMs: observation.durationMs,
   });
+  return compactTraceMetadata({
+    ...base,
+    trace: isRecord(base.trace)
+      ? base.trace
+      : compactTraceMetadata({
+          status: observation.status,
+          kind: observation.kind,
+          turn: observation.turn,
+          parentObservationId: observation.parentObservationId ?? null,
+          startedAt: observation.startedAt,
+          endedAt: observation.endedAt ?? null,
+          durationMs: observation.durationMs,
+        }),
+    modelInfo: isRecord(base.modelInfo) ? base.modelInfo : modelInfoMetadata(base),
+    modelCall: isRecord(base.modelCall) ? base.modelCall : modelCallMetadata(base),
+    response: isRecord(base.response) ? base.response : responseMetadata(base),
+    tools: isRecord(base.tools) ? base.tools : toolsMetadata(base),
+    timing: isRecord(base.timing) ? base.timing : timingMetadata(base),
+  });
+}
+
+function modelInfoMetadata(metadata: Record<string, unknown>): Record<string, unknown> | undefined {
+  const group = compactTraceMetadata({
+    provider: metadata.provider,
+    model: metadata.model,
+    requestedModel: metadata.requestedModel,
+    defaultModel: metadata.defaultModel,
+  });
+  return Object.keys(group).length === 0 ? undefined : group;
+}
+
+function modelCallMetadata(metadata: Record<string, unknown>): Record<string, unknown> | undefined {
+  const request = compactTraceMetadata({
+    messageCount: metadata.historyCount,
+    documentCount: metadata.documentCount,
+    toolCount: metadata.toolCount,
+    toolNames: metadata.toolNames,
+    temperature: metadata.temperature,
+    maxTokens: metadata.maxTokens,
+    toolChoice: metadata.toolChoice,
+    hasOutputSchema: metadata.hasOutputSchema,
+    additionalParamKeys: metadata.additionalParamKeys,
+  });
+  const group = compactTraceMetadata({
+    request: Object.keys(request).length === 0 ? undefined : request,
+    providerRequest: metadata.providerRequest,
+  });
+  return Object.keys(group).length === 0 ? undefined : group;
+}
+
+function responseMetadata(metadata: Record<string, unknown>): Record<string, unknown> | undefined {
+  const group = compactTraceMetadata({
+    messageId: metadata.messageId,
+    usage: metadata.usage,
+    providerResponse: metadata.providerResponse,
+  });
+  return Object.keys(group).length === 0 ? undefined : group;
+}
+
+function toolsMetadata(metadata: Record<string, unknown>): Record<string, unknown> | undefined {
+  const group = compactTraceMetadata({
+    count: metadata.toolCount,
+    names: metadata.toolNames,
+    toolChoice: metadata.toolChoice,
+    internalCallId: metadata.internalCallId,
+    toolCallId: metadata.toolCallId,
+    skipped: metadata.skipped,
+    description: metadata.toolDescription,
+    parameterKeys: metadata.parameterKeys,
+    requiredParameterKeys: metadata.requiredParameterKeys,
+    approvalRequired: metadata.approvalRequired,
+    mcpServerName: metadata.mcpServerName,
+    argumentBytes: metadata.argumentBytes,
+    resultBytes: metadata.resultBytes,
+  });
+  return Object.keys(group).length === 0 ? undefined : group;
+}
+
+function timingMetadata(metadata: Record<string, unknown>): Record<string, unknown> | undefined {
+  const group = compactTraceMetadata({
+    firstDeltaMs: metadata.firstDeltaMs,
+    durationMs: metadata.durationMs,
+    startedAt: metadata.startedAt,
+    endedAt: metadata.endedAt,
+  });
+  return Object.keys(group).length === 0 ? undefined : group;
 }
 
 function observationStatusSummary(observations: TraceObservationItem[]): string {

--- a/packages/tools/studio/src/ui/app/modules/tracing/trace-browser.tsx
+++ b/packages/tools/studio/src/ui/app/modules/tracing/trace-browser.tsx
@@ -1,4 +1,5 @@
 import { ArrowLeft, Bot, Cpu, GitBranch, Route, Wrench } from "lucide-react";
+import type { ReactNode } from "react";
 import { useEffect, useMemo, useState } from "react";
 import type { StudioConfig, StudioTrace } from "../../../../types";
 import { Button } from "../../components/ui/button";
@@ -542,16 +543,14 @@ function TraceDetailPane(props: {
                 </div>
               </div>
             </div>
-            {selected.usage.length > 0 ? (
-              <div className="shrink-0 font-mono text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-                {selected.usage}
-              </div>
-            ) : null}
           </div>
           <div className="grid min-w-0 grid-cols-[repeat(auto-fit,minmax(150px,1fr))] gap-px overflow-hidden border border-border/80 bg-border/80">
             <TraceMetric label="Duration" value={formatDuration(selected.durationMs)} />
             {selected.firstDeltaMs === undefined ? null : (
               <TraceMetric label="First delta" value={formatDuration(selected.firstDeltaMs)} />
+            )}
+            {selected.usage.length === 0 ? null : (
+              <TraceMetric label="Usage" value={selected.usage} />
             )}
             <button
               className="grid min-w-0 gap-1 bg-background px-4 py-3 text-left transition duration-200 hover:bg-accent hover:text-accent-foreground"
@@ -579,7 +578,7 @@ function TraceDetailPane(props: {
           {selected.error === undefined ? null : (
             <TraceDataSection title="Error" value={selected.error} tone="error" />
           )}
-          <TraceDataSection title="Metadata" value={selected.metadata} compact />
+          <TraceDataSection title="Metadata" value={selected.metadata} rawJson />
         </div>
       </div>
     </section>
@@ -604,6 +603,7 @@ function TraceDataSection(props: {
   value: unknown;
   tone?: "success" | "error";
   compact?: boolean;
+  rawJson?: boolean;
 }) {
   const rows = plainTraceValue(props.title, props.value);
   return (
@@ -612,39 +612,132 @@ function TraceDataSection(props: {
         <h3 className="m-0 text-lg font-semibold leading-tight text-foreground">{props.title}</h3>
         <span className="h-px flex-1 bg-border/80" aria-hidden="true" />
       </div>
-      <div className="grid min-w-0 gap-3">
-        {rows.map((item) => (
-          <article
-            className={cn(
-              "grid min-w-0 gap-3 bg-card/65 px-4 py-4",
-              props.compact &&
-                "grid-cols-[150px_minmax(0,1fr)] items-start gap-4 max-lg:grid-cols-1",
-              props.tone === "success" && "bg-primary/[0.08]",
-              props.tone === "error" && "bg-destructive/10",
-            )}
-            key={`${item.label}-${item.text}`}
-          >
-            <span className="font-mono text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-              {item.label}
-            </span>
-            <p
+      {props.rawJson ? (
+        <pre className="m-0 overflow-x-auto bg-card/65 px-4 py-4 font-mono text-[13px] leading-6 text-foreground">
+          {highlightTraceJson(props.value)}
+        </pre>
+      ) : (
+        <div className="grid min-w-0 gap-3">
+          {rows.map((item) => (
+            <article
               className={cn(
-                "m-0 whitespace-pre-wrap text-[15px] leading-7 text-foreground [overflow-wrap:anywhere]",
-                props.compact && "font-mono text-[13px] leading-6",
-                props.tone === "success" && "text-primary",
-                props.tone === "error" && "text-destructive",
+                "grid min-w-0 gap-3 bg-card/65 px-4 py-4",
+                props.compact &&
+                  "grid-cols-[150px_minmax(0,1fr)] items-start gap-4 max-lg:grid-cols-1",
+                props.tone === "success" && "bg-primary/[0.08]",
+                props.tone === "error" && "bg-destructive/10",
               )}
+              key={`${item.label}-${item.text}`}
             >
-              {item.text}
-            </p>
-          </article>
-        ))}
-      </div>
+              <span className="font-mono text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                {item.label}
+              </span>
+              <p
+                className={cn(
+                  "m-0 whitespace-pre-wrap text-[15px] leading-7 text-foreground [overflow-wrap:anywhere]",
+                  props.compact && "font-mono text-[13px] leading-6",
+                  props.tone === "success" && !isNeutralTraceRow(item) && "text-primary",
+                  props.tone === "error" && "text-destructive",
+                )}
+              >
+                {item.text}
+              </p>
+            </article>
+          ))}
+        </div>
+      )}
     </section>
   );
 }
 
-function plainTraceValue(title: string, value: unknown): Array<{ label: string; text: string }> {
+export function rawTraceJson(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2) ?? "undefined";
+  } catch {
+    return String(value);
+  }
+}
+
+function highlightTraceJson(value: unknown): ReactNode {
+  return jsonSyntaxTokens(rawTraceJson(value)).map((token) => (
+    <span className={jsonTokenClass(token.type)} key={`${token.start}-${token.text}`}>
+      {token.text}
+    </span>
+  ));
+}
+
+export function jsonSyntaxTokens(
+  json: string,
+): Array<{ text: string; type: JsonTokenType; start: number }> {
+  const tokenPattern =
+    /("(?:\\u[\da-fA-F]{4}|\\[^u]|[^\\"])*"(?=\s*:)|"(?:\\u[\da-fA-F]{4}|\\[^u]|[^\\"])*"|-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?|\btrue\b|\bfalse\b|\bnull\b)/g;
+  const tokens: Array<{ text: string; type: JsonTokenType; start: number }> = [];
+  let cursor = 0;
+  for (const match of json.matchAll(tokenPattern)) {
+    const text = match[0];
+    const index = match.index ?? 0;
+    if (index > cursor) {
+      tokens.push({ text: json.slice(cursor, index), type: "plain", start: cursor });
+    }
+    tokens.push({
+      text,
+      type: jsonTokenType(text, json.slice(index + text.length)),
+      start: index,
+    });
+    cursor = index + text.length;
+  }
+  if (cursor < json.length) {
+    tokens.push({ text: json.slice(cursor), type: "plain", start: cursor });
+  }
+  return tokens;
+}
+
+type JsonTokenType = "plain" | "key" | "string" | "number" | "boolean" | "null";
+
+function jsonTokenType(text: string, followingText: string): JsonTokenType {
+  if (text.startsWith('"')) {
+    return followingText.trimStart().startsWith(":") ? "key" : "string";
+  }
+  if (text === "true" || text === "false") {
+    return "boolean";
+  }
+  if (text === "null") {
+    return "null";
+  }
+  return "number";
+}
+
+function jsonTokenClass(type: JsonTokenType): string {
+  switch (type) {
+    case "key":
+      return "text-chart-2";
+    case "string":
+      return "text-primary";
+    case "number":
+      return "text-chart-1";
+    case "boolean":
+      return "text-chart-4";
+    case "null":
+      return "text-muted-foreground";
+    case "plain":
+      return "text-foreground";
+  }
+}
+
+function isNeutralTraceRow(row: { label: string }): boolean {
+  return row.label === "Message Id";
+}
+
+export function plainTraceValue(
+  title: string,
+  value: unknown,
+): Array<{ label: string; text: string }> {
+  if (title === "Output") {
+    const outputRows = plainTraceOutput(value);
+    if (outputRows.length > 0) {
+      return outputRows;
+    }
+  }
   const messageRows = plainTraceInput(value, title);
   if (messageRows.length > 0) {
     return messageRows;
@@ -665,11 +758,24 @@ function plainTraceValue(title: string, value: unknown): Array<{ label: string; 
   return rows.length > 0 ? rows : [{ label: title, text: "Empty object" }];
 }
 
+function plainTraceOutput(value: unknown): Array<{ label: string; text: string }> {
+  if (!isRecord(value)) {
+    return [];
+  }
+  const rows: Array<{ label: string; text: string }> = [];
+  const choiceRows = plainTraceInput(value.choice, "choice");
+  rows.push(...choiceRows);
+  if (typeof value.messageId === "string" && value.messageId.length > 0) {
+    rows.push({ label: "Message Id", text: value.messageId });
+  }
+  return rows;
+}
+
 function plainTraceInput(
   value: unknown,
   parentKey?: string,
 ): Array<{ label: string; text: string }> {
-  if (typeof value === "string") {
+  if (typeof value === "string" && parentKey === undefined) {
     return [{ label: "Value", text: value }];
   }
   if (Array.isArray(value)) {
@@ -850,7 +956,7 @@ function selectedTraceDetail(
       input: trace.input,
       output: trace.output,
       error: trace.error,
-      metadata: trace.metadata ?? {},
+      metadata: traceDetailMetadata(trace),
     };
   }
   if (activeKey.startsWith("turn:")) {
@@ -865,10 +971,7 @@ function selectedTraceDetail(
       usage: turnUsageText(turn?.observations ?? []),
       input: turn?.observations[0]?.input,
       output: turn?.observations.at(-1)?.output,
-      metadata: {
-        turn: turnNumber,
-        observations: turn?.observations.length ?? 0,
-      },
+      metadata: turnDetailMetadata(turnNumber, turn?.observations ?? []),
     };
   }
   if (activeKey.startsWith("observation:")) {
@@ -885,14 +988,7 @@ function selectedTraceDetail(
         input: observation.input,
         output: observation.output,
         error: observation.error,
-        metadata: {
-          status: observation.status,
-          parentObservationId: observation.parentObservationId ?? null,
-          turn: observation.turn,
-          startedAt: observation.startedAt,
-          endedAt: observation.endedAt ?? null,
-          ...(observation.metadata ?? {}),
-        },
+        metadata: observationDetailMetadata(observation),
       };
     }
   }
@@ -906,8 +1002,76 @@ function selectedTraceDetail(
     input: trace.input,
     output: trace.output,
     error: trace.error,
-    metadata: trace.metadata ?? {},
+    metadata: traceDetailMetadata(trace),
   };
+}
+
+function traceDetailMetadata(trace: StudioTrace): Record<string, unknown> {
+  const metadata = isRecord(trace.metadata) ? trace.metadata : {};
+  return compactTraceMetadata({
+    ...metadata,
+    status: trace.status,
+    traceId: trace.trace?.traceId ?? trace.id,
+    observationId: trace.trace?.observationId,
+    sessionId: trace.sessionId,
+    observationCount: trace.observationCount,
+    messageCount: traceMessageCount(metadata.messages),
+    startedAt: trace.startedAt,
+    endedAt: trace.endedAt,
+    durationMs: trace.durationMs,
+  });
+}
+
+function turnDetailMetadata(
+  turn: number,
+  observations: TraceObservationItem[],
+): Record<string, unknown> {
+  return compactTraceMetadata({
+    turn,
+    observationCount: observations.length,
+    generationCount: observations.filter((observation) => observation.kind === "generation").length,
+    toolCount: observations.filter((observation) => observation.kind === "tool").length,
+    agentCount: observations.filter((observation) => observation.kind === "agent").length,
+    firstDeltaMs: firstDeltaMsFromObservations(observations),
+    status: observationStatusSummary(observations),
+    startedAt: observations[0]?.startedAt,
+    endedAt: observations.at(-1)?.endedAt,
+  });
+}
+
+function observationDetailMetadata(observation: TraceObservationItem): Record<string, unknown> {
+  const metadata = isRecord(observation.metadata) ? observation.metadata : {};
+  return compactTraceMetadata({
+    ...metadata,
+    status: observation.status,
+    kind: observation.kind,
+    turn: observation.turn,
+    parentObservationId: observation.parentObservationId ?? null,
+    startedAt: observation.startedAt,
+    endedAt: observation.endedAt ?? null,
+    durationMs: observation.durationMs,
+  });
+}
+
+function observationStatusSummary(observations: TraceObservationItem[]): string {
+  if (observations.length === 0) {
+    return "empty";
+  }
+  if (observations.some((observation) => observation.status === "error")) {
+    return "error";
+  }
+  if (observations.some((observation) => observation.status === "running")) {
+    return "running";
+  }
+  return "success";
+}
+
+function traceMessageCount(value: unknown): number | undefined {
+  return Array.isArray(value) ? value.length : undefined;
+}
+
+function compactTraceMetadata(values: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(values).filter(([, value]) => value !== undefined));
 }
 
 function traceObservationLabel(observation: TraceObservationItem): string {

--- a/packages/tools/studio/src/ui/routes.tsx
+++ b/packages/tools/studio/src/ui/routes.tsx
@@ -63,6 +63,8 @@ export function registerStudioUi(app: Hono, options: ResolvedStudioUiOptions): v
   app.get(`${options.path}/sessions`, async (c) => c.html(await renderShell()));
   app.get(`${options.path}/agents`, async (c) => c.html(await renderShell()));
   app.get(`${options.path}/knowledge`, async (c) => c.html(await renderShell()));
+  app.get(`${options.path}/knowledge/:tab`, async (c) => c.html(await renderShell()));
+  app.get(`${options.path}/knowledge/*`, async (c) => c.html(await renderShell()));
 
   if (options.rootRoutes) {
     app.get("/playground", async (c) => c.html(await renderRootShell()));

--- a/packages/tools/studio/test/runner.test.ts
+++ b/packages/tools/studio/test/runner.test.ts
@@ -18,6 +18,7 @@ import {
   type EmbeddingModel,
   embedDocuments,
   InMemoryVectorStore,
+  type JsonObject,
   type McpClient,
   Message,
   PipelineBuilder,
@@ -52,6 +53,15 @@ class QueueModel {
 
   constructor(private readonly responses: CompletionResponse[]) {}
 
+  traceRequest(request: CompletionRequest, options: { stream?: boolean } = {}): JsonObject {
+    return {
+      provider: this.provider,
+      stream: options.stream === true,
+      model: request.model ?? this.defaultModel,
+      messageCount: request.chatHistory.length,
+    };
+  }
+
   async completion(request: CompletionRequest): Promise<CompletionResponse> {
     this.requests.push(request);
     const response = this.responses.shift();
@@ -80,6 +90,15 @@ class StreamingQueueModel implements StreamingCompletionModel {
 
   async completion(): Promise<CompletionResponse> {
     throw new Error("completion should not be called");
+  }
+
+  traceRequest(request: CompletionRequest, options: { stream?: boolean } = {}): JsonObject {
+    return {
+      provider: this.provider,
+      stream: options.stream === true,
+      model: request.model ?? this.defaultModel,
+      messageCount: request.chatHistory.length,
+    };
   }
 
   async *streamCompletion(request: CompletionRequest): AsyncIterable<CompletionStreamEvent> {
@@ -2214,6 +2233,22 @@ describe("Anvia studio", () => {
             toolNames: [],
             documentCount: 0,
             historyCount: 1,
+            modelInfo: expect.objectContaining({
+              provider: "test",
+              model: "test",
+              capabilities: expect.objectContaining({ streaming: false }),
+            }),
+            modelCall: expect.objectContaining({
+              providerRequest: expect.objectContaining({
+                provider: "test",
+                stream: false,
+                model: "test",
+              }),
+            }),
+            response: expect.objectContaining({
+              usage: expect.any(Object),
+              contentTypes: ["text"],
+            }),
           }),
         },
       ],
@@ -2322,9 +2357,40 @@ describe("Anvia studio", () => {
             documentCount: 0,
             historyCount: 1,
             firstDeltaMs: expect.any(Number),
+            modelInfo: expect.objectContaining({
+              provider: "test",
+              model: "test",
+              capabilities: expect.objectContaining({ streaming: true }),
+            }),
+            modelCall: expect.objectContaining({
+              providerRequest: expect.objectContaining({
+                provider: "test",
+                stream: true,
+                model: "test",
+              }),
+            }),
           }),
         },
-        { kind: "tool", name: "add", status: "success", output: 7 },
+        {
+          kind: "tool",
+          name: "add",
+          status: "success",
+          output: 7,
+          metadata: expect.objectContaining({
+            internalCallId: expect.any(String),
+            argumentBytes: expect.any(Number),
+            resultBytes: expect.any(Number),
+            parameterKeys: ["x", "y"],
+            requiredParameterKeys: ["x", "y"],
+            approvalRequired: false,
+            tools: expect.objectContaining({
+              name: "add",
+              parameterKeys: ["x", "y"],
+              requiredParameterKeys: ["x", "y"],
+              approvalRequired: false,
+            }),
+          }),
+        },
         {
           kind: "generation",
           name: "model.turn.2",
@@ -2338,6 +2404,12 @@ describe("Anvia studio", () => {
             documentCount: 0,
             historyCount: 3,
             firstDeltaMs: expect.any(Number),
+            modelCall: expect.objectContaining({
+              providerRequest: expect.objectContaining({
+                stream: true,
+                messageCount: 3,
+              }),
+            }),
           }),
         },
       ],

--- a/packages/tools/studio/test/runner.test.ts
+++ b/packages/tools/studio/test/runner.test.ts
@@ -1899,6 +1899,10 @@ describe("Anvia studio", () => {
       "/ui/pipelines",
       "/ui/mcps",
       "/ui/knowledge",
+      "/ui/knowledge/static-context",
+      "/ui/knowledge/dynamic-context",
+      "/ui/knowledge/dynamic-tools",
+      "/ui/knowledge/retrieval-log",
     ]) {
       const routeShell = await runner.fetch(new Request(`http://runner.test${path}`));
       expect(routeShell.status).toBe(200);

--- a/packages/tools/studio/test/runner.test.ts
+++ b/packages/tools/studio/test/runner.test.ts
@@ -506,7 +506,10 @@ describe("Anvia studio", () => {
       }>;
     };
     expect(runsBody.runs).toHaveLength(1);
-    const savedRun = runsBody.runs[0]!;
+    const [savedRun] = runsBody.runs;
+    if (savedRun === undefined) {
+      throw new Error("Expected a saved pipeline run");
+    }
     expect(savedRun).toMatchObject({
       pipelineId: "audit-pipeline",
       status: "success",
@@ -514,7 +517,11 @@ describe("Anvia studio", () => {
       output: { reply: "RAW SECRET PAYLOAD" },
     });
 
-    const db = new DatabaseSync(process.env.ANVIA_STUDIO_DB!);
+    const studioDbPath = process.env.ANVIA_STUDIO_DB;
+    if (studioDbPath === undefined) {
+      throw new Error("Expected ANVIA_STUDIO_DB to be set");
+    }
+    const db = new DatabaseSync(studioDbPath);
     try {
       const row = db
         .prepare(
@@ -2194,7 +2201,22 @@ describe("Anvia studio", () => {
     await expect(trace.json()).resolves.toMatchObject({
       sessionId: session.id,
       status: "success",
-      observations: [{ kind: "generation", name: "model.turn.1", status: "success" }],
+      observations: [
+        {
+          kind: "generation",
+          name: "model.turn.1",
+          status: "success",
+          metadata: expect.objectContaining({
+            provider: "test",
+            model: "test",
+            defaultModel: "test",
+            toolCount: 0,
+            toolNames: [],
+            documentCount: 0,
+            historyCount: 1,
+          }),
+        },
+      ],
     });
   });
 
@@ -2291,14 +2313,32 @@ describe("Anvia studio", () => {
           kind: "generation",
           name: "model.turn.1",
           status: "success",
-          metadata: expect.objectContaining({ firstDeltaMs: expect.any(Number) }),
+          metadata: expect.objectContaining({
+            provider: "test",
+            model: "test",
+            defaultModel: "test",
+            toolCount: 1,
+            toolNames: ["add"],
+            documentCount: 0,
+            historyCount: 1,
+            firstDeltaMs: expect.any(Number),
+          }),
         },
         { kind: "tool", name: "add", status: "success", output: 7 },
         {
           kind: "generation",
           name: "model.turn.2",
           status: "success",
-          metadata: expect.objectContaining({ firstDeltaMs: expect.any(Number) }),
+          metadata: expect.objectContaining({
+            provider: "test",
+            model: "test",
+            defaultModel: "test",
+            toolCount: 1,
+            toolNames: ["add"],
+            documentCount: 0,
+            historyCount: 3,
+            firstDeltaMs: expect.any(Number),
+          }),
         },
       ],
     });

--- a/packages/tools/studio/test/runner.test.ts
+++ b/packages/tools/studio/test/runner.test.ts
@@ -28,6 +28,9 @@ import {
   ToolContent,
   Usage,
   UserContent,
+  type VectorSearchIndex,
+  type VectorSearchRequest,
+  type VectorSearchToolOptions,
 } from "@anvia/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { Studio } from "../src/index";
@@ -837,12 +840,135 @@ describe("Anvia studio", () => {
     expect(knowledge.agents).toEqual([
       expect.objectContaining({
         agentId: "support",
+        sources: expect.arrayContaining([
+          expect.objectContaining({
+            sourceId: "static-context",
+            kind: "static_context",
+            inspectable: true,
+            itemCount: 1,
+          }),
+        ]),
         staticContext: [{ id: "refund-policy", text: "Refund policy is 30 days." }],
       }),
     ]);
 
+    const items = (await (
+      await runner.fetch(
+        new Request("http://runner.test/knowledge/items?agentId=support&sourceId=static-context"),
+      )
+    ).json()) as unknown;
+    expect(items).toEqual({
+      agentId: "support",
+      sourceId: "static-context",
+      kind: "static_context",
+      inspectable: true,
+      items: [{ id: "refund-policy", kind: "static_context", text: "Refund policy is 30 days." }],
+      totalCount: 1,
+    });
+
     const evaluations = await runner.fetch(new Request("http://runner.test/evaluations"));
     expect(evaluations.status).toBe(404);
+  });
+
+  it("exposes inspectable dynamic knowledge items and unsupported source states", async () => {
+    const embeddings = new KeywordEmbeddingModel();
+    const embedded = await embedDocuments(
+      embeddings,
+      [
+        { id: "refund-policy", text: "Refund policy is 30 days." },
+        { id: "shipping-policy", text: "Shipping updates go to operations." },
+      ],
+      {
+        id: (document) => document.id,
+        content: (document) => document.text,
+      },
+    );
+    const inspectableIndex = InMemoryVectorStore.fromDocuments(embedded).index(embeddings);
+    const unsupportedIndex: VectorSearchIndex<{ text: string }> = {
+      search: async (_request: VectorSearchRequest) => [],
+      searchIds: async (_request: VectorSearchRequest) => [],
+      asTool: (_options: VectorSearchToolOptions) => lookupPolicyTool,
+    };
+    const toolIndex = await createToolIndex(embeddings, [lookupPolicyTool]);
+    const agent = new AgentBuilder("support", new QueueModel([]))
+      .dynamicContext(inspectableIndex, { topK: 1 })
+      .dynamicContext(unsupportedIndex, { topK: 1 })
+      .dynamicTools(toolIndex, { topK: 1 })
+      .build();
+    const runner = new Studio([agent]);
+
+    const knowledge = (await (
+      await runner.fetch(new Request("http://runner.test/knowledge"))
+    ).json()) as {
+      agents: Array<{
+        sources: Array<{ sourceId: string; inspectable: boolean; itemCount?: number }>;
+      }>;
+    };
+    expect(knowledge.agents[0]?.sources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sourceId: "dynamic-context-0",
+          inspectable: true,
+          itemCount: 2,
+        }),
+        expect.objectContaining({ sourceId: "dynamic-context-1", inspectable: false }),
+        expect.objectContaining({ sourceId: "dynamic-tools-0", inspectable: true, itemCount: 1 }),
+      ]),
+    );
+
+    const dynamicItems = (await (
+      await runner.fetch(
+        new Request(
+          "http://runner.test/knowledge/items?agentId=support&sourceId=dynamic-context-0&limit=1",
+        ),
+      )
+    ).json()) as unknown;
+    expect(dynamicItems).toMatchObject({
+      agentId: "support",
+      sourceId: "dynamic-context-0",
+      kind: "dynamic_context",
+      inspectable: true,
+      nextCursor: "1",
+      totalCount: 2,
+      items: [{ id: "refund-policy", kind: "dynamic_context", text: "Refund policy is 30 days." }],
+    });
+
+    const toolItems = (await (
+      await runner.fetch(
+        new Request("http://runner.test/knowledge/items?agentId=support&sourceId=dynamic-tools-0"),
+      )
+    ).json()) as unknown;
+    expect(toolItems).toMatchObject({
+      agentId: "support",
+      sourceId: "dynamic-tools-0",
+      kind: "dynamic_tools",
+      inspectable: true,
+      totalCount: 1,
+      items: [
+        {
+          id: "lookup_policy",
+          kind: "dynamic_tool",
+          toolName: "lookup_policy",
+          description: "Look up policy documents",
+          parameterKeys: ["query"],
+        },
+      ],
+    });
+
+    const unsupported = (await (
+      await runner.fetch(
+        new Request(
+          "http://runner.test/knowledge/items?agentId=support&sourceId=dynamic-context-1",
+        ),
+      )
+    ).json()) as unknown;
+    expect(unsupported).toMatchObject({
+      agentId: "support",
+      sourceId: "dynamic-context-1",
+      kind: "dynamic_context",
+      inspectable: false,
+      items: [],
+    });
   });
 
   it("starts a served runner from configured agents", async () => {

--- a/packages/tools/studio/test/trace-browser.test.ts
+++ b/packages/tools/studio/test/trace-browser.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  jsonSyntaxTokens,
+  plainTraceValue,
+  rawTraceJson,
+} from "../src/ui/app/modules/tracing/trace-browser";
+
+describe("trace browser metadata formatting", () => {
+  it("keeps scalar metadata labels instead of collapsing them to Value", () => {
+    expect(plainTraceValue("Metadata", { agentName: "Support Operations" })).toEqual([
+      { label: "Agent Name", text: "Support Operations" },
+    ]);
+  });
+
+  it("formats metadata as raw JSON", () => {
+    expect(rawTraceJson({ agentName: "Support Operations", toolCount: 1 })).toBe(
+      '{\n  "agentName": "Support Operations",\n  "toolCount": 1\n}',
+    );
+  });
+
+  it("classifies JSON tokens for syntax highlighting", () => {
+    expect(
+      jsonSyntaxTokens('{"agentName":"Support Operations","toolCount":1,"active":true}').map(
+        ({ text, type }) => ({ text, type }),
+      ),
+    ).toEqual([
+      { text: "{", type: "plain" },
+      { text: '"agentName"', type: "key" },
+      { text: ":", type: "plain" },
+      { text: '"Support Operations"', type: "string" },
+      { text: ",", type: "plain" },
+      { text: '"toolCount"', type: "key" },
+      { text: ":", type: "plain" },
+      { text: "1", type: "number" },
+      { text: ",", type: "plain" },
+      { text: '"active"', type: "key" },
+      { text: ":", type: "plain" },
+      { text: "true", type: "boolean" },
+      { text: "}", type: "plain" },
+    ]);
+  });
+
+  it("does not show raw response instructions or usage in output rows", () => {
+    expect(
+      plainTraceValue("Output", {
+        choice: [{ type: "text", text: "Hey! How can I help?" }],
+        usage: { inputTokens: 69, outputTokens: 11, totalTokens: 80 },
+        rawResponse: {
+          instructions: "Use tools when useful.",
+        },
+        messageId: "resp_123",
+      }),
+    ).toEqual([
+      { label: "Assistant output", text: "Hey! How can I help?" },
+      { label: "Message Id", text: "resp_123" },
+    ]);
+  });
+});

--- a/packages/tools/studio/test/trace-browser.test.ts
+++ b/packages/tools/studio/test/trace-browser.test.ts
@@ -1,3 +1,4 @@
+import { Message } from "@anvia/core";
 import { describe, expect, it } from "vitest";
 import {
   jsonSyntaxTokens,
@@ -53,6 +54,43 @@ describe("trace browser metadata formatting", () => {
     ).toEqual([
       { label: "Assistant output", text: "Hey! How can I help?" },
       { label: "Message Id", text: "resp_123" },
+    ]);
+  });
+
+  it("groups chat history separately from the current prompt", () => {
+    expect(
+      plainTraceValue("Input", {
+        instructions: "Use tools when useful.",
+        chatHistory: [
+          Message.user("Hello!"),
+          Message.assistant("Hello! How can I help you today?"),
+          Message.user("What tools do you have?"),
+        ],
+      }),
+    ).toEqual([
+      { label: "System prompt", text: "Use tools when useful." },
+      {
+        label: "Conversation history (2)",
+        text: "1. User\nHello!\n\n2. Assistant\nHello! How can I help you today?",
+      },
+      { label: "Current prompt", text: "What tools do you have?" },
+    ]);
+  });
+
+  it("groups agent run history while keeping the prompt separate", () => {
+    expect(
+      plainTraceValue("Input", {
+        instructions: "Use tools when useful.",
+        history: [Message.user("Hello!"), Message.assistant("Hello! How can I help you today?")],
+        prompt: Message.user("Get ORDER 11001"),
+      }),
+    ).toEqual([
+      { label: "System prompt", text: "Use tools when useful." },
+      {
+        label: "Conversation history (2)",
+        text: "1. User\nHello!\n\n2. Assistant\nHello! How can I help you today?",
+      },
+      { label: "Current prompt", text: "Get ORDER 11001" },
     ]);
   });
 });

--- a/packages/tools/studio/vitest.config.ts
+++ b/packages/tools/studio/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@anvia/core": new URL("../../core/src/index.ts", import.meta.url).pathname,
+      "@": new URL("./src/ui/app", import.meta.url).pathname,
     },
   },
   test: {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - "packages/*/*"
   - "apps/*"
   - "examples/*"
+minimumReleaseAge: 10080
 overrides:
   '@anvia/core': "workspace:*"
 allowBuilds:


### PR DESCRIPTION
## Summary
- Split Studio Knowledge into routed tabs for static context, dynamic context, dynamic tools, and retrieval log
- Restyle dynamic tools into a dense definition/schema table and align inspect page widths
- Patch-bump and publish changed packages

## Published packages
- @anvia/core@0.2.1
- @anvia/anthropic@0.1.6
- @anvia/gemini@0.1.5
- @anvia/mistral@0.1.2
- @anvia/openai@0.1.6
- @anvia/studio@0.2.2

## Verification
- pnpm --filter @anvia/core --filter @anvia/anthropic --filter @anvia/gemini --filter @anvia/mistral --filter @anvia/openai --filter @anvia/studio typecheck
- pnpm --filter @anvia/core --filter @anvia/anthropic --filter @anvia/gemini --filter @anvia/mistral --filter @anvia/openai --filter @anvia/studio test
- pnpm --filter @anvia/core --filter @anvia/anthropic --filter @anvia/gemini --filter @anvia/mistral --filter @anvia/openai --filter @anvia/studio build