### PR TITLE
Fix Bun Studio import and streamed tool args

### DIFF
--- a/.changeset/lazy-studio-sqlite-bun.md
+++ b/.changeset/lazy-studio-sqlite-bun.md
@@ -1,0 +1,5 @@
+---
+"@anvia/studio": patch
+---
+
+Lazy-load the default SQLite store so importing Studio does not require `node:sqlite` in Bun-compatible runtimes.

--- a/.changeset/streamed-tool-arguments-win.md
+++ b/.changeset/streamed-tool-arguments-win.md
@@ -1,0 +1,5 @@
+---
+"@anvia/core": patch
+---
+
+Preserve accumulated streamed tool arguments when a provider final response contains an empty tool input.

--- a/packages/core/src/agent/stream-accumulator.ts
+++ b/packages/core/src/agent/stream-accumulator.ts
@@ -100,10 +100,11 @@ export class CompletionStreamAccumulator<RawResponse = unknown> {
   }
 
   response(): CompletionResponse<RawResponse> {
+    const accumulatedResponse = this.buildAccumulatedResponse();
     if (this.finalResponse !== undefined) {
       if (this.finalResponse.choice.length === 0) {
         const response = {
-          ...this.buildAccumulatedResponse(),
+          ...accumulatedResponse,
           usage: this.finalResponse.usage,
           rawResponse: this.finalResponse.rawResponse,
         };
@@ -112,10 +113,10 @@ export class CompletionStreamAccumulator<RawResponse = unknown> {
         }
         return response;
       }
-      return this.finalResponse;
+      return this.mergeFinalResponse(accumulatedResponse, this.finalResponse);
     }
 
-    return this.buildAccumulatedResponse();
+    return accumulatedResponse;
   }
 
   private buildAccumulatedResponse(): CompletionResponse<RawResponse> {
@@ -182,6 +183,47 @@ export class CompletionStreamAccumulator<RawResponse = unknown> {
     this.toolCalls.set(toolCall.id, partial);
   }
 
+  private mergeFinalResponse(
+    accumulatedResponse: CompletionResponse<RawResponse>,
+    finalResponse: CompletionResponse<RawResponse>,
+  ): CompletionResponse<RawResponse> {
+    const accumulatedById = new Map<string, ToolCall>();
+    const accumulatedByCallId = new Map<string, ToolCall>();
+    for (const content of accumulatedResponse.choice) {
+      if (content.type !== "tool_call") {
+        continue;
+      }
+      accumulatedById.set(content.id, content);
+      if (content.callId !== undefined) {
+        accumulatedByCallId.set(content.callId, content);
+      }
+    }
+
+    return {
+      ...finalResponse,
+      choice: finalResponse.choice.map((content) => {
+        if (content.type !== "tool_call" || !isEmptyToolArguments(content.function.arguments)) {
+          return content;
+        }
+
+        const accumulated =
+          accumulatedById.get(content.id) ??
+          (content.callId === undefined ? undefined : accumulatedByCallId.get(content.callId));
+        if (accumulated === undefined || isEmptyToolArguments(accumulated.function.arguments)) {
+          return content;
+        }
+
+        return {
+          ...content,
+          function: {
+            ...content.function,
+            arguments: accumulated.function.arguments,
+          },
+        };
+      }),
+    };
+  }
+
   private appendReasoning(
     reasoning: ReasoningState,
     event: Extract<CompletionStreamEvent<RawResponse>, { type: "reasoning_delta" }>,
@@ -239,4 +281,20 @@ function reasoningDeltaEvent(
   if (event.contentType !== undefined) mapped.contentType = event.contentType;
   if (event.signature !== undefined) mapped.signature = event.signature;
   return mapped;
+}
+
+function isEmptyToolArguments(value: unknown): boolean {
+  if (value === undefined || value === null) {
+    return true;
+  }
+  if (typeof value === "string") {
+    return value.trim().length === 0;
+  }
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+  if (typeof value === "object") {
+    return Object.values(value).every((item) => item === undefined);
+  }
+  return false;
 }

--- a/packages/core/test/stream-accumulator.test.ts
+++ b/packages/core/test/stream-accumulator.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { CompletionStreamAccumulator } from "../src/agent/stream-accumulator";
+import { AssistantContent, Usage } from "../src/completion";
+
+describe("CompletionStreamAccumulator", () => {
+  it("preserves accumulated streamed tool arguments when the final tool input is empty", () => {
+    const accumulator = new CompletionStreamAccumulator();
+    const rawResponse = { provider: "minimax" };
+
+    accumulator.accept({
+      type: "message_id",
+      id: "msg_1",
+    });
+    accumulator.accept({
+      type: "tool_call_delta",
+      id: "toolu_1",
+      name: "Write",
+    });
+    accumulator.accept({
+      type: "tool_call_delta",
+      id: "toolu_1",
+      argumentsDelta: '{"file_path":"src/main.tsx","content":"hello"}',
+    });
+    accumulator.accept({
+      type: "final",
+      response: {
+        choice: [AssistantContent.toolCall("toolu_1", "Write", {})],
+        usage: { ...Usage.empty(), inputTokens: 2, outputTokens: 1, totalTokens: 3 },
+        rawResponse,
+        messageId: "msg_1",
+      },
+    });
+
+    expect(accumulator.response()).toEqual({
+      choice: [
+        AssistantContent.toolCall("toolu_1", "Write", {
+          file_path: "src/main.tsx",
+          content: "hello",
+        }),
+      ],
+      usage: { ...Usage.empty(), inputTokens: 2, outputTokens: 1, totalTokens: 3 },
+      rawResponse,
+      messageId: "msg_1",
+    });
+  });
+
+  it("preserves accumulated start-block tool input when the final tool input is empty", () => {
+    const accumulator = new CompletionStreamAccumulator();
+
+    accumulator.accept({
+      type: "tool_call_delta",
+      id: "toolu_1",
+      name: "Write",
+      argumentsDelta: '{"file_path":"src/main.tsx","content":"hello"}',
+    });
+    accumulator.accept({
+      type: "final",
+      response: {
+        choice: [AssistantContent.toolCall("toolu_1", "Write", {})],
+        usage: Usage.empty(),
+        rawResponse: {},
+      },
+    });
+
+    expect(accumulator.response().choice).toEqual([
+      AssistantContent.toolCall("toolu_1", "Write", {
+        file_path: "src/main.tsx",
+        content: "hello",
+      }),
+    ]);
+  });
+
+  it("keeps non-empty final tool arguments over accumulated streamed arguments", () => {
+    const accumulator = new CompletionStreamAccumulator();
+
+    accumulator.accept({
+      type: "tool_call_delta",
+      id: "toolu_1",
+      name: "Write",
+      argumentsDelta: '{"file_path":"src/main.tsx","content":"streamed"}',
+    });
+    accumulator.accept({
+      type: "final",
+      response: {
+        choice: [
+          AssistantContent.toolCall("toolu_1", "Write", {
+            file_path: "src/main.tsx",
+            content: "final",
+          }),
+        ],
+        usage: Usage.empty(),
+        rawResponse: {},
+      },
+    });
+
+    expect(accumulator.response().choice).toEqual([
+      AssistantContent.toolCall("toolu_1", "Write", {
+        file_path: "src/main.tsx",
+        content: "final",
+      }),
+    ]);
+  });
+});

--- a/packages/providers/anthropic/test/anthropic-completion.test.ts
+++ b/packages/providers/anthropic/test/anthropic-completion.test.ts
@@ -1,8 +1,10 @@
 import {
+  AgentBuilder,
   AssistantContent,
   type CompletionRequest,
   type CompletionStreamEvent,
   Message,
+  type Tool,
   Usage,
   UserContent,
 } from "@anvia/core";
@@ -420,6 +422,89 @@ describe("Anthropic Messages mapping", () => {
       content: "start",
     });
   });
+
+  it("keeps streamed input_json_delta tool arguments when the final message has empty tool input", async () => {
+    const toolCalls: unknown[] = [];
+    const model = anthropicModelWithStreams([
+      [
+        { type: "message_start", message: { id: "msg_1" } },
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "tool_use", id: "toolu_1", name: "Write", input: {} },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: {
+            type: "input_json_delta",
+            partial_json: '{"file_path":"src/main.tsx","content":"hello"}',
+          },
+        },
+        {
+          type: "message_stop",
+          message: {
+            id: "msg_1",
+            content: [{ type: "tool_use", id: "toolu_1", name: "Write", input: {} }],
+          },
+        },
+      ],
+      finalTextStream(),
+    ]);
+    const agent = new AgentBuilder("test-agent", model).tool(writeTool(toolCalls)).build();
+
+    const events = await collect(agent.prompt("write").stream());
+
+    expect(events).toContainEqual({
+      type: "tool_call",
+      turn: 1,
+      toolCall: AssistantContent.toolCall("toolu_1", "Write", {
+        file_path: "src/main.tsx",
+        content: "hello",
+      }),
+    });
+    expect(toolCalls).toEqual([{ file_path: "src/main.tsx", content: "hello" }]);
+  });
+
+  it("keeps streamed start-block tool arguments when the final message has empty tool input", async () => {
+    const toolCalls: unknown[] = [];
+    const model = anthropicModelWithStreams([
+      [
+        { type: "message_start", message: { id: "msg_1" } },
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: {
+            type: "tool_use",
+            id: "toolu_1",
+            name: "Write",
+            input: { file_path: "src/main.tsx", content: "hello" },
+          },
+        },
+        {
+          type: "message_stop",
+          message: {
+            id: "msg_1",
+            content: [{ type: "tool_use", id: "toolu_1", name: "Write", input: {} }],
+          },
+        },
+      ],
+      finalTextStream(),
+    ]);
+    const agent = new AgentBuilder("test-agent", model).tool(writeTool(toolCalls)).build();
+
+    const events = await collect(agent.prompt("write").stream());
+
+    expect(events).toContainEqual({
+      type: "tool_call",
+      turn: 1,
+      toolCall: AssistantContent.toolCall("toolu_1", "Write", {
+        file_path: "src/main.tsx",
+        content: "hello",
+      }),
+    });
+    expect(toolCalls).toEqual([{ file_path: "src/main.tsx", content: "hello" }]);
+  });
 });
 
 async function collectStreamEvents(events: unknown[]): Promise<CompletionStreamEvent[]> {
@@ -443,10 +528,67 @@ async function collectStreamEvents(events: unknown[]): Promise<CompletionStreamE
   return mapped;
 }
 
+function anthropicModelWithStreams(streams: unknown[][]): AnthropicCompletionModel {
+  return new AnthropicCompletionModel(
+    {
+      messages: {
+        create: async () => streamFrom(streams.shift() ?? []),
+      },
+    } as never,
+    "claude-test",
+  );
+}
+
+function writeTool(calls: unknown[]): Tool {
+  return {
+    name: "Write",
+    definition() {
+      return {
+        name: "Write",
+        description: "Write a file",
+        parameters: {
+          type: "object",
+          properties: {
+            file_path: { type: "string" },
+            content: { type: "string" },
+          },
+          required: ["file_path", "content"],
+        },
+      };
+    },
+    call(args) {
+      calls.push(args);
+      return "written";
+    },
+  };
+}
+
+function finalTextStream(): unknown[] {
+  return [
+    { type: "message_start", message: { id: "msg_2" } },
+    { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "done" } },
+    {
+      type: "message_stop",
+      message: {
+        id: "msg_2",
+        content: [{ type: "text", text: "done" }],
+      },
+    },
+  ];
+}
+
 async function* streamFrom(events: unknown[]): AsyncIterable<unknown> {
   for (const event of events) {
     yield event;
   }
+}
+
+async function collect<T>(events: AsyncIterable<T>): Promise<T[]> {
+  const result: T[] = [];
+  for await (const event of events) {
+    result.push(event);
+  }
+  return result;
 }
 
 function accumulatedToolArguments(events: CompletionStreamEvent[], id: string): unknown {

--- a/packages/tools/studio/src/storage/sqlite-store.ts
+++ b/packages/tools/studio/src/storage/sqlite-store.ts
@@ -37,13 +37,13 @@ import type {
   StudioTranscriptEntry,
 } from "../types";
 
-const { DatabaseSync } = createRequire(import.meta.url)(
-  "node:sqlite",
-) as typeof import("node:sqlite");
-
 export type SqliteSessionStoreOptions = {
   path?: string;
 };
+
+type DatabaseSyncConstructor = typeof DatabaseSyncType;
+
+let DatabaseSync: DatabaseSyncConstructor | undefined;
 
 type SessionRow = {
   id: string;
@@ -827,7 +827,7 @@ class SqliteSessionStore
       mkdirSync(dirname(resolve(this.path)), { recursive: true });
     }
 
-    const db = new DatabaseSync(this.path, {
+    const db = new (loadDatabaseSync())(this.path, {
       allowUnknownNamedParameters: true,
       timeout: 5000,
     });
@@ -1238,6 +1238,24 @@ function guardAgainstLegacySessionSchema(db: DatabaseSyncType): void {
   if (columns.some((column) => column.name === "messages_json")) {
     throw new Error(
       "Existing Studio SQLite DB uses the legacy messages_json schema. Delete or recreate the Studio SQLite DB to use normalized session messages.",
+    );
+  }
+}
+
+function loadDatabaseSync(): DatabaseSyncConstructor {
+  if (DatabaseSync !== undefined) {
+    return DatabaseSync;
+  }
+
+  try {
+    ({ DatabaseSync } = createRequire(import.meta.url)(
+      "node:sqlite",
+    ) as typeof import("node:sqlite"));
+    return DatabaseSync;
+  } catch (error) {
+    throw new Error(
+      "The default Studio SQLite store requires Node.js with node:sqlite support. Provide custom Studio stores or disable persisted stores when running Studio in a runtime without node:sqlite.",
+      { cause: error },
     );
   }
 }


### PR DESCRIPTION
## Summary
- Lazy-load Studio's default SQLite store so importing @anvia/studio does not require node:sqlite in Bun-compatible runtimes.
- Reconcile streamed tool-call arguments in @anvia/core so accumulated non-empty args are not overwritten by empty final provider tool inputs.
- Add core accumulator tests and Anthropic-compatible streaming acceptance tests for MiniMax-style final messages.

## Validation
- pnpm --filter @anvia/studio typecheck
- pnpm --filter @anvia/studio test
- pnpm --filter @anvia/studio build
- bun -e "await import('./packages/tools/studio/dist/index.js')"
- pnpm --filter @anvia/core typecheck
- pnpm --filter @anvia/core test
- pnpm --filter @anvia/core build
- pnpm --filter @anvia/anthropic typecheck
- pnpm --filter @anvia/anthropic test
- pnpm --filter @anvia/anthropic build
- pnpm exec biome check ...
- git diff --check

Fixes #30