### PR TITLE
Fix Anthropic streaming tools and update deps

### DIFF
--- a/.changeset/patch-anthropic-and-update-deps.md
+++ b/.changeset/patch-anthropic-and-update-deps.md
@@ -1,0 +1,9 @@
+---
+"@anvia/anthropic": patch
+"@anvia/gemini": patch
+"@anvia/openai": patch
+"@anvia/pgvector": patch
+"@anvia/studio": patch
+---
+
+Fix Anthropic-compatible streaming tool inputs and update provider dependencies.

--- a/packages/providers/anthropic/src/anthropic/completion.ts
+++ b/packages/providers/anthropic/src/anthropic/completion.ts
@@ -69,6 +69,7 @@ export class AnthropicCompletionModel implements StreamingCompletionModel {
     const params = { ...toAnthropicMessagesParams(this.defaultModel, request), stream: true };
     const stream = await this.client.messages.create(params as never);
     const toolIdsByIndex = new Map<number, string>();
+    const blocksWithInitialToolInput = new Set<number>();
     for await (const event of stream as unknown as AsyncIterable<unknown>) {
       if (isPlainObject(event) && event.type === "content_block_start") {
         const index = numberFrom(event.index);
@@ -77,8 +78,20 @@ export class AnthropicCompletionModel implements StreamingCompletionModel {
         if (id !== undefined) {
           toolIdsByIndex.set(index, id);
         }
+        if (toolInputArgumentsDelta(block.input) !== undefined) {
+          blocksWithInitialToolInput.add(index);
+        }
       }
       for (const mapped of fromAnthropicStreamEvent(event)) {
+        if (
+          mapped.type === "tool_call_delta" &&
+          mapped.argumentsDelta !== undefined &&
+          isPlainObject(event) &&
+          event.type === "content_block_delta" &&
+          blocksWithInitialToolInput.has(numberFrom(event.index))
+        ) {
+          continue;
+        }
         if (mapped.type === "tool_call_delta" && mapped.id.startsWith("tool_")) {
           const index = Number(mapped.id.slice("tool_".length));
           yield { ...mapped, id: toolIdsByIndex.get(index) ?? mapped.id };
@@ -254,6 +267,7 @@ export function fromAnthropicStreamEvent(event: unknown): CompletionStreamEvent[
       return [
         toolCallDelta(stringFrom(block.id) ?? `tool_${numberFrom(event.index)}`, {
           name: stringFrom(block.name),
+          argumentsDelta: toolInputArgumentsDelta(block.input),
         }),
       ];
     }
@@ -508,6 +522,31 @@ function toJsonValue(value: unknown): JsonValue {
   }
 
   return String(value);
+}
+
+function toolInputArgumentsDelta(input: unknown): string | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+
+  if (typeof input === "string") {
+    const trimmed = input.trim();
+    if (trimmed.length === 0 || trimmed === "{}") {
+      return undefined;
+    }
+    try {
+      JSON.parse(trimmed);
+      return trimmed;
+    } catch {
+      return JSON.stringify(input);
+    }
+  }
+
+  if (isPlainObject(input) && Object.keys(input).length === 0) {
+    return undefined;
+  }
+
+  return JSON.stringify(toJsonValue(input));
 }
 
 function toolCallDelta(

--- a/packages/providers/anthropic/test/anthropic-completion.test.ts
+++ b/packages/providers/anthropic/test/anthropic-completion.test.ts
@@ -1,4 +1,11 @@
-import { AssistantContent, type CompletionRequest, Message, Usage, UserContent } from "@anvia/core";
+import {
+  AssistantContent,
+  type CompletionRequest,
+  type CompletionStreamEvent,
+  Message,
+  Usage,
+  UserContent,
+} from "@anvia/core";
 import { describe, expect, it } from "vitest";
 import {
   AnthropicCompletionModel,
@@ -355,4 +362,100 @@ describe("Anthropic Messages mapping", () => {
       }),
     ).toEqual([{ type: "tool_call_delta", id: "toolu_1", name: "lookup" }]);
   });
+
+  it("preserves complete tool input from streamed content_block_start events", async () => {
+    const events = await collectStreamEvents([
+      {
+        type: "content_block_start",
+        index: 2,
+        content_block: {
+          type: "tool_use",
+          id: "toolu_write",
+          name: "Write",
+          input: {
+            file_path: "src/main.tsx",
+            content: "console.log('ok');",
+          },
+        },
+      },
+      { type: "content_block_stop", index: 2 },
+    ]);
+
+    expect(accumulatedToolArguments(events, "toolu_write")).toEqual({
+      file_path: "src/main.tsx",
+      content: "console.log('ok');",
+    });
+  });
+
+  it("does not duplicate streamed tool input when input_json_delta also arrives", async () => {
+    const events = await collectStreamEvents([
+      {
+        type: "content_block_start",
+        index: 2,
+        content_block: {
+          type: "tool_use",
+          id: "toolu_write",
+          name: "Write",
+          input: '{"file_path":"src/main.tsx","content":"start"}',
+        },
+      },
+      {
+        type: "content_block_delta",
+        index: 2,
+        delta: {
+          type: "input_json_delta",
+          partial_json: '{"file_path":"src/main.tsx","content":"delta"}',
+        },
+      },
+      { type: "content_block_stop", index: 2 },
+    ]);
+
+    expect(
+      events.filter(
+        (event) => event.type === "tool_call_delta" && event.argumentsDelta !== undefined,
+      ),
+    ).toHaveLength(1);
+    expect(accumulatedToolArguments(events, "toolu_write")).toEqual({
+      file_path: "src/main.tsx",
+      content: "start",
+    });
+  });
 });
+
+async function collectStreamEvents(events: unknown[]): Promise<CompletionStreamEvent[]> {
+  const model = new AnthropicCompletionModel(
+    {
+      messages: {
+        create: async () => streamFrom(events),
+      },
+    } as never,
+    "claude-test",
+  );
+
+  const mapped: CompletionStreamEvent[] = [];
+  for await (const event of model.streamCompletion({
+    chatHistory: [Message.user("write a file")],
+    documents: [],
+    tools: [],
+  })) {
+    mapped.push(event);
+  }
+  return mapped;
+}
+
+async function* streamFrom(events: unknown[]): AsyncIterable<unknown> {
+  for (const event of events) {
+    yield event;
+  }
+}
+
+function accumulatedToolArguments(events: CompletionStreamEvent[], id: string): unknown {
+  const argumentsText = events
+    .flatMap((event) =>
+      event.type === "tool_call_delta" && event.id === id && event.argumentsDelta !== undefined
+        ? [event.argumentsDelta]
+        : [],
+    )
+    .join("");
+  return argumentsText.length === 0 ? {} : JSON.parse(argumentsText);
+}

--- a/packages/providers/gemini/package.json
+++ b/packages/providers/gemini/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@anvia/core": "^0.2.1",
-    "@google/genai": "^2.2.0"
+    "@google/genai": "^2.4.0"
   },
   "devDependencies": {
     "@types/node": "^24.9.1",

--- a/packages/providers/openai/package.json
+++ b/packages/providers/openai/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@anvia/core": "workspace:*",
-    "openai": "^6.37.0"
+    "openai": "^6.38.0"
   },
   "devDependencies": {
     "@types/node": "^24.9.1",

--- a/packages/tools/studio/package.json
+++ b/packages/tools/studio/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@anvia/core": "workspace:*",
-    "@hono/node-server": "^2.0.2",
+    "@hono/node-server": "^2.0.3",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",
@@ -38,7 +38,7 @@
     "@xyflow/react": "^12.10.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "hono": "^4.12.18",
+    "hono": "^4.12.19",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-markdown": "^10.1.0",

--- a/packages/vector-stores/pgvector/package.json
+++ b/packages/vector-stores/pgvector/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@anvia/core": "workspace:*",
-    "pg": "^8.20.0",
+    "pg": "^8.21.0",
     "pgvector": "^0.2.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -369,8 +369,8 @@ importers:
         specifier: workspace:*
         version: link:../../core
       '@google/genai':
-        specifier: ^2.2.0
-        version: 2.2.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
+        specifier: ^2.4.0
+        version: 2.4.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
     devDependencies:
       '@types/node':
         specifier: ^24.9.1
@@ -413,8 +413,8 @@ importers:
         specifier: workspace:*
         version: link:../../core
       openai:
-        specifier: ^6.37.0
-        version: 6.37.0(ws@8.20.0)(zod@4.4.3)
+        specifier: ^6.38.0
+        version: 6.38.0(ws@8.20.0)(zod@4.4.3)
     devDependencies:
       '@types/node':
         specifier: ^24.9.1
@@ -435,8 +435,8 @@ importers:
         specifier: workspace:*
         version: link:../../core
       '@hono/node-server':
-        specifier: ^2.0.2
-        version: 2.0.2(hono@4.12.18)
+        specifier: ^2.0.3
+        version: 2.0.3(hono@4.12.19)
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -468,8 +468,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       hono:
-        specifier: ^4.12.18
-        version: 4.12.18
+        specifier: ^4.12.19
+        version: 4.12.19
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -548,8 +548,8 @@ importers:
         specifier: workspace:*
         version: link:../../core
       pg:
-        specifier: ^8.20.0
-        version: 8.20.0
+        specifier: ^8.21.0
+        version: 8.21.0
       pgvector:
         specifier: ^0.2.1
         version: 0.2.1
@@ -1458,8 +1458,8 @@ packages:
       tailwindcss:
         optional: true
 
-  '@google/genai@2.2.0':
-    resolution: {integrity: sha512-RA3cuaKLldWTrpxhNm2nAe0Oez/UEuoH11jFjPzbYL7TSP83lMk+ic7pQKZ4ekJdZfnIdgxWl1DwJoUwxmvWGQ==}
+  '@google/genai@2.4.0':
+    resolution: {integrity: sha512-q5q26X/yNKjbzrRdVVDIM9KEmN4dhezmhyliCDIn8mPGT0AlfzOqQfZ5iNCGRCEHSPd86oUdhpNpuzAkEZ5LQg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.25.2
@@ -1482,8 +1482,8 @@ packages:
     peerDependencies:
       hono: ^4
 
-  '@hono/node-server@2.0.2':
-    resolution: {integrity: sha512-tXlTi1h/4V7sDe7i97IVP+9re9ZU7wXZZggnR5ucCRclf1+AX6YhGStrR5w8bLj+3Mlyl0pKfBh9gqTqqnGKfQ==}
+  '@hono/node-server@2.0.3':
+    resolution: {integrity: sha512-a0jV+/HRe3G5zjFID3zObAQFdkl6zpxTuqktdDDXS3MJKcrZIkB8OkLpNBlY/WXFqv2HF4a0takPej+aNFczWA==}
     engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
@@ -4559,8 +4559,8 @@ packages:
     resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
     engines: {node: '>=16.9.0'}
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.19:
+    resolution: {integrity: sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==}
     engines: {node: '>=16.9.0'}
 
   html-url-attributes@3.0.1:
@@ -5291,8 +5291,8 @@ packages:
   onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
     resolution: {integrity: sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==}
 
-  openai@6.37.0:
-    resolution: {integrity: sha512-0H5dEGFmmLv6KSd0W1w2nyL8WsLkX6yoLeQpU+dZAOuGcany5qkYQMmj35ZrKgb6yiyYqpUzFOpR8mZQkgqeEQ==}
+  openai@6.38.0:
+    resolution: {integrity: sha512-AoMplt2UalrpgUDMh3L09QWjNRlgJPipclQvA6sYAaeF6nHNBMgmikAZGmcYLn8on4d9sQY9Q8bOLfrBS7Lc8g==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -5393,30 +5393,33 @@ packages:
     resolution: {integrity: sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw==}
     engines: {node: '>=22.13.0 || >=24'}
 
-  pg-cloudflare@1.3.0:
-    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
 
-  pg-connection-string@2.12.0:
-    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+  pg-connection-string@2.13.0:
+    resolution: {integrity: sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==}
 
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
 
-  pg-pool@3.13.0:
-    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
     peerDependencies:
       pg: '>=8.0'
 
   pg-protocol@1.13.0:
     resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
 
+  pg-protocol@1.14.0:
+    resolution: {integrity: sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==}
+
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
     engines: {node: '>=4'}
 
-  pg@8.20.0:
-    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
+  pg@8.21.0:
+    resolution: {integrity: sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
       pg-native: '>=3.0.1'
@@ -7146,7 +7149,7 @@ snapshots:
       '@tailwindcss/oxide': 4.2.4
       tailwindcss: 4.2.4
 
-  '@google/genai@2.2.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
+  '@google/genai@2.4.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
@@ -7175,9 +7178,9 @@ snapshots:
     dependencies:
       hono: 4.12.15
 
-  '@hono/node-server@2.0.2(hono@4.12.18)':
+  '@hono/node-server@2.0.3(hono@4.12.19)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.19
 
   '@huggingface/hub@2.11.0':
     dependencies:
@@ -10727,7 +10730,7 @@ snapshots:
 
   hono@4.12.15: {}
 
-  hono@4.12.18: {}
+  hono@4.12.19: {}
 
   html-url-attributes@3.0.1: {}
 
@@ -11683,7 +11686,7 @@ snapshots:
       platform: 1.3.6
       protobufjs: 7.5.6
 
-  openai@6.37.0(ws@8.20.0)(zod@4.4.3):
+  openai@6.38.0(ws@8.20.0)(zod@4.4.3):
     optionalDependencies:
       ws: 8.20.0
       zod: 4.4.3
@@ -11770,18 +11773,20 @@ snapshots:
     optionalDependencies:
       '@napi-rs/canvas': 0.1.100
 
-  pg-cloudflare@1.3.0:
+  pg-cloudflare@1.4.0:
     optional: true
 
-  pg-connection-string@2.12.0: {}
+  pg-connection-string@2.13.0: {}
 
   pg-int8@1.0.1: {}
 
-  pg-pool@3.13.0(pg@8.20.0):
+  pg-pool@3.14.0(pg@8.21.0):
     dependencies:
-      pg: 8.20.0
+      pg: 8.21.0
 
   pg-protocol@1.13.0: {}
+
+  pg-protocol@1.14.0: {}
 
   pg-types@2.2.0:
     dependencies:
@@ -11791,15 +11796,15 @@ snapshots:
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
 
-  pg@8.20.0:
+  pg@8.21.0:
     dependencies:
-      pg-connection-string: 2.12.0
-      pg-pool: 3.13.0(pg@8.20.0)
-      pg-protocol: 1.13.0
+      pg-connection-string: 2.13.0
+      pg-pool: 3.14.0(pg@8.21.0)
+      pg-protocol: 1.14.0
       pg-types: 2.2.0
       pgpass: 1.0.5
     optionalDependencies:
-      pg-cloudflare: 1.3.0
+      pg-cloudflare: 1.4.0
 
   pgpass@1.0.5:
     dependencies:


### PR DESCRIPTION
## Summary
- preserve complete Anthropic-compatible streamed tool inputs from content_block_start events
- avoid duplicating tool arguments when later input_json_delta events also arrive
- update provider/runtime dependencies for Gemini, OpenAI, pgvector, and Studio
- add patch changeset for affected packages

## Verification
- pnpm --filter @anvia/anthropic test
- pnpm --filter @anvia/anthropic typecheck
- bin/check-upstream-deps.sh
- pnpm install --frozen-lockfile --ignore-scripts
- pnpm exec biome check packages/providers/gemini/package.json packages/providers/openai/package.json packages/vector-stores/pgvector/package.json packages/tools/studio/package.json pnpm-lock.yaml pnpm-workspace.yaml
- pnpm --filter @anvia/gemini typecheck
- pnpm --filter @anvia/openai typecheck
- pnpm --filter @anvia/pgvector typecheck
- pnpm --filter @anvia/studio typecheck
- pnpm --filter @anvia/gemini test
- pnpm --filter @anvia/openai test
- pnpm --filter @anvia/pgvector test
- pnpm --filter @anvia/studio test