### PR TITLE
Add MCP SSE transport support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/license-MIT-89c83f?style=flat-square" alt="MIT license" />
-  <img src="https://img.shields.io/badge/core-v0.2.1-2f80c7?style=flat-square" alt="@anvia/core v0.2.1" />
+  <img src="https://img.shields.io/badge/core-v0.2.2-2f80c7?style=flat-square" alt="@anvia/core v0.2.2" />
   <img src="https://img.shields.io/badge/TypeScript-5.9-3178c6?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript 5.9" />
   <img src="https://img.shields.io/badge/pnpm-11.0.4-f69220?style=flat-square&logo=pnpm&logoColor=white" alt="pnpm 11.0.4" />
   <img src="https://img.shields.io/badge/runtime-Node.js-3c873a?style=flat-square&logo=node.js&logoColor=white" alt="Node.js runtime" />

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/core",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Core runtime primitives for context-aware Anvia agents.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/core/src/mcp/connections.ts
+++ b/packages/core/src/mcp/connections.ts
@@ -1,7 +1,14 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import type { McpClient, McpConnection, McpHttpOptions, McpStdioOptions } from "./types";
+import type {
+  McpClient,
+  McpConnection,
+  McpHttpOptions,
+  McpSseOptions,
+  McpStdioOptions,
+} from "./types";
 
 export const mcp = {
   stdio(options: McpStdioOptions): McpConnection {
@@ -25,6 +32,19 @@ export const mcp = {
           asSdkTransport(
             new StreamableHTTPClientTransport(new URL(options.url), options.transport),
           ),
+        );
+        return client as McpClient;
+      },
+    };
+  },
+
+  sse(options: McpSseOptions): McpConnection {
+    return {
+      name: options.name,
+      async connect(): Promise<McpClient> {
+        const client = createSdkClient();
+        await client.connect(
+          asSdkTransport(new SSEClientTransport(new URL(options.url), options.transport)),
         );
         return client as McpClient;
       },

--- a/packages/core/src/mcp/types.ts
+++ b/packages/core/src/mcp/types.ts
@@ -1,3 +1,4 @@
+import type { SSEClientTransportOptions } from "@modelcontextprotocol/sdk/client/sse.js";
 import type { StdioServerParameters } from "@modelcontextprotocol/sdk/client/stdio.js";
 import type { StreamableHTTPClientTransportOptions } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { JsonObject } from "../completion/index";
@@ -71,4 +72,10 @@ export type McpHttpOptions = {
   name: string;
   url: string | URL;
   transport?: StreamableHTTPClientTransportOptions | undefined;
+};
+
+export type McpSseOptions = {
+  name: string;
+  url: string | URL;
+  transport?: SSEClientTransportOptions | undefined;
 };

--- a/packages/core/test/mcp-connections.test.ts
+++ b/packages/core/test/mcp-connections.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mcp } from "../src/mcp";
+
+const sdk = vi.hoisted(() => {
+  type ClientRecord = {
+    metadata: unknown;
+    connectCalls: unknown[];
+  };
+
+  type SseTransportRecord = {
+    url: URL;
+    options: unknown;
+  };
+
+  const clients: ClientRecord[] = [];
+  const sseTransports: SseTransportRecord[] = [];
+
+  class Client {
+    readonly metadata: unknown;
+    readonly connectCalls: unknown[] = [];
+
+    constructor(metadata: unknown) {
+      this.metadata = metadata;
+      clients.push(this);
+    }
+
+    async connect(transport: unknown): Promise<void> {
+      this.connectCalls.push(transport);
+    }
+  }
+
+  class SSEClientTransport {
+    readonly url: URL;
+    readonly options: unknown;
+
+    constructor(url: URL, options: unknown) {
+      this.url = url;
+      this.options = options;
+      sseTransports.push(this);
+    }
+  }
+
+  return { Client, SSEClientTransport, clients, sseTransports };
+});
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: sdk.Client,
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({
+  SSEClientTransport: sdk.SSEClientTransport,
+}));
+
+describe("MCP connection factories", () => {
+  beforeEach(() => {
+    sdk.clients.length = 0;
+    sdk.sseTransports.length = 0;
+  });
+
+  it("creates legacy SSE connections with the SDK SSE transport", async () => {
+    const transportOptions = {
+      requestInit: {
+        headers: {
+          "x-api-key": "test-key",
+        },
+      },
+    };
+
+    const connection = mcp.sse({
+      name: "legacy-server",
+      url: "http://localhost:3000/sse",
+      transport: transportOptions,
+    });
+
+    expect(connection.name).toBe("legacy-server");
+
+    const client = await connection.connect();
+
+    expect(sdk.clients).toHaveLength(1);
+    expect(client).toBe(sdk.clients[0]);
+    expect(sdk.clients[0]?.metadata).toEqual({
+      name: "@anvia/core",
+      version: "0.1.0",
+    });
+    expect(sdk.sseTransports).toHaveLength(1);
+    expect(sdk.sseTransports[0]).toBeInstanceOf(sdk.SSEClientTransport);
+    expect(sdk.sseTransports[0]?.url.href).toBe("http://localhost:3000/sse");
+    expect(sdk.sseTransports[0]?.options).toBe(transportOptions);
+    expect(sdk.clients[0]?.connectCalls).toEqual([sdk.sseTransports[0]]);
+  });
+});


### PR DESCRIPTION
## Summary
- add `mcp.sse(...)` for legacy MCP `/sse` endpoints
- expose `McpSseOptions` using the SDK `SSEClientTransportOptions`
- add a focused connection factory test for SSE transport wiring

## Verification
- `pnpm --filter @anvia/core typecheck`
- `pnpm --filter @anvia/core test`
- live SSE smoke test against `https://p123-mcp-agent-production.up.railway.app/sse` returned 11 tools