### PR TITLE
docs: refresh README coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/license-MIT-89c83f?style=flat-square" alt="MIT license" />
-  <img src="https://img.shields.io/badge/core-v0.1.5-2f80c7?style=flat-square" alt="@anvia/core v0.1.5" />
+  <img src="https://img.shields.io/badge/core-v0.2.1-2f80c7?style=flat-square" alt="@anvia/core v0.2.1" />
   <img src="https://img.shields.io/badge/TypeScript-5.9-3178c6?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript 5.9" />
   <img src="https://img.shields.io/badge/pnpm-11.0.4-f69220?style=flat-square&logo=pnpm&logoColor=white" alt="pnpm 11.0.4" />
   <img src="https://img.shields.io/badge/runtime-Node.js-3c873a?style=flat-square&logo=node.js&logoColor=white" alt="Node.js runtime" />
@@ -83,7 +83,7 @@ const normalizedTicket = await workflow.run(
 | `@anvia/langfuse` | `packages/observability/langfuse` | Langfuse tracing adapter for Anvia observers. |
 | `@anvia/otel` | `packages/observability/otel` | OpenTelemetry tracing adapter for Anvia observers. |
 | `@anvia/transformers` | `packages/embeddings/transformers` | Transformers.js embedding model adapter, defaulting to local All-MiniLM. |
-| `@anvia/studio` | `packages/tools/studio` | HTTP runtime and browser UI for serving agents, sessions, traces, and approvals. |
+| `@anvia/studio` | `packages/tools/studio` | HTTP runtime and browser UI for serving agents, sessions, traces, pipelines, tools, MCPs, approvals, and knowledge inspection. |
 | `docs` | `apps/docs` | Private documentation app. |
 | `cookbook` | `examples/cookbook` | Runnable examples that document the public learning path. |
 
@@ -140,7 +140,7 @@ The cookbook is a product learning path. It starts with a plain text call, then 
 | Retrieval | Local embeddings, vector search, metadata filters, RAG context, document loaders, ChromaDB, Qdrant, pgvector, FastEmbed, and Mistral embeddings. |
 | Multi-agent | Agents as tools and pipeline-backed parallel specialists. |
 | Evals | Deterministic metrics, semantic similarity, custom metrics, agent eval targets, and LLM judge/score. |
-| Studio | Served agents, browser sessions, traces, multi-agent runners, tool approvals, human feedback, and Knowledge. |
+| Studio | Served agents, browser sessions, traces, pipeline inspection, multi-agent runners, tool approvals, human feedback, and Knowledge. |
 | Integrations | MCP tools, local skills, Langfuse tracing, Langfuse eval reporting, and OpenTelemetry tracing. |
 
 Run the default example for a level:
@@ -207,9 +207,11 @@ pnpm --filter cookbook typecheck
 │   │   ├── qdrant/                   # @anvia/qdrant
 │   │   └── pgvector/                 # @anvia/pgvector
 │   ├── observability/
-│   │   └── langfuse/                 # @anvia/langfuse
+│   │   ├── langfuse/                 # @anvia/langfuse
+│   │   └── otel/                     # @anvia/otel
 │   ├── embeddings/
-│   │   └── transformers/             # @anvia/transformers
+│   │   ├── transformers/             # @anvia/transformers
+│   │   └── fastembed/                # @anvia/fastembed
 │   └── tools/
 │       └── studio/                   # @anvia/studio
 ├── apps/

--- a/packages/providers/mistral/README.md
+++ b/packages/providers/mistral/README.md
@@ -1,6 +1,22 @@
 # @anvia/mistral
 
-Mistral provider adapter for Anvia.
+Mistral completion and embedding provider adapter for Anvia.
+
+Use this package when you want Anvia agents, extractors, pipelines, embeddings, or model listing to run on Mistral APIs.
+
+## Installation
+
+```sh
+pnpm add @anvia/mistral @anvia/core
+```
+
+In this monorepo, the package is available through the workspace:
+
+```sh
+pnpm --filter @anvia/mistral build
+```
+
+## Usage
 
 ```ts
 import { AgentBuilder } from "@anvia/core";
@@ -24,6 +40,30 @@ const embeddings = client.embeddingModel("mistral-embed");
 const vectors = await embeddings.embedTexts(["Refunds take five business days."]);
 ```
 
+## Model Listing
+
+```ts
+const models = await client.listModels();
+```
+
 ## Capabilities
 
-The v1 adapter supports text completions, streaming, tools, tool choice, structured output, and Mistral embeddings. Image inputs, document file inputs, transcription, audio generation, image generation, and model listing are not implemented yet.
+The v1 adapter supports text completions, streaming, tools, tool choice, structured output, Mistral embeddings, and model listing. Image inputs, document file inputs, transcription, audio generation, and image generation are not implemented yet.
+
+## Exports
+
+- `MistralClient`
+- `MistralCompletionModel`
+- `MistralEmbeddingModel`
+- `MistralClientOptions`
+- `MistralEmbeddingModelOptions`
+- `mistralMessageHelpers`
+- `mistral`
+
+## Development
+
+```sh
+pnpm --filter @anvia/mistral typecheck
+pnpm --filter @anvia/mistral test
+pnpm --filter @anvia/mistral build
+```

--- a/packages/tools/studio/README.md
+++ b/packages/tools/studio/README.md
@@ -1,8 +1,8 @@
 # @anvia/studio
 
-Studio UI and HTTP runtime for Anvia agents.
+Studio UI and HTTP runtime for Anvia agents, pipelines, tools, MCPs, and knowledge inspection.
 
-Use this package to serve local agents over HTTP, inspect sessions and traces in the browser UI, and exercise tool approval workflows during development.
+Use this package to serve local agents and pipelines over HTTP, inspect sessions, traces, tools, MCPs, and Knowledge in the browser UI, and exercise tool approval workflows during development.
 
 ## Installation
 
@@ -44,9 +44,19 @@ Then open:
 http://localhost:4021/playground
 ```
 
+## Browser UI
+
+Studio exposes:
+
+- Chat playground and persisted sessions
+- Trace browser and session logs
+- Pipeline graph, logs, and run history
+- Agent, static tool, dynamic tool, and MCP inspectors
+- Knowledge tabs for static context, dynamic context, dynamic tools, and retrieval log
+
 ## Session Storage
 
-Studio uses a local SQLite store by default so sessions and traces can persist across process restarts. If you omit the port, Studio uses `RUNNER_PORT` and then falls back to `4021`.
+Studio uses a local SQLite store by default so sessions, traces, and pipeline run history can persist across process restarts. If you omit the port, Studio uses `RUNNER_PORT` and then falls back to `4021`.
 
 Set `ANVIA_STUDIO_DB` to control the database path:
 
@@ -58,7 +68,7 @@ ANVIA_STUDIO_DB=.anvia/studio.sqlite node ./dist/server.js
 
 - `Studio`
 - `createSqliteSessionStore`
-- Studio session, trace, approval, and runtime types
+- Studio session, trace, approval, pipeline, knowledge, tool, MCP, and runtime types
 
 ## Development
 


### PR DESCRIPTION
## Summary
- update the root README badge, package table, cookbook Studio scope, and repository layout
- expand the Mistral README with installation, model listing, exports, and current capabilities
- update the Studio README for pipelines, tools, MCPs, Knowledge tabs, and pipeline history

## Verification
- pnpm --filter @anvia/mistral typecheck
- pnpm --filter @anvia/mistral test
- pnpm --filter @anvia/mistral build
- pnpm --filter @anvia/studio typecheck
- pnpm --filter @anvia/studio test
- pnpm --filter @anvia/studio build