### PR TITLE
Broaden core runtime hooks and middleware

### DIFF
--- a/.changeset/broaden-core-runtime-hooks.md
+++ b/.changeset/broaden-core-runtime-hooks.md
@@ -1,0 +1,5 @@
+---
+"@anvia/core": minor
+---
+
+Broaden agent runtime hooks and add general middleware for completion requests, completion responses, tool inputs, and tool outputs while keeping existing tool middleware APIs as deprecated aliases.

--- a/apps/docs/content/docs/frameworks/hono/09-human-in-the-loop.mdx
+++ b/apps/docs/content/docs/frameworks/hono/09-human-in-the-loop.mdx
@@ -63,7 +63,7 @@ app.post("/api/support", zValidator("json", SupportRequest), async (c) => {
 
   const response = await supportAgent
     .prompt(message)
-    .requestHook(createApprovalHook({ userId, approvalRunId }))
+    .withHook(createApprovalHook({ userId, approvalRunId }))
     .send();
 
   return c.json({ output: response.output });

--- a/apps/docs/content/docs/frameworks/nextjs/09-human-in-the-loop.mdx
+++ b/apps/docs/content/docs/frameworks/nextjs/09-human-in-the-loop.mdx
@@ -74,7 +74,7 @@ Attach the hook in the route:
 ```ts
 const response = await supportAgent
   .prompt(message)
-  .requestHook(createApprovalHook({ userId, conversationId }))
+  .withHook(createApprovalHook({ userId, conversationId }))
   .send();
 ```
 

--- a/apps/docs/content/docs/frameworks/tanstack-start/09-human-in-the-loop.mdx
+++ b/apps/docs/content/docs/frameworks/tanstack-start/09-human-in-the-loop.mdx
@@ -51,7 +51,7 @@ Attach the hook from a server route:
 ```ts
 const response = await supportAgent
   .prompt(message)
-  .requestHook(createApprovalHook({ userId, runId }))
+  .withHook(createApprovalHook({ userId, runId }))
   .send();
 ```
 

--- a/apps/docs/content/docs/guides/agents/agent-tools.mdx
+++ b/apps/docs/content/docs/guides/agents/agent-tools.mdx
@@ -103,7 +103,7 @@ const approvalHook = createHook({
 
 const response = await agent
   .prompt("Refund order A-100.")
-  .requestHook(approvalHook)
+  .withHook(approvalHook)
   .send();
 ```
 

--- a/apps/docs/content/docs/guides/agents/run-limits.mdx
+++ b/apps/docs/content/docs/guides/agents/run-limits.mdx
@@ -65,7 +65,7 @@ const hook = createHook({
 });
 
 try {
-  await agent.prompt(userInput).requestHook(hook).send();
+  await agent.prompt(userInput).withHook(hook).send();
 } catch (error) {
   if (error instanceof PromptCancelledError) {
     return {

--- a/apps/docs/content/docs/guides/agents/runtime-hooks.mdx
+++ b/apps/docs/content/docs/guides/agents/runtime-hooks.mdx
@@ -3,7 +3,7 @@ title: Runtime Hooks
 description: Observe and customize agent runtime behavior with hooks.
 ---
 
-Hooks run inside a prompt request and can inspect or alter runtime behavior. Use observers for telemetry. Use hooks for guardrails, approval checks, skipped tools, and cancellation. Use [tool middleware](/docs/guides/tools/tool-middleware) when you need to transform tool result text before the model receives it.
+Hooks run inside a prompt request and can inspect or alter runtime behavior. Use observers for telemetry. Use hooks for lifecycle guardrails, approval checks, skipped tools, errors, and cancellation. Use [middleware](/docs/guides/tools/tool-middleware) when you need to transform model requests, model responses, tool inputs, or tool outputs.
 
 ## Create a Hook
 
@@ -11,6 +11,12 @@ Hooks run inside a prompt request and can inspect or alter runtime behavior. Use
 import { createHook } from "@anvia/core";
 
 const hook = createHook({
+  onRunStart({ prompt }) {
+    console.log("run_start", { role: prompt.role });
+  },
+  onTurnStart({ turn }) {
+    console.log("turn_start", turn);
+  },
   onCompletionCall({ prompt, history }) {
     console.log("model_call", { role: prompt.role, history: history.length });
   },
@@ -23,12 +29,20 @@ const hook = createHook({
   onToolResult({ toolName, result }) {
     console.log("tool_result", { toolName, result });
   },
+  onTurnEnd({ turn }) {
+    console.log("turn_end", turn);
+  },
+  onRunEnd({ output }) {
+    console.log("run_end", output);
+  },
 });
 
 const agent = new AgentBuilder("support", model).hook(hook).build();
 ```
 
-Register an agent hook with `.hook(...)`, or set a hook for one prompt request with `.requestHook(...)`. A request hook replaces the agent hook for that request.
+Register an agent hook with `.hook(...)`, or set a hook for one prompt request with `.withHook(...)`. A request hook replaces the agent hook for that request.
+
+`requestHook(...)` is still available as a deprecated alias for `.withHook(...)`.
 
 ## Control a Tool Call
 
@@ -41,12 +55,12 @@ const hook = createHook({
       return tool.skip("Order lookup is temporarily unavailable.");
     }
 
-    return tool.run();
+    return undefined;
   },
 });
 ```
 
-`tool.run()` executes the tool. `tool.skip(...)` does not execute the tool; the message becomes the tool result sent back to the model. `tool.requestApproval(...)` asks an approval-capable runtime such as Studio to pause the tool call for a human decision.
+Returning `undefined` executes the tool. `tool.run()` is still available when explicit continuation reads better. `tool.skip(...)` does not execute the tool; the message becomes the tool result sent back to the model. `tool.requestApproval(...)` asks an approval-capable runtime such as Studio to pause the tool call for a human decision.
 
 Tool result middleware runs after this decision produces a result string and before `onToolResult(...)` observes it.
 
@@ -84,7 +98,7 @@ const hook = createHook({
       return run.cancel("Prompt blocked by policy.");
     }
 
-    return run.continue();
+    return undefined;
   },
 });
 ```
@@ -104,3 +118,25 @@ const hook = createHook({
 ```
 
 Cancellation throws `PromptCancelledError`. Catch it at the application boundary when you want to return a user-facing message.
+
+## Handle Runtime Errors
+
+Use error hooks when cancellation or cleanup depends on a specific failure point.
+
+```ts
+const hook = createHook({
+  onCompletionError({ error, run }) {
+    if (isPolicyError(error)) {
+      return run.cancel("Model call blocked by policy.");
+    }
+  },
+  onToolError({ toolName, error }) {
+    console.warn("tool_error", { toolName, error });
+  },
+  onRunError({ error }) {
+    console.error("run_error", error);
+  },
+});
+```
+
+`onCompletionError(...)` runs when the model call fails. `onToolError(...)` runs when a tool throws before the error is converted into a model-visible tool result. `onRunError(...)` runs before the failed run is recorded.

--- a/apps/docs/content/docs/guides/human-in-the-loop/index.mdx
+++ b/apps/docs/content/docs/guides/human-in-the-loop/index.mdx
@@ -61,7 +61,7 @@ const approvalHook = createHook({
   },
 });
 
-await agent.prompt("Refund order A-100.").requestHook(approvalHook).send();
+await agent.prompt("Refund order A-100.").withHook(approvalHook).send();
 ```
 
 The model sees skipped tools as tool results, so write rejection messages as text the model can use in its final answer.

--- a/apps/docs/content/docs/guides/human-in-the-loop/tool-approval.mdx
+++ b/apps/docs/content/docs/guides/human-in-the-loop/tool-approval.mdx
@@ -35,7 +35,7 @@ Attach the hook to one request when approval rules are request-specific.
 ```ts
 const response = await agent
   .prompt("Refund order A-100.")
-  .requestHook(approvalHook)
+  .withHook(approvalHook)
   .send();
 ```
 
@@ -112,12 +112,12 @@ Use `tool.cancel(...)` for malformed or unsafe runs that should stop immediately
 
 ## Request Hook vs Agent Hook
 
-Use `.requestHook(...)` when approval rules are specific to one prompt request.
+Use `.withHook(...)` when approval rules are specific to one prompt request.
 
 ```ts
 await agent
   .prompt("Refund order A-100.")
-  .requestHook(approvalHook)
+  .withHook(approvalHook)
   .send();
 ```
 

--- a/apps/docs/content/docs/guides/observability/observers.mdx
+++ b/apps/docs/content/docs/guides/observability/observers.mdx
@@ -5,6 +5,8 @@ description: Observe agent runs, generations, tools, usage, and errors.
 
 Observers are plain TypeScript objects or classes that receive runtime events from an agent run. Use them for logs, metrics, traces, and debugging.
 
+Observers should not change runtime behavior. Use [runtime hooks](/docs/guides/agents/runtime-hooks) for cancellation, approval, and guardrails. Use [middleware](/docs/guides/tools/tool-middleware) to transform model requests, model responses, tool inputs, or tool outputs.
+
 ## 1. Create an Observer
 
 ```ts

--- a/apps/docs/content/docs/guides/tools/tool-middleware.mdx
+++ b/apps/docs/content/docs/guides/tools/tool-middleware.mdx
@@ -1,17 +1,32 @@
 ---
-title: Tool Middleware
-description: Transform tool results before they are returned to the model.
+title: Middleware
+description: Transform model requests, model responses, tool inputs, and tool outputs.
 ---
 
-Tool result middleware runs after a tool produces its serialized string result and before that result is sent back to the model. Use it for output gates, redaction, compression, or file references when a tool result is too large.
+Middleware transforms data at runtime boundaries. Use hooks for cancellation, approvals, and guardrails. Use observers for telemetry. Use middleware when you need to change what goes into or comes out of a model or tool call.
 
 ## Create Middleware
 
 ```ts
-import { createToolMiddleware } from "@anvia/core/tool";
+import { createMiddleware } from "@anvia/core";
 
-const outputGate = createToolMiddleware({
-  async onResult({ toolName, result, internalCallId }) {
+const runtimePolicy = createMiddleware({
+  onCompletionRequest({ request }) {
+    return {
+      request: {
+        ...request,
+        temperature: 0.2,
+      },
+    };
+  },
+
+  onToolInput({ toolName, args }) {
+    if (toolName === "search") {
+      return { args: { ...JSON.parse(args), limit: 5 } };
+    }
+  },
+
+  async onToolOutput({ toolName, result, internalCallId }) {
     if (result.length <= 1_000) {
       return undefined;
     }
@@ -31,40 +46,63 @@ const outputGate = createToolMiddleware({
 });
 ```
 
-Return a string to replace the current tool result. Return `undefined` to keep the current result.
+Return `undefined` to keep the current value.
+
+Middleware can implement:
+
+- `onCompletionRequest(...)`: replace the model request before the provider call.
+- `onCompletionResponse(...)`: replace the model response before response hooks, memory, tool execution, and final output handling.
+- `onToolInput(...)`: replace serialized tool args before the tool executes.
+- `onToolOutput(...)`: replace tool result text or structured result content before `onToolResult(...)` and before the model receives the tool message.
 
 ## Register On An Agent
 
 ```ts
 const agent = new AgentBuilder("support", model)
   .tools([lookupOrder, exportReport])
-  .toolMiddleware(outputGate)
+  .middleware(runtimePolicy)
   .build();
 ```
 
-Middleware applies to tool results from local tools, MCP tools, dynamic tools, vector search tools, and agents exposed with `agent.asTool(...)`.
+Middleware applies to local tools, MCP tools, dynamic tools, vector search tools, and agents exposed with `agent.asTool(...)`.
 
 ## Register For One Request
 
 ```ts
 const response = await agent
   .prompt("Summarize the large report.")
-  .withToolMiddleware(outputGate)
+  .withMiddleware(runtimePolicy)
   .send();
 ```
 
-Use request middleware when one caller needs stricter output policy than the agent default.
+Use request middleware when one caller needs stricter policy than the agent default.
 
 ## Compose Middleware
 
 ```ts
 const agent = new AgentBuilder("support", model)
-  .toolMiddlewares([redactSecrets, outputGate])
+  .middlewares([redactSecrets, outputGate])
   .build();
 ```
 
 Middleware runs in registration order. Agent middleware runs before request middleware. Each middleware receives the latest `result` and the unchanged `originalResult`.
 
+The previous tool-result-only APIs are still available as deprecated aliases:
+
+```ts
+import { createToolMiddleware } from "@anvia/core/tool";
+
+new AgentBuilder("support", model)
+  .toolMiddleware(createToolMiddleware({
+    onResult({ result }) {
+      return redact(result);
+    },
+  }))
+  .build();
+```
+
+Prefer `createMiddleware(...)`, `.middleware(...)`, `.middlewares(...)`, `.withMiddleware(...)`, and `.withMiddlewares(...)` for new code.
+
 ## Skill Tools
 
-Skill runtime tools are excluded from tool result middleware. Their behavior is owned by the skills runtime, including loading instructions, reading references, and running skill scripts.
+Skill runtime tools are excluded from tool output middleware. Their behavior is owned by the skills runtime, including loading instructions, reading references, and running skill scripts.

--- a/apps/docs/content/docs/reference/core/agent.mdx
+++ b/apps/docs/content/docs/reference/core/agent.mdx
@@ -26,6 +26,8 @@ class Agent<M extends CompletionModel = CompletionModel> {
   readonly observers: AgentObserverRegistration[];
   readonly dynamicContexts: DynamicContextRegistration[];
   readonly dynamicTools: DynamicToolRegistration[];
+  readonly middlewares: AgentMiddleware[];
+  /** @deprecated Use middlewares instead. */
   readonly toolMiddlewares: ToolMiddleware[];
   readonly memory?: MemoryRegistration;
   readonly eventStore?: AgentEventStoreRegistration;
@@ -66,6 +68,8 @@ type AgentOptions<M extends CompletionModel = CompletionModel> = {
   observers?: AgentObserverRegistration[];
   dynamicContexts?: DynamicContextRegistration[];
   dynamicTools?: DynamicToolRegistration[];
+  middlewares?: AgentMiddleware[];
+  /** @deprecated Use middlewares instead. */
   toolMiddlewares?: ToolMiddleware[];
   memory?: MemoryRegistration;
   eventStore?: AgentEventStoreRegistration;
@@ -100,7 +104,11 @@ class AgentBuilder<M extends CompletionModel = CompletionModel> {
   toolChoice(toolChoice: ToolChoice): this;
   defaultMaxTurns(defaultMaxTurns: number): this;
   hook(hook: PromptHook): this;
+  middleware(middleware: AgentMiddleware): this;
+  middlewares(middlewares: AgentMiddleware[]): this;
+  /** @deprecated Use middleware instead. */
   toolMiddleware(middleware: ToolMiddleware): this;
+  /** @deprecated Use middlewares instead. */
   toolMiddlewares(middlewares: ToolMiddleware[]): this;
   observe(observer: AgentObserver, options?: ObserveOptions): this;
   memory(store: MemoryStore, options?: MemoryOptions): this;
@@ -235,9 +243,15 @@ class PromptRequest<M extends CompletionModel = CompletionModel> {
   ): PromptRequest<M>;
 
   maxTurns(maxTurns: number): this;
+  withHook(hook: PromptHook): this;
+  /** @deprecated Use withHook instead. */
   requestHook(hook: PromptHook): this;
   withToolConcurrency(concurrency: number): this;
+  withMiddleware(middleware: AgentMiddleware): this;
+  withMiddlewares(middlewares: AgentMiddleware[]): this;
+  /** @deprecated Use withMiddleware instead. */
   withToolMiddleware(middleware: ToolMiddleware): this;
+  /** @deprecated Use withMiddlewares instead. */
   withToolMiddlewares(middlewares: ToolMiddleware[]): this;
   withTrace(trace: AgentTraceOptions): this;
   send(): Promise<PromptResponse>;
@@ -328,9 +342,49 @@ type CompletionCallHookArgs = {
   run: RunControl;
 };
 
+type RunStartHookArgs = {
+  prompt: Message;
+  history: Message[];
+  maxTurns: number;
+  run: RunControl;
+};
+
+type RunEndHookArgs = {
+  output: string;
+  usage: Usage;
+  messages: Message[];
+  run: RunControl;
+};
+
+type RunErrorHookArgs = {
+  error: unknown;
+  usage: Usage;
+  messages: Message[];
+  run: RunControl;
+};
+
+type TurnStartHookArgs = {
+  turn: number;
+  prompt: Message;
+  history: Message[];
+  run: RunControl;
+};
+
+type TurnEndHookArgs<RawResponse = unknown> = {
+  turn: number;
+  response: CompletionResponse<RawResponse>;
+  run: RunControl;
+};
+
 type CompletionResponseHookArgs<RawResponse = unknown> = {
   prompt: Message;
   response: CompletionResponse<RawResponse>;
+  run: RunControl;
+};
+
+type CompletionErrorHookArgs = {
+  prompt: Message;
+  error: unknown;
   run: RunControl;
 };
 
@@ -350,6 +404,11 @@ type ToolResultHookArgs = ToolHookArgs & {
   run: RunControl;
 };
 
+type ToolErrorHookArgs = ToolHookArgs & {
+  error: unknown;
+  run: RunControl;
+};
+
 const runControl: RunControl;
 const toolCallControl: ToolCallControl;
 
@@ -359,7 +418,7 @@ function skipTool(reason: string): ToolCallHookAction;
 function requestToolApproval(options?: ToolApprovalRequestOptions): ToolCallHookAction;
 ```
 
-Purpose: intercept completion calls, completion responses, tool calls, and tool results.
+Purpose: intercept run lifecycle, turn lifecycle, completion calls, completion responses, completion errors, tool calls, tool results, and tool errors.
 
 Return behavior: callback controls such as `tool.run()`, `tool.skip(...)`, `tool.cancel(...)`, `tool.requestApproval(...)`, `run.continue()`, and `run.cancel(...)` create actions consumed by `PromptRequest`. The low-level `cancelPrompt(...)`, `skipTool(...)`, and `requestToolApproval(...)` helpers are also available.
 

--- a/apps/docs/content/docs/reference/core/tools.mdx
+++ b/apps/docs/content/docs/reference/core/tools.mdx
@@ -92,9 +92,46 @@ Return behavior: core stores this metadata only. Core prompt execution ignores i
 
 Notable errors: runtime-specific approval evaluators can surface errors thrown by `when(...)`, `reason(...)`, or `rejectMessage(...)`.
 
-## ToolMiddleware
+## AgentMiddleware
 
 ```ts
+type CompletionRequestMiddlewareArgs = {
+  turn: number;
+  request: CompletionRequest;
+  originalRequest: CompletionRequest;
+};
+
+type CompletionRequestMiddlewareResult =
+  | { request: CompletionRequest }
+  | undefined
+  | void;
+
+type CompletionResponseMiddlewareArgs = {
+  turn: number;
+  request: CompletionRequest;
+  response: CompletionResponse;
+  originalResponse: CompletionResponse;
+};
+
+type CompletionResponseMiddlewareResult =
+  | { response: CompletionResponse }
+  | undefined
+  | void;
+
+type ToolInputMiddlewareArgs = {
+  toolName: string;
+  args: string;
+  originalArgs: string;
+  turn: number;
+  toolCallId?: string;
+  internalCallId: string;
+};
+
+type ToolInputMiddlewareResult =
+  | { args: JsonValue | string }
+  | undefined
+  | void;
+
 type ToolResultMiddlewareArgs = {
   toolName: string;
   args: string;
@@ -105,16 +142,35 @@ type ToolResultMiddlewareArgs = {
   internalCallId: string;
 };
 
-interface ToolMiddleware {
+type ToolOutputMiddlewareArgs = ToolResultMiddlewareArgs;
+
+type ToolOutputMiddlewareResult =
+  | string
+  | { result?: string; structuredResult?: ToolResultContent[] }
+  | undefined
+  | void;
+
+interface AgentMiddleware {
+  onCompletionRequest?(args: CompletionRequestMiddlewareArgs): CompletionRequestMiddlewareResult | Promise<CompletionRequestMiddlewareResult>;
+  onCompletionResponse?(args: CompletionResponseMiddlewareArgs): CompletionResponseMiddlewareResult | Promise<CompletionResponseMiddlewareResult>;
+  onToolInput?(args: ToolInputMiddlewareArgs): ToolInputMiddlewareResult | Promise<ToolInputMiddlewareResult>;
+  onToolOutput?(args: ToolOutputMiddlewareArgs): ToolOutputMiddlewareResult | Promise<ToolOutputMiddlewareResult>;
+  /** @deprecated Use onToolOutput instead. */
   onResult?(args: ToolResultMiddlewareArgs): string | undefined | Promise<string | undefined>;
 }
 
+function createMiddleware(middleware: AgentMiddleware): AgentMiddleware;
+
+/** @deprecated Use AgentMiddleware instead. */
+type ToolMiddleware = AgentMiddleware;
+
+/** @deprecated Use createMiddleware instead. */
 function createToolMiddleware(middleware: ToolMiddleware): ToolMiddleware;
 ```
 
-Purpose: transform serialized tool results during agent runs before the model, stream events, hooks, observers, and messages receive the result.
+Purpose: transform model requests, model responses, tool inputs, and tool outputs during agent runs.
 
-Return behavior: returning a string replaces the current result; returning `undefined` keeps it. Multiple middleware callbacks run in registration order. Skill runtime tools are excluded.
+Return behavior: returning `undefined` keeps the current value. Returning a replacement from `onCompletionRequest`, `onCompletionResponse`, `onToolInput`, or `onToolOutput` passes that value to later middleware and the runtime. Multiple middleware callbacks run in registration order. Agent-level middleware runs before request-level middleware. Skill runtime tools are excluded from tool output middleware.
 
 Notable errors: errors thrown by middleware surface as prompt run errors.
 

--- a/apps/docs/content/docs/studio/human-in-the-loop/tool-approvals.mdx
+++ b/apps/docs/content/docs/studio/human-in-the-loop/tool-approvals.mdx
@@ -105,7 +105,7 @@ const approvalHook = createHook({
 });
 ```
 
-Attach the hook to the agent with `.hook(approvalHook)` or to one run with `.requestHook(approvalHook)`. Studio emits the same approval request and result events for hook-based approvals.
+Attach the hook to the agent with `.hook(approvalHook)` or to one run with `.withHook(approvalHook)`. Studio emits the same approval request and result events for hook-based approvals.
 
 ## Approval Flow
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -11,7 +11,7 @@ import type { MemoryRegistration, SessionOptions } from "../memory";
 import type { AgentObserverRegistration } from "../observability";
 import { createTool } from "../tool/create-tool";
 import type { ToolSearchDocument } from "../tool/dynamic-tools";
-import type { ToolMiddleware } from "../tool/middleware";
+import type { AgentMiddleware } from "../tool/middleware";
 import { isSkillTool } from "../tool/skill-tool-marker";
 import type { AnyTool, NormalizedToolOutput, Tool, ToolCallContext } from "../tool/tool";
 import { ToolSet } from "../tool/tool-set";
@@ -39,7 +39,11 @@ export type AgentOptions<M extends CompletionModel = CompletionModel> = {
   observers?: AgentObserverRegistration[] | undefined;
   dynamicContexts?: DynamicContextRegistration[] | undefined;
   dynamicTools?: DynamicToolRegistration[] | undefined;
-  toolMiddlewares?: ToolMiddleware[] | undefined;
+  middlewares?: AgentMiddleware[] | undefined;
+  /**
+   * @deprecated Use `middlewares` instead.
+   */
+  toolMiddlewares?: AgentMiddleware[] | undefined;
   memory?: MemoryRegistration | undefined;
   eventStore?: AgentEventStoreRegistration | undefined;
 };
@@ -126,7 +130,11 @@ export class Agent<M extends CompletionModel = CompletionModel> {
   readonly observers: AgentObserverRegistration[];
   readonly dynamicContexts: DynamicContextRegistration[];
   readonly dynamicTools: DynamicToolRegistration[];
-  readonly toolMiddlewares: ToolMiddleware[];
+  readonly middlewares: AgentMiddleware[];
+  /**
+   * @deprecated Use `middlewares` instead.
+   */
+  readonly toolMiddlewares: AgentMiddleware[];
   readonly memory: MemoryRegistration | undefined;
   readonly eventStore: AgentEventStoreRegistration | undefined;
 
@@ -148,7 +156,8 @@ export class Agent<M extends CompletionModel = CompletionModel> {
     this.observers = options.observers ?? [];
     this.dynamicContexts = options.dynamicContexts ?? [];
     this.dynamicTools = options.dynamicTools ?? [];
-    this.toolMiddlewares = options.toolMiddlewares ?? [];
+    this.middlewares = options.middlewares ?? options.toolMiddlewares ?? [];
+    this.toolMiddlewares = this.middlewares;
     this.memory = options.memory;
     this.eventStore = options.eventStore;
   }

--- a/packages/core/src/agent/builder.ts
+++ b/packages/core/src/agent/builder.ts
@@ -10,7 +10,7 @@ import type { AgentObserver, AgentObserverRegistration, ObserveOptions } from ".
 import { toProviderJsonSchema, type ZodSchema } from "../schema/zod-schema";
 import type { SkillSet } from "../skills";
 import type { ToolSearchDocument } from "../tool/dynamic-tools";
-import type { ToolMiddleware } from "../tool/middleware";
+import type { AgentMiddleware, ToolMiddleware } from "../tool/middleware";
 import type { AnyTool } from "../tool/tool";
 import { ToolSet } from "../tool/tool-set";
 import type { VectorSearchIndex } from "../vector-store";
@@ -44,7 +44,7 @@ export class AgentBuilder<M extends CompletionModel = CompletionModel> {
   private observerRegistrations: AgentObserverRegistration[] = [];
   private dynamicContextRegistrations: DynamicContextRegistration[] = [];
   private dynamicToolRegistrations: DynamicToolRegistration[] = [];
-  private middlewareRegistrations: ToolMiddleware[] = [];
+  private middlewareRegistrations: AgentMiddleware[] = [];
   private memoryRegistration: MemoryRegistration | undefined;
   private eventStoreRegistration: AgentEventStoreRegistration | undefined;
   private activeToolSet = new ToolSet();
@@ -149,14 +149,28 @@ export class AgentBuilder<M extends CompletionModel = CompletionModel> {
     return this;
   }
 
-  toolMiddleware(middleware: ToolMiddleware): this {
+  middleware(middleware: AgentMiddleware): this {
     this.middlewareRegistrations.push(middleware);
     return this;
   }
 
-  toolMiddlewares(middlewares: ToolMiddleware[]): this {
+  middlewares(middlewares: AgentMiddleware[]): this {
     this.middlewareRegistrations.push(...middlewares);
     return this;
+  }
+
+  /**
+   * @deprecated Use `middleware` instead.
+   */
+  toolMiddleware(middleware: ToolMiddleware): this {
+    return this.middleware(middleware);
+  }
+
+  /**
+   * @deprecated Use `middlewares` instead.
+   */
+  toolMiddlewares(middlewares: ToolMiddleware[]): this {
+    return this.middlewares(middlewares);
   }
 
   observe(observer: AgentObserver, options: ObserveOptions = {}): this {
@@ -209,7 +223,7 @@ export class AgentBuilder<M extends CompletionModel = CompletionModel> {
       observers: this.observerRegistrations,
       dynamicContexts: this.dynamicContextRegistrations,
       dynamicTools: this.dynamicToolRegistrations,
-      toolMiddlewares: this.middlewareRegistrations,
+      middlewares: this.middlewareRegistrations,
       memory: this.memoryRegistration,
       eventStore: this.eventStoreRegistration,
     });

--- a/packages/core/src/agent/hooks.ts
+++ b/packages/core/src/agent/hooks.ts
@@ -1,4 +1,4 @@
-import type { CompletionResponse, Message, ToolResultContent } from "../completion/index";
+import type { CompletionResponse, Message, ToolResultContent, Usage } from "../completion/index";
 
 export type HookAction = { type: "continue" } | { type: "terminate"; reason: string };
 export type ToolApprovalRequestOptions = {
@@ -40,9 +40,49 @@ export type CompletionCallHookArgs = {
   run: RunControl;
 };
 
+export type RunStartHookArgs = {
+  prompt: Message;
+  history: Message[];
+  maxTurns: number;
+  run: RunControl;
+};
+
+export type RunEndHookArgs = {
+  output: string;
+  usage: Usage;
+  messages: Message[];
+  run: RunControl;
+};
+
+export type RunErrorHookArgs = {
+  error: unknown;
+  usage: Usage;
+  messages: Message[];
+  run: RunControl;
+};
+
+export type TurnStartHookArgs = {
+  turn: number;
+  prompt: Message;
+  history: Message[];
+  run: RunControl;
+};
+
+export type TurnEndHookArgs<RawResponse = unknown> = {
+  turn: number;
+  response: CompletionResponse<RawResponse>;
+  run: RunControl;
+};
+
 export type CompletionResponseHookArgs<RawResponse = unknown> = {
   prompt: Message;
   response: CompletionResponse<RawResponse>;
+  run: RunControl;
+};
+
+export type CompletionErrorHookArgs = {
+  prompt: Message;
+  error: unknown;
   run: RunControl;
 };
 
@@ -60,6 +100,11 @@ export type ToolCallHookArgs = ToolHookArgs & {
 export type ToolResultHookArgs = ToolHookArgs & {
   result: string;
   structuredResult?: ToolResultContent[] | undefined;
+  run: RunControl;
+};
+
+export type ToolErrorHookArgs = ToolHookArgs & {
+  error: unknown;
   run: RunControl;
 };
 
@@ -110,8 +155,15 @@ export const toolCallControl: ToolCallControl = {
 };
 
 export interface PromptHook<RawResponse = unknown> {
+  onRunStart?: HookCallback<RunStartHookArgs>;
+  onRunEnd?: HookCallback<RunEndHookArgs>;
+  onRunError?: HookCallback<RunErrorHookArgs>;
+  onTurnStart?: HookCallback<TurnStartHookArgs>;
+  onTurnEnd?: HookCallback<TurnEndHookArgs<RawResponse>>;
   onCompletionCall?: HookCallback<CompletionCallHookArgs>;
   onCompletionResponse?: HookCallback<CompletionResponseHookArgs<RawResponse>>;
+  onCompletionError?: HookCallback<CompletionErrorHookArgs>;
   onToolCall?: ToolCallHookCallback<ToolCallHookArgs>;
   onToolResult?: HookCallback<ToolResultHookArgs>;
+  onToolError?: HookCallback<ToolErrorHookArgs>;
 }

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -1,4 +1,18 @@
 export type {
+  AgentMiddleware,
+  CompletionRequestMiddlewareArgs,
+  CompletionRequestMiddlewareResult,
+  CompletionResponseMiddlewareArgs,
+  CompletionResponseMiddlewareResult,
+  ToolInputMiddlewareArgs,
+  ToolInputMiddlewareResult,
+  ToolMiddleware,
+  ToolOutputMiddlewareArgs,
+  ToolOutputMiddlewareResult,
+  ToolResultMiddlewareArgs,
+} from "../tool/middleware";
+export { createMiddleware, createToolMiddleware } from "../tool/middleware";
+export type {
   AgentEventAppendInput,
   AgentEventRecord,
   AgentEventStore,
@@ -9,18 +23,25 @@ export { AgentBuilder } from "./builder";
 export { MaxTurnsError, PromptCancelledError } from "./errors";
 export type {
   CompletionCallHookArgs,
+  CompletionErrorHookArgs,
   CompletionResponseHookArgs,
   HookAction,
   HookResult,
   PromptHook,
   RunControl,
+  RunEndHookArgs,
+  RunErrorHookArgs,
+  RunStartHookArgs,
   ToolApprovalRequestOptions,
   ToolCallControl,
   ToolCallHookAction,
   ToolCallHookArgs,
   ToolCallHookResult,
+  ToolErrorHookArgs,
   ToolHookArgs,
   ToolResultHookArgs,
+  TurnEndHookArgs,
+  TurnStartHookArgs,
 } from "./hooks";
 export {
   cancelPrompt,

--- a/packages/core/src/agent/request.ts
+++ b/packages/core/src/agent/request.ts
@@ -19,7 +19,7 @@ import type { MemoryContext } from "../memory";
 import { type ActiveAgentRunObservers, startAgentRunObservers } from "../observability/group";
 import type { AgentTraceInfo, AgentTraceOptions } from "../observability/types";
 import { toReadableStream } from "../streaming";
-import type { ToolMiddleware } from "../tool/middleware";
+import type { AgentMiddleware, ToolMiddleware } from "../tool/middleware";
 import type { Agent } from "./agent";
 import { MaxTurnsError, PromptCancelledError } from "./errors";
 import type { PromptHook } from "./hooks";
@@ -114,7 +114,7 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
   private activeHook: PromptHook | undefined;
   private concurrency = 1;
   private traceOptions: AgentTraceOptions | undefined;
-  private requestToolMiddlewares: ToolMiddleware[] = [];
+  private requestMiddlewares: AgentMiddleware[] = [];
   private readonly memoryRecorder: PromptRequestMemory;
 
   private constructor(
@@ -143,9 +143,16 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
     return this;
   }
 
-  requestHook(hook: PromptHook): this {
+  withHook(hook: PromptHook): this {
     this.activeHook = hook;
     return this;
+  }
+
+  /**
+   * @deprecated Use `withHook` instead.
+   */
+  requestHook(hook: PromptHook): this {
+    return this.withHook(hook);
   }
 
   withToolConcurrency(concurrency: number): this {
@@ -153,14 +160,28 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
     return this;
   }
 
-  withToolMiddleware(middleware: ToolMiddleware): this {
-    this.requestToolMiddlewares.push(middleware);
+  withMiddleware(middleware: AgentMiddleware): this {
+    this.requestMiddlewares.push(middleware);
     return this;
   }
 
-  withToolMiddlewares(middlewares: ToolMiddleware[]): this {
-    this.requestToolMiddlewares.push(...middlewares);
+  withMiddlewares(middlewares: AgentMiddleware[]): this {
+    this.requestMiddlewares.push(...middlewares);
     return this;
+  }
+
+  /**
+   * @deprecated Use `withMiddleware` instead.
+   */
+  withToolMiddleware(middleware: ToolMiddleware): this {
+    return this.withMiddleware(middleware);
+  }
+
+  /**
+   * @deprecated Use `withMiddlewares` instead.
+   */
+  withToolMiddlewares(middlewares: ToolMiddleware[]): this {
+    return this.withMiddlewares(middlewares);
   }
 
   withTrace(trace: AgentTraceOptions): this {
@@ -179,6 +200,7 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
     const runObservers = await this.startRunObservers();
 
     try {
+      await this.runRunStartHook(newMessages);
       while (currentTurns <= this.maxTurnCount + 1) {
         const prompt = newMessages.at(-1);
         if (prompt === undefined) {
@@ -189,12 +211,13 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
         currentTurns += 1;
 
         const historyForRequest = [...this.chatHistory, ...newMessages.slice(0, -1)];
+        await this.runTurnStartHook(currentTurns, prompt, historyForRequest, newMessages);
         await this.runCompletionCallHook(prompt, historyForRequest, newMessages);
 
         const ragText = extractRagText(prompt);
         const dynamicContext = await fetchDynamicContext(this.agent, ragText);
         const toolDefs = await fetchToolDefinitions(this.agent, ragText);
-        const request = new CompletionRequestBuilder(this.agent.model, prompt)
+        let request = new CompletionRequestBuilder(this.agent.model, prompt)
           .instructions(this.agent.instructions)
           .messages(historyForRequest)
           .documents([...this.agent.staticContext, ...dynamicContext])
@@ -205,10 +228,19 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
           .toolChoice(this.agent.toolChoice)
           .outputSchema(this.agent.outputSchema)
           .build();
+        request = await this.runCompletionRequestMiddlewares(request, currentTurns);
 
-        const response = await this.runCompletion(request, currentTurns, runObservers);
+        let response: CompletionResponse;
+        try {
+          response = await this.runCompletion(request, currentTurns, runObservers);
+        } catch (error) {
+          await this.runCompletionErrorHook(prompt, error, newMessages);
+          throw error;
+        }
+        response = await this.runCompletionResponseMiddlewares(request, response, currentTurns);
         usage = Usage.add(usage, response.usage);
         await this.runCompletionResponseHook(prompt, response, newMessages);
+        await this.runTurnEndHook(currentTurns, response, newMessages);
 
         const assistantMessage = Message.assistant(response.choice, response.messageId);
         newMessages.push(assistantMessage);
@@ -234,6 +266,7 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
             messages: [...newMessages],
             trace: runObservers.trace,
           };
+          await this.runRunEndHook(result, newMessages);
           await runObservers.end(result);
           return result;
         }
@@ -262,9 +295,10 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
 
       throw new MaxTurnsError(this.maxTurnCount, [...this.chatHistory, ...newMessages], lastPrompt);
     } catch (error) {
-      await runObservers.error({ error, usage, messages: [...newMessages] });
-      await this.memoryRecorder.recordError(runId, error, newMessages);
-      throw error;
+      const finalError = await this.runRunErrorHook(error, usage, newMessages);
+      await runObservers.error({ error: finalError, usage, messages: [...newMessages] });
+      await this.memoryRecorder.recordError(runId, finalError, newMessages);
+      throw finalError;
     }
   }
 
@@ -287,6 +321,7 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
     };
 
     try {
+      await this.runRunStartHook(newMessages);
       while (currentTurns <= this.maxTurnCount + 1) {
         const prompt = newMessages.at(-1);
         if (prompt === undefined) {
@@ -303,12 +338,13 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
           prompt,
           history: historyForRequest,
         });
+        await this.runTurnStartHook(currentTurns, prompt, historyForRequest, newMessages);
         await this.runCompletionCallHook(prompt, historyForRequest, newMessages);
 
         const ragText = extractRagText(prompt);
         const dynamicContext = await fetchDynamicContext(this.agent, ragText);
         const toolDefs = await fetchToolDefinitions(this.agent, ragText);
-        const request = new CompletionRequestBuilder(this.agent.model, prompt)
+        let request = new CompletionRequestBuilder(this.agent.model, prompt)
           .instructions(this.agent.instructions)
           .messages(historyForRequest)
           .documents([...this.agent.staticContext, ...dynamicContext])
@@ -319,6 +355,7 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
           .toolChoice(this.agent.toolChoice)
           .outputSchema(this.agent.outputSchema)
           .build();
+        request = await this.runCompletionRequestMiddlewares(request, currentTurns);
 
         assertCompletionRequestSupported(this.agent.model, request, { streaming: true });
         const providerRequest = this.providerTraceRequest(request, { stream: true });
@@ -350,17 +387,20 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
           }
         } catch (error) {
           await generationObservers.error({ turn: currentTurns, error });
+          await this.runCompletionErrorHook(prompt, error, newMessages);
           throw error;
         }
 
-        const response = accumulator.response();
+        let response = accumulator.response();
         await generationObservers.end({
           turn: currentTurns,
           response,
           ...(firstDeltaMs === undefined ? {} : { firstDeltaMs }),
         });
+        response = await this.runCompletionResponseMiddlewares(request, response, currentTurns);
         usage = Usage.add(usage, response.usage);
         await this.runCompletionResponseHook(prompt, response, newMessages);
+        await this.runTurnEndHook(currentTurns, response, newMessages);
 
         const assistantMessage = Message.assistant(response.choice, response.messageId);
         newMessages.push(assistantMessage);
@@ -394,6 +434,7 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
             messages: [...newMessages],
             trace: runObservers.trace,
           });
+          await this.runRunEndHook({ output, usage, messages: [...newMessages] }, newMessages);
           await runObservers.end({ output, usage, messages: [...newMessages] });
           return;
         }
@@ -435,10 +476,11 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
 
       throw new MaxTurnsError(this.maxTurnCount, [...this.chatHistory, ...newMessages], lastPrompt);
     } catch (error) {
-      await runObservers.error({ error, usage, messages: [...newMessages] });
-      await this.memoryRecorder.recordError(runId, error, newMessages);
-      yield await emit({ type: "error", error });
-      throw error;
+      const finalError = await this.runRunErrorHook(error, usage, newMessages);
+      await runObservers.error({ error: finalError, usage, messages: [...newMessages] });
+      await this.memoryRecorder.recordError(runId, finalError, newMessages);
+      yield await emit({ type: "error", error: finalError });
+      throw finalError;
     }
   }
 
@@ -501,7 +543,7 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
       this.agent,
       this.activeHook,
       this.concurrency,
-      this.requestToolMiddlewares,
+      this.requestMiddlewares,
       (reason) => this.cancelled(newMessages, reason),
     );
     return executor.execute(toolCalls, onResult, onStreamEvent, observation);
@@ -569,6 +611,117 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
     }
   }
 
+  private async runRunStartHook(newMessages: MessageType[]): Promise<void> {
+    const action = await this.activeHook?.onRunStart?.({
+      prompt: this.promptMessage,
+      history: this.chatHistory,
+      maxTurns: this.maxTurnCount,
+      run: runControl,
+    });
+    if (action?.type === "terminate") {
+      throw this.cancelled(newMessages, action.reason);
+    }
+  }
+
+  private async runRunEndHook(result: PromptResponse, newMessages: MessageType[]): Promise<void> {
+    const action = await this.activeHook?.onRunEnd?.({
+      output: result.output,
+      usage: result.usage,
+      messages: result.messages,
+      run: runControl,
+    });
+    if (action?.type === "terminate") {
+      throw this.cancelled(newMessages, action.reason);
+    }
+  }
+
+  private async runRunErrorHook(
+    error: unknown,
+    usage: Usage,
+    newMessages: MessageType[],
+  ): Promise<unknown> {
+    const action = await this.activeHook?.onRunError?.({
+      error,
+      usage,
+      messages: [...this.chatHistory, ...newMessages],
+      run: runControl,
+    });
+    if (action?.type === "terminate") {
+      return this.cancelled(newMessages, action.reason);
+    }
+    return error;
+  }
+
+  private async runTurnStartHook(
+    turn: number,
+    prompt: MessageType,
+    history: MessageType[],
+    newMessages: MessageType[],
+  ): Promise<void> {
+    const action = await this.activeHook?.onTurnStart?.({
+      turn,
+      prompt,
+      history,
+      run: runControl,
+    });
+    if (action?.type === "terminate") {
+      throw this.cancelled(newMessages, action.reason);
+    }
+  }
+
+  private async runTurnEndHook(
+    turn: number,
+    response: CompletionResponse,
+    newMessages: MessageType[],
+  ): Promise<void> {
+    const action = await this.activeHook?.onTurnEnd?.({
+      turn,
+      response,
+      run: runControl,
+    });
+    if (action?.type === "terminate") {
+      throw this.cancelled(newMessages, action.reason);
+    }
+  }
+
+  private async runCompletionRequestMiddlewares(
+    request: ReturnType<CompletionRequestBuilder["build"]>,
+    turn: number,
+  ): Promise<ReturnType<CompletionRequestBuilder["build"]>> {
+    let current = request;
+    for (const middleware of this.activeMiddlewares()) {
+      const replacement = await middleware.onCompletionRequest?.({
+        turn,
+        request: current,
+        originalRequest: request,
+      });
+      if (replacement?.request !== undefined) {
+        current = replacement.request;
+      }
+    }
+    return current;
+  }
+
+  private async runCompletionResponseMiddlewares(
+    request: ReturnType<CompletionRequestBuilder["build"]>,
+    response: CompletionResponse,
+    turn: number,
+  ): Promise<CompletionResponse> {
+    let current = response;
+    for (const middleware of this.activeMiddlewares()) {
+      const replacement = await middleware.onCompletionResponse?.({
+        turn,
+        request,
+        response: current,
+        originalResponse: response,
+      });
+      if (replacement?.response !== undefined) {
+        current = replacement.response;
+      }
+    }
+    return current;
+  }
+
   private async runCompletionResponseHook(
     prompt: MessageType,
     response:
@@ -584,6 +737,25 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
     if (action?.type === "terminate") {
       throw this.cancelled(newMessages, action.reason);
     }
+  }
+
+  private async runCompletionErrorHook(
+    prompt: MessageType,
+    error: unknown,
+    newMessages: MessageType[],
+  ): Promise<void> {
+    const action = await this.activeHook?.onCompletionError?.({
+      prompt,
+      error,
+      run: runControl,
+    });
+    if (action?.type === "terminate") {
+      throw this.cancelled(newMessages, action.reason);
+    }
+  }
+
+  private activeMiddlewares(): AgentMiddleware[] {
+    return [...this.agent.middlewares, ...this.requestMiddlewares];
   }
 
   private cancelled(newMessages: MessageType[], reason: string): PromptCancelledError {

--- a/packages/core/src/agent/tool-execution.ts
+++ b/packages/core/src/agent/tool-execution.ts
@@ -10,7 +10,11 @@ import { mapWithConcurrency } from "../internal/concurrency";
 import type { ActiveAgentRunObservers, ActiveToolObservers } from "../observability/group";
 import type { AnyTool, NormalizedToolOutput, ToolCallStreamEvent } from "../tool";
 import { toolResultContentToText } from "../tool";
-import type { ToolMiddleware, ToolResultMiddlewareArgs } from "../tool/middleware";
+import type {
+  AgentMiddleware,
+  ToolOutputMiddlewareArgs,
+  ToolOutputMiddlewareResult,
+} from "../tool/middleware";
 import type { Agent } from "./agent";
 import type { PromptHook, ToolHookArgs } from "./hooks";
 import { runControl, toolCallControl } from "./hooks";
@@ -51,7 +55,7 @@ export class ToolCallExecutor {
     private readonly agent: Agent,
     private readonly activeHook: PromptHook | undefined,
     private readonly concurrency: number,
-    private readonly requestToolMiddlewares: ToolMiddleware[],
+    private readonly requestMiddlewares: AgentMiddleware[],
     private readonly cancel: (reason: string) => Error,
   ) {}
 
@@ -119,19 +123,25 @@ export class ToolCallExecutor {
 
       let output: NormalizedToolOutput;
       let skipped = false;
+      let effectiveArgs = args;
       if (callAction?.type === "skip") {
         output = callAction.reason;
         skipped = true;
       } else {
+        effectiveArgs = await this.runToolInputMiddlewares({
+          ...hookArgs,
+          turn: observation?.turn ?? 0,
+          originalArgs: args,
+        });
         try {
-          output = await this.agent.callTool(toolCall.function.name, args, {
+          output = await this.agent.callTool(toolCall.function.name, effectiveArgs, {
             emitStreamEvent: async (event) => {
               await toolObservers?.streamEvent({
                 turn: observation?.turn ?? 0,
                 toolCall,
                 toolName: toolCall.function.name,
                 internalCallId,
-                args,
+                args: effectiveArgs,
                 ...(toolCall.callId === undefined ? {} : { toolCallId: toolCall.callId }),
                 event,
               });
@@ -142,6 +152,24 @@ export class ToolCallExecutor {
             },
           });
         } catch (error) {
+          const errorAction = await this.activeHook?.onToolError?.({
+            ...hookArgs,
+            args: effectiveArgs,
+            error,
+            run: runControl,
+          });
+          await toolObservers?.error({
+            turn: observation?.turn ?? 0,
+            toolCall,
+            toolName: toolCall.function.name,
+            internalCallId,
+            args: effectiveArgs,
+            ...(toolCall.callId === undefined ? {} : { toolCallId: toolCall.callId }),
+            error,
+          });
+          if (errorAction?.type === "terminate") {
+            throw this.cancel(errorAction.reason);
+          }
           output = error instanceof Error ? error.toString() : String(error);
         }
       }
@@ -151,6 +179,7 @@ export class ToolCallExecutor {
       if (this.agent.shouldApplyToolMiddleware(toolCall.function.name)) {
         const middlewareReplacement = await this.runToolResultMiddlewares({
           ...hookArgs,
+          args: effectiveArgs,
           result,
           originalResult: result,
           structuredResult,
@@ -159,13 +188,14 @@ export class ToolCallExecutor {
         });
         if (middlewareReplacement !== undefined) {
           output = middlewareReplacement;
-          result = middlewareReplacement;
-          structuredResult = undefined;
+          result = toolOutputToText(middlewareReplacement);
+          structuredResult = toolOutputToStructuredResult(middlewareReplacement);
         }
       }
 
       const resultAction = await this.activeHook?.onToolResult?.({
         ...hookArgs,
+        args: effectiveArgs,
         result,
         structuredResult,
         run: runControl,
@@ -175,7 +205,7 @@ export class ToolCallExecutor {
         toolCall,
         toolName: toolCall.function.name,
         internalCallId,
-        args,
+        args: effectiveArgs,
         result,
         structuredResult,
         skipped,
@@ -189,7 +219,7 @@ export class ToolCallExecutor {
         type: "tool_result",
         toolName: toolCall.function.name,
         internalCallId,
-        args,
+        args: effectiveArgs,
         result,
         structuredResult,
       };
@@ -202,22 +232,75 @@ export class ToolCallExecutor {
   }
 
   private async runToolResultMiddlewares(
-    args: ToolResultMiddlewareArgs,
-  ): Promise<string | undefined> {
+    args: ToolOutputMiddlewareArgs,
+  ): Promise<NormalizedToolOutput | undefined> {
     let result = args.result;
+    let structuredResult = args.structuredResult;
     let replaced = false;
-    for (const middleware of [...this.agent.toolMiddlewares, ...this.requestToolMiddlewares]) {
-      const replacement = await middleware.onResult?.({
+    for (const middleware of this.activeMiddlewares()) {
+      const outputReplacement = await middleware.onToolOutput?.({
         ...args,
         result,
+        structuredResult,
       });
-      if (replacement !== undefined) {
-        result = replacement;
+      if (outputReplacement !== undefined) {
+        const normalized = normalizeToolOutputMiddlewareResult(outputReplacement);
+        if (normalized.result !== undefined) {
+          result = normalized.result;
+          structuredResult = undefined;
+        }
+        if (normalized.structuredResult !== undefined) {
+          structuredResult = normalized.structuredResult;
+          result = toolResultContentToText(normalized.structuredResult);
+        }
+        replaced = true;
+      }
+      const legacyReplacement = await middleware.onResult?.({
+        ...args,
+        result,
+        structuredResult,
+      });
+      if (legacyReplacement !== undefined) {
+        result = legacyReplacement;
+        structuredResult = undefined;
         replaced = true;
       }
     }
-    return replaced ? result : undefined;
+    return replaced ? (structuredResult ?? result) : undefined;
   }
+
+  private async runToolInputMiddlewares(
+    args: ToolHookArgs & { turn: number; originalArgs: string },
+  ): Promise<string> {
+    let current = args.args;
+    for (const middleware of this.activeMiddlewares()) {
+      const replacement = await middleware.onToolInput?.({
+        ...args,
+        args: current,
+      });
+      if (replacement?.args !== undefined) {
+        current =
+          typeof replacement.args === "string"
+            ? replacement.args
+            : JSON.stringify(replacement.args);
+      }
+    }
+    return current;
+  }
+
+  private activeMiddlewares(): AgentMiddleware[] {
+    return [...this.agent.middlewares, ...this.requestMiddlewares];
+  }
+}
+
+function normalizeToolOutputMiddlewareResult(result: ToolOutputMiddlewareResult): {
+  result?: string | undefined;
+  structuredResult?: ToolResultContent[] | undefined;
+} {
+  if (typeof result === "string") {
+    return { result };
+  }
+  return result ?? {};
 }
 
 function toolTraceMetadata(tool: AnyTool | undefined): JsonObject | undefined {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,3 +51,17 @@ export type {
   ToolCallStreamEvent,
 } from "./tool/index";
 export { createThinkTool, createTool } from "./tool/index";
+export type {
+  AgentMiddleware,
+  CompletionRequestMiddlewareArgs,
+  CompletionRequestMiddlewareResult,
+  CompletionResponseMiddlewareArgs,
+  CompletionResponseMiddlewareResult,
+  ToolInputMiddlewareArgs,
+  ToolInputMiddlewareResult,
+  ToolMiddleware,
+  ToolOutputMiddlewareArgs,
+  ToolOutputMiddlewareResult,
+  ToolResultMiddlewareArgs,
+} from "./tool/middleware";
+export { createMiddleware, createToolMiddleware } from "./tool/middleware";

--- a/packages/core/src/tool/middleware.ts
+++ b/packages/core/src/tool/middleware.ts
@@ -1,4 +1,51 @@
-import type { ToolResultContent } from "../completion";
+import type {
+  CompletionRequest,
+  CompletionResponse,
+  JsonValue,
+  ToolResultContent,
+} from "../completion";
+
+type MaybePromise<T> = T | Promise<T>;
+
+export type CompletionRequestMiddlewareArgs = {
+  turn: number;
+  request: CompletionRequest;
+  originalRequest: CompletionRequest;
+};
+
+export type CompletionRequestMiddlewareResult =
+  | {
+      request: CompletionRequest;
+    }
+  | undefined;
+
+export type CompletionResponseMiddlewareArgs<RawResponse = unknown> = {
+  turn: number;
+  request: CompletionRequest;
+  response: CompletionResponse<RawResponse>;
+  originalResponse: CompletionResponse<RawResponse>;
+};
+
+export type CompletionResponseMiddlewareResult<RawResponse = unknown> =
+  | {
+      response: CompletionResponse<RawResponse>;
+    }
+  | undefined;
+
+export type ToolInputMiddlewareArgs = {
+  toolName: string;
+  args: string;
+  originalArgs: string;
+  turn: number;
+  toolCallId?: string | undefined;
+  internalCallId: string;
+};
+
+export type ToolInputMiddlewareResult =
+  | {
+      args: JsonValue | string;
+    }
+  | undefined;
 
 export type ToolResultMiddlewareArgs = {
   toolName: string;
@@ -12,10 +59,47 @@ export type ToolResultMiddlewareArgs = {
   internalCallId: string;
 };
 
-export interface ToolMiddleware {
+export type ToolOutputMiddlewareArgs = ToolResultMiddlewareArgs;
+
+export type ToolOutputMiddlewareResult =
+  | string
+  | {
+      result?: string | undefined;
+      structuredResult?: ToolResultContent[] | undefined;
+    }
+  | undefined;
+
+export interface AgentMiddleware<RawResponse = unknown> {
+  onCompletionRequest?(
+    args: CompletionRequestMiddlewareArgs,
+  ): MaybePromise<CompletionRequestMiddlewareResult>;
+  onCompletionResponse?(
+    args: CompletionResponseMiddlewareArgs<RawResponse>,
+  ): MaybePromise<CompletionResponseMiddlewareResult<RawResponse>>;
+  onToolInput?(args: ToolInputMiddlewareArgs): MaybePromise<ToolInputMiddlewareResult>;
+  onToolOutput?(args: ToolOutputMiddlewareArgs): MaybePromise<ToolOutputMiddlewareResult>;
+  /**
+   * @deprecated Use `onToolOutput` instead.
+   */
   onResult?(args: ToolResultMiddlewareArgs): string | undefined | Promise<string | undefined>;
 }
 
-export function createToolMiddleware(middleware: ToolMiddleware): ToolMiddleware {
+/**
+ * @deprecated Use `AgentMiddleware` instead.
+ */
+export type ToolMiddleware<RawResponse = unknown> = AgentMiddleware<RawResponse>;
+
+export function createMiddleware<RawResponse = unknown>(
+  middleware: AgentMiddleware<RawResponse>,
+): AgentMiddleware<RawResponse> {
+  return middleware;
+}
+
+/**
+ * @deprecated Use `createMiddleware` instead.
+ */
+export function createToolMiddleware<RawResponse = unknown>(
+  middleware: ToolMiddleware<RawResponse>,
+): ToolMiddleware<RawResponse> {
   return middleware;
 }

--- a/packages/core/test/prompt-request.test.ts
+++ b/packages/core/test/prompt-request.test.ts
@@ -8,6 +8,7 @@ import {
   type CompletionResponse,
   cancelPrompt,
   createHook,
+  createMiddleware,
   createTool,
   createToolMiddleware,
   MaxTurnsError,
@@ -50,6 +51,13 @@ function response(choice: CompletionResponse["choice"]): CompletionResponse {
     usage: Usage.empty(),
     rawResponse: {},
   };
+}
+
+function textFromChoice(choice: CompletionResponse["choice"]): string {
+  return choice
+    .filter((item) => item.type === "text")
+    .map((item) => item.text)
+    .join("");
 }
 
 const addTool = createTool({
@@ -328,6 +336,166 @@ describe("PromptRequest", () => {
     ]);
   });
 
+  it("runs lifecycle hooks around prompt turns", async () => {
+    const model = new QueueModel([response([AssistantContent.text("done")])]);
+    const events: string[] = [];
+    const agent = new AgentBuilder("test-agent", model)
+      .hook(
+        createHook({
+          onRunStart({ prompt, history, maxTurns }) {
+            events.push(`run_start:${prompt.role}:${history.length}:${maxTurns}`);
+          },
+          onTurnStart({ turn, prompt, history }) {
+            events.push(`turn_start:${turn}:${prompt.role}:${history.length}`);
+          },
+          onTurnEnd({ turn, response }) {
+            events.push(`turn_end:${turn}:${response.choice.length}`);
+          },
+          onRunEnd({ output, messages }) {
+            events.push(`run_end:${output}:${messages.length}`);
+          },
+        }),
+      )
+      .build();
+
+    await expect(agent.prompt("hello").send()).resolves.toMatchObject({ output: "done" });
+
+    expect(events).toEqual([
+      "run_start:user:0:20",
+      "turn_start:1:user:0",
+      "turn_end:1:1",
+      "run_end:done:2",
+    ]);
+  });
+
+  it("runs completion middleware before the model and before response hooks", async () => {
+    const model = new QueueModel([response([AssistantContent.text("original")])]);
+    const events: string[] = [];
+    const agent = new AgentBuilder("test-agent", model)
+      .middleware(
+        createMiddleware({
+          onCompletionRequest({ request, originalRequest }) {
+            events.push(
+              `request:${request.chatHistory.length}:${originalRequest.chatHistory.length}`,
+            );
+            return {
+              request: {
+                ...request,
+                instructions: "middleware instructions",
+              },
+            };
+          },
+          onCompletionResponse({ response, originalResponse }) {
+            events.push(
+              `response:${textFromChoice(response.choice)}:${textFromChoice(originalResponse.choice)}`,
+            );
+            return {
+              response: {
+                ...response,
+                choice: [AssistantContent.text("changed")],
+              },
+            };
+          },
+        }),
+      )
+      .hook(
+        createHook({
+          onCompletionResponse({ response }) {
+            events.push(`hook:${textFromChoice(response.choice)}`);
+          },
+        }),
+      )
+      .build();
+
+    await expect(agent.prompt("hello").send()).resolves.toMatchObject({ output: "changed" });
+
+    expect(model.requests[0]?.instructions).toBe("middleware instructions");
+    expect(events).toEqual(["request:1:1", "response:original:original", "hook:changed"]);
+  });
+
+  it("runs tool input and output middleware through the new API", async () => {
+    const model = new QueueModel([
+      response([AssistantContent.toolCall("call_1", "add", { x: 1, y: 1 })]),
+      response([AssistantContent.text("done")]),
+    ]);
+    const events: string[] = [];
+    const agent = new AgentBuilder("test-agent", model)
+      .tool(addTool)
+      .middleware(
+        createMiddleware({
+          onToolInput({ args, originalArgs }) {
+            events.push(`input:${args}:${originalArgs}`);
+            return { args: { x: 2, y: 5 } };
+          },
+          onToolOutput({ result, originalResult, args }) {
+            events.push(`output:${result}:${originalResult}:${args}`);
+            return { result: `stored:${result}` };
+          },
+        }),
+      )
+      .build();
+
+    await expect(agent.prompt("add").send()).resolves.toMatchObject({ output: "done" });
+
+    expect(events).toEqual(['input:{"x":1,"y":1}:{"x":1,"y":1}', 'output:7:7:{"x":2,"y":5}']);
+    expect(model.requests[1]?.chatHistory.at(-1)).toEqual(
+      Message.tool([
+        {
+          type: "tool_result",
+          id: "call_1",
+          content: [{ type: "text", text: "stored:7" }],
+        },
+      ]),
+    );
+  });
+
+  it("composes new and deprecated middleware registrations in order", async () => {
+    const model = new QueueModel([
+      response([AssistantContent.toolCall("call_1", "add", { x: 2, y: 5 })]),
+      response([AssistantContent.text("done")]),
+    ]);
+    const agent = new AgentBuilder("test-agent", model)
+      .tool(addTool)
+      .middlewares([
+        createMiddleware({
+          onToolOutput({ result }) {
+            return { result: `${result}:agent` };
+          },
+        }),
+      ])
+      .build();
+
+    await expect(
+      agent
+        .prompt("add")
+        .withMiddlewares([
+          createMiddleware({
+            onToolOutput({ result }) {
+              return { result: `${result}:request` };
+            },
+          }),
+        ])
+        .withToolMiddleware(
+          createToolMiddleware({
+            onResult({ result }) {
+              return `${result}:legacy`;
+            },
+          }),
+        )
+        .send(),
+    ).resolves.toMatchObject({ output: "done" });
+
+    expect(model.requests[1]?.chatHistory.at(-1)).toEqual(
+      Message.tool([
+        {
+          type: "tool_result",
+          id: "call_1",
+          content: [{ type: "text", text: "7:agent:request:legacy" }],
+        },
+      ]),
+    );
+  });
+
   it("can run tool calls from a hook helper", async () => {
     const model = new QueueModel([
       response([AssistantContent.toolCall("call_1", "add", { x: 2, y: 5 })]),
@@ -532,6 +700,67 @@ describe("PromptRequest", () => {
     const agent = new AgentBuilder("test-agent", model).hook(hook).build();
 
     await expect(agent.prompt("hello").send()).rejects.toBeInstanceOf(PromptCancelledError);
+  });
+
+  it("runs completion error hooks before run error hooks", async () => {
+    const model = new QueueModel([]);
+    const events: string[] = [];
+    const agent = new AgentBuilder("test-agent", model)
+      .hook(
+        createHook({
+          onCompletionError({ error }) {
+            events.push(`completion_error:${error instanceof Error ? error.message : error}`);
+          },
+          onRunError({ error }) {
+            events.push(`run_error:${error instanceof Error ? error.message : error}`);
+          },
+        }),
+      )
+      .build();
+
+    await expect(agent.prompt("hello").send()).rejects.toThrow("No queued response");
+
+    expect(events).toEqual(["completion_error:No queued response", "run_error:No queued response"]);
+  });
+
+  it("runs tool error hooks and keeps tool errors as model-visible results", async () => {
+    const failingTool = createTool({
+      name: "fail",
+      description: "Fail",
+      input: z.object({}),
+      output: z.string(),
+      execute() {
+        throw new Error("tool failed");
+      },
+    });
+    const model = new QueueModel([
+      response([AssistantContent.toolCall("call_1", "fail", {})]),
+      response([AssistantContent.text("handled")]),
+    ]);
+    const events: string[] = [];
+    const agent = new AgentBuilder("test-agent", model)
+      .tool(failingTool)
+      .hook(
+        createHook({
+          onToolError({ toolName, error }) {
+            events.push(`${toolName}:${error instanceof Error ? error.message : error}`);
+          },
+        }),
+      )
+      .build();
+
+    await expect(agent.prompt("fail").send()).resolves.toMatchObject({ output: "handled" });
+
+    expect(events).toEqual(["fail:tool failed"]);
+    expect(model.requests[1]?.chatHistory.at(-1)).toEqual(
+      Message.tool([
+        {
+          type: "tool_result",
+          id: "call_1",
+          content: [{ type: "text", text: "ToolCallError: tool failed" }],
+        },
+      ]),
+    );
   });
 
   it("keeps low-level hook action helpers available", () => {

--- a/packages/core/test/public-exports.test.ts
+++ b/packages/core/test/public-exports.test.ts
@@ -25,6 +25,15 @@ describe("public exports", () => {
     expect("AgentBuilder" in publicAgent).toBe(true);
   });
 
+  it("exposes middleware helpers from public entrypoints", () => {
+    expect("createMiddleware" in publicCore).toBe(true);
+    expect("createToolMiddleware" in publicCore).toBe(true);
+    expect("createMiddleware" in publicAgent).toBe(true);
+    expect("createToolMiddleware" in publicAgent).toBe(true);
+    expect("createMiddleware" in tool).toBe(true);
+    expect("createToolMiddleware" in tool).toBe(true);
+  });
+
   it("keeps runtime Agent out of public entrypoints", () => {
     expect("Agent" in publicCore).toBe(false);
     expect("Agent" in publicAgent).toBe(false);


### PR DESCRIPTION
## Summary
- broaden agent hooks with run, turn, completion error, and tool error lifecycle callbacks
- add general middleware for completion requests/responses and tool inputs/outputs
- keep existing tool middleware and request hook APIs as deprecated compatibility aliases
- update docs/reference coverage and add a changeset for @anvia/core

## Verification
- pnpm --filter @anvia/core test
- pnpm --filter @anvia/core typecheck
- pnpm --filter @anvia/core build
- pnpm --filter docs typecheck
- pnpm exec biome check packages/core/src/agent packages/core/src/tool packages/core/src/index.ts packages/core/test/prompt-request.test.ts packages/core/test/public-exports.test.ts apps/docs/content/docs/guides/agents/runtime-hooks.mdx apps/docs/content/docs/guides/tools/tool-middleware.mdx apps/docs/content/docs/guides/observability/observers.mdx apps/docs/content/docs/reference/core/agent.mdx apps/docs/content/docs/reference/core/tools.mdx apps/docs/content/docs/frameworks/tanstack-start/09-human-in-the-loop.mdx apps/docs/content/docs/frameworks/hono/09-human-in-the-loop.mdx apps/docs/content/docs/frameworks/nextjs/09-human-in-the-loop.mdx apps/docs/content/docs/studio/human-in-the-loop/tool-approvals.mdx .changeset/broaden-core-runtime-hooks.md
- git diff --check