### PR TITLE
Add multimodal tool results

### DIFF
--- a/.changeset/large-screens-tell.md
+++ b/.changeset/large-screens-tell.md
@@ -1,0 +1,17 @@
+---
+"@anvia/core": minor
+"@anvia/openai": minor
+"@anvia/anthropic": minor
+"@anvia/studio": patch
+"@anvia/gemini": patch
+"@anvia/mistral": patch
+"@anvia/langfuse": patch
+---
+
+Add first-class multimodal tool result support.
+
+Tools can now return `ToolResultContent[]` directly, or use `ToolOutput.content(...)`, and agent execution will pass structured text/image tool results to model turns instead of JSON-stringifying them. Tool middleware, hooks, observers, stream events, and Studio transcript surfaces keep the existing display string while exposing optional structured result content.
+
+OpenAI Responses and Anthropic now serialize multimodal tool result images as provider-visible image blocks. Text-only provider fallbacks render image results as media-type placeholders instead of raw base64.
+
+Update provider and tracing wrapper dependencies to the latest checked upstream releases.

--- a/apps/docs/content/docs/reference/core/tools.mdx
+++ b/apps/docs/content/docs/reference/core/tools.mdx
@@ -193,15 +193,20 @@ Notable errors: validation errors can occur if the model calls it with invalid a
 ## Serialization Helpers
 
 ```ts
+type NormalizedToolOutput = string | ToolResultContent[];
+
 function serializeToolOutput(output: unknown): string;
+function isToolResultContentArray(value: unknown): value is ToolResultContent[];
+function normalizeToolResultOutput(output: unknown): NormalizedToolOutput;
+function toolResultContentToText(content: ToolResultContent[]): string;
 function parseToolArgs(args: string): JsonValue;
 ```
 
 Purpose: convert tool outputs and model-supplied argument strings.
 
-Return behavior: `parseToolArgs("")` returns `{}`; `serializeToolOutput(...)` returns strings unchanged and JSON-stringifies other values.
+Return behavior: `parseToolArgs("")` returns `{}`; `serializeToolOutput(...)` returns strings unchanged and JSON-stringifies other values. `normalizeToolResultOutput(...)` preserves `ToolResultContent[]` for multimodal tool results and serializes other values to text. `toolResultContentToText(...)` creates a display string for structured tool result content, rendering image blocks as media-type placeholders.
 
-Notable errors: `parseToolArgs(...)` throws `SyntaxError` for invalid JSON.
+Notable errors: `parseToolArgs(...)` throws `SyntaxError` for invalid JSON. `isToolResultContentArray(...)` only recognizes text and image tool result blocks.
 
 ## Error Classes
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -13,7 +13,7 @@ import { createTool } from "../tool/create-tool";
 import type { ToolSearchDocument } from "../tool/dynamic-tools";
 import type { ToolMiddleware } from "../tool/middleware";
 import { isSkillTool } from "../tool/skill-tool-marker";
-import type { AnyTool, Tool, ToolCallContext } from "../tool/tool";
+import type { AnyTool, NormalizedToolOutput, Tool, ToolCallContext } from "../tool/tool";
 import { ToolSet } from "../tool/tool-set";
 import type { VectorFilter, VectorSearchIndex, VectorSearchResult } from "../vector-store";
 import type { PromptHook } from "./hooks";
@@ -227,7 +227,11 @@ export class Agent<M extends CompletionModel = CompletionModel> {
     return undefined;
   }
 
-  async callTool(toolName: string, args: string, context?: ToolCallContext): Promise<string> {
+  async callTool(
+    toolName: string,
+    args: string,
+    context?: ToolCallContext,
+  ): Promise<NormalizedToolOutput> {
     if (this.toolSet.contains(toolName)) {
       return this.toolSet.call(toolName, args, context);
     }

--- a/packages/core/src/agent/hooks.ts
+++ b/packages/core/src/agent/hooks.ts
@@ -1,4 +1,4 @@
-import type { CompletionResponse, Message } from "../completion/index";
+import type { CompletionResponse, Message, ToolResultContent } from "../completion/index";
 
 export type HookAction = { type: "continue" } | { type: "terminate"; reason: string };
 export type ToolApprovalRequestOptions = {
@@ -59,6 +59,7 @@ export type ToolCallHookArgs = ToolHookArgs & {
 
 export type ToolResultHookArgs = ToolHookArgs & {
   result: string;
+  structuredResult?: ToolResultContent[] | undefined;
   run: RunControl;
 };
 

--- a/packages/core/src/agent/request.ts
+++ b/packages/core/src/agent/request.ts
@@ -12,6 +12,7 @@ import {
   ToolContent,
   type ToolDefinition,
   type ToolResult,
+  type ToolResultContent,
   textFromAssistantContent,
   Usage,
 } from "../completion/index";
@@ -23,7 +24,12 @@ import {
 } from "../observability/group";
 import type { AgentTraceInfo, AgentTraceOptions } from "../observability/types";
 import { toReadableStream } from "../streaming";
-import type { AnyTool, ToolCallStreamEvent } from "../tool";
+import {
+  type AnyTool,
+  type NormalizedToolOutput,
+  type ToolCallStreamEvent,
+  toolResultContentToText,
+} from "../tool";
 import type { ToolMiddleware, ToolResultMiddlewareArgs } from "../tool/middleware";
 import type { Agent } from "./agent";
 import { MaxTurnsError, PromptCancelledError } from "./errors";
@@ -74,6 +80,7 @@ export type AgentChildStreamEvent<RawResponse = unknown> =
       internalCallId: string;
       args: string;
       result: string;
+      structuredResult?: ToolResultContent[] | undefined;
     }
   | {
       type: "turn_end";
@@ -556,7 +563,7 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
         throw this.cancelled(newMessages, reason);
       }
 
-      let output: string;
+      let output: NormalizedToolOutput;
       let skipped = false;
       if (callAction?.type === "skip") {
         output = callAction.reason;
@@ -585,18 +592,28 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
         }
       }
 
+      let result = toolOutputToText(output);
+      let structuredResult = toolOutputToStructuredResult(output);
       if (this.agent.shouldApplyToolMiddleware(toolCall.function.name)) {
-        output = await this.runToolResultMiddlewares({
+        const middlewareReplacement = await this.runToolResultMiddlewares({
           ...hookArgs,
-          result: output,
-          originalResult: output,
+          result,
+          originalResult: result,
+          structuredResult,
+          originalStructuredResult: structuredResult,
           turn: observation?.turn ?? 0,
         });
+        if (middlewareReplacement !== undefined) {
+          output = middlewareReplacement;
+          result = middlewareReplacement;
+          structuredResult = undefined;
+        }
       }
 
       const resultAction = await this.activeHook?.onToolResult?.({
         ...hookArgs,
-        result: output,
+        result,
+        structuredResult,
         run: runControl,
       });
       await toolObservers?.end({
@@ -605,7 +622,8 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
         toolName: toolCall.function.name,
         internalCallId,
         args,
-        result: output,
+        result,
+        structuredResult,
         skipped,
         toolCallId: toolCall.callId,
       });
@@ -618,7 +636,8 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
         toolName: toolCall.function.name,
         internalCallId,
         args,
-        result: output,
+        result,
+        structuredResult,
       };
       if (toolCall.callId !== undefined) {
         resultPayload.toolCallId = toolCall.callId;
@@ -628,8 +647,11 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
     });
   }
 
-  private async runToolResultMiddlewares(args: ToolResultMiddlewareArgs): Promise<string> {
+  private async runToolResultMiddlewares(
+    args: ToolResultMiddlewareArgs,
+  ): Promise<string | undefined> {
     let result = args.result;
+    let replaced = false;
     for (const middleware of [...this.agent.toolMiddlewares, ...this.requestToolMiddlewares]) {
       const replacement = await middleware.onResult?.({
         ...args,
@@ -637,9 +659,10 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
       });
       if (replacement !== undefined) {
         result = replacement;
+        replaced = true;
       }
     }
-    return result;
+    return replaced ? result : undefined;
   }
 
   private async startRunObservers(): Promise<ActiveAgentRunObservers> {
@@ -946,6 +969,7 @@ type ToolResultEventPayload = {
   internalCallId: string;
   args: string;
   result: string;
+  structuredResult?: ToolResultContent[] | undefined;
 };
 
 type AgentToolEventPayload = {
@@ -959,6 +983,16 @@ type AgentToolEventPayload = {
 };
 
 type ToolExecutionEventPayload = ToolResultEventPayload | AgentToolEventPayload;
+
+function toolOutputToText(output: NormalizedToolOutput): string {
+  return typeof output === "string" ? output : toolResultContentToText(output);
+}
+
+function toolOutputToStructuredResult(
+  output: NormalizedToolOutput,
+): ToolResultContent[] | undefined {
+  return typeof output === "string" ? undefined : output;
+}
 
 function agentToolEventPayload(
   toolCall: ToolCall,

--- a/packages/core/src/observability/types.ts
+++ b/packages/core/src/observability/types.ts
@@ -6,6 +6,7 @@ import type {
   Message,
   ToolCall,
   ToolDefinition,
+  ToolResultContent,
   Usage,
 } from "../completion";
 import type { ToolCallStreamEvent } from "../tool";
@@ -83,6 +84,7 @@ export type AgentToolStartArgs = {
 
 export type AgentToolEndArgs = AgentToolStartArgs & {
   result: string;
+  structuredResult?: ToolResultContent[] | undefined;
   skipped: boolean;
 };
 

--- a/packages/core/src/tool/create-tool.ts
+++ b/packages/core/src/tool/create-tool.ts
@@ -5,6 +5,7 @@ import type { Tool, ToolApprovalPolicy, ToolCallContext } from "./tool";
 export type CreateToolOptions<
   InputSchema extends ZodSchema,
   OutputSchema extends ZodSchema | undefined = undefined,
+  Output = unknown,
 > = {
   name: string;
   description: string;
@@ -16,19 +17,29 @@ export type CreateToolOptions<
     context: ToolCallContext,
   ): OutputSchema extends ZodSchema
     ? z.input<OutputSchema> | Promise<z.input<OutputSchema>>
-    : unknown | Promise<unknown>;
+    : Output | Promise<Output>;
 };
 
-type ToolOutput<OutputSchema extends ZodSchema | undefined> = OutputSchema extends ZodSchema
-  ? z.output<OutputSchema>
-  : unknown;
+type CreateToolOutput<
+  OutputSchema extends ZodSchema | undefined,
+  Output,
+> = OutputSchema extends ZodSchema ? z.output<OutputSchema> : Output;
+
+export function createTool<InputSchema extends ZodSchema, Output = unknown>(
+  options: CreateToolOptions<InputSchema, undefined, Output> & { output?: undefined },
+): Tool<z.output<InputSchema>, Output>;
+
+export function createTool<InputSchema extends ZodSchema, OutputSchema extends ZodSchema>(
+  options: CreateToolOptions<InputSchema, OutputSchema>,
+): Tool<z.output<InputSchema>, z.output<OutputSchema>>;
 
 export function createTool<
   InputSchema extends ZodSchema,
   OutputSchema extends ZodSchema | undefined = undefined,
+  Output = unknown,
 >(
-  options: CreateToolOptions<InputSchema, OutputSchema>,
-): Tool<z.output<InputSchema>, ToolOutput<OutputSchema>> {
+  options: CreateToolOptions<InputSchema, OutputSchema, Output>,
+): Tool<z.output<InputSchema>, CreateToolOutput<OutputSchema, Output>> {
   const parameters = toProviderJsonSchema(options.input);
 
   return {
@@ -41,12 +52,12 @@ export function createTool<
         parameters,
       };
     },
-    async call(args, context = {}): Promise<ToolOutput<OutputSchema>> {
+    async call(args, context = {}): Promise<CreateToolOutput<OutputSchema, Output>> {
       const parsedArgs = options.input.parse(args);
       const result = await options.execute(parsedArgs, context);
       return (
         options.output === undefined ? result : options.output.parse(result)
-      ) as ToolOutput<OutputSchema>;
+      ) as CreateToolOutput<OutputSchema, Output>;
     },
     parseApprovalArgs(args): z.output<InputSchema> {
       return options.input.parse(args);

--- a/packages/core/src/tool/middleware.ts
+++ b/packages/core/src/tool/middleware.ts
@@ -1,8 +1,12 @@
+import type { ToolResultContent } from "../completion";
+
 export type ToolResultMiddlewareArgs = {
   toolName: string;
   args: string;
   result: string;
   originalResult: string;
+  structuredResult?: ToolResultContent[] | undefined;
+  originalStructuredResult?: ToolResultContent[] | undefined;
   turn: number;
   toolCallId?: string | undefined;
   internalCallId: string;

--- a/packages/core/src/tool/tool-set.ts
+++ b/packages/core/src/tool/tool-set.ts
@@ -1,6 +1,12 @@
 import type { ToolDefinition } from "../completion/types";
 import { ToolCallError, ToolJsonError, ToolNotFoundError } from "./errors";
-import { type AnyTool, parseToolArgs, serializeToolOutput, type ToolCallContext } from "./tool";
+import {
+  type AnyTool,
+  type NormalizedToolOutput,
+  normalizeToolResultOutput,
+  parseToolArgs,
+  type ToolCallContext,
+} from "./tool";
 
 export class ToolSet {
   private readonly tools = new Map<string, AnyTool>();
@@ -50,7 +56,11 @@ export class ToolSet {
     return defs;
   }
 
-  async call(toolName: string, args: string, context?: ToolCallContext): Promise<string> {
+  async call(
+    toolName: string,
+    args: string,
+    context?: ToolCallContext,
+  ): Promise<NormalizedToolOutput> {
     const tool = this.tools.get(toolName);
     if (tool === undefined) {
       throw new ToolNotFoundError(toolName);
@@ -65,7 +75,7 @@ export class ToolSet {
 
     try {
       const output = await tool.call(parsedArgs, context);
-      return serializeToolOutput(output);
+      return normalizeToolResultOutput(output);
     } catch (error) {
       if (error instanceof Error) {
         throw new ToolCallError(error.message, error);

--- a/packages/core/src/tool/tool.ts
+++ b/packages/core/src/tool/tool.ts
@@ -1,4 +1,4 @@
-import type { JsonObject, JsonValue, ToolDefinition } from "../completion/types";
+import type { JsonObject, JsonValue, ToolDefinition, ToolResultContent } from "../completion/types";
 
 export type ToolApprovalRunContext = {
   agentId: string;
@@ -44,6 +44,14 @@ export type AnyTool = Omit<Tool<unknown, unknown>, "approval"> & {
   readonly approval?: unknown;
 };
 
+export type NormalizedToolOutput = string | ToolResultContent[];
+
+export const ToolOutput = {
+  content(content: ToolResultContent[]): ToolResultContent[] {
+    return content;
+  },
+};
+
 export function serializeToolOutput(output: unknown): string {
   if (typeof output === "string") {
     return output;
@@ -51,6 +59,41 @@ export function serializeToolOutput(output: unknown): string {
 
   const serialized = JSON.stringify(output);
   return serialized === undefined ? String(output) : serialized;
+}
+
+export function isToolResultContentArray(value: unknown): value is ToolResultContent[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every((item) => {
+      if (typeof item !== "object" || item === null || !("type" in item)) {
+        return false;
+      }
+      if (item.type === "text") {
+        return "text" in item && typeof item.text === "string";
+      }
+      if (item.type === "image") {
+        return (
+          "data" in item &&
+          typeof item.data === "string" &&
+          (!("mediaType" in item) ||
+            item.mediaType === undefined ||
+            typeof item.mediaType === "string")
+        );
+      }
+      return false;
+    })
+  );
+}
+
+export function normalizeToolResultOutput(output: unknown): NormalizedToolOutput {
+  return isToolResultContentArray(output) ? output : serializeToolOutput(output);
+}
+
+export function toolResultContentToText(content: ToolResultContent[]): string {
+  return content
+    .map((item) => (item.type === "text" ? item.text : `[image:${item.mediaType ?? "image/png"}]`))
+    .join("\n");
 }
 
 export function parseToolArgs(args: string): JsonValue {

--- a/packages/core/test/prompt-request.test.ts
+++ b/packages/core/test/prompt-request.test.ts
@@ -14,6 +14,7 @@ import {
   Message,
   PromptCancelledError,
   requestToolApproval,
+  ToolOutput,
   Usage,
 } from "../src/index";
 
@@ -161,6 +162,88 @@ describe("PromptRequest", () => {
           id: "call_1",
           callId: "fc_1",
           content: [{ type: "text", text: "stored:7" }],
+        },
+      ]),
+    );
+  });
+
+  it("sends structured tool result content to the next model turn", async () => {
+    const structuredContent = ToolOutput.content([
+      { type: "text", text: '{"coordMap":"0,0,100,100,100,100"}' },
+      { type: "image", data: "base64-png", mediaType: "image/png" },
+    ]);
+    const screenshotTool = createTool({
+      name: "computer_screenshot",
+      description: "Return screenshot",
+      input: z.object({}),
+      execute: () => structuredContent,
+    });
+    const model = new QueueModel([
+      response([AssistantContent.toolCall("call_1", "computer_screenshot", {}, "fc_1")]),
+      response([AssistantContent.text("done")]),
+    ]);
+    const events: string[] = [];
+    const hook = createHook({
+      onToolResult({ result, structuredResult }) {
+        events.push(`${result}:${structuredResult?.length ?? 0}`);
+      },
+    });
+    const agent = new AgentBuilder("test-agent", model).tool(screenshotTool).hook(hook).build();
+
+    await expect(agent.prompt("screenshot").send()).resolves.toMatchObject({ output: "done" });
+
+    expect(events).toEqual(['{"coordMap":"0,0,100,100,100,100"}\n[image:image/png]:2']);
+    expect(model.requests[1]?.chatHistory.at(-1)).toEqual(
+      Message.tool([
+        {
+          type: "tool_result",
+          id: "call_1",
+          callId: "fc_1",
+          content: structuredContent,
+        },
+      ]),
+    );
+  });
+
+  it("lets middleware observe structured results and replace them with text", async () => {
+    const structuredContent = ToolOutput.content([
+      { type: "text", text: "screen" },
+      { type: "image", data: "base64-png", mediaType: "image/png" },
+    ]);
+    const screenshotTool = createTool({
+      name: "computer_screenshot",
+      description: "Return screenshot",
+      input: z.object({}),
+      execute: () => structuredContent,
+    });
+    const model = new QueueModel([
+      response([AssistantContent.toolCall("call_1", "computer_screenshot", {})]),
+      response([AssistantContent.text("done")]),
+    ]);
+    const seen: string[] = [];
+    const agent = new AgentBuilder("test-agent", model)
+      .tool(screenshotTool)
+      .toolMiddleware(
+        createToolMiddleware({
+          onResult({ result, structuredResult, originalStructuredResult }) {
+            seen.push(
+              `${result}:${structuredResult?.length ?? 0}:${originalStructuredResult?.length ?? 0}`,
+            );
+            return "stored:screenshot";
+          },
+        }),
+      )
+      .build();
+
+    await expect(agent.prompt("screenshot").send()).resolves.toMatchObject({ output: "done" });
+
+    expect(seen).toEqual(["screen\n[image:image/png]:2:2"]);
+    expect(model.requests[1]?.chatHistory.at(-1)).toEqual(
+      Message.tool([
+        {
+          type: "tool_result",
+          id: "call_1",
+          content: [{ type: "text", text: "stored:screenshot" }],
         },
       ]),
     );

--- a/packages/core/test/streaming.test.ts
+++ b/packages/core/test/streaming.test.ts
@@ -14,6 +14,7 @@ import {
   createToolMiddleware,
   Message,
   type StreamingCompletionModel,
+  ToolOutput,
   toReadableStream,
 } from "../src/index";
 
@@ -212,6 +213,64 @@ describe("PromptRequest streaming", () => {
         },
       ]),
     );
+  });
+
+  it("streams structured tool results with a display string", async () => {
+    const structuredContent = ToolOutput.content([
+      { type: "text", text: "screen" },
+      { type: "image", data: "base64-png", mediaType: "image/png" },
+    ]);
+    const screenshotTool = createTool({
+      name: "computer_screenshot",
+      description: "Return screenshot",
+      input: z.object({}),
+      execute: () => structuredContent,
+    });
+    const model = new StreamingQueueModel([
+      [
+        {
+          type: "tool_call",
+          toolCall: AssistantContent.toolCall("call_1", "computer_screenshot", {}),
+        },
+      ],
+      [{ type: "text_delta", delta: "done" }],
+    ]);
+    const eventStore = new RecordingEventStore();
+    const agent = new AgentBuilder("test-agent", model)
+      .tool(screenshotTool)
+      .eventStore(eventStore, { include: "all" })
+      .build();
+
+    const events = await collect(agent.prompt("screenshot").stream());
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "tool_result",
+        turn: 1,
+        toolName: "computer_screenshot",
+        result: "screen\n[image:image/png]",
+        structuredResult: structuredContent,
+      }),
+    );
+    expect(model.requests[1]?.chatHistory.at(-1)).toEqual(
+      Message.tool([
+        {
+          type: "tool_result",
+          id: "call_1",
+          content: structuredContent,
+        },
+      ]),
+    );
+    expect(
+      eventStore.appendCalls.some((call) => {
+        const event = JSON.parse(JSON.stringify(call.event)) as AgentStreamEvent;
+        return (
+          event.type === "tool_result" &&
+          event.result === "screen\n[image:image/png]" &&
+          event.structuredResult?.[1]?.type === "image"
+        );
+      }),
+    ).toBe(true);
   });
 
   it("streams concurrent tool results as each tool finishes", async () => {

--- a/packages/core/test/tool-set.test.ts
+++ b/packages/core/test/tool-set.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
-import { createTool, ToolCallError, ToolJsonError, ToolNotFoundError, ToolSet } from "../src/index";
+import {
+  createTool,
+  ToolCallError,
+  ToolJsonError,
+  ToolNotFoundError,
+  ToolOutput,
+  ToolSet,
+} from "../src/index";
 
 const addTool = createTool({
   name: "add",
@@ -125,6 +132,23 @@ describe("ToolSet", () => {
     ]);
 
     await expect(toolSet.call("object_output", "{}")).resolves.toBe('{"ok":true}');
+  });
+
+  it("passes through structured tool result content", async () => {
+    const content = ToolOutput.content([
+      { type: "text", text: '{"coordMap":"0,0,100,100,100,100"}' },
+      { type: "image", data: "base64-png", mediaType: "image/png" },
+    ]);
+    const toolSet = ToolSet.fromTools([
+      createTool({
+        name: "screenshot",
+        description: "Return screenshot",
+        input: z.object({}),
+        execute: () => content,
+      }),
+    ]);
+
+    await expect(toolSet.call("screenshot", "{}")).resolves.toEqual(content);
   });
 
   it("adds tool arrays and tool sets without duplicate definitions", async () => {

--- a/packages/observability/langfuse/package.json
+++ b/packages/observability/langfuse/package.json
@@ -32,8 +32,8 @@
   },
   "dependencies": {
     "@anvia/core": "^0.2.0",
-    "@langfuse/otel": "^5.3.0",
-    "@langfuse/tracing": "^5.3.0",
+    "@langfuse/otel": "^5.4.0",
+    "@langfuse/tracing": "^5.4.0",
     "@opentelemetry/sdk-node": "^0.218.0"
   },
   "devDependencies": {

--- a/packages/providers/anthropic/package.json
+++ b/packages/providers/anthropic/package.json
@@ -31,7 +31,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.98.0",
+    "@anthropic-ai/sdk": "^0.100.1",
     "@anvia/core": "^0.2.1"
   },
   "devDependencies": {

--- a/packages/providers/anthropic/src/anthropic/completion.ts
+++ b/packages/providers/anthropic/src/anthropic/completion.ts
@@ -17,6 +17,7 @@ import {
   type ToolChoice,
   type ToolContent,
   type ToolDefinition,
+  type ToolResultContent,
   Usage,
   type UserContent,
 } from "@anvia/core/completion";
@@ -391,10 +392,30 @@ function toolContentToAnthropicBlock(content: ToolContent): AnthropicContentBloc
   return {
     type: "tool_result",
     tool_use_id: content.callId ?? content.id,
-    content: content.content
-      .map((item) => (item.type === "text" ? item.text : item.data))
-      .join("\n"),
+    content: toolResultContentToAnthropicContent(content.content),
   };
+}
+
+function toolResultContentToAnthropicContent(
+  content: ToolResultContent[],
+): string | AnthropicContentBlock[] {
+  if (content.every((item) => item.type === "text")) {
+    return content.map((item) => item.text).join("\n");
+  }
+
+  return content.map((item) => {
+    if (item.type === "text") {
+      return { type: "text", text: item.text };
+    }
+    return {
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: item.mediaType ?? "image/png",
+        data: item.data,
+      },
+    };
+  });
 }
 
 function reasoningContentToAnthropicBlocks(content: ReasoningContent): AnthropicContentBlock[] {

--- a/packages/providers/anthropic/test/anthropic-completion.test.ts
+++ b/packages/providers/anthropic/test/anthropic-completion.test.ts
@@ -5,6 +5,7 @@ import {
   type CompletionStreamEvent,
   Message,
   type Tool,
+  ToolContent,
   Usage,
   UserContent,
 } from "@anvia/core";
@@ -94,6 +95,49 @@ describe("Anthropic Messages mapping", () => {
     expect(params.messages).toContainEqual({
       role: "user",
       content: [{ type: "tool_result", tool_use_id: "toolu_1", content: "7" }],
+    });
+  });
+
+  it("maps multimodal tool results to Anthropic content blocks", () => {
+    const params = toAnthropicMessagesParams("claude-sonnet-4-20250514", {
+      chatHistory: [
+        Message.assistant([
+          AssistantContent.toolCall("toolu_1", "computer_screenshot", {}, "fc_1"),
+        ]),
+        Message.tool(
+          ToolContent.toolResult(
+            "toolu_1",
+            [
+              { type: "text", text: '{"coordMap":"0,0,100,100,100,100"}' },
+              { type: "image", data: "base64-png", mediaType: "image/png" },
+            ],
+            "fc_1",
+          ),
+        ),
+      ],
+      documents: [],
+      tools: [],
+    });
+
+    expect(params.messages).toContainEqual({
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "fc_1",
+          content: [
+            { type: "text", text: '{"coordMap":"0,0,100,100,100,100"}' },
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/png",
+                data: "base64-png",
+              },
+            },
+          ],
+        },
+      ],
     });
   });
 

--- a/packages/providers/gemini/package.json
+++ b/packages/providers/gemini/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@anvia/core": "^0.2.1",
-    "@google/genai": "^2.6.0"
+    "@google/genai": "^2.7.0"
   },
   "devDependencies": {
     "@types/node": "^24.9.1",

--- a/packages/providers/gemini/src/gemini/completion.ts
+++ b/packages/providers/gemini/src/gemini/completion.ts
@@ -376,7 +376,11 @@ function toolResultResponse(
   >,
 ): Record<string, unknown> {
   return {
-    content: content.map((item) => (item.type === "text" ? item.text : item.data)).join("\n"),
+    content: content
+      .map((item) =>
+        item.type === "text" ? item.text : `[image:${item.mediaType ?? "image/png"}]`,
+      )
+      .join("\n"),
   };
 }
 

--- a/packages/providers/mistral/package.json
+++ b/packages/providers/mistral/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@anvia/core": "workspace:*",
-    "@mistralai/mistralai": "^2.2.1"
+    "@mistralai/mistralai": "^2.2.5"
   },
   "devDependencies": {
     "@types/node": "^24.9.1",

--- a/packages/providers/mistral/src/mistral/completion.ts
+++ b/packages/providers/mistral/src/mistral/completion.ts
@@ -317,7 +317,9 @@ function toolContentToMistralMessage(content: ToolContent): MistralChatMessage {
     toolCallId: content.callId ?? content.id,
     name: content.id,
     content: content.content
-      .map((item) => (item.type === "text" ? item.text : item.data))
+      .map((item) =>
+        item.type === "text" ? item.text : `[image:${item.mediaType ?? "image/png"}]`,
+      )
       .join("\n"),
   };
 }

--- a/packages/providers/openai/package.json
+++ b/packages/providers/openai/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@anvia/core": "workspace:*",
-    "openai": "^6.39.0"
+    "openai": "^6.39.1"
   },
   "devDependencies": {
     "@types/node": "^24.9.1",

--- a/packages/providers/openai/src/openai/chat-completion.ts
+++ b/packages/providers/openai/src/openai/chat-completion.ts
@@ -369,7 +369,9 @@ function toolContentToChatMessage(content: ToolContent): ChatMessage {
     role: "tool",
     tool_call_id: content.callId ?? content.id,
     content: content.content
-      .map((item) => (item.type === "text" ? item.text : item.data))
+      .map((item) =>
+        item.type === "text" ? item.text : `[image:${item.mediaType ?? "image/png"}]`,
+      )
       .join("\n"),
   };
 }

--- a/packages/providers/openai/src/openai/responses.ts
+++ b/packages/providers/openai/src/openai/responses.ts
@@ -17,6 +17,7 @@ import {
   type ToolChoice,
   type ToolContent,
   type ToolDefinition,
+  type ToolResultContent,
   Usage,
   type UserContent,
 } from "@anvia/core/completion";
@@ -396,10 +397,27 @@ function toolContentToOpenAIResponsesItem(content: ToolContent): ResponsesInputI
   return {
     type: "function_call_output",
     call_id: content.callId ?? content.id,
-    output: content.content
-      .map((item) => (item.type === "text" ? item.text : item.data))
-      .join("\n"),
+    output: toolResultContentToOpenAIResponsesOutput(content.content),
   };
+}
+
+function toolResultContentToOpenAIResponsesOutput(
+  content: ToolResultContent[],
+): string | ResponsesInputItem[] {
+  if (content.every((item) => item.type === "text")) {
+    return content.map((item) => item.text).join("\n");
+  }
+
+  return content.map((item) => {
+    if (item.type === "text") {
+      return { type: "input_text", text: item.text };
+    }
+    return {
+      type: "input_image",
+      image_url: `data:${item.mediaType ?? "image/png"};base64,${item.data}`,
+      detail: "auto",
+    };
+  });
 }
 
 function reasoningItemToAssistantContent(item: Record<string, unknown>): Reasoning {

--- a/packages/providers/openai/test/openai-responses.test.ts
+++ b/packages/providers/openai/test/openai-responses.test.ts
@@ -1,4 +1,11 @@
-import { AssistantContent, type CompletionRequest, Message, Usage, UserContent } from "@anvia/core";
+import {
+  AssistantContent,
+  type CompletionRequest,
+  Message,
+  ToolContent,
+  Usage,
+  UserContent,
+} from "@anvia/core";
 import { describe, expect, it } from "vitest";
 import { OpenAIResponsesCompletionModel } from "../src/index";
 import {
@@ -67,6 +74,39 @@ describe("OpenAI Responses mapping", () => {
       type: "function_call_output",
       call_id: "fc_1",
       output: "7",
+    });
+  });
+
+  it("maps multimodal tool outputs to Responses API output content", () => {
+    const params = toOpenAIResponsesParams("gpt-5", {
+      chatHistory: [
+        Message.assistant([AssistantContent.toolCall("call_1", "computer_screenshot", {}, "fc_1")]),
+        Message.tool(
+          ToolContent.toolResult(
+            "call_1",
+            [
+              { type: "text", text: '{"coordMap":"0,0,100,100,100,100"}' },
+              { type: "image", data: "base64-png", mediaType: "image/png" },
+            ],
+            "fc_1",
+          ),
+        ),
+      ],
+      documents: [],
+      tools: [],
+    });
+
+    expect(params.input).toContainEqual({
+      type: "function_call_output",
+      call_id: "fc_1",
+      output: [
+        { type: "input_text", text: '{"coordMap":"0,0,100,100,100,100"}' },
+        {
+          type: "input_image",
+          image_url: "data:image/png;base64,base64-png",
+          detail: "auto",
+        },
+      ],
     });
   });
 

--- a/packages/tools/studio/src/runtime/runs.ts
+++ b/packages/tools/studio/src/runtime/runs.ts
@@ -230,11 +230,17 @@ function acceptTranscriptStreamEvent(
         ...(event.toolCallId === undefined ? {} : { callId: event.toolCallId }),
         args: event.args,
         result: event.result,
+        ...(event.structuredResult === undefined
+          ? {}
+          : { structuredResult: event.structuredResult }),
       });
       return;
     }
     matched.args = matched.args ?? event.args;
     matched.result = event.result;
+    if (event.structuredResult !== undefined) {
+      matched.structuredResult = event.structuredResult;
+    }
   }
   if (event.type === "agent_tool_event") {
     const matched = findTranscriptToolEntry(transcript, event.toolName, event.toolCallId);
@@ -416,6 +422,7 @@ function childAgentTranscriptEvent(
       ...(child.toolCallId === undefined ? {} : { callId: child.toolCallId }),
       args: child.args,
       result: child.result,
+      ...(child.structuredResult === undefined ? {} : { structuredResult: child.structuredResult }),
     };
   }
   if (child.type === "error") {
@@ -487,8 +494,11 @@ export function transcriptFromMessages(messages: Message[]): StudioTranscriptEnt
           toolName: "tool_result",
           callId: content.callId ?? content.id,
           result: content.content
-            .map((item) => ("text" in item ? item.text : "[image]"))
+            .map((item) =>
+              "text" in item ? item.text : `[image:${item.mediaType ?? "image/png"}]`,
+            )
             .join("\n"),
+          structuredResult: content.content,
         });
       }
       continue;
@@ -614,7 +624,9 @@ function extractMessageText(message: string | Message): string {
         return [`${item.function.name}(${formatJson(item.function.arguments)})`];
       }
       if (item.type === "tool_result") {
-        return item.content.map((result) => ("text" in result ? result.text : "[image]"));
+        return item.content.map((result) =>
+          "text" in result ? result.text : `[image:${result.mediaType ?? "image/png"}]`,
+        );
       }
       return [];
     })

--- a/packages/tools/studio/src/runtime/session-logs.ts
+++ b/packages/tools/studio/src/runtime/session-logs.ts
@@ -246,6 +246,10 @@ function logsFromStreamEvent(props: {
           internalCallId: event.internalCallId,
           argumentBytes: byteLength(event.args),
           resultBytes: byteLength(event.result),
+          structuredResultBytes:
+            event.structuredResult === undefined
+              ? undefined
+              : byteLength(JSON.stringify(event.structuredResult)),
         }),
       },
     ];
@@ -423,6 +427,10 @@ function childAgentLog(
           toolName: child.toolName,
           callId: child.toolCallId,
           resultBytes: byteLength(child.result),
+          structuredResultBytes:
+            child.structuredResult === undefined
+              ? undefined
+              : byteLength(JSON.stringify(child.structuredResult)),
         }),
       },
     ];

--- a/packages/tools/studio/src/storage/sqlite-store.ts
+++ b/packages/tools/studio/src/storage/sqlite-store.ts
@@ -1358,8 +1358,11 @@ function transcriptFromMessagesFallback(messages: Message[]): StudioTranscriptEn
           toolName: "tool_result",
           callId: content.callId ?? content.id,
           result: content.content
-            .map((item) => ("text" in item ? item.text : "[image]"))
+            .map((item) =>
+              "text" in item ? item.text : `[image:${item.mediaType ?? "image/png"}]`,
+            )
             .join("\n"),
+          structuredResult: content.content,
         });
       }
       continue;

--- a/packages/tools/studio/src/types.ts
+++ b/packages/tools/studio/src/types.ts
@@ -10,6 +10,7 @@ import type {
   Pipeline,
   PipelineGraph,
   PromptResponse,
+  ToolResultContent,
   Usage,
 } from "@anvia/core";
 import type { Hono } from "hono";
@@ -150,6 +151,7 @@ export type StudioTranscriptToolEntry = {
   callId?: string;
   args?: string;
   result?: string;
+  structuredResult?: ToolResultContent[];
   childEvents?: StudioTranscriptChildAgentEvent[];
   approval?: StudioToolApprovalTranscript;
   question?: StudioToolQuestionTranscript;
@@ -177,6 +179,7 @@ export type StudioTranscriptChildAgentEvent =
       callId?: string;
       args?: string;
       result?: string;
+      structuredResult?: ToolResultContent[];
     };
 
 export type StudioTranscriptEntry =

--- a/packages/tools/studio/src/ui/app/app.tsx
+++ b/packages/tools/studio/src/ui/app/app.tsx
@@ -1,3 +1,4 @@
+import type { ToolResultContent } from "@anvia/core";
 import { Archive, ArrowSquareOut, ArrowUp, Moon, Plus, Sun } from "@phosphor-icons/react";
 import {
   type ChangeEvent,
@@ -956,6 +957,9 @@ export function StudioConsole() {
         callId: event.toolCallId,
         args: event.args,
         result: event.result,
+        ...(event.structuredResult === undefined
+          ? {}
+          : { structuredResult: event.structuredResult }),
       });
       return true;
     }
@@ -1218,6 +1222,7 @@ export function StudioConsole() {
     callId: string | undefined;
     args: string;
     result: string;
+    structuredResult?: ToolResultContent[];
   }) {
     setMessages((current) => {
       const next = [...current];
@@ -1229,6 +1234,9 @@ export function StudioConsole() {
             ...existing,
             args: existing.args ?? props.args,
             result: props.result,
+            ...(props.structuredResult === undefined
+              ? {}
+              : { structuredResult: props.structuredResult }),
           };
           return next;
         }
@@ -1241,6 +1249,9 @@ export function StudioConsole() {
         ...(props.callId === undefined ? {} : { callId: props.callId }),
         args: props.args,
         result: props.result,
+        ...(props.structuredResult === undefined
+          ? {}
+          : { structuredResult: props.structuredResult }),
       });
       return next;
     });
@@ -1321,6 +1332,9 @@ export function StudioConsole() {
         ...(child.toolCallId === undefined ? {} : { callId: child.toolCallId }),
         args: child.args,
         result: child.result,
+        ...(child.structuredResult === undefined
+          ? {}
+          : { structuredResult: child.structuredResult }),
       };
     }
     if (child.type === "error") {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,11 +297,11 @@ importers:
         specifier: workspace:*
         version: link:../../core
       '@langfuse/otel':
-        specifier: ^5.3.0
-        version: 5.3.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))
+        specifier: ^5.4.0
+        version: 5.4.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))
       '@langfuse/tracing':
-        specifier: ^5.3.0
-        version: 5.3.0(@opentelemetry/api@1.9.1)
+        specifier: ^5.4.0
+        version: 5.4.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-node':
         specifier: ^0.218.0
         version: 0.218.0(@opentelemetry/api@1.9.1)
@@ -344,8 +344,8 @@ importers:
   packages/providers/anthropic:
     dependencies:
       '@anthropic-ai/sdk':
-        specifier: ^0.98.0
-        version: 0.98.0(zod@4.4.3)
+        specifier: ^0.100.1
+        version: 0.100.1(zod@4.4.3)
       '@anvia/core':
         specifier: workspace:*
         version: link:../../core
@@ -369,8 +369,8 @@ importers:
         specifier: workspace:*
         version: link:../../core
       '@google/genai':
-        specifier: ^2.6.0
-        version: 2.6.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
+        specifier: ^2.7.0
+        version: 2.7.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
     devDependencies:
       '@types/node':
         specifier: ^24.9.1
@@ -391,8 +391,8 @@ importers:
         specifier: workspace:*
         version: link:../../core
       '@mistralai/mistralai':
-        specifier: ^2.2.1
-        version: 2.2.1
+        specifier: ^2.2.5
+        version: 2.2.5
     devDependencies:
       '@types/node':
         specifier: ^24.9.1
@@ -413,8 +413,8 @@ importers:
         specifier: workspace:*
         version: link:../../core
       openai:
-        specifier: ^6.39.0
-        version: 6.39.0(ws@8.20.0)(zod@4.4.3)
+        specifier: ^6.39.1
+        version: 6.39.1(ws@8.21.0)(zod@4.4.3)
     devDependencies:
       '@types/node':
         specifier: ^24.9.1
@@ -427,7 +427,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/tools/studio:
     dependencies:
@@ -488,7 +488,7 @@ importers:
         version: 0.5.19(tailwindcss@4.2.4)
       '@tailwindcss/vite':
         specifier: ^4.2.4
-        version: 4.2.4(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.2.4(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
       '@types/node':
         specifier: ^24.9.1
         version: 24.12.2
@@ -500,7 +500,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 6.0.1(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -515,10 +515,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.10
-        version: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
+        version: 8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.0.8
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/vector-stores/chroma:
     dependencies:
@@ -601,8 +601,8 @@ packages:
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
-  '@anthropic-ai/sdk@0.98.0':
-    resolution: {integrity: sha512-N7aXtCvC5g6T1Y4V29lJjceu/zTkVkIZF0jdBvagr0TRFHuKeImffalGWEfqZKrvjH+IQbzJWw6TmSmUzrlMgg==}
+  '@anthropic-ai/sdk@0.100.1':
+    resolution: {integrity: sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -709,6 +709,10 @@ packages:
 
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
@@ -1458,8 +1462,8 @@ packages:
       tailwindcss:
         optional: true
 
-  '@google/genai@2.6.0':
-    resolution: {integrity: sha512-HjoW3mPuEn7pnuKABJl9VbDoWDSF4nbwYKYvYYor7YjPeDxrrBxHzu2d1Prcd+BAuC4w+85UP6y7ZdcrQAoO7g==}
+  '@google/genai@2.7.0':
+    resolution: {integrity: sha512-tv0DRtcndt2oEhBYy+5mA0TaXH98+L1Gt0AP9unBfH7DP20KhB7+O3QqAN1Lz+laMARGTHS7BFQSNpLbl4gm1g==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.25.2
@@ -1700,13 +1704,13 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
-  '@langfuse/core@5.3.0':
-    resolution: {integrity: sha512-9JnDpSMBxsy6Mw5YTc0vERpAYJG5jJKxLtgv1mgA4yrNGWOtqV6ShkSSb/mWE7CeyKFnIFM0lRJpqblrMaRfQA==}
+  '@langfuse/core@5.4.0':
+    resolution: {integrity: sha512-E9gggJOpIZONUiN9V+FNC8Lz8GNb4RQj2HArtdJDtQ6MVEXqLERwTMO+DUx9+9Hf8nX7CaVTa7KIdmgYwMk7Ew==}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
 
-  '@langfuse/otel@5.3.0':
-    resolution: {integrity: sha512-CJUz3oCD0RMbe+1cPxnuLD/JhsUnLt02DhLP6ZXzhFoi07rHsf8T5oUyCwLRNRH4x2tl87u3aTiOcBJqSK6/fQ==}
+  '@langfuse/otel@5.4.0':
+    resolution: {integrity: sha512-oC6YDspXdUTznNEmzNcy+rD5/Z3Zgt2VGCX2bpaEpACzQNyhq/0eF2BZ/5zvOevCG9RwbZiA2K025kS2ef+Dag==}
     engines: {node: '>=20'}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
@@ -1714,8 +1718,8 @@ packages:
       '@opentelemetry/exporter-trace-otlp-http': '>=0.202.0 <1.0.0'
       '@opentelemetry/sdk-trace-base': ^2.0.1
 
-  '@langfuse/tracing@5.3.0':
-    resolution: {integrity: sha512-Fz6da1O+OqrwG69nF1UAjdaZrYUfR+h+DyVjXJLTNhTrOCqx/jTiIVAP5A32rB07+l4ESgzfO4K222A6cdPW1w==}
+  '@langfuse/tracing@5.4.0':
+    resolution: {integrity: sha512-dUptGzKk2HxE+p7761VdSVK3rtyXRAIUuKamYGzFSEJGxmBe3gzz/injyKKMldH561RVnIADmIbwmPMrTU1DBg==}
     engines: {node: '>=20'}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
@@ -1732,8 +1736,8 @@ packages:
   '@mermaid-js/parser@1.1.1':
     resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
 
-  '@mistralai/mistralai@2.2.1':
-    resolution: {integrity: sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==}
+  '@mistralai/mistralai@2.2.5':
+    resolution: {integrity: sha512-ATbWzKkNzNAZ+gtw9MI/c/ULTMG80tKUiRNIbQFfg4OP0uEZZpTfXZeBCNfs5Dq0uqMQ/tQWc4o6RRJQtMrpDA==}
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -2163,14 +2167,23 @@ packages:
   '@protobufjs/eventemitter@1.1.0':
     resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
 
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
   '@protobufjs/fetch@1.1.0':
     resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
 
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
 
   '@protobufjs/inquire@1.1.1':
     resolution: {integrity: sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==}
+
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
 
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
@@ -5291,8 +5304,8 @@ packages:
   onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
     resolution: {integrity: sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==}
 
-  openai@6.39.0:
-    resolution: {integrity: sha512-O61LIsimY3acVabwvomwFhwrnN36yvHY2quIfy9keEcFytGgWeV35yLHQ6NVMLSBxRpHmcg2yuhCnlu2HT4pLQ==}
+  openai@6.39.1:
+    resolution: {integrity: sha512-z3dO9fEWOXBzlXynVb/xZ/tujzUjFWQWn3C0n0mw6Vo0zJTbEkaN4b2cLWjhJ6haJQx8LlREoafHRl+Gu/Hl+A==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -5530,6 +5543,10 @@ packages:
 
   protobufjs@7.5.6:
     resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
+    engines: {node: '>=12.0.0'}
+
+  protobufjs@7.6.1:
+    resolution: {integrity: sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==}
     engines: {node: '>=12.0.0'}
 
   protobufjs@8.0.1:
@@ -5877,6 +5894,11 @@ packages:
 
   srvx@0.11.15:
     resolution: {integrity: sha512-iXsux0UcOjdvs0LCMa2Ws3WwcDUozA3JN3BquNXkaFPP7TpRqgunKdEgoZ/uwb1J6xaYHfxtz9Twlh6yzwM6Tg==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
+
+  srvx@0.11.16:
+    resolution: {integrity: sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==}
     engines: {node: '>=20.16.0'}
     hasBin: true
 
@@ -6368,6 +6390,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xmlbuilder2@4.0.3:
     resolution: {integrity: sha512-bx8Q1STctnNaaDymWnkfQLKofs0mGNN7rLLapJlGuV3VlvegD7Ls4ggMjE3aUSWItCCzU0PEv45lI87iSigiCA==}
     engines: {node: '>=20.0'}
@@ -6469,7 +6503,7 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.1.1
 
-  '@anthropic-ai/sdk@0.98.0(zod@4.4.3)':
+  '@anthropic-ai/sdk@0.100.1(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
       standardwebhooks: 1.0.0
@@ -6587,6 +6621,8 @@ snapshots:
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/runtime@7.29.2': {}
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -7149,12 +7185,12 @@ snapshots:
       '@tailwindcss/oxide': 4.2.4
       tailwindcss: 4.2.4
 
-  '@google/genai@2.6.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
+  '@google/genai@2.7.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
-      protobufjs: 7.5.6
-      ws: 8.20.0
+      protobufjs: 7.6.1
+      ws: 8.21.0
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
     transitivePeerDependencies:
@@ -7343,21 +7379,21 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
-  '@langfuse/core@5.3.0(@opentelemetry/api@1.9.1)':
+  '@langfuse/core@5.4.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@langfuse/otel@5.3.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))':
+  '@langfuse/otel@5.4.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))':
     dependencies:
-      '@langfuse/core': 5.3.0(@opentelemetry/api@1.9.1)
+      '@langfuse/core': 5.4.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-http': 0.218.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
 
-  '@langfuse/tracing@5.3.0(@opentelemetry/api@1.9.1)':
+  '@langfuse/tracing@5.4.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@langfuse/core': 5.3.0(@opentelemetry/api@1.9.1)
+      '@langfuse/core': 5.4.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/api': 1.9.1
 
   '@manypkg/find-root@1.1.0':
@@ -7410,9 +7446,9 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
-  '@mistralai/mistralai@2.2.1':
+  '@mistralai/mistralai@2.2.5':
     dependencies:
-      ws: 8.20.0
+      ws: 8.21.0
       zod: 4.4.3
       zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
@@ -7972,14 +8008,22 @@ snapshots:
 
   '@protobufjs/eventemitter@1.1.0': {}
 
+  '@protobufjs/eventemitter@1.1.1': {}
+
   '@protobufjs/fetch@1.1.0':
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/inquire': 1.1.1
 
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
   '@protobufjs/float@1.0.2': {}
 
   '@protobufjs/inquire@1.1.1': {}
+
+  '@protobufjs/inquire@1.1.2': {}
 
   '@protobufjs/path@1.1.2': {}
 
@@ -8897,13 +8941,6 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.2.4
 
-  '@tailwindcss/vite@4.2.4(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))':
-    dependencies:
-      '@tailwindcss/node': 4.2.4
-      '@tailwindcss/oxide': 4.2.4
-      tailwindcss: 4.2.4
-      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
-
   '@tailwindcss/vite@4.2.4(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.2.4
@@ -9312,11 +9349,6 @@ snapshots:
     optionalDependencies:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
-
-  '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -10612,7 +10644,7 @@ snapshots:
   h3@2.0.1-rc.20:
     dependencies:
       rou3: 0.8.1
-      srvx: 0.11.15
+      srvx: 0.11.16
 
   hachure-fill@0.5.2: {}
 
@@ -10919,7 +10951,7 @@ snapshots:
 
   json-schema-to-ts@3.1.1:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       ts-algebra: 2.0.0
 
   json-schema-traverse@1.0.0: {}
@@ -11698,9 +11730,9 @@ snapshots:
       platform: 1.3.6
       protobufjs: 7.5.6
 
-  openai@6.39.0(ws@8.20.0)(zod@4.4.3):
+  openai@6.39.1(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
-      ws: 8.20.0
+      ws: 8.21.0
       zod: 4.4.3
 
   outdent@0.5.0: {}
@@ -11898,6 +11930,21 @@ snapshots:
       '@protobufjs/fetch': 1.1.0
       '@protobufjs/float': 1.0.2
       '@protobufjs/inquire': 1.1.1
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 24.12.2
+      long: 5.3.2
+
+  protobufjs@7.6.1:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.2
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
@@ -12431,6 +12478,8 @@ snapshots:
 
   srvx@0.11.15: {}
 
+  srvx@0.11.16: {}
+
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
@@ -12917,6 +12966,8 @@ snapshots:
   ws@8.18.0: {}
 
   ws@8.20.0: {}
+
+  ws@8.21.0: {}
 
   xmlbuilder2@4.0.3:
     dependencies:


### PR DESCRIPTION
## Summary
- add first-class structured `ToolResultContent[]` outputs and `ToolOutput.content(...)`
- preserve display strings for middleware, hooks, stream events, observers, and Studio transcripts while carrying optional structured results
- serialize multimodal tool results as provider-visible image blocks for OpenAI Responses and Anthropic
- update checked upstream wrapper dependencies and add a changeset

## Tests
- `pnpm --filter @anvia/core test -- tool-set.test.ts prompt-request.test.ts streaming.test.ts`
- `pnpm --filter @anvia/openai test -- openai-responses.test.ts openai-chat-completion.test.ts`
- `pnpm --filter @anvia/anthropic test -- anthropic-completion.test.ts`
- `pnpm --filter @anvia/gemini test -- completion.test.ts`
- `pnpm --filter @anvia/mistral test -- completion.test.ts`
- `pnpm --filter @anvia/core typecheck`
- provider typechecks for OpenAI, Anthropic, Gemini, and Mistral
- `pnpm --filter @anvia/studio typecheck`
- `pnpm --filter @anvia/studio test`
- `pnpm --filter @anvia/langfuse typecheck && pnpm --filter @anvia/langfuse test`
- focused `biome check` on touched files
- `bin/check-upstream-deps.sh`