### PR TITLE
Refactor Studio shared stream helpers

### DIFF
--- a/.changeset/studio-shared-stream-helpers.md
+++ b/.changeset/studio-shared-stream-helpers.md
@@ -1,0 +1,5 @@
+---
+"@anvia/studio": patch
+---
+
+Use shared `@anvia/server` and `@anvia/react` stream helpers internally while preserving Studio stream behavior and UI transcript handling.

--- a/packages/tools/studio/package.json
+++ b/packages/tools/studio/package.json
@@ -32,6 +32,8 @@
   },
   "dependencies": {
     "@anvia/core": "workspace:*",
+    "@anvia/react": "workspace:*",
+    "@anvia/server": "workspace:*",
     "@hono/node-server": "^2.0.4",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-alert-dialog": "^1.1.16",

--- a/packages/tools/studio/src/runtime/observability.ts
+++ b/packages/tools/studio/src/runtime/observability.ts
@@ -1,5 +1,4 @@
 import type { Hono } from "hono";
-import { stream as streamResponse } from "hono/streaming";
 import type {
   StudioObservabilityEvent,
   StudioObservabilityEventType,
@@ -10,6 +9,7 @@ import type {
   StudioTraceSummary,
 } from "../types";
 import type { ResolvedStores } from "./shared";
+import { streamStudioJsonl } from "./streams";
 
 type ObservabilitySubscription = {
   close: () => void;
@@ -72,27 +72,27 @@ export function registerObservabilityRoutes(app: Hono, hub: StudioObservabilityH
       );
     }
 
-    c.header("content-type", "application/x-ndjson; charset=utf-8");
-    c.header("cache-control", "no-cache, no-transform");
-    c.header("connection", "keep-alive");
-    c.header("transfer-encoding", "chunked");
-    c.header("x-accel-buffering", "no");
-
-    return streamResponse(c, async (stream) => {
-      const subscription = hub.subscribe(types === undefined ? {} : { types });
-      try {
-        while (true) {
-          const next = await subscription.next();
-          if (next.done === true) {
-            break;
-          }
-          await stream.write(`${JSON.stringify(next.value)}\n`);
-        }
-      } finally {
-        subscription.close();
-      }
-    });
+    return streamStudioJsonl(observabilityEvents(hub, types));
   });
+}
+
+function observabilityEvents(
+  hub: StudioObservabilityHub,
+  types: Set<StudioObservabilityEventType> | undefined,
+): AsyncIterable<StudioObservabilityEvent> {
+  const subscription = hub.subscribe(types === undefined ? {} : { types });
+
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        next: () => subscription.next(),
+        async return() {
+          subscription.close();
+          return { done: true, value: undefined };
+        },
+      };
+    },
+  };
 }
 
 function createSubscription(

--- a/packages/tools/studio/src/runtime/pipelines.ts
+++ b/packages/tools/studio/src/runtime/pipelines.ts
@@ -1,7 +1,6 @@
 import type { JsonObject, JsonValue } from "@anvia/core/completion";
 import type { PipelineRunEvent } from "@anvia/core/pipeline";
 import type { Context, Hono } from "hono";
-import { stream as streamResponse } from "hono/streaming";
 import type {
   AgentRunStreamEvent,
   StudioPipeline,
@@ -24,6 +23,7 @@ import {
 } from "./pipeline-logs";
 import { AsyncEventQueue } from "./runs";
 import { errorResponse, isJsonObject, isObject, pipelineConfig, serializeError } from "./shared";
+import { streamStudioJsonl } from "./streams";
 
 export function registerPipelineRoutes(
   app: Hono,
@@ -275,7 +275,7 @@ function pipelineDetail(pipeline: StudioPipeline): StudioPipelineDetail {
 }
 
 function streamPipelineRun(
-  c: Context,
+  _c: Context,
   props: {
     pipeline: StudioPipeline;
     runId: string;
@@ -287,23 +287,7 @@ function streamPipelineRun(
     runStore?: StudioPipelineRunStore;
   },
 ): Response {
-  c.header("content-type", "application/x-ndjson; charset=utf-8");
-  c.header("cache-control", "no-cache, no-transform");
-  c.header("connection", "keep-alive");
-  c.header("transfer-encoding", "chunked");
-  c.header("x-accel-buffering", "no");
-
-  return streamResponse(
-    c,
-    async (stream) => {
-      for await (const event of pipelineRunEvents(props)) {
-        await stream.write(`${JSON.stringify(event)}\n`);
-      }
-    },
-    async (error, stream) => {
-      await stream.write(`${JSON.stringify({ type: "error", error: serializeError(error) })}\n`);
-    },
-  );
+  return streamStudioJsonl(pipelineRunEvents(props));
 }
 
 async function* pipelineRunEvents(props: {

--- a/packages/tools/studio/src/runtime/runs.ts
+++ b/packages/tools/studio/src/runtime/runs.ts
@@ -2,7 +2,6 @@ import type { AgentStreamEvent } from "@anvia/core/agent";
 import type { Message } from "@anvia/core/completion";
 import type { AgentTraceOptions } from "@anvia/core/observability";
 import type { Context } from "hono";
-import { stream as streamResponse } from "hono/streaming";
 import type {
   AgentRunRequest,
   AgentRunStreamEvent,
@@ -22,6 +21,7 @@ import {
   isPositiveInteger,
   serializeError,
 } from "./shared";
+import { streamStudioJsonl } from "./streams";
 
 export class AsyncEventQueue<T> {
   private readonly values: T[] = [];
@@ -112,26 +112,10 @@ export async function* mergeRunAndApprovalEvents(
 }
 
 export function streamAgentRunEvents(
-  c: Context,
+  _c: Context,
   events: AsyncIterable<AgentRunStreamEvent>,
 ): Response {
-  c.header("content-type", "application/x-ndjson; charset=utf-8");
-  c.header("cache-control", "no-cache, no-transform");
-  c.header("connection", "keep-alive");
-  c.header("transfer-encoding", "chunked");
-  c.header("x-accel-buffering", "no");
-
-  return streamResponse(
-    c,
-    async (stream) => {
-      for await (const event of events) {
-        await stream.write(`${JSON.stringify(event)}\n`);
-      }
-    },
-    async (error, stream) => {
-      await stream.write(`${JSON.stringify({ type: "error", error: serializeError(error) })}\n`);
-    },
-  );
+  return streamStudioJsonl(events);
 }
 
 export function traceForRun(
@@ -191,6 +175,7 @@ export async function* persistStreamingSessionTranscript(props: {
       yield event;
     }
   } catch (error) {
+    appendTranscriptAssistantError(transcript, errorText(error));
     await props.store.saveSessionRunTranscript({
       id: props.session.id,
       runId: props.runId,
@@ -329,6 +314,9 @@ function acceptTranscriptStreamEvent(
   if (event.type === "final" && event.trace?.traceId !== undefined) {
     assignTranscriptTraceId(transcript, event.trace.traceId);
   }
+  if (event.type === "error") {
+    appendTranscriptAssistantError(transcript, errorText(event.error));
+  }
 }
 
 function approvalCallId(approval: { callId?: string; toolCallId?: string }): string | undefined {
@@ -439,9 +427,6 @@ function childAgentTranscriptEvent(
 }
 
 function errorText(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message;
-  }
   if (typeof error === "string") {
     return error;
   }
@@ -540,7 +525,7 @@ function messageToTranscriptEntry(
 
 function appendTranscriptAssistantText(transcript: StudioTranscriptEntry[], delta: string): void {
   const last = transcript.at(-1);
-  if (last?.kind === "message" && last.role === "assistant") {
+  if (last?.kind === "message" && last.role === "assistant" && last.tone !== "error") {
     last.text = `${last.text}${delta}`;
     return;
   }
@@ -549,6 +534,25 @@ function appendTranscriptAssistantText(transcript: StudioTranscriptEntry[], delt
     kind: "message",
     role: "assistant",
     text: delta,
+  });
+}
+
+function appendTranscriptAssistantError(transcript: StudioTranscriptEntry[], text: string): void {
+  const last = transcript.at(-1);
+  if (
+    last?.kind === "message" &&
+    last.role === "assistant" &&
+    last.tone === "error" &&
+    last.text === text
+  ) {
+    return;
+  }
+  transcript.push({
+    entryId: transcript.length,
+    kind: "message",
+    role: "assistant",
+    text,
+    tone: "error",
   });
 }
 

--- a/packages/tools/studio/src/runtime/streams.ts
+++ b/packages/tools/studio/src/runtime/streams.ts
@@ -1,0 +1,67 @@
+import { createEventStream } from "@anvia/server";
+import { serializeError } from "./shared";
+
+type StudioStreamErrorEvent = {
+  type: "error";
+  error: unknown;
+};
+
+const studioJsonlHeaders: HeadersInit = {
+  "cache-control": "no-cache, no-transform",
+  connection: "keep-alive",
+  "content-type": "application/x-ndjson; charset=utf-8",
+  "transfer-encoding": "chunked",
+  "x-accel-buffering": "no",
+};
+
+export function streamStudioJsonl<TEvent>(events: AsyncIterable<TEvent>): Response {
+  return createEventStream(withStudioStreamErrors(events), {
+    format: "jsonl",
+    headers: studioJsonlHeaders,
+  });
+}
+
+function withStudioStreamErrors<TEvent>(
+  events: AsyncIterable<TEvent>,
+): AsyncIterable<TEvent | StudioStreamErrorEvent> {
+  const iterator = events[Symbol.asyncIterator]();
+  let done = false;
+
+  return {
+    [Symbol.asyncIterator](): AsyncIterator<TEvent | StudioStreamErrorEvent> {
+      return {
+        async next(): Promise<IteratorResult<TEvent | StudioStreamErrorEvent>> {
+          if (done) {
+            return { done: true, value: undefined };
+          }
+
+          try {
+            const next = await iterator.next();
+            if (next.done === true) {
+              done = true;
+            }
+            return next;
+          } catch (error) {
+            done = true;
+            return {
+              done: false,
+              value: studioStreamError(error),
+            };
+          }
+        },
+        async return(): Promise<IteratorResult<TEvent | StudioStreamErrorEvent>> {
+          done = true;
+          await iterator.return?.();
+          return { done: true, value: undefined };
+        },
+      };
+    },
+  };
+}
+
+function studioStreamError(error: unknown): StudioStreamErrorEvent {
+  return {
+    type: "error",
+    error: serializeError(error),
+  };
+}

--- a/packages/tools/studio/src/types.ts
+++ b/packages/tools/studio/src/types.ts
@@ -209,6 +209,7 @@ export type StudioTranscriptChatEntry = {
   kind: "message";
   role: "user" | "assistant";
   text: string;
+  tone?: "error";
   traceId?: string;
 };
 

--- a/packages/tools/studio/src/ui/app/app.tsx
+++ b/packages/tools/studio/src/ui/app/app.tsx
@@ -1,4 +1,5 @@
-import type { ToolResultContent } from "@anvia/core/completion";
+import type { Message, ToolResultContent } from "@anvia/core/completion";
+import { createChatTransport, EventStreamHttpError, useChat } from "@anvia/react";
 import { Archive, ArrowSquareOut, ArrowUp, Moon, Plus, Sun } from "@phosphor-icons/react";
 import {
   type ChangeEvent,
@@ -90,6 +91,17 @@ import { TraceBrowser } from "./modules/tracing/trace-browser";
 
 type StudioTheme = "light" | "dark";
 
+type StudioAgentRunRequest = {
+  agentId: string;
+  message: string;
+  sessionId?: string;
+  history?: Message[];
+  stream: true;
+  metadata: {
+    source: string;
+  };
+};
+
 const studioThemeStorageKey = "anvia-studio-theme";
 
 function readInitialStudioTheme(): StudioTheme {
@@ -142,6 +154,26 @@ async function responseErrorMessage(response: Response, label: string): Promise<
     // Ignore non-JSON error bodies.
   }
   return `${label} with HTTP ${response.status}${detail}`;
+}
+
+function agentRunErrorMessage(error: unknown): string {
+  if (error instanceof EventStreamHttpError) {
+    return error.response.status === 401
+      ? "Authentication required"
+      : `Run failed with HTTP ${error.response.status}`;
+  }
+  return errorMessage(error);
+}
+
+function serializedStreamErrorText(error: unknown): string {
+  if (typeof error === "string") {
+    return error;
+  }
+  try {
+    return JSON.stringify(error) ?? String(error);
+  } catch {
+    return String(error);
+  }
 }
 
 export function StudioConsole() {
@@ -199,6 +231,9 @@ export function StudioConsole() {
   const promptRef = useRef<HTMLTextAreaElement | null>(null);
   const transcriptScrollerRef = useRef<HTMLElement | null>(null);
   const transcriptStickToBottomRef = useRef(true);
+  const playgroundRunRequestRef = useRef<StudioAgentRunRequest | undefined>(undefined);
+  const playgroundRunErrorRef = useRef<unknown>(undefined);
+  const playgroundVisibleEventRef = useRef<Promise<void>>(Promise.resolve());
 
   function updateTranscriptStickiness() {
     const node = transcriptScrollerRef.current;
@@ -275,11 +310,51 @@ export function StudioConsole() {
     agents.find((agent) => agent.id === selectedAgentId) ?? agents[0] ?? undefined;
   const selectedAgentQuickPrompts = selectedAgent?.quickPrompts ?? [];
   const hasMessages = messages.length > 0;
+  const playgroundChat = useChat<StudioAgentRunRequest, AgentRunStreamEvent>({
+    transport: createChatTransport<StudioAgentRunRequest, AgentRunStreamEvent>({
+      endpoint: (request) => `/agents/${encodeURIComponent(request.agentId)}/runs`,
+      method: "POST",
+      format: "jsonl",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: (request) => {
+        const { agentId: _agentId, ...body } = request;
+        return JSON.stringify(body);
+      },
+      mapEvent: (event) => event as AgentRunStreamEvent,
+    }),
+    createRequest: () => {
+      const request = playgroundRunRequestRef.current;
+      if (request === undefined) {
+        throw new Error("Missing playground run request");
+      }
+      return request;
+    },
+    eventToDelta: () => undefined,
+    eventToFinal: () => undefined,
+    onEvent(event) {
+      const visibleDelta = acceptStreamEvent(event);
+      if (visibleDelta) {
+        playgroundVisibleEventRef.current = playgroundVisibleEventRef.current.then(nextPaint);
+      }
+    },
+    onError(error) {
+      playgroundRunErrorRef.current = error;
+      const message = agentRunErrorMessage(error);
+      setError(message);
+      appendAssistantError(message);
+    },
+  });
 
   useEffect(() => {
     applyStudioTheme(theme);
     storeStudioTheme(theme);
   }, [theme]);
+
+  useEffect(() => {
+    setRunState(playgroundChat.status === "streaming" ? "running" : "idle");
+  }, [playgroundChat.status]);
 
   const loadAllSessions = useCallback(async () => {
     if (!sessionsEnabled) {
@@ -813,7 +888,12 @@ export function StudioConsole() {
   async function runPrompt(text: string) {
     const trimmed = text.trim();
     const agentId = selectedAgent?.id ?? selectedAgentId;
-    if (trimmed.length === 0 || agentId.length === 0 || runState === "running") {
+    if (
+      trimmed.length === 0 ||
+      agentId.length === 0 ||
+      runState === "running" ||
+      playgroundChat.status === "streaming"
+    ) {
       return;
     }
 
@@ -834,50 +914,41 @@ export function StudioConsole() {
           ? (await createSession(titleFromText(trimmed))).id
           : selectedSessionId;
       const history = sessionsEnabled ? undefined : toHistory(messages);
-      const response = await fetch(`/agents/${encodeURIComponent(agentId)}/runs`, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
+      playgroundRunErrorRef.current = undefined;
+      playgroundVisibleEventRef.current = Promise.resolve();
+      playgroundRunRequestRef.current = {
+        agentId,
+        message: trimmed,
+        ...(sessionId.length === 0 ? {} : { sessionId }),
+        ...(history === undefined ? {} : { history }),
+        stream: true,
+        metadata: {
+          source: "anvia-studio",
         },
-        body: JSON.stringify({
-          message: trimmed,
-          ...(sessionId.length === 0 ? {} : { sessionId }),
-          ...(history === undefined ? {} : { history }),
-          stream: true,
-          metadata: {
-            source: "anvia-studio",
-          },
-        }),
-      });
+      };
 
-      if (response.status === 401) {
-        throw new Error("Authentication required");
-      }
-      if (!response.ok || response.body === null) {
-        throw new Error(`Run failed with HTTP ${response.status}`);
-      }
+      await playgroundChat.send(trimmed);
+      await playgroundVisibleEventRef.current;
 
-      await readJsonl(response.body, async (event) => {
-        const visibleDelta = acceptStreamEvent(event as AgentRunStreamEvent);
-        if (visibleDelta) {
-          await nextPaint();
+      if (playgroundRunErrorRef.current === undefined) {
+        await loadAllSessions();
+        if (sessionId.length > 0) {
+          setSelectedSessionId(sessionId);
+          const [traceSummaries] = await Promise.all([
+            loadSessionTraceSummaries(sessionId),
+            loadSessionLogs(sessionId),
+          ]);
+          setMessages((current) => enrichTranscriptWithTraceIds(current, traceSummaries));
         }
-      });
-      await loadAllSessions();
-      if (sessionId.length > 0) {
-        setSelectedSessionId(sessionId);
-        const [traceSummaries] = await Promise.all([
-          loadSessionTraceSummaries(sessionId),
-          loadSessionLogs(sessionId),
-        ]);
-        setMessages((current) => enrichTranscriptWithTraceIds(current, traceSummaries));
+        setStatus("Connected");
       }
-      setStatus("Connected");
     } catch (runError) {
       const message = errorMessage(runError);
       setError(message);
-      appendAssistantText(`\n${message}`);
+      appendAssistantError(message);
     } finally {
+      playgroundRunRequestRef.current = undefined;
+      playgroundChat.reset();
       setRunState("idle");
     }
   }
@@ -1078,7 +1149,11 @@ export function StudioConsole() {
       return true;
     }
     if (event.type === "error") {
-      setError(JSON.stringify(event.error));
+      const message = serializedStreamErrorText(event.error);
+      playgroundRunErrorRef.current = event.error;
+      setError(message);
+      appendAssistantError(message);
+      return true;
     }
     return false;
   }
@@ -1117,6 +1192,19 @@ export function StudioConsole() {
       }
       return next;
     });
+  }
+
+  function appendAssistantError(message: string) {
+    setMessages((current) => [
+      ...current,
+      {
+        entryId: nextTranscriptId(),
+        kind: "message",
+        role: "assistant",
+        text: message,
+        tone: "error",
+      },
+    ]);
   }
 
   function assignAssistantTraceId(traceId: string) {

--- a/packages/tools/studio/src/ui/app/modules/playground/transcript-item.tsx
+++ b/packages/tools/studio/src/ui/app/modules/playground/transcript-item.tsx
@@ -45,13 +45,16 @@ export function TranscriptItem(props: {
 
   const traceId = props.entry.role === "assistant" ? props.entry.traceId : undefined;
   const hasTable = props.entry.role === "assistant" && hasMarkdownTable(props.entry.text);
+  const isError =
+    props.entry.role === "assistant" && "tone" in props.entry && props.entry.tone === "error";
 
   return (
     <article
       className={cn(
         "self-start",
         hasTable ? "w-full max-w-full" : "max-w-[min(82ch,100%)]",
-        props.entry.role === "assistant" && "justify-self-start text-foreground",
+        props.entry.role === "assistant" &&
+          cn("justify-self-start text-foreground", isError && "text-destructive"),
         props.entry.role === "user" &&
           "w-fit max-w-[min(64ch,82%)] justify-self-end rounded-2xl bg-primary/10 px-4 py-2.5 text-foreground shadow-sm shadow-primary/10",
       )}

--- a/packages/tools/studio/src/ui/app/modules/shared/transcript.ts
+++ b/packages/tools/studio/src/ui/app/modules/shared/transcript.ts
@@ -1,4 +1,5 @@
 import type { Message } from "@anvia/core/completion";
+import { readJsonlStream } from "@anvia/react";
 import type { ChangeEvent } from "react";
 import { formatToolValue } from "./format";
 import { isRecord } from "./object";
@@ -130,28 +131,8 @@ export async function readJsonl(
   stream: ReadableStream<Uint8Array>,
   onEvent: (event: unknown) => void | Promise<void>,
 ): Promise<void> {
-  const reader = stream.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-
-  while (true) {
-    const next = await reader.read();
-    if (next.done) {
-      break;
-    }
-    buffer += decoder.decode(next.value, { stream: true });
-    const lines = buffer.split("\n");
-    buffer = lines.pop() ?? "";
-    for (const line of lines) {
-      if (line.trim().length > 0) {
-        await onEvent(JSON.parse(line));
-      }
-    }
-  }
-
-  buffer += decoder.decode();
-  if (buffer.trim().length > 0) {
-    await onEvent(JSON.parse(buffer));
+  for await (const event of readJsonlStream(stream)) {
+    await onEvent(event);
   }
 }
 

--- a/packages/tools/studio/test/runner.test.ts
+++ b/packages/tools/studio/test/runner.test.ts
@@ -27,8 +27,10 @@ import {
   type VectorSearchRequest,
   type VectorSearchToolOptions,
 } from "@anvia/core/vector-store";
+import { Hono } from "hono";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { Studio } from "../src/index";
+import { registerObservabilityRoutes, StudioObservabilityHub } from "../src/runtime/observability";
 import { createSqliteSessionStore } from "../src/sqlite";
 
 const { DatabaseSync } = createRequire(import.meta.url)(
@@ -462,6 +464,7 @@ describe("Anvia studio", () => {
     );
 
     expect(run.status).toBe(200);
+    expect(run.headers.get("content-type")).toContain("application/x-ndjson");
     const events = await readJsonl(run);
     expect(events).toContainEqual(
       expect.objectContaining({
@@ -2838,6 +2841,7 @@ describe("Anvia studio", () => {
     );
 
     expect(run.status).toBe(200);
+    expect(run.headers.get("content-type")).toContain("application/x-ndjson");
     expect(await readJsonl(run)).toContainEqual(
       expect.objectContaining({
         type: "error",
@@ -2852,6 +2856,12 @@ describe("Anvia studio", () => {
       transcript: [
         { kind: "message", role: "user", text: "stream fail" },
         { kind: "message", role: "assistant", text: "partial" },
+        {
+          kind: "message",
+          role: "assistant",
+          text: expect.stringContaining('"message":"stream failed"'),
+          tone: "error",
+        },
       ],
     });
   });
@@ -3188,6 +3198,37 @@ describe("Anvia studio", () => {
     );
   });
 
+  it("closes realtime observability subscriptions when streams are cancelled", async () => {
+    const hub = new StudioObservabilityHub();
+    const app = new Hono();
+    registerObservabilityRoutes(app, hub);
+
+    const stream = await app.request("http://runner.test/observability/events");
+    expect(stream.status).toBe(200);
+    expect(stream.headers.get("content-type")).toContain("application/x-ndjson");
+    if (stream.body === null) {
+      throw new Error("Expected observability response body");
+    }
+
+    const reader = stream.body.getReader();
+    const pendingRead = reader.read();
+    await waitFor(() => observabilitySubscriptionCount(hub) === 1);
+    hub.emit({
+      type: "trace",
+      trace: {
+        id: "trace_cancel",
+        sessionId: "session_cancel",
+        status: "success",
+        startedAt: new Date().toISOString(),
+        observationCount: 0,
+      },
+    });
+    await expect(pendingRead).resolves.toMatchObject({ done: false });
+
+    await reader.cancel();
+    await waitFor(() => observabilitySubscriptionCount(hub) === 0);
+  });
+
   it("runs registered eval suites", async () => {
     const metric: EvalMetric<string, string, boolean, string> = {
       name: "uppercase_match",
@@ -3317,6 +3358,10 @@ function isTraceObservabilityEvent(event: unknown): boolean {
   return typeof event === "object" && event !== null && "type" in event && event.type === "trace";
 }
 
+function observabilitySubscriptionCount(hub: StudioObservabilityHub): number {
+  return (hub as unknown as { subscriptions: Set<unknown> }).subscriptions.size;
+}
+
 async function readRemainingJsonl(reader: { read: () => Promise<unknown> }): Promise<unknown[]> {
   const events: unknown[] = [];
   while (true) {
@@ -3344,5 +3389,15 @@ async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
     if (timeout !== undefined) {
       clearTimeout(timeout);
     }
+  }
+}
+
+async function waitFor(predicate: () => boolean, ms = 1000): Promise<void> {
+  const startedAt = Date.now();
+  while (!predicate()) {
+    if (Date.now() - startedAt > ms) {
+      throw new Error("Timed out waiting for condition");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
   }
 }

--- a/packages/tools/studio/vite.config.ts
+++ b/packages/tools/studio/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     alias: {
       "@": resolve(import.meta.dirname, "src/ui/app"),
     },
+    dedupe: ["react", "react-dom"],
   },
   build: {
     outDir: resolve(import.meta.dirname, "dist/ui"),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -501,6 +501,12 @@ importers:
       '@anvia/core':
         specifier: workspace:*
         version: link:../../core
+      '@anvia/react':
+        specifier: workspace:*
+        version: link:../../react
+      '@anvia/server':
+        specifier: workspace:*
+        version: link:../../server
       '@hono/node-server':
         specifier: ^2.0.4
         version: 2.0.4(hono@4.12.24)


### PR DESCRIPTION
## Summary
- add @anvia/server and @anvia/react as Studio workspace dependencies
- route Studio NDJSON streams through shared server stream helpers while preserving headers and error payloads
- use shared React stream parsing/useChat lifecycle primitives while keeping Studio transcript rendering authoritative
- persist streamed run failures as red assistant transcript entries across refreshes

## Changeset
- added patch changeset for @anvia/studio

## Tests
- pnpm --filter @anvia/studio typecheck
- pnpm --filter @anvia/studio test
- pnpm --filter @anvia/studio build
- pnpm --filter @anvia/react typecheck
- pnpm --filter @anvia/server typecheck