### PR TITLE
docs: update package and framework docs

### DIFF
--- a/apps/docs/content/docs/changelog/anthropic.mdx
+++ b/apps/docs/content/docs/changelog/anthropic.mdx
@@ -9,6 +9,23 @@ Anthropic provider adapter for Anvia.
 
 Source: [`packages/providers/anthropic/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/providers/anthropic/CHANGELOG.md)
 
+## 0.3.1
+
+### Patch Changes
+
+- c9728d4: Update upstream runtime dependencies to their latest compatible releases.
+
+## 0.3.0
+
+### Minor Changes
+
+- e84d775: Clean up the `@anvia/core` public import surface by keeping common app-authoring APIs on the root export, moving advanced APIs to focused subpaths, and exposing runtime agent internals through `@anvia/core/internal/agent` for Anvia integration packages.
+
+### Patch Changes
+
+- Updated dependencies [e84d775]
+  - @anvia/core@0.4.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/apps/docs/content/docs/changelog/chroma.mdx
+++ b/apps/docs/content/docs/changelog/chroma.mdx
@@ -9,6 +9,17 @@ ChromaDB vector store adapter for Anvia.
 
 Source: [`packages/vector-stores/chroma/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/vector-stores/chroma/CHANGELOG.md)
 
+## 0.2.0
+
+### Minor Changes
+
+- e84d775: Clean up the `@anvia/core` public import surface by keeping common app-authoring APIs on the root export, moving advanced APIs to focused subpaths, and exposing runtime agent internals through `@anvia/core/internal/agent` for Anvia integration packages.
+
+### Patch Changes
+
+- Updated dependencies [e84d775]
+  - @anvia/core@0.4.0
+
 ## 0.1.4
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/core.mdx
+++ b/apps/docs/content/docs/changelog/core.mdx
@@ -9,6 +9,12 @@ Core runtime primitives for context-aware Anvia agents.
 
 Source: [`packages/core/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/core/CHANGELOG.md)
 
+## 0.4.0
+
+### Minor Changes
+
+- e84d775: Clean up the `@anvia/core` public import surface by keeping common app-authoring APIs on the root export, moving advanced APIs to focused subpaths, and exposing runtime agent internals through `@anvia/core/internal/agent` for Anvia integration packages.
+
 ## 0.3.1
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/fastembed.mdx
+++ b/apps/docs/content/docs/changelog/fastembed.mdx
@@ -9,6 +9,17 @@ FastEmbed embedding model adapter for Anvia.
 
 Source: [`packages/embeddings/fastembed/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/embeddings/fastembed/CHANGELOG.md)
 
+## 0.2.0
+
+### Minor Changes
+
+- e84d775: Clean up the `@anvia/core` public import surface by keeping common app-authoring APIs on the root export, moving advanced APIs to focused subpaths, and exposing runtime agent internals through `@anvia/core/internal/agent` for Anvia integration packages.
+
+### Patch Changes
+
+- Updated dependencies [e84d775]
+  - @anvia/core@0.4.0
+
 ## 0.1.4
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/gemini.mdx
+++ b/apps/docs/content/docs/changelog/gemini.mdx
@@ -9,6 +9,23 @@ Gemini provider adapter for Anvia.
 
 Source: [`packages/providers/gemini/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/providers/gemini/CHANGELOG.md)
 
+## 0.2.1
+
+### Patch Changes
+
+- c9728d4: Update upstream runtime dependencies to their latest compatible releases.
+
+## 0.2.0
+
+### Minor Changes
+
+- e84d775: Clean up the `@anvia/core` public import surface by keeping common app-authoring APIs on the root export, moving advanced APIs to focused subpaths, and exposing runtime agent internals through `@anvia/core/internal/agent` for Anvia integration packages.
+
+### Patch Changes
+
+- Updated dependencies [e84d775]
+  - @anvia/core@0.4.0
+
 ## 0.1.10
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/index.mdx
+++ b/apps/docs/content/docs/changelog/index.mdx
@@ -7,63 +7,67 @@ Anvia package release notes are generated from the package changelog files maint
 
 Developers should keep writing release notes with `pnpm changeset`. The docs pages in this section are generated from `packages/**/CHANGELOG.md`.
 
+<div className="package-changelog-index">
+
 ## Core
 
 | Package | Current version | Release notes |
 | --- | --- | --- |
-| `@anvia/core` | `0.3.1` | [View changelog](/docs/changelog/core) |
+| `@anvia/core` | `0.4.0` | [View changelog](/docs/changelog/core) |
 
 ## Providers
 
 | Package | Current version | Release notes |
 | --- | --- | --- |
-| `@anvia/anthropic` | `0.2.0` | [View changelog](/docs/changelog/anthropic) |
-| `@anvia/gemini` | `0.1.10` | [View changelog](/docs/changelog/gemini) |
-| `@anvia/mistral` | `0.1.6` | [View changelog](/docs/changelog/mistral) |
-| `@anvia/openai` | `0.2.1` | [View changelog](/docs/changelog/openai) |
+| `@anvia/anthropic` | `0.3.1` | [View changelog](/docs/changelog/anthropic) |
+| `@anvia/gemini` | `0.2.1` | [View changelog](/docs/changelog/gemini) |
+| `@anvia/mistral` | `0.2.0` | [View changelog](/docs/changelog/mistral) |
+| `@anvia/openai` | `0.3.1` | [View changelog](/docs/changelog/openai) |
 
 ## Embeddings
 
 | Package | Current version | Release notes |
 | --- | --- | --- |
-| `@anvia/fastembed` | `0.1.4` | [View changelog](/docs/changelog/fastembed) |
-| `@anvia/transformers` | `0.1.4` | [View changelog](/docs/changelog/transformers) |
+| `@anvia/fastembed` | `0.2.0` | [View changelog](/docs/changelog/fastembed) |
+| `@anvia/transformers` | `0.2.0` | [View changelog](/docs/changelog/transformers) |
 
 ## Vector Stores
 
 | Package | Current version | Release notes |
 | --- | --- | --- |
-| `@anvia/chroma` | `0.1.4` | [View changelog](/docs/changelog/chroma) |
-| `@anvia/pgvector` | `0.1.6` | [View changelog](/docs/changelog/pgvector) |
-| `@anvia/qdrant` | `0.1.4` | [View changelog](/docs/changelog/qdrant) |
+| `@anvia/chroma` | `0.2.0` | [View changelog](/docs/changelog/chroma) |
+| `@anvia/pgvector` | `0.2.0` | [View changelog](/docs/changelog/pgvector) |
+| `@anvia/qdrant` | `0.2.0` | [View changelog](/docs/changelog/qdrant) |
 
 ## Logger
 
 | Package | Current version | Release notes |
 | --- | --- | --- |
-| `@anvia/logger` | `0.2.0` | [View changelog](/docs/changelog/logger) |
+| `@anvia/logger` | `0.3.1` | [View changelog](/docs/changelog/logger) |
 
 ## Observability
 
 | Package | Current version | Release notes |
 | --- | --- | --- |
-| `@anvia/langfuse` | `0.1.7` | [View changelog](/docs/changelog/langfuse) |
-| `@anvia/otel` | `0.1.5` | [View changelog](/docs/changelog/otel) |
+| `@anvia/langfuse` | `0.2.0` | [View changelog](/docs/changelog/langfuse) |
+| `@anvia/otel` | `0.2.0` | [View changelog](/docs/changelog/otel) |
 
 ## Tools
 
 | Package | Current version | Release notes |
 | --- | --- | --- |
-| `@anvia/studio` | `0.2.11` | [View changelog](/docs/changelog/studio) |
+| `@anvia/studio` | `0.5.1` | [View changelog](/docs/changelog/studio) |
 
 ## React
 
 | Package | Current version | Release notes |
 | --- | --- | --- |
-| `@anvia/react` | `0.2.0` | [View changelog](/docs/changelog/react) |
+| `@anvia/react` | `0.3.0` | [View changelog](/docs/changelog/react) |
 
 ## Server
 
 | Package | Current version | Release notes |
 | --- | --- | --- |
-| `@anvia/server` | `0.2.0` | [View changelog](/docs/changelog/server) |
+| `@anvia/server` | `0.3.0` | [View changelog](/docs/changelog/server) |
+
+</div>

--- a/apps/docs/content/docs/changelog/langfuse.mdx
+++ b/apps/docs/content/docs/changelog/langfuse.mdx
@@ -9,6 +9,17 @@ Langfuse tracing adapter for Anvia.
 
 Source: [`packages/observability/langfuse/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/observability/langfuse/CHANGELOG.md)
 
+## 0.2.0
+
+### Minor Changes
+
+- e84d775: Clean up the `@anvia/core` public import surface by keeping common app-authoring APIs on the root export, moving advanced APIs to focused subpaths, and exposing runtime agent internals through `@anvia/core/internal/agent` for Anvia integration packages.
+
+### Patch Changes
+
+- Updated dependencies [e84d775]
+  - @anvia/core@0.4.0
+
 ## 0.1.7
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/logger.mdx
+++ b/apps/docs/content/docs/changelog/logger.mdx
@@ -9,6 +9,23 @@ Structured logger adapters for Anvia.
 
 Source: [`packages/logger/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/logger/CHANGELOG.md)
 
+## 0.3.1
+
+### Patch Changes
+
+- c9728d4: Update upstream runtime dependencies to their latest compatible releases.
+
+## 0.3.0
+
+### Minor Changes
+
+- e84d775: Clean up the `@anvia/core` public import surface by keeping common app-authoring APIs on the root export, moving advanced APIs to focused subpaths, and exposing runtime agent internals through `@anvia/core/internal/agent` for Anvia integration packages.
+
+### Patch Changes
+
+- Updated dependencies [e84d775]
+  - @anvia/core@0.4.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/apps/docs/content/docs/changelog/mistral.mdx
+++ b/apps/docs/content/docs/changelog/mistral.mdx
@@ -9,6 +9,17 @@ Mistral provider adapter for Anvia.
 
 Source: [`packages/providers/mistral/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/providers/mistral/CHANGELOG.md)
 
+## 0.2.0
+
+### Minor Changes
+
+- e84d775: Clean up the `@anvia/core` public import surface by keeping common app-authoring APIs on the root export, moving advanced APIs to focused subpaths, and exposing runtime agent internals through `@anvia/core/internal/agent` for Anvia integration packages.
+
+### Patch Changes
+
+- Updated dependencies [e84d775]
+  - @anvia/core@0.4.0
+
 ## 0.1.6
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/openai.mdx
+++ b/apps/docs/content/docs/changelog/openai.mdx
@@ -9,6 +9,23 @@ OpenAI provider adapter for Anvia.
 
 Source: [`packages/providers/openai/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/providers/openai/CHANGELOG.md)
 
+## 0.3.1
+
+### Patch Changes
+
+- c9728d4: Update upstream runtime dependencies to their latest compatible releases.
+
+## 0.3.0
+
+### Minor Changes
+
+- e84d775: Clean up the `@anvia/core` public import surface by keeping common app-authoring APIs on the root export, moving advanced APIs to focused subpaths, and exposing runtime agent internals through `@anvia/core/internal/agent` for Anvia integration packages.
+
+### Patch Changes
+
+- Updated dependencies [e84d775]
+  - @anvia/core@0.4.0
+
 ## 0.2.1
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/otel.mdx
+++ b/apps/docs/content/docs/changelog/otel.mdx
@@ -9,6 +9,17 @@ OpenTelemetry tracing adapter for Anvia.
 
 Source: [`packages/observability/otel/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/observability/otel/CHANGELOG.md)
 
+## 0.2.0
+
+### Minor Changes
+
+- e84d775: Clean up the `@anvia/core` public import surface by keeping common app-authoring APIs on the root export, moving advanced APIs to focused subpaths, and exposing runtime agent internals through `@anvia/core/internal/agent` for Anvia integration packages.
+
+### Patch Changes
+
+- Updated dependencies [e84d775]
+  - @anvia/core@0.4.0
+
 ## 0.1.5
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/pgvector.mdx
+++ b/apps/docs/content/docs/changelog/pgvector.mdx
@@ -9,6 +9,17 @@ Postgres pgvector store adapter for Anvia.
 
 Source: [`packages/vector-stores/pgvector/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/vector-stores/pgvector/CHANGELOG.md)
 
+## 0.2.0
+
+### Minor Changes
+
+- e84d775: Clean up the `@anvia/core` public import surface by keeping common app-authoring APIs on the root export, moving advanced APIs to focused subpaths, and exposing runtime agent internals through `@anvia/core/internal/agent` for Anvia integration packages.
+
+### Patch Changes
+
+- Updated dependencies [e84d775]
+  - @anvia/core@0.4.0
+
 ## 0.1.6
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/qdrant.mdx
+++ b/apps/docs/content/docs/changelog/qdrant.mdx
@@ -9,6 +9,17 @@ Qdrant vector store adapter for Anvia.
 
 Source: [`packages/vector-stores/qdrant/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/vector-stores/qdrant/CHANGELOG.md)
 
+## 0.2.0
+
+### Minor Changes
+
+- e84d775: Clean up the `@anvia/core` public import surface by keeping common app-authoring APIs on the root export, moving advanced APIs to focused subpaths, and exposing runtime agent internals through `@anvia/core/internal/agent` for Anvia integration packages.
+
+### Patch Changes
+
+- Updated dependencies [e84d775]
+  - @anvia/core@0.4.0
+
 ## 0.1.4
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/react.mdx
+++ b/apps/docs/content/docs/changelog/react.mdx
@@ -9,6 +9,12 @@ React hooks and client transports for Anvia applications.
 
 Source: [`packages/react/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/react/CHANGELOG.md)
 
+## 0.3.0
+
+### Minor Changes
+
+- e84d775: Clean up the `@anvia/core` public import surface by keeping common app-authoring APIs on the root export, moving advanced APIs to focused subpaths, and exposing runtime agent internals through `@anvia/core/internal/agent` for Anvia integration packages.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/apps/docs/content/docs/changelog/server.mdx
+++ b/apps/docs/content/docs/changelog/server.mdx
@@ -9,6 +9,12 @@ Server-side event stream helpers for Anvia applications.
 
 Source: [`packages/server/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/server/CHANGELOG.md)
 
+## 0.3.0
+
+### Minor Changes
+
+- e84d775: Clean up the `@anvia/core` public import surface by keeping common app-authoring APIs on the root export, moving advanced APIs to focused subpaths, and exposing runtime agent internals through `@anvia/core/internal/agent` for Anvia integration packages.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/apps/docs/content/docs/changelog/studio.mdx
+++ b/apps/docs/content/docs/changelog/studio.mdx
@@ -9,6 +9,45 @@ Studio UI and HTTP runtime for Anvia agents.
 
 Source: [`packages/tools/studio/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/tools/studio/CHANGELOG.md)
 
+## 0.5.1
+
+### Patch Changes
+
+- c9728d4: Update upstream runtime dependencies to their latest compatible releases.
+
+## 0.5.0
+
+### Minor Changes
+
+- e84d775: Clean up the `@anvia/core` public import surface by keeping common app-authoring APIs on the root export, moving advanced APIs to focused subpaths, and exposing runtime agent internals through `@anvia/core/internal/agent` for Anvia integration packages.
+
+### Patch Changes
+
+- Updated dependencies [e84d775]
+  - @anvia/core@0.4.0
+
+## 0.4.1
+
+### Patch Changes
+
+- 6c53426: Make Studio UI routes consistently use the configured UI path, add the missing Evals shell route, restore the dynamic tools Knowledge tab, and make runtime JSON serialization safe for cyclic model metadata.
+
+## 0.4.0
+
+### Minor Changes
+
+- b542b87: Add Studio inspection surfaces for memory, runtime status, richer agent metadata, direct tool invocation, pipeline replay controls, realtime observability events, and eval suite runs, with in-memory storage as the default and optional SQLite persistence.
+
+### Patch Changes
+
+- b542b87: Allow Studio to accept typed pipelines with arbitrary input and output types, and update the cookbook Studio inspection example to point at the correct UI routes.
+
+## 0.3.0
+
+### Minor Changes
+
+- e74df22: Add Studio inspection surfaces for memory, runtime status, richer agent metadata, direct tool invocation, pipeline replay controls, realtime observability events, and eval suite runs, with in-memory storage as the default and optional SQLite persistence.
+
 ## 0.2.11
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/transformers.mdx
+++ b/apps/docs/content/docs/changelog/transformers.mdx
@@ -9,6 +9,17 @@ Transformers.js embedding model adapter for Anvia.
 
 Source: [`packages/embeddings/transformers/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/embeddings/transformers/CHANGELOG.md)
 
+## 0.2.0
+
+### Minor Changes
+
+- e84d775: Clean up the `@anvia/core` public import surface by keeping common app-authoring APIs on the root export, moving advanced APIs to focused subpaths, and exposing runtime agent internals through `@anvia/core/internal/agent` for Anvia integration packages.
+
+### Patch Changes
+
+- Updated dependencies [e84d775]
+  - @anvia/core@0.4.0
+
 ## 0.1.4
 
 ### Patch Changes

--- a/apps/docs/content/docs/frameworks/express/01-prep.mdx
+++ b/apps/docs/content/docs/frameworks/express/01-prep.mdx
@@ -18,7 +18,7 @@ pnpm add -D tsx typescript @types/node @types/express
 ## 2. Install Anvia
 
 ```sh
-pnpm add @anvia/core @anvia/openai
+pnpm add @anvia/core @anvia/openai @anvia/server
 ```
 
 Install other provider packages when needed:

--- a/apps/docs/content/docs/frameworks/express/04-streaming.mdx
+++ b/apps/docs/content/docs/frameworks/express/04-streaming.mdx
@@ -3,11 +3,13 @@ title: 04 Streaming
 description: Stream Anvia run events from an Express route.
 ---
 
-Express uses Node response objects. Read from Anvia's Web `ReadableStream` and write NDJSON chunks to `res`.
+Express uses Node response objects. Use `@anvia/server` to create the event stream response, then bridge its Web stream into `res`.
 
 ## 1. Add `/api/support/stream`
 
 ```ts
+import { Readable } from "node:stream";
+import { createEventStream } from "@anvia/server";
 import { Router } from "express";
 import { z } from "zod";
 import { supportAgent } from "../ai/support-agent";
@@ -28,19 +30,20 @@ supportRouter.post("/support/stream", async (req, res, next) => {
       });
     }
 
-    res.setHeader("Content-Type", "application/x-ndjson");
-    res.setHeader("Cache-Control", "no-cache");
+    const streamResponse = createEventStream(supportAgent.prompt(parsed.data.message).stream(), {
+      format: "jsonl",
+    });
 
-    const reader = supportAgent.prompt(parsed.data.message).readableStream().getReader();
-    const decoder = new TextDecoder();
+    streamResponse.headers.forEach((value, key) => {
+      res.setHeader(key, value);
+    });
 
-    while (true) {
-      const next = await reader.read();
-      if (next.done) break;
-      res.write(decoder.decode(next.value));
+    if (streamResponse.body === null) {
+      res.end();
+      return;
     }
 
-    res.end();
+    Readable.fromWeb(streamResponse.body).on("error", next).pipe(res);
   } catch (error) {
     next(error);
   }

--- a/apps/docs/content/docs/frameworks/express/08-troubleshooting.mdx
+++ b/apps/docs/content/docs/frameworks/express/08-troubleshooting.mdx
@@ -28,11 +28,12 @@ if (!parsed.success) {
 
 ## Stream Does Not Flush
 
-Set `application/x-ndjson`, call `res.write(...)`, and check proxy buffering.
+Use `createEventStream(...)`, pipe the response body to `res`, and check proxy buffering.
 
 ```ts
-res.setHeader("Content-Type", "application/x-ndjson");
-res.write(chunk);
+const streamResponse = createEventStream(agent.prompt(message).stream());
+streamResponse.headers.forEach((value, key) => res.setHeader(key, value));
+Readable.fromWeb(streamResponse.body).pipe(res);
 ```
 
 ## Provider Failures Leak Details

--- a/apps/docs/content/docs/frameworks/express/10-setup-tests.mdx
+++ b/apps/docs/content/docs/frameworks/express/10-setup-tests.mdx
@@ -53,7 +53,7 @@ const response = await request(app)
 expect(response.headers["content-type"]).toContain("application/x-ndjson");
 ```
 
-Mock `readableStream()` with a small `ReadableStream` that emits one `final` event.
+Mock `stream()` with a small async iterable that emits one `final` event.
 
 ## 4. Test Studio Without A Port
 

--- a/apps/docs/content/docs/frameworks/fastify/01-prep.mdx
+++ b/apps/docs/content/docs/frameworks/fastify/01-prep.mdx
@@ -18,7 +18,7 @@ pnpm add -D tsx typescript @types/node
 ## 2. Install Anvia
 
 ```sh
-pnpm add @anvia/core @anvia/openai
+pnpm add @anvia/core @anvia/openai @anvia/server
 ```
 
 Install other provider packages when needed:

--- a/apps/docs/content/docs/frameworks/fastify/04-streaming.mdx
+++ b/apps/docs/content/docs/frameworks/fastify/04-streaming.mdx
@@ -3,11 +3,13 @@ title: 04 Streaming
 description: Stream Anvia run events from a Fastify route.
 ---
 
-Fastify replies can send stream-like payloads. Set NDJSON headers and return Anvia's `readableStream()`.
+Fastify replies can send stream-like payloads. Use `@anvia/server` to serialize Anvia events and set the correct stream headers.
 
 ## 1. Add `/api/support/stream`
 
 ```ts
+import { Readable } from "node:stream";
+import { createEventStream } from "@anvia/server";
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { supportAgent } from "../ai/support-agent";
@@ -26,10 +28,19 @@ export async function supportRoutes(app: FastifyInstance) {
       });
     }
 
-    return reply
-      .header("Content-Type", "application/x-ndjson")
-      .header("Cache-Control", "no-cache")
-      .send(supportAgent.prompt(parsed.data.message).readableStream());
+    const streamResponse = createEventStream(supportAgent.prompt(parsed.data.message).stream(), {
+      format: "jsonl",
+    });
+
+    streamResponse.headers.forEach((value, key) => {
+      reply.header(key, value);
+    });
+
+    if (streamResponse.body === null) {
+      return reply.status(streamResponse.status).send();
+    }
+
+    return reply.status(streamResponse.status).send(Readable.fromWeb(streamResponse.body));
   });
 }
 ```

--- a/apps/docs/content/docs/frameworks/fastify/08-troubleshooting.mdx
+++ b/apps/docs/content/docs/frameworks/fastify/08-troubleshooting.mdx
@@ -31,9 +31,9 @@ if (!parsed.success) {
 Set the NDJSON content type and check proxy buffering.
 
 ```ts
-return reply
-  .header("Content-Type", "application/x-ndjson")
-  .send(agent.prompt(message).readableStream());
+const streamResponse = createEventStream(agent.prompt(message).stream());
+streamResponse.headers.forEach((value, key) => reply.header(key, value));
+return reply.send(Readable.fromWeb(streamResponse.body));
 ```
 
 ## Provider Failures Leak Details

--- a/apps/docs/content/docs/frameworks/fastify/10-setup-tests.mdx
+++ b/apps/docs/content/docs/frameworks/fastify/10-setup-tests.mdx
@@ -55,7 +55,7 @@ const response = await app.inject({
 expect(response.headers["content-type"]).toContain("application/x-ndjson");
 ```
 
-Mock `readableStream()` with a small `ReadableStream` that emits one `final` event.
+Mock `stream()` with a small async iterable that emits one `final` event.
 
 ## 4. Test Studio Without A Port
 

--- a/apps/docs/content/docs/frameworks/hono/01-prep.mdx
+++ b/apps/docs/content/docs/frameworks/hono/01-prep.mdx
@@ -18,7 +18,7 @@ pnpm add -D tsx typescript @types/node
 ## 2. Install Anvia
 
 ```sh
-pnpm add @anvia/core @anvia/openai @hono/zod-validator zod
+pnpm add @anvia/core @anvia/openai @anvia/server @hono/zod-validator zod
 ```
 
 Install other provider packages when you need them:

--- a/apps/docs/content/docs/frameworks/hono/04-streaming.mdx
+++ b/apps/docs/content/docs/frameworks/hono/04-streaming.mdx
@@ -3,12 +3,13 @@ title: 04 Streaming
 description: Stream Anvia run events from a Hono route.
 ---
 
-Hono handlers can return a standard `Response`, so Anvia `readableStream()` can be used directly.
+Hono handlers can return a standard `Response`, so `@anvia/server` can serialize Anvia events directly.
 
 ## 1. Add `/api/support/stream`
 
 ```ts
 import { zValidator } from "@hono/zod-validator";
+import { createEventStream } from "@anvia/server";
 import { z } from "zod";
 import { supportAgent } from "./ai/support-agent";
 
@@ -18,12 +19,7 @@ const SupportStreamRequest = z.object({
 
 app.post("/api/support/stream", zValidator("json", SupportStreamRequest), async (c) => {
   const { message } = c.req.valid("json");
-  return new Response(supportAgent.prompt(message).readableStream(), {
-    headers: {
-      "Content-Type": "application/x-ndjson",
-      "Cache-Control": "no-cache",
-    },
-  });
+  return createEventStream(supportAgent.prompt(message).stream(), { format: "jsonl" });
 });
 ```
 

--- a/apps/docs/content/docs/frameworks/hono/08-troubleshooting.mdx
+++ b/apps/docs/content/docs/frameworks/hono/08-troubleshooting.mdx
@@ -48,12 +48,10 @@ if (!apiKey) throw new Error("OPENAI_API_KEY is required");
 
 ## Streaming Does Not Flush
 
-Return a Web `Response` with the Anvia stream and NDJSON content type:
+Return the event stream response from `@anvia/server`:
 
 ```ts
-return new Response(agent.prompt(message).readableStream(), {
-  headers: { "Content-Type": "application/x-ndjson" },
-});
+return createEventStream(agent.prompt(message).stream(), { format: "jsonl" });
 ```
 
 Check adapter support, reverse proxy buffering, and route timeouts.

--- a/apps/docs/content/docs/frameworks/hono/10-setup-tests.mdx
+++ b/apps/docs/content/docs/frameworks/hono/10-setup-tests.mdx
@@ -68,7 +68,7 @@ const response = await app.request("/api/support/stream", {
 expect(response.headers.get("content-type")).toContain("application/x-ndjson");
 ```
 
-Mock `readableStream()` with a small `ReadableStream` that emits one final event.
+Mock `stream()` with a small async iterable that emits one final event.
 
 ## 5. Test Studio Without a Port
 

--- a/apps/docs/content/docs/frameworks/index.mdx
+++ b/apps/docs/content/docs/frameworks/index.mdx
@@ -5,6 +5,8 @@ description: Add Anvia agents to application frameworks without giving up your a
 
 These guides show how to move Anvia from a local script into real HTTP runtimes.
 
+Use `@anvia/server` at the HTTP boundary to return JSONL or SSE event streams. In React-based apps, use `@anvia/react` for chat state and fetch-backed stream transports.
+
 Each framework follows the same path:
 
 | Step | Goal |
@@ -12,7 +14,7 @@ Each framework follows the same path:
 | 01 Prep | Create the project shape and install Anvia packages |
 | 02 Setup Anvia | Build provider clients, models, tools, and agents in server-side modules |
 | 03 Route Handler | Return a normal JSON response from a framework route |
-| 04 Streaming | Return newline-delimited stream events from the same agent |
+| 04 Streaming | Return `@anvia/server` event streams from the same agent |
 | 05 Tools and Context | Pass request-local auth, product data, and retrieval context safely |
 | 06 Persistence | Store conversation history through your application storage |
 | 07 Deploy | Check runtime, environment, and operational constraints |

--- a/apps/docs/content/docs/frameworks/nestjs/01-prep.mdx
+++ b/apps/docs/content/docs/frameworks/nestjs/01-prep.mdx
@@ -17,7 +17,7 @@ Use TypeScript and the default Express HTTP adapter unless your app already uses
 ## 2. Install Anvia
 
 ```sh
-pnpm add @anvia/core @anvia/openai zod
+pnpm add @anvia/core @anvia/openai @anvia/server zod
 pnpm add -D @types/express
 ```
 

--- a/apps/docs/content/docs/frameworks/nestjs/02-setup-anvia.mdx
+++ b/apps/docs/content/docs/frameworks/nestjs/02-setup-anvia.mdx
@@ -61,7 +61,7 @@ export class SupportAgentService {
   }
 
   streamSupport(message: string) {
-    return this.agent.prompt(message).readableStream();
+    return this.agent.prompt(message).stream();
   }
 
   getAgent() {

--- a/apps/docs/content/docs/frameworks/nestjs/04-streaming.mdx
+++ b/apps/docs/content/docs/frameworks/nestjs/04-streaming.mdx
@@ -3,11 +3,12 @@ title: 04 Streaming
 description: Stream Anvia run events from a NestJS controller.
 ---
 
-With the default Express adapter, inject `@Res()` and pipe Anvia's Web stream into the Node response.
+With the default Express adapter, inject `@Res()`, create the Anvia event response with `@anvia/server`, and pipe its Web stream into the Node response.
 
 ## 1. Add A Streaming Controller Method
 
 ```ts
+import { createEventStream } from "@anvia/server";
 import { BadRequestException, Body, Controller, Post, Res } from "@nestjs/common";
 import type { Response } from "express";
 import { Readable } from "node:stream";
@@ -30,11 +31,20 @@ export class SupportController {
       throw new BadRequestException(parsed.error.issues[0]?.message);
     }
 
-    res.setHeader("Content-Type", "application/x-ndjson");
-    res.setHeader("Cache-Control", "no-cache");
+    const streamResponse = createEventStream(this.supportAgent.streamSupport(parsed.data.message), {
+      format: "jsonl",
+    });
 
-    const stream = Readable.fromWeb(this.supportAgent.streamSupport(parsed.data.message));
-    stream.pipe(res);
+    streamResponse.headers.forEach((value, key) => {
+      res.setHeader(key, value);
+    });
+
+    if (streamResponse.body === null) {
+      res.end();
+      return;
+    }
+
+    Readable.fromWeb(streamResponse.body).pipe(res);
   }
 }
 ```

--- a/apps/docs/content/docs/frameworks/nestjs/10-setup-tests.mdx
+++ b/apps/docs/content/docs/frameworks/nestjs/10-setup-tests.mdx
@@ -57,7 +57,7 @@ Nest returns `201` for `POST` by default unless you set `@HttpCode(200)`.
 
 ## 3. Test The Stream Method
 
-Mock `streamSupport()` with a small `ReadableStream` that emits one `final` event. Assert the controller sets `application/x-ndjson`.
+Mock `streamSupport()` with a small async iterable that emits one `final` event. Assert the controller sets `application/x-ndjson`.
 
 ## 4. Test Studio Without A Port
 

--- a/apps/docs/content/docs/frameworks/nextjs/01-prep.mdx
+++ b/apps/docs/content/docs/frameworks/nextjs/01-prep.mdx
@@ -17,7 +17,7 @@ If you already have a Next.js app, use the App Router `app/` directory. The rout
 ## 2. Install Anvia
 
 ```sh
-pnpm add @anvia/core @anvia/openai zod
+pnpm add @anvia/core @anvia/openai @anvia/server @anvia/react zod
 ```
 
 Install other provider packages when you need them:
@@ -54,7 +54,7 @@ Keep these files server-only:
 | `app/api/support/route.ts` | Non-streaming prompt endpoint |
 | `app/api/support/stream/route.ts` | Streaming prompt endpoint |
 
-Next.js route handlers use the Web `Request` and `Response` APIs, so Anvia `readableStream()` can be returned directly.
+Next.js route handlers use the Web `Request` and `Response` APIs, so `@anvia/server` can return Anvia streams directly. React client components can consume those streams with `@anvia/react`.
 
 ## Next
 

--- a/apps/docs/content/docs/frameworks/nextjs/04-streaming.mdx
+++ b/apps/docs/content/docs/frameworks/nextjs/04-streaming.mdx
@@ -3,11 +3,12 @@ title: 04 Streaming
 description: Stream Anvia run events from a Next.js route handler.
 ---
 
-Anvia exposes a Web `ReadableStream`, so Next.js route handlers can return it directly.
+Next.js route handlers can return the streaming `Response` created by `@anvia/server`.
 
 ## 1. Create `app/api/support/stream/route.ts`
 
 ```ts
+import { createEventStream } from "@anvia/server";
 import { supportAgent } from "@/app/ai/support-agent";
 
 export const runtime = "nodejs";
@@ -27,34 +28,32 @@ export async function POST(request: Request): Promise<Response> {
     );
   }
 
-  return new Response(supportAgent.prompt(message).readableStream(), {
-    headers: {
-      "Content-Type": "application/x-ndjson",
-      "Cache-Control": "no-cache",
-    },
-  });
+  return createEventStream(supportAgent.prompt(message).stream(), { format: "jsonl" });
 }
 ```
 
-## 2. Consume Events
+## 2. Consume Events From React
 
-```ts
-const response = await fetch("/api/support/stream", {
-  method: "POST",
-  headers: { "Content-Type": "application/json" },
-  body: JSON.stringify({ message: "Draft a refund reply." }),
-});
+```tsx
+"use client";
 
-const reader = response.body?.getReader();
-const decoder = new TextDecoder();
+import { useChat } from "@anvia/react";
 
-while (reader) {
-  const next = await reader.read();
-  if (next.done) break;
+export function SupportChat() {
+  const chat = useChat({ endpoint: "/api/support/stream" });
 
-  for (const line of decoder.decode(next.value).split("\n")) {
-    if (line.trim()) console.log(JSON.parse(line));
-  }
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        void chat.send();
+      }}
+    >
+      <div>{chat.text}</div>
+      <input value={chat.input} onChange={(event) => chat.setInput(event.target.value)} />
+      <button disabled={chat.status === "streaming"}>Send</button>
+    </form>
+  );
 }
 ```
 

--- a/apps/docs/content/docs/frameworks/nextjs/08-troubleshooting.mdx
+++ b/apps/docs/content/docs/frameworks/nextjs/08-troubleshooting.mdx
@@ -33,12 +33,7 @@ The agent module was imported by a client component. Import it only from route h
 Check proxy buffering, function timeouts, and response headers:
 
 ```ts
-return new Response(agent.prompt(message).readableStream(), {
-  headers: {
-    "Content-Type": "application/x-ndjson",
-    "Cache-Control": "no-cache",
-  },
-});
+return createEventStream(agent.prompt(message).stream(), { format: "jsonl" });
 ```
 
 ## Tool Can Read The Wrong User

--- a/apps/docs/content/docs/frameworks/nextjs/10-setup-tests.mdx
+++ b/apps/docs/content/docs/frameworks/nextjs/10-setup-tests.mdx
@@ -63,7 +63,7 @@ const response = await POST(
 expect(response.headers.get("content-type")).toContain("application/x-ndjson");
 ```
 
-Mock `readableStream()` with a small `ReadableStream` that emits one `final` event.
+Mock `stream()` with a small async iterable that emits one `final` event.
 
 ## 4. Test Studio Without a Port
 

--- a/apps/docs/content/docs/frameworks/sveltekit/01-prep.mdx
+++ b/apps/docs/content/docs/frameworks/sveltekit/01-prep.mdx
@@ -18,7 +18,7 @@ Choose TypeScript. Anvia code belongs in server-only files, not client component
 ## 2. Install Anvia
 
 ```sh
-pnpm add @anvia/core @anvia/openai zod
+pnpm add @anvia/core @anvia/openai @anvia/server zod
 ```
 
 Install other providers when needed:

--- a/apps/docs/content/docs/frameworks/sveltekit/04-streaming.mdx
+++ b/apps/docs/content/docs/frameworks/sveltekit/04-streaming.mdx
@@ -3,11 +3,12 @@ title: 04 Streaming
 description: Stream Anvia run events from a SvelteKit endpoint.
 ---
 
-SvelteKit endpoints can return standard `Response` objects, so Anvia streams can be returned directly.
+SvelteKit endpoints can return standard `Response` objects, so `@anvia/server` can serialize Anvia events directly.
 
 ## 1. Create `src/routes/api/support/stream/+server.ts`
 
 ```ts
+import { createEventStream } from "@anvia/server";
 import type { RequestHandler } from "@sveltejs/kit";
 import { z } from "zod";
 import { supportAgent } from "$lib/server/ai/support-agent";
@@ -26,11 +27,8 @@ export const POST: RequestHandler = async ({ request }) => {
     );
   }
 
-  return new Response(supportAgent.prompt(parsed.data.message).readableStream(), {
-    headers: {
-      "Content-Type": "application/x-ndjson",
-      "Cache-Control": "no-cache",
-    },
+  return createEventStream(supportAgent.prompt(parsed.data.message).stream(), {
+    format: "jsonl",
   });
 };
 ```

--- a/apps/docs/content/docs/frameworks/sveltekit/08-troubleshooting.mdx
+++ b/apps/docs/content/docs/frameworks/sveltekit/08-troubleshooting.mdx
@@ -31,12 +31,10 @@ if (!parsed.success) {
 
 ## Stream Does Not Flush
 
-Check the adapter and hosting platform. Return a `Response` with `application/x-ndjson` and avoid wrapping the stream in `json(...)`.
+Check the adapter and hosting platform. Return the event stream response from `@anvia/server` and avoid wrapping the stream in `json(...)`.
 
 ```ts
-return new Response(agent.prompt(message).readableStream(), {
-  headers: { "Content-Type": "application/x-ndjson" },
-});
+return createEventStream(agent.prompt(message).stream(), { format: "jsonl" });
 ```
 
 ## Provider Failures

--- a/apps/docs/content/docs/frameworks/sveltekit/10-setup-tests.mdx
+++ b/apps/docs/content/docs/frameworks/sveltekit/10-setup-tests.mdx
@@ -53,17 +53,14 @@ describe("POST /api/support", () => {
 ## 3. Test The Stream Endpoint
 
 ```ts
-const stream = new ReadableStream({
-  start(controller) {
-    controller.enqueue(new TextEncoder().encode('{"type":"final"}\n'));
-    controller.close();
-  },
-});
+async function* stream() {
+  yield { type: "final", output: "Hello" };
+}
 
 vi.mock("$lib/server/ai/support-agent", () => ({
   supportAgent: {
     prompt: () => ({
-      readableStream: () => stream,
+      stream,
     }),
   },
 }));

--- a/apps/docs/content/docs/frameworks/tanstack-start/01-prep.mdx
+++ b/apps/docs/content/docs/frameworks/tanstack-start/01-prep.mdx
@@ -17,7 +17,7 @@ cd anvia-start
 ## 2. Install Anvia
 
 ```sh
-pnpm add @anvia/core @anvia/openai zod
+pnpm add @anvia/core @anvia/openai @anvia/server @anvia/react zod
 ```
 
 Install other provider packages only when you need them:

--- a/apps/docs/content/docs/frameworks/tanstack-start/04-streaming.mdx
+++ b/apps/docs/content/docs/frameworks/tanstack-start/04-streaming.mdx
@@ -3,11 +3,12 @@ title: 04 Streaming
 description: Stream Anvia run events from a TanStack Start server route.
 ---
 
-Use a server route for streaming because it gives direct access to `Response`.
+Use a server route for streaming because it gives direct access to the `Response` created by `@anvia/server`.
 
 ## 1. Add `POST` Streaming Handler
 
 ```ts
+import { createEventStream } from "@anvia/server";
 import { createFileRoute } from "@tanstack/react-router";
 import { supportAgent } from "~/ai/support-agent";
 
@@ -29,37 +30,33 @@ export const Route = createFileRoute("/api/support/stream")({
           );
         }
 
-        return new Response(supportAgent.prompt(message).readableStream(), {
-          headers: {
-            "Content-Type": "application/x-ndjson",
-            "Cache-Control": "no-cache",
-          },
-        });
+        return createEventStream(supportAgent.prompt(message).stream(), { format: "jsonl" });
       },
     },
   },
 });
 ```
 
-## 2. Consume Stream Lines
+## 2. Consume Stream Events From React
 
-```ts
-const response = await fetch("/api/support/stream", {
-  method: "POST",
-  headers: { "Content-Type": "application/json" },
-  body: JSON.stringify({ message: "Draft a support reply." }),
-});
+```tsx
+import { useChat } from "@anvia/react";
 
-const reader = response.body?.getReader();
-const decoder = new TextDecoder();
+export function SupportChat() {
+  const chat = useChat({ endpoint: "/api/support/stream" });
 
-while (reader) {
-  const next = await reader.read();
-  if (next.done) break;
-
-  for (const line of decoder.decode(next.value).split("\n")) {
-    if (line.trim()) console.log(JSON.parse(line));
-  }
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        void chat.send();
+      }}
+    >
+      <div>{chat.text}</div>
+      <input value={chat.input} onChange={(event) => chat.setInput(event.target.value)} />
+      <button disabled={chat.status === "streaming"}>Send</button>
+    </form>
+  );
 }
 ```
 

--- a/apps/docs/content/docs/frameworks/tanstack-start/08-troubleshooting.mdx
+++ b/apps/docs/content/docs/frameworks/tanstack-start/08-troubleshooting.mdx
@@ -32,12 +32,10 @@ Keep provider clients, agents, database clients, and scoped tool factories out o
 
 ## Streaming Does Not Flush
 
-Use a server route, return a `Response`, and set NDJSON headers:
+Use a server route and return the event stream response from `@anvia/server`:
 
 ```ts
-return new Response(agent.prompt(message).readableStream(), {
-  headers: { "Content-Type": "application/x-ndjson" },
-});
+return createEventStream(agent.prompt(message).stream(), { format: "jsonl" });
 ```
 
 Also check host buffering and route timeouts.

--- a/apps/docs/scripts/generate-changelogs.mjs
+++ b/apps/docs/scripts/generate-changelogs.mjs
@@ -144,7 +144,11 @@ Anvia package release notes are generated from the package changelog files maint
 
 Developers should keep writing release notes with \`pnpm changeset\`. The docs pages in this section are generated from \`packages/**/CHANGELOG.md\`.
 
+<div className="package-changelog-index">
+
 ${sections.join("\n\n")}
+
+</div>
 `;
 }
 

--- a/apps/docs/src/lib/layout.shared.tsx
+++ b/apps/docs/src/lib/layout.shared.tsx
@@ -7,6 +7,7 @@ const discordUrl = "https://discord.gg/6yegrFJBgp";
 const resourceLinks = [
   { text: "Best Practices", url: "/docs/best-practices" },
   { text: "Frameworks", url: "/docs/frameworks" },
+  { text: "Changelog", url: "/docs/changelog" },
   { text: "Studio", url: "/docs/studio/overview" },
   { text: "Reference", url: "/docs/reference" },
   { text: "Models", url: "/docs/models" },

--- a/apps/docs/src/routes/index.tsx
+++ b/apps/docs/src/routes/index.tsx
@@ -35,9 +35,9 @@ export const Route = createFileRoute("/")({
 });
 
 const metrics = [
-  { value: "13", label: "Runtime packages", icon: Package },
+  { value: "16", label: "Runtime packages", icon: Package },
   { value: "4", label: "Model adapters", icon: Boxes },
-  { value: "7", label: "Integration packages", icon: BookOpen },
+  { value: "8", label: "Integration packages", icon: BookOpen },
   { value: "1", label: "Core package", icon: Zap },
 ];
 
@@ -102,8 +102,8 @@ const docsEntrypoints = [
 const packageGroups = [
   {
     title: "Runtime",
-    description: "Core agent primitives plus the local inspection surface.",
-    packages: ["@anvia/core", "@anvia/studio"],
+    description: "Core agent primitives, application transports, hooks, and inspection.",
+    packages: ["@anvia/core", "@anvia/server", "@anvia/react", "@anvia/studio"],
   },
   {
     title: "Model adapters",
@@ -124,7 +124,7 @@ const packageGroups = [
   {
     title: "Observability",
     description: "Trace and score Anvia runs through existing telemetry systems.",
-    packages: ["@anvia/langfuse", "@anvia/otel"],
+    packages: ["@anvia/logger", "@anvia/langfuse", "@anvia/otel"],
   },
 ];
 

--- a/apps/docs/src/styles/app.css
+++ b/apps/docs/src/styles/app.css
@@ -151,6 +151,26 @@ body {
   background: var(--color-fd-accent);
 }
 
+.package-changelog-index table {
+  width: 100%;
+  table-layout: fixed;
+}
+
+.package-changelog-index table th:nth-child(1),
+.package-changelog-index table td:nth-child(1) {
+  width: 42%;
+}
+
+.package-changelog-index table th:nth-child(2),
+.package-changelog-index table td:nth-child(2) {
+  width: 28%;
+}
+
+.package-changelog-index table th:nth-child(3),
+.package-changelog-index table td:nth-child(3) {
+  width: 30%;
+}
+
 @media (max-width: 767px) {
   #nd-docs-layout.docs-with-section-tabs {
     --fd-header-height: 7.25rem;


### PR DESCRIPTION
## Summary
- update the docs homepage package count and package groups to include all current workspace packages
- update framework docs to use @anvia/server streaming helpers and @anvia/react in React framework examples
- add Changelog under the Resources menu and standardize changelog table column widths
- regenerate changelog docs from the existing package changelog files

## Testing
- pnpm exec biome check apps/docs/content/docs/frameworks apps/docs/src/routes/index.tsx
- pnpm exec biome check apps/docs/src/lib/layout.shared.tsx
- pnpm exec biome check apps/docs/scripts/generate-changelogs.mjs apps/docs/src/styles/app.css
- pnpm --filter docs exec fumadocs-mdx
- pnpm --filter docs typecheck

## Changeset
Not added. This PR changes docs and docs tooling only; it does not modify package source, package manifests, or releaseable package behavior.