### PR TITLE
Publish pnpm-packed package tarballs

### DIFF
--- a/.changeset/fix-published-workspace-dependencies.md
+++ b/.changeset/fix-published-workspace-dependencies.md
@@ -1,0 +1,7 @@
+---
+"@anvia/openai": patch
+"@anvia/studio": patch
+"@anvia/pgvector": patch
+---
+
+Republish packages with registry-safe dependency metadata.

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 const root = process.cwd();
@@ -27,13 +28,28 @@ for (const pkg of sortedPackages) {
     continue;
   }
 
+  console.info(`Packing "${name}" at "${version}"`);
+  const packedPackage = packPackage(pkg);
+  if (packedPackage === undefined) {
+    failed.push({ name, version });
+    continue;
+  }
+
   console.info(`Publishing "${name}" at "${version}"`);
-  const args = ["publish", "--access", publishConfig?.access ?? "public", "--tag", "latest"];
+  const args = [
+    "publish",
+    packedPackage.filename,
+    "--access",
+    publishConfig?.access ?? "public",
+    "--tag",
+    "latest",
+  ];
   const result = spawnSync("npm", args, {
-    cwd: pkg.dir,
+    cwd: root,
     env: process.env,
     stdio: "inherit",
   });
+  packedPackage.cleanup();
 
   if (result.status === 0) {
     published.push({ name, version });
@@ -106,6 +122,34 @@ async function isVersionPublished(name, version) {
 
   console.error(output.trim());
   throw new Error(`Failed checking npm version for ${name}@${version}`);
+}
+
+function packPackage(pkg) {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "anvia-publish-"));
+  const cleanup = () => rmSync(tempDir, { recursive: true, force: true });
+  const result = spawnSync("pnpm", ["pack", "--pack-destination", tempDir, "--json"], {
+    cwd: pkg.dir,
+    env: process.env,
+    encoding: "utf8",
+  });
+
+  if (result.status !== 0) {
+    process.stdout.write(result.stdout);
+    process.stderr.write(result.stderr);
+    cleanup();
+    return undefined;
+  }
+
+  try {
+    const packed = JSON.parse(result.stdout);
+    if (typeof packed.filename !== "string" || !existsSync(packed.filename)) {
+      throw new Error("pnpm pack did not return a package filename");
+    }
+    return { filename: packed.filename, cleanup };
+  } catch (error) {
+    cleanup();
+    throw error;
+  }
 }
 
 function createGitTags(releases) {


### PR DESCRIPTION
## Summary
- keep workspace:* dependency specs in source package manifests
- pack packages with pnpm before publishing so workspace protocol dependencies are rewritten only in the tarball
- publish the generated tarball with npm so provenance and existing auth flow still work
- add patch changesets for @anvia/openai, @anvia/studio, and @anvia/pgvector because their already-published latest versions contain immutable workspace:* dependency metadata

## Verification
- pnpm exec biome check scripts/publish-packages.mjs
- pnpm install --frozen-lockfile --ignore-scripts
- pnpm pack checks for @anvia/openai, @anvia/studio, and @anvia/pgvector confirmed packed package.json has @anvia/core=0.2.3 and no workspace: specs
- npm view check confirmed only @anvia/openai, @anvia/studio, and @anvia/pgvector latest versions currently have @anvia/core@workspace:* metadata