### PR TITLE
Replace workspace dependency specs before publishing

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,11 @@
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anvia-hq/anvia",
+    "directory": "packages/core"
+  },
   "files": [
     "dist"
   ],

--- a/packages/embeddings/fastembed/package.json
+++ b/packages/embeddings/fastembed/package.json
@@ -31,7 +31,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
+    "@anvia/core": "^0.2.3",
     "fastembed": "^2.1.0"
   },
   "devDependencies": {

--- a/packages/embeddings/fastembed/package.json
+++ b/packages/embeddings/fastembed/package.json
@@ -5,6 +5,11 @@
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anvia-hq/anvia",
+    "directory": "packages/embeddings/fastembed"
+  },
   "files": [
     "dist"
   ],

--- a/packages/embeddings/transformers/package.json
+++ b/packages/embeddings/transformers/package.json
@@ -31,7 +31,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
+    "@anvia/core": "^0.2.3",
     "@huggingface/transformers": "^4.2.0"
   },
   "devDependencies": {

--- a/packages/embeddings/transformers/package.json
+++ b/packages/embeddings/transformers/package.json
@@ -5,6 +5,11 @@
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anvia-hq/anvia",
+    "directory": "packages/embeddings/transformers"
+  },
   "files": [
     "dist"
   ],

--- a/packages/observability/langfuse/package.json
+++ b/packages/observability/langfuse/package.json
@@ -5,6 +5,11 @@
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anvia-hq/anvia",
+    "directory": "packages/observability/langfuse"
+  },
   "files": [
     "dist"
   ],

--- a/packages/observability/otel/package.json
+++ b/packages/observability/otel/package.json
@@ -5,6 +5,11 @@
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anvia-hq/anvia",
+    "directory": "packages/observability/otel"
+  },
   "files": [
     "dist"
   ],

--- a/packages/observability/otel/package.json
+++ b/packages/observability/otel/package.json
@@ -31,7 +31,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
+    "@anvia/core": "^0.2.3",
     "@opentelemetry/api": "^1.9.1"
   },
   "devDependencies": {

--- a/packages/providers/anthropic/package.json
+++ b/packages/providers/anthropic/package.json
@@ -5,6 +5,11 @@
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anvia-hq/anvia",
+    "directory": "packages/providers/anthropic"
+  },
   "files": [
     "dist"
   ],

--- a/packages/providers/gemini/package.json
+++ b/packages/providers/gemini/package.json
@@ -5,6 +5,11 @@
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anvia-hq/anvia",
+    "directory": "packages/providers/gemini"
+  },
   "files": [
     "dist"
   ],

--- a/packages/providers/mistral/package.json
+++ b/packages/providers/mistral/package.json
@@ -31,7 +31,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
+    "@anvia/core": "^0.2.3",
     "@mistralai/mistralai": "^2.2.1"
   },
   "devDependencies": {

--- a/packages/providers/mistral/package.json
+++ b/packages/providers/mistral/package.json
@@ -5,6 +5,11 @@
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anvia-hq/anvia",
+    "directory": "packages/providers/mistral"
+  },
   "files": [
     "dist"
   ],

--- a/packages/providers/openai/package.json
+++ b/packages/providers/openai/package.json
@@ -31,7 +31,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
+    "@anvia/core": "^0.2.3",
     "openai": "^6.38.0"
   },
   "devDependencies": {

--- a/packages/providers/openai/package.json
+++ b/packages/providers/openai/package.json
@@ -5,6 +5,11 @@
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anvia-hq/anvia",
+    "directory": "packages/providers/openai"
+  },
   "files": [
     "dist"
   ],

--- a/packages/tools/studio/package.json
+++ b/packages/tools/studio/package.json
@@ -31,7 +31,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
+    "@anvia/core": "^0.2.3",
     "@hono/node-server": "^2.0.3",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/packages/tools/studio/package.json
+++ b/packages/tools/studio/package.json
@@ -5,6 +5,11 @@
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anvia-hq/anvia",
+    "directory": "packages/tools/studio"
+  },
   "files": [
     "dist"
   ],

--- a/packages/vector-stores/chroma/package.json
+++ b/packages/vector-stores/chroma/package.json
@@ -5,6 +5,11 @@
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anvia-hq/anvia",
+    "directory": "packages/vector-stores/chroma"
+  },
   "files": [
     "dist"
   ],

--- a/packages/vector-stores/chroma/package.json
+++ b/packages/vector-stores/chroma/package.json
@@ -31,7 +31,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
+    "@anvia/core": "^0.2.3",
     "chromadb": "^3.4.3"
   },
   "devDependencies": {

--- a/packages/vector-stores/pgvector/package.json
+++ b/packages/vector-stores/pgvector/package.json
@@ -5,6 +5,11 @@
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anvia-hq/anvia",
+    "directory": "packages/vector-stores/pgvector"
+  },
   "files": [
     "dist"
   ],

--- a/packages/vector-stores/pgvector/package.json
+++ b/packages/vector-stores/pgvector/package.json
@@ -31,7 +31,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
+    "@anvia/core": "^0.2.3",
     "pg": "^8.21.0",
     "pgvector": "^0.2.1"
   },

--- a/packages/vector-stores/qdrant/package.json
+++ b/packages/vector-stores/qdrant/package.json
@@ -5,6 +5,11 @@
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anvia-hq/anvia",
+    "directory": "packages/vector-stores/qdrant"
+  },
   "files": [
     "dist"
   ],

--- a/packages/vector-stores/qdrant/package.json
+++ b/packages/vector-stores/qdrant/package.json
@@ -31,7 +31,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
+    "@anvia/core": "^0.2.3",
     "@qdrant/js-client-rest": "^1.18.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- replace remaining published package dependencies on @anvia/core from workspace:* to ^0.2.3
- keep local workspace linking through the existing pnpm workspace override
- prevent npm publish from packing workspace protocol dependencies when publishing from package directories

## Verification
- rg -n 'workspace:\*|workspace:' packages -g 'package.json' returns no package manifest matches
- npm pack --json packages/providers/openai and inspected packed package/package.json dependencies
- pnpm exec biome check affected package manifests
- pnpm install --frozen-lockfile --ignore-scripts