### PR TITLE
Fix npm provenance repository metadata

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,11 @@
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anvia-hq/anvia",
+    "directory": "packages/core"
+  },
   "files": [
     "dist"
   ],

--- a/packages/embeddings/fastembed/package.json
+++ b/packages/embeddings/fastembed/package.json
@@ -5,6 +5,11 @@
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anvia-hq/anvia",
+    "directory": "packages/embeddings/fastembed"
+  },
   "files": [
     "dist"
   ],

--- a/packages/embeddings/transformers/package.json
+++ b/packages/embeddings/transformers/package.json
@@ -5,6 +5,11 @@
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anvia-hq/anvia",
+    "directory": "packages/embeddings/transformers"
+  },
   "files": [
     "dist"
   ],

--- a/packages/observability/langfuse/package.json
+++ b/packages/observability/langfuse/package.json
@@ -5,6 +5,11 @@
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anvia-hq/anvia",
+    "directory": "packages/observability/langfuse"
+  },
   "files": [
     "dist"
   ],

--- a/packages/observability/otel/package.json
+++ b/packages/observability/otel/package.json
@@ -5,6 +5,11 @@
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anvia-hq/anvia",
+    "directory": "packages/observability/otel"
+  },
   "files": [
     "dist"
   ],

--- a/packages/providers/anthropic/package.json
+++ b/packages/providers/anthropic/package.json
@@ -5,6 +5,11 @@
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anvia-hq/anvia",
+    "directory": "packages/providers/anthropic"
+  },
   "files": [
     "dist"
   ],

--- a/packages/providers/gemini/package.json
+++ b/packages/providers/gemini/package.json
@@ -5,6 +5,11 @@
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anvia-hq/anvia",
+    "directory": "packages/providers/gemini"
+  },
   "files": [
     "dist"
   ],

--- a/packages/providers/mistral/package.json
+++ b/packages/providers/mistral/package.json
@@ -5,6 +5,11 @@
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anvia-hq/anvia",
+    "directory": "packages/providers/mistral"
+  },
   "files": [
     "dist"
   ],

--- a/packages/providers/openai/package.json
+++ b/packages/providers/openai/package.json
@@ -5,6 +5,11 @@
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anvia-hq/anvia",
+    "directory": "packages/providers/openai"
+  },
   "files": [
     "dist"
   ],

--- a/packages/tools/studio/package.json
+++ b/packages/tools/studio/package.json
@@ -5,6 +5,11 @@
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anvia-hq/anvia",
+    "directory": "packages/tools/studio"
+  },
   "files": [
     "dist"
   ],

--- a/packages/vector-stores/chroma/package.json
+++ b/packages/vector-stores/chroma/package.json
@@ -5,6 +5,11 @@
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anvia-hq/anvia",
+    "directory": "packages/vector-stores/chroma"
+  },
   "files": [
     "dist"
   ],

--- a/packages/vector-stores/pgvector/package.json
+++ b/packages/vector-stores/pgvector/package.json
@@ -5,6 +5,11 @@
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anvia-hq/anvia",
+    "directory": "packages/vector-stores/pgvector"
+  },
   "files": [
     "dist"
   ],

--- a/packages/vector-stores/qdrant/package.json
+++ b/packages/vector-stores/qdrant/package.json
@@ -5,6 +5,11 @@
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anvia-hq/anvia",
+    "directory": "packages/vector-stores/qdrant"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Summary
- add repository metadata to all publishable @anvia/* package manifests
- include package-specific repository.directory values for monorepo packages
- allow npm provenance validation to match GitHub Actions source repository

## Verification
- pnpm exec biome check packages/core/package.json packages/embeddings/fastembed/package.json packages/embeddings/transformers/package.json packages/observability/langfuse/package.json packages/observability/otel/package.json packages/providers/anthropic/package.json packages/providers/gemini/package.json packages/providers/mistral/package.json packages/providers/openai/package.json packages/tools/studio/package.json packages/vector-stores/chroma/package.json packages/vector-stores/pgvector/package.json packages/vector-stores/qdrant/package.json
- validated each publishable package has repository.url=https://github.com/anvia-hq/anvia and matching repository.directory
- npm pack --json packages/providers/anthropic and inspected packed package/package.json repository metadata