### PR TITLE
Add generated changelog docs and GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,3 +97,8 @@ jobs:
 
       - name: Push release tags
         run: git push --follow-tags
+
+      - name: Create GitHub Releases
+        run: pnpm github-releases
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/docs/content/docs/changelog/anthropic.mdx
+++ b/apps/docs/content/docs/changelog/anthropic.mdx
@@ -1,0 +1,23 @@
+---
+title: "@anvia/anthropic"
+description: "Release notes for @anvia/anthropic."
+---
+
+# `@anvia/anthropic`
+
+Anthropic provider adapter for Anvia.
+
+Source: [`packages/providers/anthropic/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/providers/anthropic/CHANGELOG.md)
+
+## 0.1.9
+
+### Patch Changes
+
+- 896ae21: Update upstream provider and runtime dependencies.
+
+## 0.1.8
+
+### Patch Changes
+
+- 1ad360d: Fix Anthropic-compatible streaming tool inputs and update provider dependencies.
+

--- a/apps/docs/content/docs/changelog/chroma.mdx
+++ b/apps/docs/content/docs/changelog/chroma.mdx
@@ -1,0 +1,18 @@
+---
+title: "@anvia/chroma"
+description: "Release notes for @anvia/chroma."
+---
+
+# `@anvia/chroma`
+
+ChromaDB vector store adapter for Anvia.
+
+Source: [`packages/vector-stores/chroma/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/vector-stores/chroma/CHANGELOG.md)
+
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies [a0a5def]
+  - @anvia/core@0.2.4
+

--- a/apps/docs/content/docs/changelog/core.mdx
+++ b/apps/docs/content/docs/changelog/core.mdx
@@ -1,0 +1,17 @@
+---
+title: "@anvia/core"
+description: "Release notes for @anvia/core."
+---
+
+# `@anvia/core`
+
+Core runtime primitives for context-aware Anvia agents.
+
+Source: [`packages/core/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/core/CHANGELOG.md)
+
+## 0.2.4
+
+### Patch Changes
+
+- a0a5def: Preserve accumulated streamed tool arguments when a provider final response contains an empty tool input.
+

--- a/apps/docs/content/docs/changelog/fastembed.mdx
+++ b/apps/docs/content/docs/changelog/fastembed.mdx
@@ -1,0 +1,18 @@
+---
+title: "@anvia/fastembed"
+description: "Release notes for @anvia/fastembed."
+---
+
+# `@anvia/fastembed`
+
+FastEmbed embedding model adapter for Anvia.
+
+Source: [`packages/embeddings/fastembed/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/embeddings/fastembed/CHANGELOG.md)
+
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies [a0a5def]
+  - @anvia/core@0.2.4
+

--- a/apps/docs/content/docs/changelog/gemini.mdx
+++ b/apps/docs/content/docs/changelog/gemini.mdx
@@ -1,0 +1,23 @@
+---
+title: "@anvia/gemini"
+description: "Release notes for @anvia/gemini."
+---
+
+# `@anvia/gemini`
+
+Gemini provider adapter for Anvia.
+
+Source: [`packages/providers/gemini/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/providers/gemini/CHANGELOG.md)
+
+## 0.1.8
+
+### Patch Changes
+
+- 896ae21: Update upstream provider and runtime dependencies.
+
+## 0.1.7
+
+### Patch Changes
+
+- 1ad360d: Fix Anthropic-compatible streaming tool inputs and update provider dependencies.
+

--- a/apps/docs/content/docs/changelog/index.mdx
+++ b/apps/docs/content/docs/changelog/index.mdx
@@ -1,0 +1,51 @@
+---
+title: Package Changelog
+description: Release history for Anvia packages.
+---
+
+Anvia package release notes are generated from the package changelog files maintained by Changesets.
+
+Developers should keep writing release notes with `pnpm changeset`. The docs pages in this section are generated from `packages/**/CHANGELOG.md`.
+
+## Core
+
+| Package | Current version | Release notes |
+| --- | --- | --- |
+| `@anvia/core` | `0.2.4` | [View changelog](/docs/changelog/core) |
+
+## Providers
+
+| Package | Current version | Release notes |
+| --- | --- | --- |
+| `@anvia/anthropic` | `0.1.9` | [View changelog](/docs/changelog/anthropic) |
+| `@anvia/gemini` | `0.1.8` | [View changelog](/docs/changelog/gemini) |
+| `@anvia/mistral` | `0.1.4` | [View changelog](/docs/changelog/mistral) |
+| `@anvia/openai` | `0.1.10` | [View changelog](/docs/changelog/openai) |
+
+## Embeddings
+
+| Package | Current version | Release notes |
+| --- | --- | --- |
+| `@anvia/fastembed` | `0.1.2` | [View changelog](/docs/changelog/fastembed) |
+| `@anvia/transformers` | `0.1.2` | [View changelog](/docs/changelog/transformers) |
+
+## Vector Stores
+
+| Package | Current version | Release notes |
+| --- | --- | --- |
+| `@anvia/chroma` | `0.1.2` | [View changelog](/docs/changelog/chroma) |
+| `@anvia/pgvector` | `0.1.4` | [View changelog](/docs/changelog/pgvector) |
+| `@anvia/qdrant` | `0.1.2` | [View changelog](/docs/changelog/qdrant) |
+
+## Observability
+
+| Package | Current version | Release notes |
+| --- | --- | --- |
+| `@anvia/langfuse` | `0.1.5` | [View changelog](/docs/changelog/langfuse) |
+| `@anvia/otel` | `0.1.3` | [View changelog](/docs/changelog/otel) |
+
+## Tools
+
+| Package | Current version | Release notes |
+| --- | --- | --- |
+| `@anvia/studio` | `0.2.8` | [View changelog](/docs/changelog/studio) |

--- a/apps/docs/content/docs/changelog/langfuse.mdx
+++ b/apps/docs/content/docs/changelog/langfuse.mdx
@@ -1,0 +1,17 @@
+---
+title: "@anvia/langfuse"
+description: "Release notes for @anvia/langfuse."
+---
+
+# `@anvia/langfuse`
+
+Langfuse tracing adapter for Anvia.
+
+Source: [`packages/observability/langfuse/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/observability/langfuse/CHANGELOG.md)
+
+## No release notes yet
+
+`@anvia/langfuse` is public, but `packages/observability/langfuse/CHANGELOG.md` does not exist yet.
+
+Release notes will appear here after the next Changesets version bump creates the package changelog.
+

--- a/apps/docs/content/docs/changelog/meta.json
+++ b/apps/docs/content/docs/changelog/meta.json
@@ -1,0 +1,30 @@
+{
+  "title": "Changelog",
+  "description": "Package release notes",
+  "icon": "History",
+  "root": true,
+  "defaultOpen": false,
+  "collapsible": true,
+  "pages": [
+    "index",
+    "---Core---",
+    "core",
+    "---Providers---",
+    "anthropic",
+    "gemini",
+    "mistral",
+    "openai",
+    "---Embeddings---",
+    "fastembed",
+    "transformers",
+    "---Vector Stores---",
+    "chroma",
+    "pgvector",
+    "qdrant",
+    "---Observability---",
+    "langfuse",
+    "otel",
+    "---Tools---",
+    "studio"
+  ]
+}

--- a/apps/docs/content/docs/changelog/mistral.mdx
+++ b/apps/docs/content/docs/changelog/mistral.mdx
@@ -1,0 +1,18 @@
+---
+title: "@anvia/mistral"
+description: "Release notes for @anvia/mistral."
+---
+
+# `@anvia/mistral`
+
+Mistral provider adapter for Anvia.
+
+Source: [`packages/providers/mistral/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/providers/mistral/CHANGELOG.md)
+
+## 0.1.4
+
+### Patch Changes
+
+- Updated dependencies [a0a5def]
+  - @anvia/core@0.2.4
+

--- a/apps/docs/content/docs/changelog/openai.mdx
+++ b/apps/docs/content/docs/changelog/openai.mdx
@@ -1,0 +1,30 @@
+---
+title: "@anvia/openai"
+description: "Release notes for @anvia/openai."
+---
+
+# `@anvia/openai`
+
+OpenAI provider adapter for Anvia.
+
+Source: [`packages/providers/openai/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/providers/openai/CHANGELOG.md)
+
+## 0.1.10
+
+### Patch Changes
+
+- Updated dependencies [a0a5def]
+  - @anvia/core@0.2.4
+
+## 0.1.9
+
+### Patch Changes
+
+- 1f7d3aa: Republish packages with registry-safe dependency metadata.
+
+## 0.1.8
+
+### Patch Changes
+
+- 1ad360d: Fix Anthropic-compatible streaming tool inputs and update provider dependencies.
+

--- a/apps/docs/content/docs/changelog/otel.mdx
+++ b/apps/docs/content/docs/changelog/otel.mdx
@@ -1,0 +1,18 @@
+---
+title: "@anvia/otel"
+description: "Release notes for @anvia/otel."
+---
+
+# `@anvia/otel`
+
+OpenTelemetry tracing adapter for Anvia.
+
+Source: [`packages/observability/otel/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/observability/otel/CHANGELOG.md)
+
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies [a0a5def]
+  - @anvia/core@0.2.4
+

--- a/apps/docs/content/docs/changelog/pgvector.mdx
+++ b/apps/docs/content/docs/changelog/pgvector.mdx
@@ -1,0 +1,30 @@
+---
+title: "@anvia/pgvector"
+description: "Release notes for @anvia/pgvector."
+---
+
+# `@anvia/pgvector`
+
+Postgres pgvector store adapter for Anvia.
+
+Source: [`packages/vector-stores/pgvector/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/vector-stores/pgvector/CHANGELOG.md)
+
+## 0.1.4
+
+### Patch Changes
+
+- Updated dependencies [a0a5def]
+  - @anvia/core@0.2.4
+
+## 0.1.3
+
+### Patch Changes
+
+- 1f7d3aa: Republish packages with registry-safe dependency metadata.
+
+## 0.1.2
+
+### Patch Changes
+
+- 1ad360d: Fix Anthropic-compatible streaming tool inputs and update provider dependencies.
+

--- a/apps/docs/content/docs/changelog/qdrant.mdx
+++ b/apps/docs/content/docs/changelog/qdrant.mdx
@@ -1,0 +1,18 @@
+---
+title: "@anvia/qdrant"
+description: "Release notes for @anvia/qdrant."
+---
+
+# `@anvia/qdrant`
+
+Qdrant vector store adapter for Anvia.
+
+Source: [`packages/vector-stores/qdrant/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/vector-stores/qdrant/CHANGELOG.md)
+
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies [a0a5def]
+  - @anvia/core@0.2.4
+

--- a/apps/docs/content/docs/changelog/studio.mdx
+++ b/apps/docs/content/docs/changelog/studio.mdx
@@ -1,0 +1,43 @@
+---
+title: "@anvia/studio"
+description: "Release notes for @anvia/studio."
+---
+
+# `@anvia/studio`
+
+Studio UI and HTTP runtime for Anvia agents.
+
+Source: [`packages/tools/studio/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/tools/studio/CHANGELOG.md)
+
+## 0.2.8
+
+### Patch Changes
+
+- 896ae21: Update upstream provider and runtime dependencies.
+
+## 0.2.7
+
+### Patch Changes
+
+- a0a5def: Lazy-load the default SQLite store so importing Studio does not require `node:sqlite` in Bun-compatible runtimes.
+- Updated dependencies [a0a5def]
+  - @anvia/core@0.2.4
+
+## 0.2.6
+
+### Patch Changes
+
+- 1f7d3aa: Republish packages with registry-safe dependency metadata.
+
+## 0.2.5
+
+### Patch Changes
+
+- 1ad360d: Fix Anthropic-compatible streaming tool inputs and update provider dependencies.
+
+## 0.2.4
+
+### Patch Changes
+
+- 1e5b78d: Polish the Studio UI with updated sidebar, page surfaces, tracing views, playground logs, transcript auto-scroll, and full-width markdown tables.
+

--- a/apps/docs/content/docs/changelog/transformers.mdx
+++ b/apps/docs/content/docs/changelog/transformers.mdx
@@ -1,0 +1,18 @@
+---
+title: "@anvia/transformers"
+description: "Release notes for @anvia/transformers."
+---
+
+# `@anvia/transformers`
+
+Transformers.js embedding model adapter for Anvia.
+
+Source: [`packages/embeddings/transformers/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/embeddings/transformers/CHANGELOG.md)
+
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies [a0a5def]
+  - @anvia/core@0.2.4
+

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Anvia",
-  "pages": ["guides", "best-practices", "frameworks", "models", "studio", "reference"]
+  "pages": ["guides", "best-practices", "frameworks", "models", "studio", "reference", "changelog"]
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -4,13 +4,14 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "vite build",
+    "build": "pnpm run changelog:generate && vite build",
+    "changelog:generate": "node scripts/generate-changelogs.mjs",
     "cf-typegen": "wrangler types",
     "deploy": "pnpm run build && wrangler deploy",
-    "dev": "vite dev",
+    "dev": "pnpm run changelog:generate && vite dev",
     "preview": "vite preview",
     "reference-check": "node scripts/check-reference-coverage.mjs",
-    "typecheck": "pnpm run reference-check && fumadocs-mdx && tsr generate && tsc --noEmit"
+    "typecheck": "pnpm run changelog:generate && pnpm run reference-check && fumadocs-mdx && tsr generate && tsc --noEmit"
   },
   "dependencies": {
     "@tanstack/react-router": "^1.168.26",

--- a/apps/docs/scripts/generate-changelogs.mjs
+++ b/apps/docs/scripts/generate-changelogs.mjs
@@ -1,0 +1,208 @@
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(scriptDir, "../../..");
+const packagesRoot = join(repoRoot, "packages");
+const outputDir = join(repoRoot, "apps/docs/content/docs/changelog");
+
+const groupOrder = ["core", "providers", "embeddings", "vector-stores", "observability", "tools"];
+const groupTitles = new Map([
+  ["core", "Core"],
+  ["providers", "Providers"],
+  ["embeddings", "Embeddings"],
+  ["vector-stores", "Vector Stores"],
+  ["observability", "Observability"],
+  ["tools", "Tools"],
+]);
+
+const packages = discoverPackages()
+  .filter(({ pkg }) => pkg.private !== true)
+  .filter(({ pkg }) => typeof pkg.name === "string" && typeof pkg.version === "string")
+  .sort((a, b) => {
+    const groupDiff = groupRank(a.group) - groupRank(b.group);
+    return groupDiff === 0 ? a.pkg.name.localeCompare(b.pkg.name) : groupDiff;
+  });
+
+rmSync(outputDir, { recursive: true, force: true });
+mkdirSync(outputDir, { recursive: true });
+
+writeFileSync(join(outputDir, "meta.json"), `${JSON.stringify(createMeta(packages), null, 2)}\n`);
+writeFileSync(join(outputDir, "index.mdx"), createIndex(packages));
+
+for (const item of packages) {
+  writeFileSync(join(outputDir, `${item.slug}.mdx`), createPackagePage(item));
+}
+
+console.info(
+  `Generated ${packages.length + 2} changelog docs files in ${relative(repoRoot, outputDir)}`,
+);
+
+function discoverPackages() {
+  return findPackageDirs(packagesRoot).map((dir) => {
+    const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
+    const pathParts = relative(packagesRoot, dir).split("/");
+
+    return {
+      dir,
+      pkg,
+      group: pathParts[0],
+      slug: packageSlug(pkg.name),
+      changelogPath: join(dir, "CHANGELOG.md"),
+    };
+  });
+}
+
+function findPackageDirs(dir) {
+  const entries = readdirSync(dir).sort();
+  const dirs = [];
+
+  for (const entry of entries) {
+    const entryPath = join(dir, entry);
+    if (!statSync(entryPath).isDirectory()) continue;
+
+    if (existsSync(join(entryPath, "package.json"))) {
+      dirs.push(entryPath);
+      continue;
+    }
+
+    dirs.push(...findPackageDirs(entryPath));
+  }
+
+  return dirs;
+}
+
+function packageSlug(name) {
+  return name.replace(/^@anvia\//, "").replaceAll("/", "-");
+}
+
+function createMeta(items) {
+  const pages = ["index"];
+
+  for (const group of orderedGroups(items)) {
+    const groupItems = items.filter((item) => item.group === group);
+    if (groupItems.length === 0) continue;
+
+    pages.push(`---${groupTitles.get(group) ?? titleCase(group)}---`);
+    pages.push(...groupItems.map((item) => item.slug));
+  }
+
+  return {
+    title: "Changelog",
+    description: "Package release notes",
+    icon: "History",
+    root: true,
+    defaultOpen: false,
+    collapsible: true,
+    pages,
+  };
+}
+
+function createIndex(items) {
+  const sections = [];
+
+  for (const group of orderedGroups(items)) {
+    const groupItems = items.filter((item) => item.group === group);
+    if (groupItems.length === 0) continue;
+
+    sections.push(`## ${groupTitles.get(group) ?? titleCase(group)}
+
+| Package | Current version | Release notes |
+| --- | --- | --- |
+${groupItems
+  .map(
+    (item) =>
+      `| \`${item.pkg.name}\` | \`${item.pkg.version}\` | [View changelog](/docs/changelog/${item.slug}) |`,
+  )
+  .join("\n")}`);
+  }
+
+  return `---
+title: Package Changelog
+description: Release history for Anvia packages.
+---
+
+Anvia package release notes are generated from the package changelog files maintained by Changesets.
+
+Developers should keep writing release notes with \`pnpm changeset\`. The docs pages in this section are generated from \`packages/**/CHANGELOG.md\`.
+
+${sections.join("\n\n")}
+`;
+}
+
+function createPackagePage(item) {
+  const relativeChangelogPath = relative(repoRoot, item.changelogPath);
+  const sourceUrl = `https://github.com/anvia-hq/anvia/blob/main/${relativeChangelogPath}`;
+  const body = existsSync(item.changelogPath)
+    ? normalizeChangelog(readFileSync(item.changelogPath, "utf8"), item.pkg.name)
+    : missingChangelog(item);
+
+  return `---
+title: ${frontmatterString(item.pkg.name)}
+description: ${frontmatterString(`Release notes for ${item.pkg.name}.`)}
+---
+
+# \`${item.pkg.name}\`
+
+${item.pkg.description}
+
+Source: [\`${relativeChangelogPath}\`](${sourceUrl})
+
+${body}
+`;
+}
+
+function normalizeChangelog(content, packageName) {
+  const trimmed = content.trim();
+  if (trimmed.length === 0) {
+    return "No release notes have been recorded yet.\n";
+  }
+
+  return `${trimmed.replace(new RegExp(`^# ${escapeRegExp(packageName)}\\s*\\n+`), "")}\n`;
+}
+
+function missingChangelog(item) {
+  return `## No release notes yet
+
+\`${item.pkg.name}\` is public, but \`${relative(repoRoot, item.changelogPath)}\` does not exist yet.
+
+Release notes will appear here after the next Changesets version bump creates the package changelog.
+`;
+}
+
+function titleCase(value) {
+  return value
+    .split("-")
+    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
+    .join(" ");
+}
+
+function orderedGroups(items) {
+  const discovered = [...new Set(items.map((item) => item.group))];
+  return discovered.sort((a, b) => {
+    const rankDiff = groupRank(a) - groupRank(b);
+    return rankDiff === 0 ? a.localeCompare(b) : rankDiff;
+  });
+}
+
+function groupRank(group) {
+  const index = groupOrder.indexOf(group);
+  return index === -1 ? groupOrder.length : index;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function frontmatterString(value) {
+  return JSON.stringify(value);
+}

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "cookbook:multimodal:03": "pnpm --filter cookbook multimodal:03",
     "docs:typecheck": "pnpm --filter docs typecheck",
     "changeset": "changeset",
+    "github-releases": "node scripts/create-github-releases.mjs",
     "version-packages": "changeset version",
     "release": "pnpm --filter @anvia/core build && pnpm --filter './packages/**' --filter '!@anvia/core' build && node scripts/publish-packages.mjs",
     "check": "biome check .",

--- a/scripts/create-github-releases.mjs
+++ b/scripts/create-github-releases.mjs
@@ -1,0 +1,182 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const packagesRoot = path.join(root, "packages");
+const dryRun = process.argv.includes("--dry-run");
+const repository = process.env.GITHUB_REPOSITORY ?? getRepositoryFromGitRemote();
+const token = process.env.GITHUB_TOKEN;
+
+if (repository === undefined) {
+  throw new Error("GITHUB_REPOSITORY is not set and the GitHub repository could not be inferred.");
+}
+
+if (!dryRun && (token === undefined || token.length === 0)) {
+  throw new Error("GITHUB_TOKEN is required to create GitHub Releases. Use --dry-run to preview.");
+}
+
+const packages = findPackageDirs(packagesRoot)
+  .map((dir) => ({ dir, packageJson: readPackageJson(dir) }))
+  .filter((pkg) => pkg.packageJson.private !== true)
+  .filter((pkg) => typeof pkg.packageJson.name === "string")
+  .filter((pkg) => typeof pkg.packageJson.version === "string")
+  .sort((a, b) => a.packageJson.name.localeCompare(b.packageJson.name));
+
+for (const pkg of packages) {
+  const { name, version } = pkg.packageJson;
+  const tagName = `${name}@${version}`;
+
+  if (!tagExists(tagName)) {
+    console.warn(`Skipping ${tagName}: local git tag does not exist.`);
+    continue;
+  }
+
+  if (!dryRun && (await releaseExists(tagName))) {
+    console.info(`Skipping ${tagName}: GitHub Release already exists.`);
+    continue;
+  }
+
+  const body = releaseBody(pkg, tagName);
+  if (dryRun) {
+    console.info(`[dry-run] Would create GitHub Release ${tagName}`);
+    continue;
+  }
+
+  await createRelease({ tagName, name: tagName, body });
+  console.info(`Created GitHub Release ${tagName}`);
+}
+
+function findPackageDirs(dir) {
+  const entries = readdirSync(dir).sort();
+  const dirs = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry);
+    if (!statSync(entryPath).isDirectory()) continue;
+
+    if (existsSync(path.join(entryPath, "package.json"))) {
+      dirs.push(entryPath);
+      continue;
+    }
+
+    dirs.push(...findPackageDirs(entryPath));
+  }
+
+  return dirs;
+}
+
+function readPackageJson(dir) {
+  return JSON.parse(readFileSync(path.join(dir, "package.json"), "utf8"));
+}
+
+function tagExists(tagName) {
+  const result = spawnSync("git", ["rev-parse", "--quiet", "--verify", `refs/tags/${tagName}`], {
+    cwd: root,
+    stdio: "ignore",
+  });
+
+  return result.status === 0;
+}
+
+async function releaseExists(tagName) {
+  const response = await githubFetch(
+    `/repos/${repository}/releases/tags/${encodeURIComponent(tagName)}`,
+    {
+      method: "GET",
+    },
+  );
+
+  if (response.status === 200) return true;
+  if (response.status === 404) return false;
+
+  throw new Error(
+    `Failed checking GitHub Release ${tagName}: ${response.status} ${await response.text()}`,
+  );
+}
+
+async function createRelease({ tagName, name, body }) {
+  const response = await githubFetch(`/repos/${repository}/releases`, {
+    method: "POST",
+    body: JSON.stringify({
+      tag_name: tagName,
+      name,
+      body,
+      draft: false,
+      prerelease: isPrereleaseVersion(tagName),
+    }),
+  });
+
+  if (response.status !== 201) {
+    throw new Error(
+      `Failed creating GitHub Release ${tagName}: ${response.status} ${await response.text()}`,
+    );
+  }
+}
+
+function releaseBody(pkg, tagName) {
+  const changelogPath = path.join(pkg.dir, "CHANGELOG.md");
+  const relativeChangelogPath = path.relative(root, changelogPath);
+  if (!existsSync(changelogPath)) {
+    return `Release notes for ${tagName} were not found in \`${relativeChangelogPath}\`.`;
+  }
+
+  const entry = extractChangelogEntry(readFileSync(changelogPath, "utf8"), pkg.packageJson.version);
+  if (entry === undefined) {
+    return `Release notes for ${tagName} were not found in \`${relativeChangelogPath}\`.`;
+  }
+
+  return entry;
+}
+
+function extractChangelogEntry(changelog, version) {
+  const lines = changelog.split(/\r?\n/);
+  const headingPattern = new RegExp(`^##\\s+\\[?${escapeRegExp(version)}\\]?\\b`);
+  const nextHeadingPattern = /^##\s+/;
+  const start = lines.findIndex((line) => headingPattern.test(line));
+
+  if (start === -1) return undefined;
+
+  const end = lines.findIndex((line, index) => index > start && nextHeadingPattern.test(line));
+  const body = lines
+    .slice(start, end === -1 ? lines.length : end)
+    .join("\n")
+    .trim();
+
+  return body.length > 0 ? body : undefined;
+}
+
+function isPrereleaseVersion(tagName) {
+  const version = tagName.slice(tagName.lastIndexOf("@") + 1);
+  return version.includes("-");
+}
+
+async function githubFetch(pathname, options) {
+  return fetch(`https://api.github.com${pathname}`, {
+    ...options,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      ...options.headers,
+    },
+  });
+}
+
+function getRepositoryFromGitRemote() {
+  const result = spawnSync("git", ["config", "--get", "remote.origin.url"], {
+    cwd: root,
+    encoding: "utf8",
+  });
+
+  if (result.status !== 0) return undefined;
+
+  const remote = result.stdout.trim();
+  const match = remote.match(/github\.com[:/](.+?\/.+?)(?:\.git)?$/);
+  return match?.[1];
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
## Summary
- generate docs changelog pages from public package CHANGELOG.md files
- wire changelog generation into docs dev/typecheck/build scripts
- create package-specific GitHub Releases after manual npm publish pushes tags

## Testing
- pnpm --filter docs typecheck
- pnpm --filter docs build
- pnpm github-releases -- --dry-run