### PR TITLE
docs: add pipeline and multi-agent best practices

### DIFF
--- a/apps/docs/content/docs/best-practices/index.mdx
+++ b/apps/docs/content/docs/best-practices/index.mdx
@@ -37,6 +37,15 @@ This section is organized as a pattern library. Start with the common harness sh
 | Run pipeline jobs from a separate BullMQ worker | [Run Pipeline Workers](/docs/best-practices/long-process-pipelines/run-pipeline-workers) |
 | Persist status, handle retries, and test long-running jobs | [Status, Retries, and Testing](/docs/best-practices/long-process-pipelines/status-retries-testing) |
 
+## Multi-agent Patterns
+
+| Need | Pattern |
+| --- | --- |
+| Stream coordinator output and nested specialist progress | [Overview](/docs/best-practices/multi-agent-patterns) |
+| Build specialist agents and expose them as streaming tools | [Build Streaming Specialists](/docs/best-practices/multi-agent-patterns/build-streaming-specialists) |
+| Group parent and child stream events in a UI | [Consume Nested Events](/docs/best-practices/multi-agent-patterns/consume-nested-events) |
+| Persist, replay, and test multi-agent streams | [Persistence and Testing](/docs/best-practices/multi-agent-patterns/persistence-and-testing) |
+
 ## MCP Patterns
 
 | Real problem | Pattern |

--- a/apps/docs/content/docs/best-practices/index.mdx
+++ b/apps/docs/content/docs/best-practices/index.mdx
@@ -28,6 +28,15 @@ This section is organized as a pattern library. Start with the common harness sh
 | Tool arguments, outputs, and product states need contracts | [Tool Validation and Contracts](/docs/best-practices/tool-patterns/tool-validation-and-contracts) |
 | A tool writes data, sends messages, or changes external state | [Side Effect Tools](/docs/best-practices/tool-patterns/side-effect-tools) |
 
+## Long Process Pipelines
+
+| Need | Pattern |
+| --- | --- |
+| Run Anvia pipelines outside the request path with BullMQ and Redis | [Overview](/docs/best-practices/long-process-pipelines) |
+| Enqueue validated pipeline work from an API boundary | [Enqueue Pipeline Jobs](/docs/best-practices/long-process-pipelines/enqueue-pipeline-jobs) |
+| Run pipeline jobs from a separate BullMQ worker | [Run Pipeline Workers](/docs/best-practices/long-process-pipelines/run-pipeline-workers) |
+| Persist status, handle retries, and test long-running jobs | [Status, Retries, and Testing](/docs/best-practices/long-process-pipelines/status-retries-testing) |
+
 ## MCP Patterns
 
 | Real problem | Pattern |

--- a/apps/docs/content/docs/best-practices/long-process-pipelines/enqueue-pipeline-jobs.mdx
+++ b/apps/docs/content/docs/best-practices/long-process-pipelines/enqueue-pipeline-jobs.mdx
@@ -1,0 +1,115 @@
+---
+title: Enqueue Pipeline Jobs
+description: Validate API input and add stable BullMQ jobs for later pipeline execution.
+---
+
+The enqueue boundary is product code. It should authorize the caller, validate input, create a durable pending record, and then call `queue.add(...)` with a stable job id.
+
+## Job Data
+
+```ts
+import { z } from "zod";
+
+export const ticketInputSchema = z.object({
+  tenantId: z.string(),
+  ticketId: z.string(),
+  summary: z.string().min(1),
+});
+
+export type TicketJobData = z.infer<typeof ticketInputSchema>;
+```
+
+Keep job data scoped and serializable. Do not enqueue request objects, database clients, provider clients, or unbounded conversation history.
+
+## Queue Setup
+
+```ts
+import { Queue, type JobsOptions } from "bullmq";
+import IORedis from "ioredis";
+import type { TicketJobData } from "./schema";
+
+export const queueName = "ticket-triage";
+
+const producerConnection = new IORedis(process.env.REDIS_URL);
+
+export const triageQueue = new Queue<TicketJobData>(queueName, {
+  connection: producerConnection,
+});
+```
+
+Use separate producer and worker connections when API and worker processes have different runtime constraints.
+
+## Job Options
+
+```ts
+export const jobOptions: JobsOptions = {
+  attempts: 3,
+  backoff: {
+    type: "exponential",
+    delay: 5_000,
+  },
+  removeOnComplete: {
+    age: 60 * 60 * 24,
+    count: 1_000,
+  },
+  removeOnFail: {
+    age: 60 * 60 * 24 * 7,
+  },
+};
+```
+
+Retries are useful for transient provider, network, and database failures. They are dangerous when the worker performs non-idempotent side effects.
+
+## Enqueue Function
+
+```ts
+import { ticketInputSchema } from "./schema";
+import { jobOptions, triageQueue } from "./queue";
+import { ticketJobs } from "./storage";
+
+export async function enqueueTicketTriage(input: unknown) {
+  const data = ticketInputSchema.parse(input);
+  const jobId = `ticket-triage:${data.tenantId}:${data.ticketId}`;
+
+  await ticketJobs.createPending({
+    jobId,
+    tenantId: data.tenantId,
+    ticketId: data.ticketId,
+  });
+
+  const job = await triageQueue.add("triage", data, {
+    ...jobOptions,
+    jobId,
+  });
+
+  return {
+    jobId: job.id,
+    status: "queued",
+  };
+}
+```
+
+The stable `jobId` prevents duplicate queue jobs for the same product operation. Keep a matching idempotency constraint in app storage because the database is the source of product truth.
+
+## API Boundary
+
+```ts
+import { enqueueTicketTriage } from "./enqueue";
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const result = await enqueueTicketTriage(body);
+
+  return Response.json(result, {
+    status: 202,
+  });
+}
+```
+
+Do authentication, tenant scoping, quotas, and validation before `queue.add(...)`. The worker should still trust only scoped job data, but the API is the first product boundary.
+
+## Related Docs
+
+- [Request Runners](/docs/best-practices/common-patterns/request-runners)
+- [Tool Validation and Contracts](/docs/best-practices/tool-patterns/tool-validation-and-contracts)
+- [Run Pipeline Workers](/docs/best-practices/long-process-pipelines/run-pipeline-workers)

--- a/apps/docs/content/docs/best-practices/long-process-pipelines/index.mdx
+++ b/apps/docs/content/docs/best-practices/long-process-pipelines/index.mdx
@@ -1,0 +1,69 @@
+---
+title: Long Process Pipelines
+description: Run Anvia pipelines outside the request path with a durable queue.
+---
+
+Use a long process pipeline when the work should not finish inside one HTTP request. The request validates input and creates a job. A worker process runs the Anvia pipeline, persists the result, and reports progress through app-owned status records.
+
+## What is BullMQ?
+
+[BullMQ](https://docs.bullmq.io/) is a Node.js queue library built on Redis. A [`Queue`](https://docs.bullmq.io/guide/queues) adds jobs, a [`Worker`](https://docs.bullmq.io/guide/workers) processes jobs, and [`QueueEvents`](https://docs.bullmq.io/guide/events) can observe queue lifecycle events. BullMQ uses Redis [connections](https://docs.bullmq.io/guide/connections) so API producers and worker processes can run separately and scale independently.
+
+Install BullMQ in the application that owns the queue and worker:
+
+```sh
+pnpm add bullmq ioredis
+```
+
+The docs app does not need these dependencies unless it is also running a queue worker.
+
+## When to Use It
+
+Use this pattern when:
+
+- a pipeline can run longer than the caller should wait
+- work should survive API process restarts
+- jobs need retry, backoff, delayed execution, or worker concurrency
+- pipeline results should be persisted for later polling or review
+- API and worker processes scale independently
+
+## Architecture Shape
+
+| Layer | Responsibility |
+| --- | --- |
+| API route | authorize caller, validate input, create app record, enqueue job |
+| BullMQ queue | store pending jobs, retry policy, backoff, job lifecycle |
+| worker process | consume jobs, run the Anvia pipeline, update progress |
+| pipeline | own typed stages, agents, extractors, and deterministic transforms |
+| app storage | durable status, result, errors, audit metadata |
+| observability | connect queue job ids, pipeline stage events, traces, and logs |
+
+## Baseline Flow
+
+<Mermaid
+  chart={`
+flowchart LR
+  A["API request"] --> B["Validate and authorize"]
+  B --> C["Create pending job record"]
+  C --> D["BullMQ Queue.add"]
+  D --> E["BullMQ Worker"]
+  E --> F["pipeline.run"]
+  F --> G["Persist result or error"]
+  G --> H["Status endpoint or review UI"]
+`}
+/>
+
+Keep the API response small. Return a job id and store user-facing status in your own database. BullMQ return values are useful for worker internals and queue inspection, but product status pages should read durable app records.
+
+## Pages
+
+- [Enqueue Pipeline Jobs](/docs/best-practices/long-process-pipelines/enqueue-pipeline-jobs) shows the API producer boundary.
+- [Run Pipeline Workers](/docs/best-practices/long-process-pipelines/run-pipeline-workers) shows the worker and `pipeline.run(...)` boundary.
+- [Status, Retries, and Testing](/docs/best-practices/long-process-pipelines/status-retries-testing) covers production behavior and tests.
+
+## Related Docs
+
+- [Pipeline](/docs/best-practices/common-patterns/pipeline)
+- [Request Runners](/docs/best-practices/common-patterns/request-runners)
+- [Production Guardrails](/docs/best-practices/common-patterns/production-guardrails)
+- [Testing and Observability](/docs/best-practices/common-patterns/testing-and-observability)

--- a/apps/docs/content/docs/best-practices/long-process-pipelines/meta.json
+++ b/apps/docs/content/docs/best-practices/long-process-pipelines/meta.json
@@ -1,0 +1,6 @@
+{
+  "title": "Long Process Pipelines",
+  "defaultOpen": false,
+  "collapsible": true,
+  "pages": ["index", "enqueue-pipeline-jobs", "run-pipeline-workers", "status-retries-testing"]
+}

--- a/apps/docs/content/docs/best-practices/long-process-pipelines/run-pipeline-workers.mdx
+++ b/apps/docs/content/docs/best-practices/long-process-pipelines/run-pipeline-workers.mdx
@@ -1,0 +1,119 @@
+---
+title: Run Pipeline Workers
+description: Consume BullMQ jobs and execute Anvia pipelines in a separate worker process.
+---
+
+The worker owns execution. It should mark jobs running, call `pipeline.run(...)`, update progress from pipeline stage events, persist the final result, and let BullMQ retry failures that should be retried.
+
+## Build the Pipeline
+
+```ts
+import { PipelineBuilder } from "@anvia/core";
+import { ticketAgent, ticketExtractor } from "./ai";
+import type { TicketJobData } from "./schema";
+
+export const ticketPipeline = new PipelineBuilder<TicketJobData>({
+  id: "ticket-triage-pipeline",
+  name: "Ticket triage pipeline",
+})
+  .step((input) => ({
+    ...input,
+    summary: input.summary.trim(),
+  }))
+  .prompt(ticketAgent, {
+    name: "Draft triage",
+  })
+  .extract(ticketExtractor, {
+    name: "Extract ticket result",
+  })
+  .build();
+```
+
+Build provider clients, agents, extractors, and reusable pipelines at worker startup. Keep request-local user and tenant data inside the job payload.
+
+## Worker Connection
+
+```ts
+import IORedis from "ioredis";
+
+export const workerConnection = new IORedis(process.env.REDIS_URL, {
+  maxRetriesPerRequest: null,
+});
+```
+
+BullMQ workers need a Redis connection suitable for blocking commands. Keep this separate from short-lived HTTP request behavior.
+
+## Worker Handler
+
+```ts
+import { type PipelineRunEvent } from "@anvia/core";
+import { Worker } from "bullmq";
+import { queueName } from "./queue";
+import { ticketPipeline } from "./pipeline";
+import type { TicketJobData } from "./schema";
+import { ticketJobs } from "./storage";
+import { workerConnection } from "./worker-connection";
+
+export const triageWorker = new Worker<TicketJobData>(
+  queueName,
+  async (job) => {
+    await ticketJobs.markRunning(job.id!, {
+      startedAt: new Date(),
+      attempt: job.attemptsMade + 1,
+    });
+
+    const output = await ticketPipeline.run(job.data, {
+      observer: {
+        async onEvent(event: PipelineRunEvent) {
+          await job.updateProgress({
+            type: event.type,
+            stage: event.node.label,
+          });
+        },
+      },
+    });
+
+    await ticketJobs.markCompleted(job.id!, {
+      completedAt: new Date(),
+      output,
+    });
+
+    return {
+      ticketId: job.data.ticketId,
+      status: "completed",
+    };
+  },
+  {
+    connection: workerConnection,
+    concurrency: 4,
+  },
+);
+```
+
+Use the pipeline observer for metadata-only progress. Do not put sensitive model output, retrieved documents, or tool results into queue progress if those values should only live in app storage or traces.
+
+## Worker Events
+
+```ts
+triageWorker.on("failed", async (job, error) => {
+  if (!job) return;
+
+  await ticketJobs.markFailed(job.id!, {
+    failedAt: new Date(),
+    message: error.message,
+    attempt: job.attemptsMade,
+  });
+});
+
+triageWorker.on("error", (error) => {
+  console.error("ticket triage worker error", error);
+});
+```
+
+The `failed` event is job-level state. The `error` event is worker-level runtime state. Handle both so job status and worker health are visible.
+
+## Related Docs
+
+- [Pipeline](/docs/best-practices/common-patterns/pipeline)
+- [Tracing and Debugging](/docs/best-practices/quality-observability/tracing-and-debugging)
+- [Inspect Pipelines](/docs/studio/pipelines/inspect-pipelines)

--- a/apps/docs/content/docs/best-practices/long-process-pipelines/status-retries-testing.mdx
+++ b/apps/docs/content/docs/best-practices/long-process-pipelines/status-retries-testing.mdx
@@ -1,0 +1,84 @@
+---
+title: Status, Retries, and Testing
+description: Persist product status and test long-running BullMQ pipeline jobs.
+---
+
+BullMQ owns queue mechanics. Your application owns product status, permissions, idempotency, audit records, and user-facing results.
+
+## Durable Status
+
+```ts
+export type TicketJobRecord = {
+  jobId: string;
+  tenantId: string;
+  ticketId: string;
+  status: "queued" | "running" | "completed" | "failed";
+  output?: unknown;
+  errorMessage?: string;
+  updatedAt: Date;
+};
+```
+
+Store status in app storage before enqueueing. Update the same record from the worker. Use BullMQ job state for operations and debugging, not as the only user-facing product record.
+
+## Queue Events
+
+```ts
+import { QueueEvents } from "bullmq";
+import { queueName } from "./queue";
+import { workerConnection } from "./worker-connection";
+
+export const triageQueueEvents = new QueueEvents(queueName, {
+  connection: workerConnection,
+});
+
+triageQueueEvents.on("completed", ({ jobId }) => {
+  console.info("ticket triage job completed", { jobId });
+});
+
+triageQueueEvents.on("failed", ({ jobId, failedReason }) => {
+  console.warn("ticket triage job failed", { jobId, failedReason });
+});
+```
+
+Queue events are useful for operational logs and metrics. Product state should still be written by the API and worker paths that understand tenant, ticket, and result data.
+
+## Retry Policy
+
+| Case | Suggested behavior |
+| --- | --- |
+| provider timeout | retry with backoff |
+| temporary Redis or database error | retry with backoff |
+| invalid job data | fail without re-enqueueing |
+| permission or tenant mismatch | fail and alert |
+| non-idempotent side effect | protect with operation id before retrying |
+
+If the pipeline writes data, sends messages, or calls external write APIs, use service-layer idempotency keys. A retried worker must not create duplicate side effects.
+
+## Failure Modes
+
+| Failure | Fix |
+| --- | --- |
+| duplicate jobs for one ticket | stable `jobId` plus app-level idempotency |
+| Redis outage blocks API too long | tune producer connection retry behavior and return a retryable API error |
+| worker retries repeat side effects | keep side effects idempotent and persist operation ids |
+| user cannot see progress after completion cleanup | store status and result in app storage |
+| worker process hides emitted errors | attach a worker `error` listener |
+| pipeline stage is hard to debug | pass a pipeline observer and include job id in logs and traces |
+
+## Test Checklist
+
+- Test input validation before enqueueing.
+- Test stable job ids for duplicate enqueue attempts.
+- Test pending records are created before `queue.add(...)`.
+- Test worker success writes completed status and output.
+- Test worker failure writes failed status and leaves retry behavior to BullMQ.
+- Test idempotent side effects when BullMQ retries the same job.
+- Test progress updates from pipeline stage events.
+- Run the pipeline directly in unit tests before testing BullMQ wiring.
+
+## Related Docs
+
+- [Production Guardrails](/docs/best-practices/common-patterns/production-guardrails)
+- [Testing and Observability](/docs/best-practices/common-patterns/testing-and-observability)
+- [Side Effect Tools](/docs/best-practices/tool-patterns/side-effect-tools)

--- a/apps/docs/content/docs/best-practices/meta.json
+++ b/apps/docs/content/docs/best-practices/meta.json
@@ -7,6 +7,7 @@
     "index",
     "common-patterns",
     "long-process-pipelines",
+    "multi-agent-patterns",
     "tool-patterns",
     "mcp-patterns",
     "knowledge-patterns",

--- a/apps/docs/content/docs/best-practices/meta.json
+++ b/apps/docs/content/docs/best-practices/meta.json
@@ -6,6 +6,7 @@
   "pages": [
     "index",
     "common-patterns",
+    "long-process-pipelines",
     "tool-patterns",
     "mcp-patterns",
     "knowledge-patterns",

--- a/apps/docs/content/docs/best-practices/multi-agent-patterns/build-streaming-specialists.mdx
+++ b/apps/docs/content/docs/best-practices/multi-agent-patterns/build-streaming-specialists.mdx
@@ -1,0 +1,93 @@
+---
+title: Build Streaming Specialists
+description: Create specialist agents and expose them as streaming tools on a coordinator.
+---
+
+Build multi-agent streaming around one coordinator and a small set of narrow specialists. Each specialist should have a clear role, stable agent id, and focused output.
+
+## Build Specialist Agents
+
+```ts
+import { AgentBuilder } from "@anvia/core";
+import { model } from "./model";
+
+export const supportAgent = new AgentBuilder("support", model)
+  .name("Support Specialist")
+  .description("Summarize customer impact and support next steps.")
+  .instructions("Return compact support triage bullets using only the provided facts.")
+  .build();
+
+export const engineeringAgent = new AgentBuilder("engineering", model)
+  .name("Engineering Specialist")
+  .description("Summarize diagnostics and engineering next steps.")
+  .instructions("Return compact engineering triage bullets without unverified root-cause claims.")
+  .build();
+
+export const commsAgent = new AgentBuilder("communications", model)
+  .name("Communications Specialist")
+  .description("Draft customer-facing incident communication guidance.")
+  .instructions("Return concise customer-safe communication notes.")
+  .build();
+```
+
+Keep specialist instructions narrow. Each child agent should own one role and return a focused result that the coordinator can use.
+
+## Expose Specialists With Streaming
+
+```ts
+import { AgentBuilder } from "@anvia/core";
+import { commsAgent, engineeringAgent, supportAgent } from "./specialists";
+import { model } from "./model";
+
+export const coordinator = new AgentBuilder("incident-coordinator", model)
+  .name("Incident Coordinator")
+  .instructions(
+    [
+      "Coordinate specialist agents through tools.",
+      "Call specialists only when their expertise is useful.",
+      "Combine specialist findings into one concise incident brief.",
+      "Do not expose internal-only notes in the final customer-facing summary.",
+    ].join("\n"),
+  )
+  .tools([
+    supportAgent.asTool({ name: "ask_support_agent", stream: true }),
+    engineeringAgent.asTool({ name: "ask_engineering_agent", stream: true }),
+    commsAgent.asTool({ name: "ask_comms_agent", stream: true }),
+  ])
+  .defaultMaxTurns(4)
+  .build();
+```
+
+The coordinator should decide which specialists to call. Do not attach every possible specialist if the model cannot choose reliably.
+
+## Run the Coordinator Stream
+
+```ts
+const prompt = [
+  "Acme Co. reports webhook retries fail for payloads larger than 512 KB.",
+  "They have missed several order updates in the last hour.",
+  "Prepare an incident brief for support, engineering, and communications.",
+].join(" ");
+
+for await (const event of coordinator
+  .prompt(prompt)
+  .withToolConcurrency(3)
+  .withTrace({
+    name: "incident-multi-agent-stream",
+    metadata: {
+      incidentId: "inc_123",
+      tenantId: "tenant_123",
+    },
+  })
+  .stream()) {
+  renderEvent(event);
+}
+```
+
+Use `.withToolConcurrency(...)` only when specialist calls are independent. If one specialist must wait for another specialist's finding, keep concurrency at `1` or split the workflow into explicit stages.
+
+## Related Docs
+
+- [Multi-Agent Workflows](/docs/guides/agents/multi-agent-workflows)
+- [Agent Structure](/docs/best-practices/common-patterns/agent-structure)
+- [Consume Nested Events](/docs/best-practices/multi-agent-patterns/consume-nested-events)

--- a/apps/docs/content/docs/best-practices/multi-agent-patterns/consume-nested-events.mdx
+++ b/apps/docs/content/docs/best-practices/multi-agent-patterns/consume-nested-events.mdx
@@ -1,0 +1,91 @@
+---
+title: Consume Nested Events
+description: Group parent and child stream events from streaming agent tools.
+---
+
+When a coordinator runs with `.stream()`, normal parent events and nested child-agent events arrive in the same stream. Render coordinator text directly and group child progress by `internalCallId`.
+
+## Render Parent and Child Events
+
+```ts
+import type { AgentStreamEvent } from "@anvia/core";
+
+function renderEvent(event: AgentStreamEvent): void {
+  switch (event.type) {
+    case "text_delta":
+      renderCoordinatorText(event.delta);
+      break;
+    case "tool_call":
+      renderDelegation(event.toolCall.function.name);
+      break;
+    case "agent_tool_event":
+      renderSpecialistEvent({
+        groupId: event.internalCallId,
+        agentLabel: event.agentName ?? event.agentId,
+        toolName: event.toolName,
+        event: event.event,
+      });
+      break;
+    case "final":
+      saveFinalResponse(event);
+      break;
+    case "error":
+      renderStreamError(event.error);
+      break;
+  }
+}
+```
+
+Group nested progress by `internalCallId` when the same specialist can be called more than once. Use `agentId`, `agentName`, and `toolName` for labels.
+
+## Render Specialist Progress
+
+```ts
+import type { AgentStreamEvent } from "@anvia/core";
+
+type SpecialistEvent = Extract<AgentStreamEvent, { type: "agent_tool_event" }>;
+
+function renderSpecialistEvent(input: {
+  groupId: string;
+  agentLabel: string;
+  toolName: string;
+  event: SpecialistEvent["event"];
+}) {
+  if (input.event.type === "text_delta") {
+    appendSpecialistText(input.groupId, input.agentLabel, input.event.delta);
+  }
+
+  if (input.event.type === "tool_call") {
+    showSpecialistToolCall(input.groupId, input.event.toolCall.function.name);
+  }
+
+  if (input.event.type === "tool_result") {
+    markSpecialistToolDone(input.groupId, input.event.toolName);
+  }
+
+  if (input.event.type === "final") {
+    markSpecialistComplete(input.groupId, input.event.output);
+  }
+}
+```
+
+Do not render raw tool results, sensitive retrieved context, or internal reasoning in a user-facing UI unless the product intentionally exposes those details. Prefer status labels and safe summaries for customer-facing screens.
+
+## Event Mapping
+
+| Event | UI use |
+| --- | --- |
+| `tool_call` | coordinator is delegating to a specialist |
+| `agent_tool_event.text_delta` | specialist is streaming visible progress |
+| `agent_tool_event.tool_call` | specialist is using one of its tools |
+| `agent_tool_event.tool_result` | specialist tool completed |
+| `agent_tool_event.final` | specialist returned final output to the coordinator |
+| `tool_result` | coordinator received the specialist's final output |
+| `text_delta` | coordinator is streaming the final answer |
+| `final` | persist final messages, usage, trace, and run id |
+
+## Related Docs
+
+- [Streaming Events](/docs/guides/streaming/streaming-events)
+- [Readable Streams](/docs/guides/streaming/readable-streams)
+- [Build Streaming Specialists](/docs/best-practices/multi-agent-patterns/build-streaming-specialists)

--- a/apps/docs/content/docs/best-practices/multi-agent-patterns/index.mdx
+++ b/apps/docs/content/docs/best-practices/multi-agent-patterns/index.mdx
@@ -1,0 +1,65 @@
+---
+title: Multi-agent Streaming
+description: Stream coordinator output while surfacing nested specialist-agent progress.
+---
+
+Use multi-agent streaming when one coordinator agent delegates work to specialist agents and the caller should see progress while the specialists run. The coordinator still owns the final answer, but the UI can show nested child-agent activity through `agent_tool_event`.
+
+## Scenario
+
+An incident coordinator receives a customer-impact report. It delegates to support, engineering, and communications specialists. The user sees the coordinator's final brief stream in normally, while each specialist's progress appears in grouped status panels.
+
+## When to Use It
+
+Use this pattern when:
+
+- one coordinator should decide which specialists to call
+- specialist work may take long enough that hidden progress feels stalled
+- the UI should group nested progress by specialist or tool call
+- the final answer should still come from one coordinator
+- child-agent progress should be replayable or inspectable after the run
+
+Do not use this pattern just to run known independent work. Use parallel pipelines when every branch should run and the coordinator does not need to decide.
+
+## Architecture Shape
+
+| Layer | Responsibility |
+| --- | --- |
+| coordinator agent | decides which specialists to call and writes the final response |
+| specialist agents | own narrow role instructions and return focused findings |
+| streaming agent tools | expose specialists with `asTool({ stream: true })` |
+| request runner | applies trace metadata, tool concurrency, and stream response shape |
+| UI stream consumer | renders parent events and groups nested `agent_tool_event` values |
+| event store | optionally persists parent and child events for replay and debugging |
+
+## Requirements
+
+Nested streaming requires:
+
+- the parent run uses `.stream()`
+- specialist tools are created with `stream: true`
+- the child model supports streaming
+
+If nested streaming is unavailable, the specialist still behaves like a normal opaque `asTool(...)` call. The parent model receives only the final specialist output as the normal `tool_result`; intermediate child events are for the caller, trace, or event store.
+
+## Pages
+
+- [Build Streaming Specialists](/docs/best-practices/multi-agent-patterns/build-streaming-specialists) shows how to build specialist agents, expose them with `asTool({ stream: true })`, and run the coordinator stream.
+- [Consume Nested Events](/docs/best-practices/multi-agent-patterns/consume-nested-events) shows how to group and render parent and child events safely.
+- [Persistence and Testing](/docs/best-practices/multi-agent-patterns/persistence-and-testing) covers event-store replay, failure modes, and test coverage.
+
+## Choose the Right Shape
+
+| Shape | Use it when |
+| --- | --- |
+| `agent.asTool(...)` | child progress can stay hidden |
+| `agent.asTool({ stream: true })` | coordinator decides which specialists to call and the caller should see child progress |
+| parallel pipelines | every branch should always run and return typed outputs |
+| separate Studio agents | operators should run specialists manually during development |
+
+## Related Docs
+
+- [Multi-Agent Workflows](/docs/guides/agents/multi-agent-workflows)
+- [Streaming Events](/docs/guides/streaming/streaming-events)
+- [Readable Streams](/docs/guides/streaming/readable-streams)
+- [Pipeline](/docs/best-practices/common-patterns/pipeline)

--- a/apps/docs/content/docs/best-practices/multi-agent-patterns/meta.json
+++ b/apps/docs/content/docs/best-practices/multi-agent-patterns/meta.json
@@ -1,0 +1,11 @@
+{
+  "title": "Multi-agent Patterns",
+  "defaultOpen": false,
+  "collapsible": true,
+  "pages": [
+    "index",
+    "build-streaming-specialists",
+    "consume-nested-events",
+    "persistence-and-testing"
+  ]
+}

--- a/apps/docs/content/docs/best-practices/multi-agent-patterns/persistence-and-testing.mdx
+++ b/apps/docs/content/docs/best-practices/multi-agent-patterns/persistence-and-testing.mdx
@@ -1,0 +1,54 @@
+---
+title: Persistence and Testing
+description: Persist, replay, and test multi-agent streaming runs.
+---
+
+Multi-agent streams are useful live, but production systems often need replay, support inspection, and regression coverage. Persist events when users may refresh, support teams need a run history, or child-agent progress is part of the product record.
+
+## Persist Events for Replay
+
+Add an event store when nested progress must be replayed after the run, inspected in support tools, or attached to a product audit trail.
+
+```ts
+import { AgentBuilder, type AgentEventStore } from "@anvia/core";
+import { supportAgent } from "./specialists";
+import { model } from "./model";
+
+declare const eventStore: AgentEventStore;
+
+export const coordinatorWithEvents = new AgentBuilder("incident-coordinator", model)
+  .instructions("Delegate support triage, then produce a short final brief.")
+  .tool(supportAgent.asTool({ name: "ask_support_agent", stream: true }))
+  .eventStore(eventStore, { include: "all" })
+  .defaultMaxTurns(3)
+  .build();
+```
+
+The final stream event includes `runId`. Use that id to load saved parent and child events from the event store.
+
+## Failure Modes
+
+| Failure | Fix |
+| --- | --- |
+| child progress never appears | check parent `.stream()`, `stream: true`, and child model streaming support |
+| nested events are hard to group | group by `internalCallId`, then label with `agentName` or `toolName` |
+| coordinator calls too many specialists | tighten instructions, lower max turns, or reduce available specialist tools |
+| tool results leak sensitive data | render safe status labels and persist sensitive details only in protected storage |
+| parallel calls overload services | lower `.withToolConcurrency(...)` or add service-level limits |
+| progress disappears after refresh | attach an event store and replay by `runId` |
+
+## Test Checklist
+
+- Test specialist agents directly with representative prompts.
+- Test coordinator tool registration includes `stream: true` for visible specialists.
+- Test stream handling for `agent_tool_event`, `tool_result`, `text_delta`, `final`, and `error`.
+- Test UI grouping when the same specialist is called more than once.
+- Test event-store replay with saved parent and child events.
+- Inspect a provider-backed run in Studio or traces before exposing nested progress to users.
+
+## Related Docs
+
+- [Event Store](/docs/guides/agents/event-store)
+- [Testing and Observability](/docs/best-practices/common-patterns/testing-and-observability)
+- [Tracing and Debugging](/docs/best-practices/quality-observability/tracing-and-debugging)
+- [Consume Nested Events](/docs/best-practices/multi-agent-patterns/consume-nested-events)

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -19,6 +19,7 @@
     "fumadocs-mdx": "^14.3.2",
     "fumadocs-ui": "^16.8.5",
     "lucide-react": "^1.14.0",
+    "mermaid": "^11.15.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"
   },

--- a/apps/docs/src/components/mdx.tsx
+++ b/apps/docs/src/components/mdx.tsx
@@ -1,9 +1,11 @@
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
+import { Mermaid } from "./mermaid";
 
 export function getMDXComponents(components?: MDXComponents) {
   return {
     ...defaultMdxComponents,
+    Mermaid,
     ...components,
   } as unknown as MDXComponents;
 }

--- a/apps/docs/src/components/mermaid.tsx
+++ b/apps/docs/src/components/mermaid.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useId, useState } from "react";
+
+type MermaidProps = {
+  chart: string;
+};
+
+type MermaidStatus =
+  | { state: "loading" }
+  | { state: "ready"; svg: string }
+  | { state: "error"; message: string };
+
+export function Mermaid({ chart }: MermaidProps) {
+  const id = useId();
+  const [status, setStatus] = useState<MermaidStatus>({ state: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    const renderId = `mermaid-${id.replace(/[^a-zA-Z0-9_-]/g, "")}`;
+
+    async function renderDiagram() {
+      try {
+        const mermaid = (await import("mermaid")).default;
+
+        mermaid.initialize({
+          startOnLoad: false,
+          theme: "default",
+          securityLevel: "strict",
+        });
+
+        const { svg } = await mermaid.render(renderId, chart);
+
+        if (!cancelled) {
+          setStatus({ state: "ready", svg });
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setStatus({
+            state: "error",
+            message: error instanceof Error ? error.message : "Unable to render diagram.",
+          });
+        }
+      }
+    }
+
+    setStatus({ state: "loading" });
+    void renderDiagram();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [chart, id]);
+
+  if (status.state === "ready") {
+    return (
+      <div
+        className="my-6 overflow-x-auto rounded-lg border bg-fd-card p-4"
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: Mermaid returns SVG markup; securityLevel strict keeps user-authored HTML disabled.
+        dangerouslySetInnerHTML={{ __html: status.svg }}
+      />
+    );
+  }
+
+  if (status.state === "error") {
+    return (
+      <pre className="my-6 overflow-x-auto rounded-lg border bg-fd-card p-4 text-sm">
+        <code>{`${status.message}\n\n${chart}`}</code>
+      </pre>
+    );
+  }
+
+  return (
+    <div className="my-6 rounded-lg border bg-fd-card p-4 text-sm text-fd-muted-foreground">
+      Loading diagram...
+    </div>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       lucide-react:
         specifier: ^1.14.0
         version: 1.14.0(react@19.2.5)
+      mermaid:
+        specifier: ^11.15.0
+        version: 11.15.0
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -592,6 +595,9 @@ packages:
     resolution: {integrity: sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==}
     engines: {node: '>=18'}
 
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
   '@anthropic-ai/sdk@0.96.0':
     resolution: {integrity: sha512-KlCsODtTyb17bLUVCSDC2HtSvAbJf60sEiPEax9dInF+aDF92vS4TZJ5XD7YCQXNb1/5icYaw8Y7wMjPlIV9Zg==}
     hasBin: true
@@ -827,6 +833,12 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
   '@cloudflare/kv-asset-handler@0.5.0':
     resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
@@ -1436,6 +1448,12 @@ packages:
   '@huggingface/transformers@4.2.0':
     resolution: {integrity: sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==}
 
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.3':
+    resolution: {integrity: sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==}
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -1637,6 +1655,9 @@ packages:
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@mermaid-js/parser@1.1.1':
+    resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
 
   '@mistralai/mistralai@2.2.1':
     resolution: {integrity: sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==}
@@ -3034,23 +3055,98 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
   '@types/d3-color@3.1.3':
     resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
 
   '@types/d3-drag@3.0.7':
     resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
 
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
   '@types/d3-interpolate@3.0.4':
     resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
 
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
   '@types/d3-selection@3.0.11':
     resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
   '@types/d3-transition@3.0.9':
     resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
 
   '@types/d3-zoom@3.0.8':
     resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
@@ -3063,6 +3159,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -3096,6 +3195,9 @@ packages:
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -3104,6 +3206,9 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
@@ -3502,6 +3607,14 @@ packages:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
   compute-scroll-into-view@3.1.1:
     resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
 
@@ -3546,6 +3659,12 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -3565,8 +3684,49 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.33.3:
+    resolution: {integrity: sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
   d3-color@3.1.0:
     resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
     engines: {node: '>=12'}
 
   d3-dispatch@3.0.1:
@@ -3577,16 +3737,86 @@ packages:
     resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
     engines: {node: '>=12'}
 
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   d3-ease@3.0.1:
     resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
     engines: {node: '>=12'}
 
   d3-interpolate@3.0.1:
     resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
     engines: {node: '>=12'}
 
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
   d3-selection@3.0.0:
     resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
     engines: {node: '>=12'}
 
   d3-timer@3.0.1:
@@ -3603,9 +3833,19 @@ packages:
     resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
     engines: {node: '>=12'}
 
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
+
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
+
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -3626,6 +3866,9 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -3661,6 +3904,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.4.3:
+    resolution: {integrity: sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -4106,6 +4352,9 @@ packages:
       crossws:
         optional: true
 
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
   has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
@@ -4197,6 +4446,9 @@ packages:
     resolution: {integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==}
     engines: {node: '>=18'}
 
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
   indent-string@5.0.0:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
     engines: {node: '>=12'}
@@ -4225,6 +4477,13 @@ packages:
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
@@ -4339,9 +4598,22 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
+  katex@0.16.46:
+    resolution: {integrity: sha512-WHy4Coo+bGZyH7NwJKHkS04YFsFcarWbAEOAC3EMndzdN6VSZqklLLIgfxzyaW9jDoeGYJX9SWbJPKpecox0Uw==}
+    hasBin: true
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -4428,6 +4700,9 @@ packages:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
@@ -4475,6 +4750,11 @@ packages:
   marked@15.0.12:
     resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
     engines: {node: '>= 18'}
+    hasBin: true
+
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
     hasBin: true
 
   marked@6.0.0:
@@ -4550,6 +4830,9 @@ packages:
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
+
+  mermaid@11.15.0:
+    resolution: {integrity: sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -4836,6 +5119,9 @@ packages:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
     engines: {node: '>=8'}
 
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
@@ -4864,6 +5150,9 @@ packages:
   patch-console@2.0.0:
     resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -4944,6 +5233,12 @@ packages:
 
   platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
@@ -5176,6 +5471,9 @@ packages:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
     engines: {node: '>=8.0'}
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rolldown@1.0.0-rc.17:
     resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5189,9 +5487,15 @@ packages:
   rou3@0.8.1:
     resolution: {integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==}
 
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
+
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -5353,6 +5657,9 @@ packages:
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -5449,6 +5756,10 @@ packages:
 
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
+  ts-dedent@2.2.0:
+    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
+    engines: {node: '>=6.10'}
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
@@ -5587,6 +5898,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+    hasBin: true
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -5872,6 +6187,11 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.6.0
+      tinyexec: 1.1.1
+
   '@anthropic-ai/sdk@0.96.0(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
@@ -6083,6 +6403,10 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.4.14':
     optional: true
+
+  '@braintree/sanitize-url@7.1.2': {}
+
+  '@chevrotain/types@11.1.2': {}
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
@@ -6458,6 +6782,14 @@ snapshots:
       onnxruntime-web: 1.26.0-dev.20260416-b7804b056c
       sharp: 0.34.5
 
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.3':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
+
   '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
@@ -6630,6 +6962,10 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@mermaid-js/parser@1.1.1':
+    dependencies:
+      '@chevrotain/types': 11.1.2
 
   '@mistralai/mistralai@2.2.1':
     dependencies:
@@ -8326,17 +8662,80 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
   '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
 
   '@types/d3-drag@3.0.7':
     dependencies:
       '@types/d3-selection': 3.0.11
 
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
   '@types/d3-interpolate@3.0.4':
     dependencies:
       '@types/d3-color': 3.1.3
 
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
   '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
 
   '@types/d3-transition@3.0.9':
     dependencies:
@@ -8346,6 +8745,39 @@ snapshots:
     dependencies:
       '@types/d3-interpolate': 3.0.4
       '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
 
   '@types/debug@4.1.13':
     dependencies:
@@ -8358,6 +8790,8 @@ snapshots:
       '@types/estree': 1.0.8
 
   '@types/estree@1.0.8': {}
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -8396,11 +8830,19 @@ snapshots:
 
   '@types/retry@0.12.0': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -8805,6 +9247,10 @@ snapshots:
 
   commander@4.1.1: {}
 
+  commander@7.2.0: {}
+
+  commander@8.3.0: {}
+
   compute-scroll-into-view@3.1.1: {}
 
   confbox@0.1.8: {}
@@ -8832,6 +9278,14 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -8852,7 +9306,49 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.33.3):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.33.3
+
+  cytoscape-fcose@2.2.0(cytoscape@3.33.3):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.33.3
+
+  cytoscape@3.33.3: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
   d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
 
   d3-dispatch@3.0.1: {}
 
@@ -8861,13 +9357,81 @@ snapshots:
       d3-dispatch: 3.0.1
       d3-selection: 3.0.0
 
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
   d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
 
   d3-interpolate@3.0.1:
     dependencies:
       d3-color: 3.1.0
 
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
   d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
 
   d3-timer@3.0.1: {}
 
@@ -8888,7 +9452,47 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
+
   data-uri-to-buffer@4.0.1: {}
+
+  dayjs@1.11.20: {}
 
   debug@4.4.3:
     dependencies:
@@ -8909,6 +9513,10 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
 
   depd@2.0.0: {}
 
@@ -8937,6 +9545,10 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.4.3:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:
@@ -9463,6 +10075,8 @@ snapshots:
       rou3: 0.8.1
       srvx: 0.11.15
 
+  hachure-fill@0.5.2: {}
+
   has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
@@ -9634,6 +10248,8 @@ snapshots:
       cjs-module-lexer: 2.2.0
       module-details-from-path: 1.0.4
 
+  import-meta-resolve@4.2.0: {}
+
   indent-string@5.0.0: {}
 
   inherits@2.0.4: {}
@@ -9681,6 +10297,10 @@ snapshots:
       - utf-8-validate
 
   inline-style-parser@0.2.7: {}
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
 
   ip-address@10.1.0: {}
 
@@ -9767,7 +10387,17 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
+  katex@0.16.46:
+    dependencies:
+      commander: 8.3.0
+
+  khroma@2.1.0: {}
+
   kleur@4.1.5: {}
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -9824,6 +10454,8 @@ snapshots:
 
   load-tsconfig@0.2.5: {}
 
+  lodash-es@4.18.1: {}
+
   lodash.camelcase@4.3.0: {}
 
   long@5.3.2: {}
@@ -9872,6 +10504,8 @@ snapshots:
       supports-hyperlinks: 3.2.0
 
   marked@15.0.12: {}
+
+  marked@16.4.2: {}
 
   marked@6.0.0: {}
 
@@ -10049,6 +10683,30 @@ snapshots:
   media-typer@1.1.0: {}
 
   merge-descriptors@2.0.0: {}
+
+  mermaid@11.15.0:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.3
+      '@mermaid-js/parser': 1.1.1
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.33.3
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.33.3)
+      cytoscape-fcose: 2.2.0(cytoscape@3.33.3)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.20
+      dompurify: 3.4.3
+      es-toolkit: 1.46.1
+      katex: 0.16.46
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.2.0
+      uuid: 14.0.0
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -10481,6 +11139,8 @@ snapshots:
       '@types/retry': 0.12.0
       retry: 0.13.1
 
+  package-manager-detector@1.6.0: {}
+
   parse-entities@4.0.2:
     dependencies:
       '@types/unist': 2.0.11
@@ -10515,6 +11175,8 @@ snapshots:
   parseurl@1.3.3: {}
 
   patch-console@2.0.0: {}
+
+  path-data-parser@0.1.0: {}
 
   path-key@3.1.1: {}
 
@@ -10582,6 +11244,13 @@ snapshots:
       pathe: 2.0.3
 
   platform@1.3.6: {}
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
@@ -10904,6 +11573,8 @@ snapshots:
       semver-compare: 1.0.0
       sprintf-js: 1.1.3
 
+  robust-predicates@3.0.3: {}
+
   rolldown@1.0.0-rc.17:
     dependencies:
       '@oxc-project/types': 0.127.0
@@ -10958,6 +11629,13 @@ snapshots:
 
   rou3@0.8.1: {}
 
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
   router@2.2.0:
     dependencies:
       debug: 4.4.3
@@ -10967,6 +11645,8 @@ snapshots:
       path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
+
+  rw@1.3.3: {}
 
   safe-buffer@5.2.1: {}
 
@@ -11169,6 +11849,8 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
+  stylis@4.4.0: {}
+
   sucrase@3.35.1:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
@@ -11257,6 +11939,8 @@ snapshots:
   trough@2.2.0: {}
 
   ts-algebra@2.0.0: {}
+
+  ts-dedent@2.2.0: {}
 
   ts-interface-checker@0.1.13: {}
 
@@ -11422,6 +12106,8 @@ snapshots:
       react: 19.2.6
 
   util-deprecate@1.0.2: {}
+
+  uuid@14.0.0: {}
 
   vary@1.1.2: {}
 


### PR DESCRIPTION
## Summary
- add a Long Process Pipelines best-practice section with BullMQ queue, worker, status, retry, and testing guidance
- add a Multi-agent Patterns section covering streaming specialist agents, nested event consumption, persistence, and testing
- add a Mermaid MDX component for Fumadocs diagram rendering

## Verification
- pnpm docs:deploy
- pnpm exec biome check on touched docs files
- pnpm --filter docs exec fumadocs-mdx
- pnpm --filter docs exec tsr generate
- pnpm --filter docs exec tsc --noEmit

## Deploy
- https://anvia-docs.me-063.workers.dev
- Version ID: d2f88198-80a3-498a-bcda-7442a82aaa7a

## Note
- pnpm --filter docs typecheck still stops at the existing reference coverage gate for unrelated undocumented @anvia/core and @anvia/studio exports.