### PR TITLE
Improve Studio runtime quality

### DIFF
--- a/.changeset/fix-studio-runtime-quality.md
+++ b/.changeset/fix-studio-runtime-quality.md
@@ -1,0 +1,5 @@
+---
+"@anvia/studio": patch
+---
+
+Improve Studio runtime lookups, store helpers, UI splitting, and regression coverage.

--- a/apps/docs/content/docs/reference/studio/types.mdx
+++ b/apps/docs/content/docs/reference/studio/types.mdx
@@ -526,10 +526,18 @@ type StudioPipelineRunListOptions = {
   limit: number;
 };
 
+type StudioPipelineRunGetOptions = {
+  pipelineId: string;
+  runId: string;
+};
+
 type StudioPipelineRunStore = {
   savePipelineRun(
     input: StudioPipelineRunSaveInput,
   ): StudioPipelineRunRecord | Promise<StudioPipelineRunRecord>;
+  getPipelineRun(
+    options: StudioPipelineRunGetOptions,
+  ): StudioPipelineRunRecord | undefined | Promise<StudioPipelineRunRecord | undefined>;
   listPipelineRuns(
     options: StudioPipelineRunListOptions,
   ): StudioPipelineRunRecord[] | Promise<StudioPipelineRunRecord[]>;
@@ -538,7 +546,7 @@ type StudioPipelineRunStore = {
 
 Purpose: persistence contract for Studio pipeline run history.
 
-Return behavior: stores normalize saved run input into `StudioPipelineRunRecord` values and list recent records per pipeline.
+Return behavior: stores normalize saved run input into `StudioPipelineRunRecord` values, load exact records by pipeline and run id, and list recent records per pipeline.
 
 Notable errors: store failures surface through the Studio runtime or HTTP route handling the pipeline request.
 

--- a/packages/tools/studio/package.json
+++ b/packages/tools/studio/package.json
@@ -26,9 +26,10 @@
     }
   },
   "scripts": {
-    "build": "tsup && vite build --config vite.config.ts",
-    "test": "vitest run",
-    "typecheck": "tsc --noEmit"
+    "build": "pnpm run build:deps && tsup && vite build --config vite.config.ts",
+    "build:deps": "pnpm --filter @anvia/core --filter @anvia/server --filter @anvia/react build",
+    "test": "pnpm run build:deps && vitest run",
+    "typecheck": "pnpm run build:deps && tsc --noEmit"
   },
   "dependencies": {
     "@anvia/core": "workspace:*",

--- a/packages/tools/studio/src/runtime/json.ts
+++ b/packages/tools/studio/src/runtime/json.ts
@@ -5,13 +5,11 @@ export function toJsonValue(value: unknown): JsonValue {
 }
 
 function toJsonValueInternal(value: unknown, seen: WeakSet<object>): JsonValue {
-  if (
-    value === null ||
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  ) {
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
     return value;
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : String(value);
   }
   if (value === undefined) {
     return null;

--- a/packages/tools/studio/src/runtime/pipelines.ts
+++ b/packages/tools/studio/src/runtime/pipelines.ts
@@ -12,6 +12,7 @@ import type {
   StudioPipelineRunSaveInput,
   StudioPipelineRunStore,
 } from "../types";
+import { toJsonValue } from "./json";
 import {
   appendPipelineLog,
   emitPipelineLog,
@@ -143,11 +144,10 @@ export function registerPipelineRoutes(
     }
 
     const sourceRunId = c.req.param("runId");
-    const runs = await props.runStore.listPipelineRuns({
+    const sourceRun = await props.runStore.getPipelineRun({
       pipelineId: pipeline.id,
-      limit: 1000,
+      runId: sourceRunId,
     });
-    const sourceRun = runs.find((run) => run.runId === sourceRunId);
     if (sourceRun === undefined) {
       return errorResponse(c, 404, "not_found", "Pipeline run not found");
     }
@@ -509,19 +509,4 @@ function isJsonValue(value: unknown): value is JsonValue {
     return Object.values(value).every((item) => item === undefined || isJsonValue(item));
   }
   return false;
-}
-
-function toJsonValue(value: unknown): JsonValue {
-  if (isJsonValue(value)) {
-    return value;
-  }
-  if (value === undefined) {
-    return null;
-  }
-  try {
-    const parsed = JSON.parse(JSON.stringify(value)) as unknown;
-    return isJsonValue(parsed) ? parsed : String(value);
-  } catch {
-    return String(value);
-  }
 }

--- a/packages/tools/studio/src/runtime/runs.ts
+++ b/packages/tools/studio/src/runtime/runs.ts
@@ -23,6 +23,8 @@ import {
 } from "./shared";
 import { streamStudioJsonl } from "./streams";
 
+export { transcriptFromMessages } from "./transcript";
+
 export class AsyncEventQueue<T> {
   private readonly values: T[] = [];
   private readonly resolvers: Array<(value: IteratorResult<T>) => void> = [];
@@ -452,62 +454,6 @@ function findChildAgentToolEvent(
     }
   }
   return undefined;
-}
-
-export function transcriptFromMessages(messages: Message[]): StudioTranscriptEntry[] {
-  const transcript: StudioTranscriptEntry[] = [];
-  for (const message of messages) {
-    if (message.role === "system") {
-      continue;
-    }
-    if (message.role === "user") {
-      for (const content of message.content) {
-        if (content.type === "text") {
-          transcript.push({
-            entryId: transcript.length,
-            kind: "message",
-            role: "user",
-            text: content.text,
-          });
-        }
-      }
-      continue;
-    }
-    if (message.role === "tool") {
-      for (const content of message.content) {
-        transcript.push({
-          entryId: transcript.length,
-          kind: "tool",
-          toolName: "tool_result",
-          callId: content.callId ?? content.id,
-          result: content.content
-            .map((item) =>
-              "text" in item ? item.text : `[image:${item.mediaType ?? "image/png"}]`,
-            )
-            .join("\n"),
-          structuredResult: content.content,
-        });
-      }
-      continue;
-    }
-
-    for (const content of message.content) {
-      if (content.type === "text") {
-        appendTranscriptAssistantText(transcript, content.text);
-      } else if (content.type === "reasoning") {
-        appendTranscriptReasoningText(transcript, content.text, content.id);
-      } else if (content.type === "tool_call") {
-        transcript.push({
-          entryId: transcript.length,
-          kind: "tool",
-          toolName: content.function.name,
-          callId: content.callId ?? content.id,
-          args: formatJson(content.function.arguments),
-        });
-      }
-    }
-  }
-  return transcript;
 }
 
 function messageToTranscriptEntry(

--- a/packages/tools/studio/src/runtime/shared.ts
+++ b/packages/tools/studio/src/runtime/shared.ts
@@ -24,7 +24,7 @@ import type {
   StudioTraceStore,
   StudioUiOptions,
 } from "../types";
-import { toJsonValue } from "./json";
+import { serializeUnknown, toJsonValue } from "./json";
 import { agentHasMcpTools, agentToolItems, mcpServerName } from "./tool-metadata";
 
 export type ResolvedStores = {
@@ -162,6 +162,7 @@ function isPipelineRunStore(store: object): store is object & StudioPipelineRunS
   const candidate = store as Partial<StudioPipelineRunStore>;
   return (
     typeof candidate.savePipelineRun === "function" &&
+    typeof candidate.getPipelineRun === "function" &&
     typeof candidate.listPipelineRuns === "function"
   );
 }
@@ -490,13 +491,5 @@ export function errorResponse(
 }
 
 export function serializeError(error: unknown): JsonValue {
-  if (error instanceof Error) {
-    return {
-      name: error.name,
-      message: error.message,
-      ...(error.stack === undefined ? {} : { stack: error.stack }),
-    };
-  }
-
-  return isJsonValue(error) ? error : String(error);
+  return serializeUnknown(error);
 }

--- a/packages/tools/studio/src/runtime/transcript.ts
+++ b/packages/tools/studio/src/runtime/transcript.ts
@@ -1,0 +1,89 @@
+import type { Message } from "@anvia/core/completion";
+import type { StudioTranscriptEntry } from "../types";
+
+export function renumberTranscript(entries: StudioTranscriptEntry[]): StudioTranscriptEntry[] {
+  return entries.map((entry, entryId) => ({ ...entry, entryId }));
+}
+
+export function transcriptFromMessages(messages: Message[]): StudioTranscriptEntry[] {
+  const transcript: StudioTranscriptEntry[] = [];
+  for (const message of messages) {
+    if (message.role === "system") {
+      continue;
+    }
+    if (message.role === "user") {
+      for (const content of message.content) {
+        if (content.type === "text") {
+          transcript.push({
+            entryId: transcript.length,
+            kind: "message",
+            role: "user",
+            text: content.text,
+          });
+        }
+      }
+      continue;
+    }
+    if (message.role === "tool") {
+      for (const content of message.content) {
+        transcript.push({
+          entryId: transcript.length,
+          kind: "tool",
+          toolName: "tool_result",
+          callId: content.callId ?? content.id,
+          result: content.content
+            .map((item) =>
+              "text" in item ? item.text : `[image:${item.mediaType ?? "image/png"}]`,
+            )
+            .join("\n"),
+          structuredResult: content.content,
+        });
+      }
+      continue;
+    }
+
+    for (const content of message.content) {
+      if (content.type === "text") {
+        appendAssistantTranscriptText(transcript, content.text);
+      } else if (content.type === "reasoning") {
+        transcript.push({
+          entryId: transcript.length,
+          kind: "reasoning",
+          ...(content.id === undefined ? {} : { reasoningId: content.id }),
+          text: content.text,
+        });
+      } else if (content.type === "tool_call") {
+        transcript.push({
+          entryId: transcript.length,
+          kind: "tool",
+          toolName: content.function.name,
+          callId: content.callId ?? content.id,
+          args: formatJson(content.function.arguments),
+        });
+      }
+    }
+  }
+  return transcript;
+}
+
+function appendAssistantTranscriptText(transcript: StudioTranscriptEntry[], text: string): void {
+  const last = transcript.at(-1);
+  if (last?.kind === "message" && last.role === "assistant") {
+    last.text = `${last.text}${text}`;
+    return;
+  }
+  transcript.push({
+    entryId: transcript.length,
+    kind: "message",
+    role: "assistant",
+    text,
+  });
+}
+
+function formatJson(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}

--- a/packages/tools/studio/src/storage/memory-store.ts
+++ b/packages/tools/studio/src/storage/memory-store.ts
@@ -1,5 +1,6 @@
 import type { JsonObject, JsonValue, Message } from "@anvia/core/completion";
 import type { MemoryAppendInput, MemoryContext, MemoryErrorInput } from "@anvia/core/memory";
+import { renumberTranscript, transcriptFromMessages } from "../runtime/transcript";
 import type {
   StudioPipelineLogAppendInput,
   StudioPipelineLogEntry,
@@ -23,7 +24,6 @@ import type {
   StudioTraceListOptions,
   StudioTraceStore,
   StudioTraceSummary,
-  StudioTranscriptEntry,
 } from "../types";
 
 type MemorySessionRecord = StudioSessionSummary & {
@@ -108,7 +108,7 @@ class InMemoryStudioStore
     await this.saveSessionRunTranscript({
       id: input.context.sessionId,
       runId: studioRunId(input.context) ?? input.runId,
-      transcript: transcriptFromMessagesFallback(input.messages),
+      transcript: transcriptFromMessages(input.messages),
       status: "error",
       error: serializeJsonError(input.error),
     });
@@ -237,6 +237,14 @@ class InMemoryStudioStore
     return record;
   }
 
+  getPipelineRun(options: {
+    pipelineId: string;
+    runId: string;
+  }): StudioPipelineRunRecord | undefined {
+    const run = this.pipelineRuns.get(options.runId);
+    return run?.pipelineId === options.pipelineId ? run : undefined;
+  }
+
   listPipelineRuns(options: StudioPipelineRunListOptions): StudioPipelineRunRecord[] {
     return [...this.pipelineRuns.values()]
       .filter((run) => run.pipelineId === options.pipelineId)
@@ -289,10 +297,6 @@ function traceAgentId(trace: StudioTrace): string | undefined {
     : undefined;
 }
 
-function renumberTranscript(entries: StudioTranscriptEntry[]): StudioTranscriptEntry[] {
-  return entries.map((entry, entryId) => ({ ...entry, entryId }));
-}
-
 function studioRunId(context: MemoryContext): string | undefined {
   const value = context.metadata?.studioRunId;
   return typeof value === "string" && value.length > 0 ? value : undefined;
@@ -306,41 +310,6 @@ function serializeJsonError(error: unknown): JsonValue {
     };
   }
   return isJsonValue(error) ? error : String(error);
-}
-
-function transcriptFromMessagesFallback(messages: Message[]): StudioTranscriptEntry[] {
-  const transcript: StudioTranscriptEntry[] = [];
-  for (const message of messages) {
-    if (message.role === "system") {
-      continue;
-    }
-    if (message.role === "user") {
-      for (const content of message.content) {
-        if (content.type === "text") {
-          transcript.push({
-            entryId: transcript.length,
-            kind: "message",
-            role: "user",
-            text: content.text,
-          });
-        }
-      }
-      continue;
-    }
-    if (message.role === "assistant") {
-      for (const content of message.content) {
-        if (content.type === "text") {
-          transcript.push({
-            entryId: transcript.length,
-            kind: "message",
-            role: "assistant",
-            text: content.text,
-          });
-        }
-      }
-    }
-  }
-  return transcript;
 }
 
 function isJsonObject(value: unknown): value is JsonObject {

--- a/packages/tools/studio/src/storage/sqlite-store.ts
+++ b/packages/tools/studio/src/storage/sqlite-store.ts
@@ -4,6 +4,7 @@ import { dirname, resolve } from "node:path";
 import type { DatabaseSync as DatabaseSyncType } from "node:sqlite";
 import type { JsonObject, JsonValue, Message } from "@anvia/core/completion";
 import type { MemoryAppendInput, MemoryContext, MemoryErrorInput } from "@anvia/core/memory";
+import { renumberTranscript, transcriptFromMessages } from "../runtime/transcript";
 import type {
   StudioPipelineLogAppendInput,
   StudioPipelineLogEntry,
@@ -300,7 +301,7 @@ class SqliteSessionStore
     const transcript =
       existing === undefined ||
       parseJsonArray<StudioTranscriptEntry>(existing.transcript_json).length === 0
-        ? transcriptFromMessagesFallback(input.messages)
+        ? transcriptFromMessages(input.messages)
         : parseJsonArray<StudioTranscriptEntry>(existing.transcript_json);
     await this.saveSessionRunTranscript({
       id: input.context.sessionId,
@@ -630,6 +631,26 @@ class SqliteSessionStore
       ...(input.endedAt === undefined ? {} : { endedAt: input.endedAt }),
       ...(input.durationMs === undefined ? {} : { durationMs: input.durationMs }),
     };
+  }
+
+  getPipelineRun(options: {
+    pipelineId: string;
+    runId: string;
+  }): StudioPipelineRunRecord | undefined {
+    const db = this.database();
+    const row = db
+      .prepare(
+        `SELECT run_id, pipeline_id, status, input_json, output_json, error_json,
+                metadata_json, started_at, ended_at, duration_ms
+         FROM anvia_studio_pipeline_runs
+         WHERE pipeline_id = $pipelineId AND run_id = $runId`,
+      )
+      .get({
+        $pipelineId: options.pipelineId,
+        $runId: options.runId,
+      }) as PipelineRunRow | undefined;
+
+    return row === undefined ? undefined : toPipelineRun(row);
   }
 
   listPipelineRuns(options: StudioPipelineRunListOptions): StudioPipelineRunRecord[] {
@@ -1300,10 +1321,6 @@ function parseJsonValue<T>(value: string | null): T | undefined {
   return JSON.parse(value) as T;
 }
 
-function renumberTranscript(entries: StudioTranscriptEntry[]): StudioTranscriptEntry[] {
-  return entries.map((entry, entryId) => ({ ...entry, entryId }));
-}
-
 function studioRunId(context: MemoryContext): string | undefined {
   const value = context.metadata?.studioRunId;
   return typeof value === "string" && value.length > 0 ? value : undefined;
@@ -1325,87 +1342,4 @@ function serializeJsonError(error: unknown): JsonValue {
     return error;
   }
   return String(error);
-}
-
-function transcriptFromMessagesFallback(messages: Message[]): StudioTranscriptEntry[] {
-  const transcript: StudioTranscriptEntry[] = [];
-  for (const message of messages) {
-    if (message.role === "system") {
-      continue;
-    }
-    if (message.role === "user") {
-      for (const content of message.content) {
-        if (content.type === "text") {
-          transcript.push({
-            entryId: transcript.length,
-            kind: "message",
-            role: "user",
-            text: content.text,
-          });
-        }
-      }
-      continue;
-    }
-    if (message.role === "tool") {
-      for (const content of message.content) {
-        transcript.push({
-          entryId: transcript.length,
-          kind: "tool",
-          toolName: "tool_result",
-          callId: content.callId ?? content.id,
-          result: content.content
-            .map((item) =>
-              "text" in item ? item.text : `[image:${item.mediaType ?? "image/png"}]`,
-            )
-            .join("\n"),
-          structuredResult: content.content,
-        });
-      }
-      continue;
-    }
-
-    for (const content of message.content) {
-      if (content.type === "text") {
-        appendAssistantTranscriptText(transcript, content.text);
-      } else if (content.type === "reasoning") {
-        transcript.push({
-          entryId: transcript.length,
-          kind: "reasoning",
-          ...(content.id === undefined ? {} : { reasoningId: content.id }),
-          text: content.text,
-        });
-      } else if (content.type === "tool_call") {
-        transcript.push({
-          entryId: transcript.length,
-          kind: "tool",
-          toolName: content.function.name,
-          callId: content.callId ?? content.id,
-          args: formatJson(content.function.arguments),
-        });
-      }
-    }
-  }
-  return transcript;
-}
-
-function appendAssistantTranscriptText(transcript: StudioTranscriptEntry[], text: string): void {
-  const last = transcript.at(-1);
-  if (last?.kind === "message" && last.role === "assistant") {
-    last.text = `${last.text}${text}`;
-    return;
-  }
-  transcript.push({
-    entryId: transcript.length,
-    kind: "message",
-    role: "assistant",
-    text,
-  });
-}
-
-function formatJson(value: unknown): string {
-  try {
-    return JSON.stringify(value, null, 2);
-  } catch {
-    return String(value);
-  }
 }

--- a/packages/tools/studio/src/traces/trace-observer.ts
+++ b/packages/tools/studio/src/traces/trace-observer.ts
@@ -15,6 +15,11 @@ import type {
   AgentToolStartArgs,
   AgentToolStreamEventArgs,
 } from "@anvia/core/observability";
+import {
+  compactJsonObject,
+  serializeUnknown as serializeError,
+  toJsonValue,
+} from "../runtime/json";
 import type {
   StudioTrace,
   StudioTraceObservation,
@@ -638,13 +643,6 @@ function byteLength(value: string): number {
   return new TextEncoder().encode(value).length;
 }
 
-function compactJsonObject(values: Record<string, unknown>): JsonObject {
-  const entries = Object.entries(values).flatMap(([key, value]) =>
-    value === undefined ? [] : [[key, toJsonValue(value)]],
-  );
-  return Object.fromEntries(entries) as JsonObject;
-}
-
 function durationMs(startedAt: Date, endedAt: Date): number {
   return Math.max(0, endedAt.getTime() - startedAt.getTime());
 }
@@ -663,36 +661,4 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function stringValue(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
-}
-
-function serializeError(error: unknown): JsonValue {
-  if (error instanceof Error) {
-    return compactJsonObject({
-      name: error.name,
-      message: error.message,
-      stack: error.stack,
-    });
-  }
-  return toJsonValue(error);
-}
-
-function toJsonValue(value: unknown): JsonValue {
-  if (
-    value === null ||
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  ) {
-    return value;
-  }
-  if (value === undefined) {
-    return null;
-  }
-  if (Array.isArray(value)) {
-    return value.map((item) => toJsonValue(item));
-  }
-  if (typeof value === "object") {
-    return compactJsonObject(value as Record<string, unknown>);
-  }
-  return String(value);
 }

--- a/packages/tools/studio/src/types.ts
+++ b/packages/tools/studio/src/types.ts
@@ -807,10 +807,18 @@ export type StudioPipelineRunListOptions = {
   limit: number;
 };
 
+export type StudioPipelineRunGetOptions = {
+  pipelineId: string;
+  runId: string;
+};
+
 export type StudioPipelineRunStore = {
   savePipelineRun(
     input: StudioPipelineRunSaveInput,
   ): StudioPipelineRunRecord | Promise<StudioPipelineRunRecord>;
+  getPipelineRun(
+    options: StudioPipelineRunGetOptions,
+  ): StudioPipelineRunRecord | undefined | Promise<StudioPipelineRunRecord | undefined>;
   listPipelineRuns(
     options: StudioPipelineRunListOptions,
   ): StudioPipelineRunRecord[] | Promise<StudioPipelineRunRecord[]>;

--- a/packages/tools/studio/src/ui/app/app.tsx
+++ b/packages/tools/studio/src/ui/app/app.tsx
@@ -4,8 +4,11 @@ import { Archive, ArrowSquareOut, ArrowUp, Moon, Plus, Sun } from "@phosphor-ico
 import {
   type ChangeEvent,
   type KeyboardEvent,
+  lazy,
+  Suspense,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -36,21 +39,18 @@ import {
 } from "./components/ui/select";
 import { Textarea } from "./components/ui/textarea";
 import { cn } from "./lib/utils";
-import { AgentsPage } from "./modules/agents/agents-page";
-import { EvalsPage } from "./modules/evals/evals-page";
-import { KnowledgePage } from "./modules/knowledge/knowledge-page";
-import { McpsPage } from "./modules/mcps/mcps-page";
-import { MemoryPage } from "./modules/memory/memory-page";
-import { PipelinesPage } from "./modules/pipelines/pipelines-page";
-import { TranscriptItem } from "./modules/playground/transcript-item";
 import { SessionLogsPanel } from "./modules/session-logs/session-logs-panel";
-import { DeleteSessionDialog, SessionsPage } from "./modules/sessions/sessions-page";
 import {
   errorMessage,
   formatRelativeTime,
   formatToolValue,
   titleFromText,
 } from "./modules/shared/format";
+import {
+  fallbackActivePage,
+  isActivePageEnabled,
+  type StudioPageAvailability,
+} from "./modules/shared/navigation";
 import {
   defaultKnowledgeTab,
   logoSrc,
@@ -85,9 +85,67 @@ import type {
   TranscriptEntry,
 } from "./modules/shared/types";
 import { NavButton } from "./modules/shell/nav-button";
-import { StatusPage } from "./modules/status/status-page";
-import { ToolsPage } from "./modules/tools/tools-page";
-import { TraceBrowser } from "./modules/tracing/trace-browser";
+
+const AgentsPage = lazy(() =>
+  import("./modules/agents/agents-page").then((module) => ({
+    default: module.AgentsPage,
+  })),
+);
+const EvalsPage = lazy(() =>
+  import("./modules/evals/evals-page").then((module) => ({
+    default: module.EvalsPage,
+  })),
+);
+const KnowledgePage = lazy(() =>
+  import("./modules/knowledge/knowledge-page").then((module) => ({
+    default: module.KnowledgePage,
+  })),
+);
+const McpsPage = lazy(() =>
+  import("./modules/mcps/mcps-page").then((module) => ({
+    default: module.McpsPage,
+  })),
+);
+const MemoryPage = lazy(() =>
+  import("./modules/memory/memory-page").then((module) => ({
+    default: module.MemoryPage,
+  })),
+);
+const PipelinesPage = lazy(() =>
+  import("./modules/pipelines/pipelines-page").then((module) => ({
+    default: module.PipelinesPage,
+  })),
+);
+const SessionsPage = lazy(() =>
+  import("./modules/sessions/sessions-page").then((module) => ({
+    default: module.SessionsPage,
+  })),
+);
+const DeleteSessionDialog = lazy(() =>
+  import("./modules/sessions/sessions-page").then((module) => ({
+    default: module.DeleteSessionDialog,
+  })),
+);
+const StatusPage = lazy(() =>
+  import("./modules/status/status-page").then((module) => ({
+    default: module.StatusPage,
+  })),
+);
+const ToolsPage = lazy(() =>
+  import("./modules/tools/tools-page").then((module) => ({
+    default: module.ToolsPage,
+  })),
+);
+const TraceBrowser = lazy(() =>
+  import("./modules/tracing/trace-browser").then((module) => ({
+    default: module.TraceBrowser,
+  })),
+);
+const TranscriptItem = lazy(() =>
+  import("./modules/playground/transcript-item").then((module) => ({
+    default: module.TranscriptItem,
+  })),
+);
 
 type StudioTheme = "light" | "dark";
 
@@ -306,6 +364,32 @@ export function StudioConsole() {
   const pipelines = config?.pipelines ?? [];
   const evals = config?.evals ?? [];
   const hasAgents = agents.length > 0;
+  const pageAvailability: StudioPageAvailability = useMemo(
+    () => ({
+      hasAgents,
+      sessionsEnabled,
+      tracesEnabled,
+      toolsEnabled,
+      mcpsEnabled,
+      pipelinesEnabled,
+      evalsEnabled,
+      memoryEnabled,
+      statusEnabled,
+      knowledgeEnabled,
+    }),
+    [
+      hasAgents,
+      sessionsEnabled,
+      tracesEnabled,
+      toolsEnabled,
+      mcpsEnabled,
+      pipelinesEnabled,
+      evalsEnabled,
+      memoryEnabled,
+      statusEnabled,
+      knowledgeEnabled,
+    ],
+  );
   const selectedAgent =
     agents.find((agent) => agent.id === selectedAgentId) ?? agents[0] ?? undefined;
   const selectedAgentQuickPrompts = selectedAgent?.quickPrompts ?? [];
@@ -1601,7 +1685,7 @@ export function StudioConsole() {
   }
 
   function navigatePage(page: ActivePage) {
-    if (page === "playground" && !hasAgents) {
+    if (!isActivePageEnabled(page, pageAvailability)) {
       return;
     }
 
@@ -1647,15 +1731,7 @@ export function StudioConsole() {
       return;
     }
 
-    const nextPage: ActivePage = pipelinesEnabled
-      ? "pipelines"
-      : evalsEnabled
-        ? "evals"
-        : sessionsEnabled
-          ? "sessions"
-          : tracesEnabled
-            ? "tracing"
-            : "agents";
+    const nextPage = fallbackActivePage("playground", pageAvailability);
 
     resetTranscriptSequence();
     setSelectedSessionId("");
@@ -1680,13 +1756,10 @@ export function StudioConsole() {
     config,
     hasAgents,
     loadPipeline,
-    evalsEnabled,
+    pageAvailability,
     pipelines,
-    pipelinesEnabled,
     selectedEvalId,
     selectedPipelineId,
-    sessionsEnabled,
-    tracesEnabled,
   ]);
 
   function selectTrace(traceId: string) {
@@ -1742,12 +1815,14 @@ export function StudioConsole() {
             active={activePage === "sessions"}
             icon="list"
             label="Sessions"
+            disabled={!sessionsEnabled}
             onClick={() => navigatePage("sessions")}
           />
           <NavButton
             active={activePage === "tracing"}
             icon="activity"
             label="Traces"
+            disabled={!tracesEnabled}
             onClick={() => navigatePage("tracing")}
           />
         </nav>
@@ -1765,18 +1840,21 @@ export function StudioConsole() {
             active={activePage === "tools"}
             icon="wrench"
             label="Tools"
+            disabled={!toolsEnabled}
             onClick={() => navigatePage("tools")}
           />
           <NavButton
             active={activePage === "mcps"}
             icon="plug"
             label="MCPs"
+            disabled={!mcpsEnabled}
             onClick={() => navigatePage("mcps")}
           />
           <NavButton
             active={activePage === "knowledge"}
             icon="database"
             label="Knowledge"
+            disabled={!knowledgeEnabled}
             onClick={() => navigatePage("knowledge")}
           />
           <NavButton
@@ -1877,6 +1955,7 @@ export function StudioConsole() {
                 className="h-8 min-h-8 border-transparent bg-transparent px-3 font-mono text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
                 type="button"
                 variant="secondary"
+                disabled={!sessionsEnabled}
                 onClick={() => navigatePage("sessions")}
               >
                 Sessions
@@ -1917,21 +1996,23 @@ export function StudioConsole() {
                         </div>
                       </div>
                     ) : null}
-                    {messages.map((message) => (
-                      <TranscriptItem
-                        key={message.entryId}
-                        entry={message}
-                        decidingApprovals={decidingApprovals}
-                        answeringQuestions={answeringQuestions}
-                        onApprovalDecision={(approvalId, approved) =>
-                          void decideToolApproval(approvalId, approved)
-                        }
-                        onQuestionAnswer={(questionId, answers) =>
-                          void answerToolQuestion(questionId, answers)
-                        }
-                        onOpenTrace={selectTrace}
-                      />
-                    ))}
+                    <Suspense fallback={null}>
+                      {messages.map((message) => (
+                        <TranscriptItem
+                          key={message.entryId}
+                          entry={message}
+                          decidingApprovals={decidingApprovals}
+                          answeringQuestions={answeringQuestions}
+                          onApprovalDecision={(approvalId, approved) =>
+                            void decideToolApproval(approvalId, approved)
+                          }
+                          onQuestionAnswer={(questionId, answers) =>
+                            void answerToolQuestion(questionId, answers)
+                          }
+                          onOpenTrace={selectTrace}
+                        />
+                      ))}
+                    </Suspense>
                   </div>
                 </section>
                 <form
@@ -2021,132 +2102,158 @@ export function StudioConsole() {
         ) : null}
 
         {activePage === "tracing" ? (
-          <TraceBrowser
-            agents={agents}
-            traces={traces}
-            tracesEnabled={tracesEnabled}
-            traceLoadState={traceLoadState}
-            selectedTraceId={selectedTraceId}
-            traceSessionDetailId={traceSessionDetailId}
-            onRefresh={() => void loadTraces()}
-            onSelectTrace={selectTrace}
-            onShowSessionTraces={(sessionId) => void showSessionTraces(sessionId)}
-          />
+          <Suspense fallback={<PageLoading />}>
+            <TraceBrowser
+              agents={agents}
+              traces={traces}
+              tracesEnabled={tracesEnabled}
+              traceLoadState={traceLoadState}
+              selectedTraceId={selectedTraceId}
+              traceSessionDetailId={traceSessionDetailId}
+              onRefresh={() => void loadTraces()}
+              onSelectTrace={selectTrace}
+              onShowSessionTraces={(sessionId) => void showSessionTraces(sessionId)}
+            />
+          </Suspense>
         ) : null}
 
         {activePage === "sessions" ? (
-          <SessionsPage
-            agents={agents}
-            sessions={allSessions}
-            sessionsEnabled={sessionsEnabled}
-            sessionLoadState={sessionLoadState}
-            selectedSessionId={selectedSessionId}
-            onOpenSession={(sessionId) => void loadSession(sessionId)}
-            onViewSessionTracing={(sessionId) => void showSessionTraces(sessionId)}
-            onDeleteSession={setDeleteCandidate}
-          />
+          <Suspense fallback={<PageLoading />}>
+            <SessionsPage
+              agents={agents}
+              sessions={allSessions}
+              sessionsEnabled={sessionsEnabled}
+              sessionLoadState={sessionLoadState}
+              selectedSessionId={selectedSessionId}
+              onOpenSession={(sessionId) => void loadSession(sessionId)}
+              onViewSessionTracing={(sessionId) => void showSessionTraces(sessionId)}
+              onDeleteSession={setDeleteCandidate}
+            />
+          </Suspense>
         ) : null}
 
         {activePage === "agents" ? (
-          <AgentsPage agents={agents} selectedAgentId={selectedAgentId} />
+          <Suspense fallback={<PageLoading />}>
+            <AgentsPage agents={agents} selectedAgentId={selectedAgentId} />
+          </Suspense>
         ) : null}
 
         {activePage === "tools" ? (
-          <ToolsPage
-            agents={agents}
-            selectedAgentId={toolsAgentId || selectedAgent?.id || selectedAgentId}
-            summary={tools}
-            enabled={toolsEnabled}
-            loading={toolsLoadState === "loading"}
-            onSelectAgent={(agentId) => {
-              setToolsAgentId(agentId);
-              void loadTools(agentId);
-            }}
-          />
+          <Suspense fallback={<PageLoading />}>
+            <ToolsPage
+              agents={agents}
+              selectedAgentId={toolsAgentId || selectedAgent?.id || selectedAgentId}
+              summary={tools}
+              enabled={toolsEnabled}
+              loading={toolsLoadState === "loading"}
+              onSelectAgent={(agentId) => {
+                setToolsAgentId(agentId);
+                void loadTools(agentId);
+              }}
+            />
+          </Suspense>
         ) : null}
 
         {activePage === "pipelines" ? (
-          <PipelinesPage
-            pipelines={pipelines}
-            selectedPipelineId={selectedPipelineId}
-            detail={pipelineDetail}
-            logs={pipelineLogs}
-            activeRunId={activePipelineRunId}
-            runs={pipelineRuns}
-            enabled={pipelinesEnabled}
-            detailLoading={pipelineDetailLoadState === "loading"}
-            logsLoading={pipelineLogLoadState === "loading"}
-            runsLoading={pipelineRunLoadState === "loading"}
-            runState={pipelineRunState}
-            runInput={pipelineRunInput}
-            runOutput={pipelineRunOutput}
-            theme={theme}
-            onSelectPipeline={(pipelineId) => {
-              setSelectedPipelineId(pipelineId);
-              setPipelineRunOutput("");
-              setActivePipelineRunId("");
-              void loadPipeline(pipelineId);
-            }}
-            onRunInputChange={setPipelineRunInput}
-            onRun={() => void runPipeline()}
-            onReplayRun={(runId) => void replayPipelineRun(runId)}
-          />
+          <Suspense fallback={<PageLoading />}>
+            <PipelinesPage
+              pipelines={pipelines}
+              selectedPipelineId={selectedPipelineId}
+              detail={pipelineDetail}
+              logs={pipelineLogs}
+              activeRunId={activePipelineRunId}
+              runs={pipelineRuns}
+              enabled={pipelinesEnabled}
+              detailLoading={pipelineDetailLoadState === "loading"}
+              logsLoading={pipelineLogLoadState === "loading"}
+              runsLoading={pipelineRunLoadState === "loading"}
+              runState={pipelineRunState}
+              runInput={pipelineRunInput}
+              runOutput={pipelineRunOutput}
+              theme={theme}
+              onSelectPipeline={(pipelineId) => {
+                setSelectedPipelineId(pipelineId);
+                setPipelineRunOutput("");
+                setActivePipelineRunId("");
+                void loadPipeline(pipelineId);
+              }}
+              onRunInputChange={setPipelineRunInput}
+              onRun={() => void runPipeline()}
+              onReplayRun={(runId) => void replayPipelineRun(runId)}
+            />
+          </Suspense>
         ) : null}
 
         {activePage === "evals" ? (
-          <EvalsPage
-            evals={evals}
-            selectedEvalId={selectedEvalId}
-            enabled={evalsEnabled}
-            runState={evalRunState}
-            result={evalRunResult}
-            onSelectEval={(evalId) => {
-              setSelectedEvalId(evalId);
-              setEvalRunResult(undefined);
-            }}
-            onRun={() => void runEvalSuite()}
-          />
+          <Suspense fallback={<PageLoading />}>
+            <EvalsPage
+              evals={evals}
+              selectedEvalId={selectedEvalId}
+              enabled={evalsEnabled}
+              runState={evalRunState}
+              result={evalRunResult}
+              onSelectEval={(evalId) => {
+                setSelectedEvalId(evalId);
+                setEvalRunResult(undefined);
+              }}
+              onRun={() => void runEvalSuite()}
+            />
+          </Suspense>
         ) : null}
 
         {activePage === "mcps" ? (
-          <McpsPage
-            agents={agents}
-            selectedAgentId={mcpsAgentId || selectedAgent?.id || selectedAgentId}
-            summary={mcps}
-            enabled={mcpsEnabled}
-            loading={mcpsLoadState === "loading"}
-            onSelectAgent={(agentId) => {
-              setMcpsAgentId(agentId);
-              void loadMcps(agentId);
-            }}
-          />
+          <Suspense fallback={<PageLoading />}>
+            <McpsPage
+              agents={agents}
+              selectedAgentId={mcpsAgentId || selectedAgent?.id || selectedAgentId}
+              summary={mcps}
+              enabled={mcpsEnabled}
+              loading={mcpsLoadState === "loading"}
+              onSelectAgent={(agentId) => {
+                setMcpsAgentId(agentId);
+                void loadMcps(agentId);
+              }}
+            />
+          </Suspense>
         ) : null}
 
         {activePage === "knowledge" ? (
-          <KnowledgePage
-            activeTab={knowledgeTab}
-            enabled={knowledgeEnabled}
-            summary={knowledge}
-            loading={knowledgeLoadState === "loading"}
-            onOpenTrace={selectTrace}
-            onRefresh={() => void loadKnowledge()}
-            onSelectTab={navigateKnowledgeTab}
-          />
+          <Suspense fallback={<PageLoading />}>
+            <KnowledgePage
+              activeTab={knowledgeTab}
+              enabled={knowledgeEnabled}
+              summary={knowledge}
+              loading={knowledgeLoadState === "loading"}
+              onOpenTrace={selectTrace}
+              onRefresh={() => void loadKnowledge()}
+              onSelectTab={navigateKnowledgeTab}
+            />
+          </Suspense>
         ) : null}
 
-        {activePage === "memory" ? <MemoryPage agents={agents} enabled={memoryEnabled} /> : null}
+        {activePage === "memory" ? (
+          <Suspense fallback={<PageLoading />}>
+            <MemoryPage agents={agents} enabled={memoryEnabled} />
+          </Suspense>
+        ) : null}
 
-        {activePage === "status" ? <StatusPage enabled={statusEnabled} /> : null}
+        {activePage === "status" ? (
+          <Suspense fallback={<PageLoading />}>
+            <StatusPage enabled={statusEnabled} />
+          </Suspense>
+        ) : null}
       </main>
-      <DeleteSessionDialog
-        session={deleteCandidate}
-        onOpenChange={(open) => {
-          if (!open) {
-            setDeleteCandidate(undefined);
-          }
-        }}
-        onConfirm={(session) => void deleteSession(session)}
-      />
+      <Suspense fallback={null}>
+        <DeleteSessionDialog
+          session={deleteCandidate}
+          onOpenChange={(open) => {
+            if (!open) {
+              setDeleteCandidate(undefined);
+            }
+          }}
+          onConfirm={(session) => void deleteSession(session)}
+        />
+      </Suspense>
     </div>
   );
 }
@@ -2162,6 +2269,14 @@ function SidebarLink(props: { href: string; label: string }) {
       <span>{props.label}</span>
       <ArrowSquareOut aria-hidden="true" className="h-3 w-3 text-muted-foreground" />
     </a>
+  );
+}
+
+function PageLoading() {
+  return (
+    <section className="grid h-full min-h-0 place-items-center bg-background/45 text-sm font-medium text-muted-foreground">
+      Loading
+    </section>
   );
 }
 

--- a/packages/tools/studio/src/ui/app/modules/shared/navigation.ts
+++ b/packages/tools/studio/src/ui/app/modules/shared/navigation.ts
@@ -1,0 +1,77 @@
+import type { ActivePage } from "./types";
+
+export type StudioPageAvailability = {
+  hasAgents: boolean;
+  sessionsEnabled: boolean;
+  tracesEnabled: boolean;
+  toolsEnabled: boolean;
+  mcpsEnabled: boolean;
+  pipelinesEnabled: boolean;
+  evalsEnabled: boolean;
+  memoryEnabled: boolean;
+  statusEnabled: boolean;
+  knowledgeEnabled: boolean;
+};
+
+export function isActivePageEnabled(
+  page: ActivePage,
+  availability: StudioPageAvailability,
+): boolean {
+  if (page === "playground") {
+    return availability.hasAgents;
+  }
+  if (page === "sessions") {
+    return availability.sessionsEnabled;
+  }
+  if (page === "tracing") {
+    return availability.tracesEnabled;
+  }
+  if (page === "tools") {
+    return availability.toolsEnabled;
+  }
+  if (page === "mcps") {
+    return availability.mcpsEnabled;
+  }
+  if (page === "pipelines") {
+    return availability.pipelinesEnabled;
+  }
+  if (page === "evals") {
+    return availability.evalsEnabled;
+  }
+  if (page === "memory") {
+    return availability.memoryEnabled;
+  }
+  if (page === "status") {
+    return availability.statusEnabled;
+  }
+  if (page === "knowledge") {
+    return availability.knowledgeEnabled;
+  }
+  return true;
+}
+
+export function fallbackActivePage(
+  preferred: ActivePage,
+  availability: StudioPageAvailability,
+): ActivePage {
+  if (isActivePageEnabled(preferred, availability)) {
+    return preferred;
+  }
+  return (
+    (
+      [
+        "playground",
+        "pipelines",
+        "evals",
+        "sessions",
+        "tracing",
+        "agents",
+        "tools",
+        "mcps",
+        "knowledge",
+        "memory",
+        "status",
+      ] as const
+    ).find((page) => isActivePageEnabled(page, availability)) ?? "agents"
+  );
+}

--- a/packages/tools/studio/test/runner.test.ts
+++ b/packages/tools/studio/test/runner.test.ts
@@ -29,7 +29,7 @@ import {
 } from "@anvia/core/vector-store";
 import { Hono } from "hono";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { Studio } from "../src/index";
+import { createInMemoryStudioStore, Studio } from "../src/index";
 import { registerObservabilityRoutes, StudioObservabilityHub } from "../src/runtime/observability";
 import { createSqliteSessionStore } from "../src/sqlite";
 
@@ -608,6 +608,81 @@ describe("Anvia studio", () => {
       });
     } finally {
       db.close();
+    }
+  });
+
+  it("replays persisted pipeline runs outside the first runs page", async () => {
+    const pipeline = new PipelineBuilder<string>({ id: "audit-pipeline" })
+      .step((input) => ({ reply: input.toUpperCase() }), { id: "shape", name: "Shape" })
+      .build();
+    const store = createSqliteSessionStore({
+      path: join(studioDbDir ?? tmpdir(), "replay.sqlite"),
+    });
+    const runner = new Studio([pipeline], {
+      stores: {
+        sessions: store,
+      },
+    });
+    const startedAt = Date.parse("2026-01-01T00:00:00.000Z");
+
+    for (let index = 0; index <= 1000; index += 1) {
+      store.savePipelineRun({
+        runId: `run_${index}`,
+        pipelineId: "audit-pipeline",
+        status: "success",
+        input: `seed ${index}`,
+        output: { reply: `SEED ${index}` },
+        startedAt: new Date(startedAt + index).toISOString(),
+      });
+    }
+
+    const replay = await runner.fetch(
+      new Request("http://runner.test/pipelines/audit-pipeline/runs/run_0/replay", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ stream: false, metadata: { source: "regression" } }),
+      }),
+    );
+
+    expect(replay.status).toBe(200);
+    await expect(replay.json()).resolves.toMatchObject({
+      pipelineId: "audit-pipeline",
+      output: { reply: "SEED 0" },
+    });
+  });
+
+  it("loads pipeline runs by exact id from built-in stores", () => {
+    const stores = [
+      createInMemoryStudioStore(),
+      createSqliteSessionStore({ path: join(studioDbDir ?? tmpdir(), "exact-run.sqlite") }),
+    ];
+
+    for (const store of stores) {
+      store.savePipelineRun({
+        runId: "run_1",
+        pipelineId: "pipeline_a",
+        status: "success",
+        input: "hello",
+        output: "HELLO",
+        startedAt: "2026-01-01T00:00:00.000Z",
+      });
+      store.savePipelineRun({
+        runId: "run_2",
+        pipelineId: "pipeline_b",
+        status: "success",
+        input: "other",
+        output: "OTHER",
+        startedAt: "2026-01-01T00:00:01.000Z",
+      });
+
+      expect(store.getPipelineRun({ pipelineId: "pipeline_a", runId: "run_1" })).toMatchObject({
+        runId: "run_1",
+        pipelineId: "pipeline_a",
+        input: "hello",
+        output: "HELLO",
+      });
+      expect(store.getPipelineRun({ pipelineId: "pipeline_b", runId: "run_1" })).toBeUndefined();
+      expect(store.getPipelineRun({ pipelineId: "pipeline_a", runId: "missing" })).toBeUndefined();
     }
   });
 

--- a/packages/tools/studio/test/studio-ui-helpers.test.ts
+++ b/packages/tools/studio/test/studio-ui-helpers.test.ts
@@ -1,0 +1,76 @@
+import { Message } from "@anvia/core";
+import { describe, expect, it } from "vitest";
+import {
+  fallbackActivePage,
+  isActivePageEnabled,
+  type StudioPageAvailability,
+} from "../src/ui/app/modules/shared/navigation";
+import {
+  findMatchingToolIndex,
+  nextSequence,
+  toHistory,
+} from "../src/ui/app/modules/shared/transcript";
+
+const baseAvailability: StudioPageAvailability = {
+  hasAgents: true,
+  sessionsEnabled: true,
+  tracesEnabled: true,
+  toolsEnabled: true,
+  mcpsEnabled: true,
+  pipelinesEnabled: true,
+  evalsEnabled: true,
+  memoryEnabled: true,
+  statusEnabled: true,
+  knowledgeEnabled: true,
+};
+
+describe("Studio UI helpers", () => {
+  it("marks pages disabled when their runtime capability is missing", () => {
+    const availability = {
+      ...baseAvailability,
+      sessionsEnabled: false,
+      tracesEnabled: false,
+      toolsEnabled: false,
+      mcpsEnabled: false,
+      knowledgeEnabled: false,
+    };
+
+    expect(isActivePageEnabled("sessions", availability)).toBe(false);
+    expect(isActivePageEnabled("tracing", availability)).toBe(false);
+    expect(isActivePageEnabled("tools", availability)).toBe(false);
+    expect(isActivePageEnabled("mcps", availability)).toBe(false);
+    expect(isActivePageEnabled("knowledge", availability)).toBe(false);
+    expect(isActivePageEnabled("agents", availability)).toBe(true);
+  });
+
+  it("falls back to the first available operational page", () => {
+    expect(
+      fallbackActivePage("playground", {
+        ...baseAvailability,
+        hasAgents: false,
+      }),
+    ).toBe("pipelines");
+    expect(
+      fallbackActivePage("playground", {
+        ...baseAvailability,
+        hasAgents: false,
+        pipelinesEnabled: false,
+        evalsEnabled: false,
+        sessionsEnabled: false,
+        tracesEnabled: false,
+      }),
+    ).toBe("agents");
+  });
+
+  it("keeps transcript helper behavior deterministic", () => {
+    const transcript = [
+      { entryId: 4, kind: "message", role: "user", text: "Hello" },
+      { entryId: 7, kind: "message", role: "assistant", text: "Hi" },
+      { entryId: 8, kind: "tool", toolName: "lookup", callId: "call_1", args: "{}" },
+    ] as const;
+
+    expect(nextSequence([...transcript])).toBe(9);
+    expect(findMatchingToolIndex([...transcript], "lookup", "call_1")).toBe(2);
+    expect(toHistory([...transcript])).toEqual([Message.user("Hello"), Message.assistant("Hi")]);
+  });
+});


### PR DESCRIPTION
## Summary
- add exact pipeline run lookup support and fix replay for persisted runs beyond the first page
- centralize Studio JSON/error/transcript helpers and add focused regression tests
- split secondary Studio UI pages into lazy chunks and add navigation helper coverage
- add a patch changeset for @anvia/studio

## Validation
- pnpm --filter @anvia/studio typecheck
- pnpm --filter @anvia/studio test
- pnpm --filter @anvia/studio build