### PR TITLE
Harden OpenAI response validation

### DIFF
--- a/.changeset/harden-openai-response-validation.md
+++ b/.changeset/harden-openai-response-validation.md
@@ -1,0 +1,5 @@
+---
+"@anvia/openai": patch
+---
+
+Harden OpenAI embedding and image response validation.

--- a/packages/providers/openai/README.md
+++ b/packages/providers/openai/README.md
@@ -112,6 +112,9 @@ const transcriptionModel = client.transcriptionModel();
 
 ## Development
 
+The package-local `typecheck` and `build` scripts build `@anvia/core` first so core subpath
+types are available in a fresh worktree.
+
 ```sh
 pnpm --filter @anvia/openai typecheck
 pnpm --filter @anvia/openai test

--- a/packages/providers/openai/package.json
+++ b/packages/providers/openai/package.json
@@ -26,7 +26,9 @@
     }
   },
   "scripts": {
+    "prebuild": "pnpm --filter @anvia/core build",
     "build": "tsup src/index.ts --format esm --dts --sourcemap --clean",
+    "pretypecheck": "pnpm --filter @anvia/core build",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/providers/openai/src/openai/embedding.ts
+++ b/packages/providers/openai/src/openai/embedding.ts
@@ -48,19 +48,68 @@ export class OpenAIEmbeddingModel implements EmbeddingModel {
     }
 
     const response = await this.client.embeddings.create(params as never);
-    const data = Array.isArray(response.data) ? response.data : [];
+    const data = embeddingDataFromResponse(response, texts.length);
     if (data.length !== texts.length) {
       throw new Error(
         `Embedding response length ${data.length} did not match input length ${texts.length}`,
       );
     }
 
-    return data
-      .slice()
-      .sort((left, right) => left.index - right.index)
-      .map((item, index) => ({
-        document: texts[index] as string,
+    return texts.map((document, index) => {
+      const item = data[index];
+      if (item === undefined) {
+        throw new Error(`Embedding response did not contain index ${index}`);
+      }
+      return {
+        document,
         vector: item.embedding,
-      }));
+      };
+    });
   }
+}
+
+type EmbeddingData = {
+  index: number;
+  embedding: number[];
+};
+
+function embeddingDataFromResponse(response: unknown, inputLength: number): EmbeddingData[] {
+  const raw = response as Record<string, unknown>;
+  const data = Array.isArray(raw.data) ? raw.data : [];
+  const byIndex = new Map<number, EmbeddingData>();
+
+  for (const [position, item] of data.entries()) {
+    if (!isObject(item) || typeof item.index !== "number" || !Number.isInteger(item.index)) {
+      throw new Error(`Embedding response item ${position} contained an invalid index`);
+    }
+
+    const index = item.index;
+    if (index < 0 || index >= inputLength) {
+      throw new Error(
+        `Embedding response index ${index} was outside input range 0..${inputLength - 1}`,
+      );
+    }
+
+    if (byIndex.has(index)) {
+      throw new Error(`Embedding response contained duplicate index ${index}`);
+    }
+
+    if (!isNumberArray(item.embedding)) {
+      throw new Error(`Embedding response item ${position} contained an invalid embedding`);
+    }
+
+    byIndex.set(index, { index, embedding: item.embedding });
+  }
+
+  return Array.from({ length: inputLength }, (_, index) => byIndex.get(index)).filter(
+    (item): item is EmbeddingData => item !== undefined,
+  );
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNumberArray(value: unknown): value is number[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "number");
 }

--- a/packages/providers/openai/src/openai/image-generation.ts
+++ b/packages/providers/openai/src/openai/image-generation.ts
@@ -48,7 +48,8 @@ export function imageResponseFromOpenAI(response: unknown): ImageGenerationRespo
   const mediaType = mediaTypeFromFormat(
     typeof raw.output_format === "string" ? raw.output_format : "png",
   );
-  const images = (Array.isArray(raw.data) ? raw.data : []).flatMap((item): GeneratedImage[] => {
+  const data = Array.isArray(raw.data) ? raw.data : [];
+  const images = data.flatMap((item): GeneratedImage[] => {
     if (!isPlainObject(item) || typeof item.b64_json !== "string") {
       return [];
     }
@@ -57,6 +58,11 @@ export function imageResponseFromOpenAI(response: unknown): ImageGenerationRespo
 
   const image = images[0]?.data;
   if (image === undefined) {
+    if (data.some((item) => isPlainObject(item) && typeof item.url === "string")) {
+      throw new Error(
+        "OpenAI image generation response contained image URLs, which are not supported.",
+      );
+    }
     throw new Error("OpenAI image generation response contained no base64 images.");
   }
 

--- a/packages/providers/openai/test/embedding.test.ts
+++ b/packages/providers/openai/test/embedding.test.ts
@@ -18,6 +18,106 @@ describe("OpenAI embedding models", () => {
     });
   });
 
+  it("maps out-of-order embedding response rows to their original input texts", async () => {
+    const client = mockOpenAIClient({
+      embeddingResponse: {
+        data: [
+          { index: 2, embedding: [20] },
+          { index: 0, embedding: [0] },
+          { index: 1, embedding: [10] },
+        ],
+      },
+    });
+
+    await expect(
+      new OpenAIClient({ client: client as never })
+        .embeddingModel("embed-a")
+        .embedTexts(["first", "second", "third"]),
+    ).resolves.toEqual([
+      { document: "first", vector: [0] },
+      { document: "second", vector: [10] },
+      { document: "third", vector: [20] },
+    ]);
+  });
+
+  it("rejects duplicate embedding response indexes", async () => {
+    const client = mockOpenAIClient({
+      embeddingResponse: {
+        data: [
+          { index: 0, embedding: [0] },
+          { index: 0, embedding: [10] },
+        ],
+      },
+    });
+
+    await expect(
+      new OpenAIClient({ client: client as never })
+        .embeddingModel("embed-a")
+        .embedTexts(["first", "second"]),
+    ).rejects.toThrow("Embedding response contained duplicate index 0");
+  });
+
+  it("rejects missing or out-of-range embedding response indexes", async () => {
+    const missingIndexClient = mockOpenAIClient({
+      embeddingResponse: {
+        data: [
+          { index: 0, embedding: [0] },
+          { index: 2, embedding: [20] },
+        ],
+      },
+    });
+
+    await expect(
+      new OpenAIClient({ client: missingIndexClient as never })
+        .embeddingModel("embed-a")
+        .embedTexts(["first", "second"]),
+    ).rejects.toThrow("Embedding response index 2 was outside input range 0..1");
+
+    const missingRowClient = mockOpenAIClient({
+      embeddingResponse: {
+        data: [{ index: 0, embedding: [0] }],
+      },
+    });
+
+    await expect(
+      new OpenAIClient({ client: missingRowClient as never })
+        .embeddingModel("embed-a")
+        .embedTexts(["first", "second"]),
+    ).rejects.toThrow("Embedding response length 1 did not match input length 2");
+  });
+
+  it("rejects invalid embedding response rows", async () => {
+    const invalidIndexClient = mockOpenAIClient({
+      embeddingResponse: {
+        data: [
+          { index: "0", embedding: [0] },
+          { index: 1, embedding: [10] },
+        ],
+      },
+    });
+
+    await expect(
+      new OpenAIClient({ client: invalidIndexClient as never })
+        .embeddingModel("embed-a")
+        .embedTexts(["first", "second"]),
+    ).rejects.toThrow("Embedding response item 0 contained an invalid index");
+
+    const invalidEmbeddingClient = mockOpenAIClient({
+      embeddingResponse: {
+        data: [
+          { index: 0, embedding: [0] },
+          { index: 1, embedding: "not-a-vector" },
+        ],
+      },
+    });
+
+    await expect(
+      new OpenAIClient({ client: invalidEmbeddingClient as never })
+        .embeddingModel("embed-a")
+        .embedTexts(["first", "second"]),
+    ).rejects.toThrow("Embedding response item 1 contained an invalid embedding");
+  });
+
   it("maps OpenAI-compatible embedding requests", async () => {
     const compatibleClient = mockOpenAIClient();
 
@@ -32,19 +132,21 @@ describe("OpenAI embedding models", () => {
   });
 });
 
-function mockOpenAIClient() {
+function mockOpenAIClient(options: { embeddingResponse?: unknown } = {}) {
   const createCalls: unknown[] = [];
   return {
     embeddings: {
       createCalls,
       async create(params: { input: string[] }) {
         createCalls.push(params);
-        return {
-          data: params.input.map((text, index) => ({
-            index,
-            embedding: [index, text.length],
-          })),
-        };
+        return (
+          options.embeddingResponse ?? {
+            data: params.input.map((text, index) => ({
+              index,
+              embedding: [index, text.length],
+            })),
+          }
+        );
       },
     },
   };

--- a/packages/providers/openai/test/multimodal.test.ts
+++ b/packages/providers/openai/test/multimodal.test.ts
@@ -49,6 +49,28 @@ describe("OpenAI multimodal models", () => {
     });
   });
 
+  it("rejects malformed image responses", async () => {
+    const client = mockOpenAIClient({ imageResponse: { output_format: "png", data: [] } });
+    const model = new OpenAIClient({ client: client as never }).imageGenerationModel();
+
+    await expect(imageGenerationRequest(model).prompt("x").send()).rejects.toThrow(
+      "OpenAI image generation response contained no base64 images.",
+    );
+  });
+
+  it("rejects url-only image responses with an unsupported response error", async () => {
+    const client = mockOpenAIClient({
+      imageResponse: {
+        data: [{ url: "https://example.com/generated.png" }],
+      },
+    });
+    const model = new OpenAIClient({ client: client as never }).imageGenerationModel();
+
+    await expect(imageGenerationRequest(model).prompt("x").send()).rejects.toThrow(
+      "OpenAI image generation response contained image URLs, which are not supported.",
+    );
+  });
+
   it("maps speech responses to Uint8Array audio", async () => {
     const client = mockOpenAIClient();
     const model = new OpenAIClient({ client: client as never }).audioGenerationModel("tts-test");
@@ -116,7 +138,11 @@ describe("OpenAI multimodal models", () => {
 });
 
 function mockOpenAIClient(
-  options: { imageError?: Error | undefined; transcriptionResponse?: unknown } = {},
+  options: {
+    imageError?: Error | undefined;
+    imageResponse?: unknown;
+    transcriptionResponse?: unknown;
+  } = {},
 ) {
   const generateCalls: unknown[] = [];
   const speechCreateCalls: unknown[] = [];
@@ -129,13 +155,15 @@ function mockOpenAIClient(
         if (options.imageError !== undefined) {
           throw options.imageError;
         }
-        return {
-          output_format: "png",
-          data: [
-            { b64_json: Buffer.from([1, 2, 3]).toString("base64") },
-            { b64_json: Buffer.from([4, 5, 6]).toString("base64") },
-          ],
-        };
+        return (
+          options.imageResponse ?? {
+            output_format: "png",
+            data: [
+              { b64_json: Buffer.from([1, 2, 3]).toString("base64") },
+              { b64_json: Buffer.from([4, 5, 6]).toString("base64") },
+            ],
+          }
+        );
       },
     },
     audio: {


### PR DESCRIPTION
## Summary
- validate OpenAI embedding response indexes before mapping vectors to input texts
- distinguish unsupported URL-only image responses from malformed base64 image responses
- add package-local OpenAI prebuild/pretypecheck steps for @anvia/core and document the workflow
- add a patch changeset for @anvia/openai

## Tests
- pnpm --filter @anvia/openai test
- pnpm --filter @anvia/core test -- embeddings-vector-store.test.ts
- pnpm --filter @anvia/openai typecheck
- pnpm --filter @anvia/openai build
- pnpm exec biome check .changeset/harden-openai-response-validation.md packages/providers/openai/src/openai/embedding.ts packages/providers/openai/src/openai/image-generation.ts packages/providers/openai/test/embedding.test.ts packages/providers/openai/test/multimodal.test.ts packages/providers/openai/package.json packages/providers/openai/README.md
- git diff --check