### PR TITLE
Harden non-OpenAI provider responses

### DIFF
--- a/.changeset/harden-provider-response-validation.md
+++ b/.changeset/harden-provider-response-validation.md
@@ -1,0 +1,7 @@
+---
+"@anvia/anthropic": patch
+"@anvia/gemini": patch
+"@anvia/mistral": patch
+---
+
+Harden non-OpenAI provider response validation and package-local build scripts.

--- a/packages/providers/anthropic/README.md
+++ b/packages/providers/anthropic/README.md
@@ -65,3 +65,5 @@ pnpm --filter @anvia/anthropic typecheck
 pnpm --filter @anvia/anthropic test
 pnpm --filter @anvia/anthropic build
 ```
+
+Package-local `typecheck` and `build` scripts build `@anvia/core` first so core subpath types are available in a fresh worktree.

--- a/packages/providers/anthropic/package.json
+++ b/packages/providers/anthropic/package.json
@@ -26,8 +26,10 @@
     }
   },
   "scripts": {
+    "prebuild": "pnpm --filter @anvia/core build",
     "build": "tsup src/index.ts --format esm --dts --sourcemap --clean",
     "test": "vitest run",
+    "pretypecheck": "pnpm --filter @anvia/core build",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/providers/gemini/README.md
+++ b/packages/providers/gemini/README.md
@@ -94,3 +94,5 @@ pnpm --filter @anvia/gemini typecheck
 pnpm --filter @anvia/gemini test
 pnpm --filter @anvia/gemini build
 ```
+
+Package-local `typecheck` and `build` scripts build `@anvia/core` first so core subpath types are available in a fresh worktree.

--- a/packages/providers/gemini/package.json
+++ b/packages/providers/gemini/package.json
@@ -26,8 +26,10 @@
     }
   },
   "scripts": {
+    "prebuild": "pnpm --filter @anvia/core build",
     "build": "tsup src/index.ts --format esm --dts --sourcemap --clean",
     "test": "vitest run",
+    "pretypecheck": "pnpm --filter @anvia/core build",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/providers/gemini/src/gemini/embedding.ts
+++ b/packages/providers/gemini/src/gemini/embedding.ts
@@ -80,17 +80,25 @@ export class GeminiEmbeddingModel implements EmbeddingModel {
 function embeddingsFromResponse(response: unknown): number[][] {
   const raw = response as Record<string, unknown>;
   if (Array.isArray(raw.embeddings)) {
-    return raw.embeddings.map(vectorFromEmbedding);
+    return raw.embeddings.map((embedding, index) => vectorFromEmbedding(embedding, index));
   }
   if (raw.embedding !== undefined) {
-    return [vectorFromEmbedding(raw.embedding)];
+    return [vectorFromEmbedding(raw.embedding, 0)];
   }
   return [];
 }
 
-function vectorFromEmbedding(embedding: unknown): number[] {
-  const raw = embedding as Record<string, unknown>;
-  return Array.isArray(raw.values)
-    ? raw.values.filter((value): value is number => typeof value === "number")
-    : [];
+function vectorFromEmbedding(embedding: unknown, position: number): number[] {
+  if (!isObject(embedding) || !isNumberArray(embedding.values)) {
+    throw new Error(`Invalid Gemini embedding response vector at position ${position}.`);
+  }
+  return embedding.values;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNumberArray(value: unknown): value is number[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "number");
 }

--- a/packages/providers/gemini/src/gemini/image-generation.ts
+++ b/packages/providers/gemini/src/gemini/image-generation.ts
@@ -92,7 +92,7 @@ export function nativeImageResponseFromGemini(response: unknown): ImageGeneratio
       }
       return [
         {
-          data: new Uint8Array(Buffer.from(data, "base64")),
+          data: decodeBase64Image(data),
           mediaType:
             typeof part.inlineData.mimeType === "string" ? part.inlineData.mimeType : "image/png",
         },
@@ -126,7 +126,7 @@ export function imagenResponseFromGemini(response: unknown): ImageGenerationResp
       }
       return [
         {
-          data: new Uint8Array(Buffer.from(imageBytes, "base64")),
+          data: decodeBase64Image(imageBytes),
           mediaType: typeof item.image.mimeType === "string" ? item.image.mimeType : "image/png",
         },
       ];
@@ -162,6 +162,16 @@ function gcd(left: number, right: number): number {
     b = next;
   }
   return a;
+}
+
+function decodeBase64Image(value: string): Uint8Array {
+  const normalized = value.replace(/\s/g, "").replace(/=+$/, "");
+  const bytes = Buffer.from(value, "base64");
+  const roundTrip = bytes.toString("base64").replace(/=+$/, "");
+  if (normalized.length === 0 || bytes.length === 0 || roundTrip !== normalized) {
+    throw new Error("Gemini image generation response contained invalid base64 image data.");
+  }
+  return new Uint8Array(bytes);
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/packages/providers/gemini/src/gemini/transcription.ts
+++ b/packages/providers/gemini/src/gemini/transcription.ts
@@ -7,7 +7,7 @@ import type {
 import type { GoogleGenAI } from "@google/genai";
 
 const TRANSCRIPTION_PREAMBLE =
-  "Translate the provided audio exactly. Do not add additional information.";
+  "Transcribe the provided audio exactly. Do not add additional information.";
 
 export class GeminiTranscriptionModel implements TranscriptionModel {
   readonly provider = "gemini";

--- a/packages/providers/gemini/test/embedding.test.ts
+++ b/packages/providers/gemini/test/embedding.test.ts
@@ -56,4 +56,34 @@ describe("Gemini embedding models", () => {
       "Embedding response length 1 did not match input length 2",
     );
   });
+
+  it("rejects invalid Gemini embedding response rows", async () => {
+    const client = new GeminiClient({
+      client: {
+        models: {
+          embedContent: async () => ({
+            embeddings: [{ values: [1, 2] }, { values: [3, "bad"] }],
+          }),
+        },
+      } as never,
+    });
+
+    await expect(client.embeddingModel().embedTexts(["a", "b"])).rejects.toThrow(
+      "Invalid Gemini embedding response vector at position 1.",
+    );
+  });
+
+  it("rejects malformed Gemini single embedding responses", async () => {
+    const client = new GeminiClient({
+      client: {
+        models: {
+          embedContent: async () => ({ embedding: { values: "bad" } }),
+        },
+      } as never,
+    });
+
+    await expect(client.embeddingModel().embedTexts(["a"])).rejects.toThrow(
+      "Invalid Gemini embedding response vector at position 0.",
+    );
+  });
 });

--- a/packages/providers/gemini/test/multimodal.test.ts
+++ b/packages/providers/gemini/test/multimodal.test.ts
@@ -69,6 +69,47 @@ describe("Gemini multimodal models", () => {
     expect(response.mediaType).toBe("image/jpeg");
   });
 
+  it("rejects malformed native Gemini image responses", async () => {
+    const client = mockGeminiClient({
+      generateContentResponse: {
+        candidates: [
+          {
+            content: {
+              parts: [{ inlineData: { data: "not base64!!!", mimeType: "image/png" } }],
+            },
+          },
+        ],
+      },
+    });
+    const model = new GeminiClient({ client: client as never }).imageGenerationModel("gemini-test");
+
+    await expect(imageGenerationRequest(model).prompt("draw").send()).rejects.toThrow(
+      "Gemini image generation response contained invalid base64 image data.",
+    );
+  });
+
+  it("rejects malformed Imagen image responses", async () => {
+    const client = mockGeminiClient({
+      generateImagesResponse: {
+        generatedImages: [
+          {
+            image: {
+              imageBytes: "not base64!!!",
+              mimeType: "image/jpeg",
+            },
+          },
+        ],
+      },
+    });
+    const model = new GeminiClient({ client: client as never }).imagenGenerationModel(
+      "imagen-test",
+    );
+
+    await expect(imageGenerationRequest(model).prompt("draw").send()).rejects.toThrow(
+      "Gemini image generation response contained invalid base64 image data.",
+    );
+  });
+
   it("maps transcription requests through generateContent inline audio", async () => {
     const client = mockGeminiClient();
     const model = new GeminiClient({ client: client as never }).transcriptionModel("gemini-test");
@@ -100,14 +141,16 @@ describe("Gemini multimodal models", () => {
         topP: 0.8,
         temperature: 0.2,
         systemInstruction:
-          "Translate the provided audio exactly. Do not add additional information.\n\nUse support terminology.",
+          "Transcribe the provided audio exactly. Do not add additional information.\n\nUse support terminology.",
       },
     });
     expect(response.text).toBe("transcribed text");
   });
 });
 
-function mockGeminiClient() {
+function mockGeminiClient(
+  responses: { generateContentResponse?: unknown; generateImagesResponse?: unknown } = {},
+) {
   const generateImagesCalls: unknown[] = [];
   const generateContentCalls: unknown[] = [];
   return {
@@ -115,37 +158,41 @@ function mockGeminiClient() {
       generateImagesCalls,
       async generateImages(params: unknown) {
         generateImagesCalls.push(params);
-        return {
-          generatedImages: [
-            {
-              image: {
-                imageBytes: Buffer.from([4, 5, 6]).toString("base64"),
-                mimeType: "image/jpeg",
+        return (
+          responses.generateImagesResponse ?? {
+            generatedImages: [
+              {
+                image: {
+                  imageBytes: Buffer.from([4, 5, 6]).toString("base64"),
+                  mimeType: "image/jpeg",
+                },
               },
-            },
-          ],
-        };
+            ],
+          }
+        );
       },
       generateContentCalls,
       async generateContent(params: unknown) {
         generateContentCalls.push(params);
-        return {
-          candidates: [
-            {
-              content: {
-                parts: [
-                  { text: "transcribed text" },
-                  {
-                    inlineData: {
-                      data: Buffer.from([1, 2, 3]).toString("base64"),
-                      mimeType: "image/png",
+        return (
+          responses.generateContentResponse ?? {
+            candidates: [
+              {
+                content: {
+                  parts: [
+                    { text: "transcribed text" },
+                    {
+                      inlineData: {
+                        data: Buffer.from([1, 2, 3]).toString("base64"),
+                        mimeType: "image/png",
+                      },
                     },
-                  },
-                ],
+                  ],
+                },
               },
-            },
-          ],
-        };
+            ],
+          }
+        );
       },
     },
   };

--- a/packages/providers/mistral/README.md
+++ b/packages/providers/mistral/README.md
@@ -67,3 +67,5 @@ pnpm --filter @anvia/mistral typecheck
 pnpm --filter @anvia/mistral test
 pnpm --filter @anvia/mistral build
 ```
+
+Package-local `typecheck` and `build` scripts build `@anvia/core` first so core subpath types are available in a fresh worktree.

--- a/packages/providers/mistral/package.json
+++ b/packages/providers/mistral/package.json
@@ -26,8 +26,10 @@
     }
   },
   "scripts": {
+    "prebuild": "pnpm --filter @anvia/core build",
     "build": "tsup src/index.ts --format esm --dts --sourcemap --clean",
     "test": "vitest run",
+    "pretypecheck": "pnpm --filter @anvia/core build",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/providers/mistral/src/mistral/embedding.ts
+++ b/packages/providers/mistral/src/mistral/embedding.ts
@@ -42,20 +42,17 @@ export class MistralEmbeddingModel implements EmbeddingModel {
     }
 
     const response = await this.client.embeddings.create(params as never);
-    const data = dataFromResponse(response);
+    const data = dataFromResponse(response, texts.length);
     if (data.length !== texts.length) {
       throw new Error(
         `Embedding response length ${data.length} did not match input length ${texts.length}`,
       );
     }
 
-    return data
-      .slice()
-      .sort((left, right) => left.index - right.index)
-      .map((item, index) => ({
-        document: texts[index] as string,
-        vector: item.embedding,
-      }));
+    return Array.from({ length: texts.length }, (_, index) => ({
+      document: texts[index] as string,
+      vector: data[index]?.embedding ?? [],
+    }));
   }
 }
 
@@ -64,20 +61,42 @@ type EmbeddingData = {
   index: number;
 };
 
-function dataFromResponse(response: unknown): EmbeddingData[] {
+function dataFromResponse(response: unknown, inputLength: number): EmbeddingData[] {
   const raw = response as Record<string, unknown>;
-  return Array.isArray(raw.data)
-    ? raw.data.flatMap((item): EmbeddingData[] => {
-        const data = item as Record<string, unknown>;
-        if (!Array.isArray(data.embedding)) {
-          return [];
-        }
-        return [
-          {
-            embedding: data.embedding.filter((value): value is number => typeof value === "number"),
-            index: typeof data.index === "number" ? data.index : 0,
-          },
-        ];
-      })
-    : [];
+  const items = Array.isArray(raw.data) ? raw.data : [];
+  const byIndex = new Map<number, EmbeddingData>();
+
+  for (const [position, item] of items.entries()) {
+    if (!isObject(item)) {
+      throw new Error(`Invalid Mistral embedding response row at position ${position}.`);
+    }
+
+    const index = item.index;
+    if (typeof index !== "number" || !Number.isInteger(index)) {
+      throw new Error(`Invalid Mistral embedding response index at position ${position}.`);
+    }
+    if (index < 0 || index >= inputLength) {
+      throw new Error(`Mistral embedding response index ${index} was outside the input range.`);
+    }
+    if (byIndex.has(index)) {
+      throw new Error(`Duplicate Mistral embedding response index ${index}.`);
+    }
+    if (!isNumberArray(item.embedding)) {
+      throw new Error(`Invalid Mistral embedding response vector at position ${position}.`);
+    }
+
+    byIndex.set(index, { embedding: item.embedding, index });
+  }
+
+  return Array.from({ length: inputLength }, (_, index) => byIndex.get(index)).filter(
+    (item): item is EmbeddingData => item !== undefined,
+  );
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNumberArray(value: unknown): value is number[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "number");
 }

--- a/packages/providers/mistral/test/embedding.test.ts
+++ b/packages/providers/mistral/test/embedding.test.ts
@@ -70,4 +70,92 @@ describe("Mistral embedding models", () => {
       "Embedding response length 1 did not match input length 2",
     );
   });
+
+  it("rejects duplicate embedding response indexes", async () => {
+    const client = new MistralClient({
+      client: {
+        embeddings: {
+          create: async () => ({
+            data: [
+              { index: 0, embedding: [1] },
+              { index: 0, embedding: [2] },
+            ],
+          }),
+        },
+      } as never,
+    });
+
+    await expect(client.embeddingModel().embedTexts(["a", "b"])).rejects.toThrow(
+      "Duplicate Mistral embedding response index 0.",
+    );
+  });
+
+  it("rejects missing or non-integer embedding response indexes", async () => {
+    const missingIndexClient = new MistralClient({
+      client: {
+        embeddings: {
+          create: async () => ({
+            data: [{ embedding: [1] }, { index: 1, embedding: [2] }],
+          }),
+        },
+      } as never,
+    });
+    const fractionalIndexClient = new MistralClient({
+      client: {
+        embeddings: {
+          create: async () => ({
+            data: [
+              { index: 0.5, embedding: [1] },
+              { index: 1, embedding: [2] },
+            ],
+          }),
+        },
+      } as never,
+    });
+
+    await expect(missingIndexClient.embeddingModel().embedTexts(["a", "b"])).rejects.toThrow(
+      "Invalid Mistral embedding response index at position 0.",
+    );
+    await expect(fractionalIndexClient.embeddingModel().embedTexts(["a", "b"])).rejects.toThrow(
+      "Invalid Mistral embedding response index at position 0.",
+    );
+  });
+
+  it("rejects out-of-range embedding response indexes", async () => {
+    const client = new MistralClient({
+      client: {
+        embeddings: {
+          create: async () => ({
+            data: [
+              { index: 0, embedding: [1] },
+              { index: 2, embedding: [2] },
+            ],
+          }),
+        },
+      } as never,
+    });
+
+    await expect(client.embeddingModel().embedTexts(["a", "b"])).rejects.toThrow(
+      "Mistral embedding response index 2 was outside the input range.",
+    );
+  });
+
+  it("rejects invalid embedding vectors", async () => {
+    const client = new MistralClient({
+      client: {
+        embeddings: {
+          create: async () => ({
+            data: [
+              { index: 0, embedding: [1] },
+              { index: 1, embedding: [2, "bad"] },
+            ],
+          }),
+        },
+      } as never,
+    });
+
+    await expect(client.embeddingModel().embedTexts(["a", "b"])).rejects.toThrow(
+      "Invalid Mistral embedding response vector at position 1.",
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- validate Mistral embedding response indexes and vectors before mapping documents
- validate Gemini embedding vectors and image base64 payloads before returning normalized responses
- fix Gemini transcription preamble wording from translate to transcribe
- add package-local core prebuild/pretypecheck parity and development notes for Anthropic, Gemini, and Mistral
- add patch changeset for affected providers

## Tests
- pnpm --filter @anvia/anthropic test
- pnpm --filter @anvia/gemini test
- pnpm --filter @anvia/mistral test
- pnpm --filter @anvia/anthropic typecheck
- pnpm --filter @anvia/gemini typecheck
- pnpm --filter @anvia/mistral typecheck
- pnpm --filter @anvia/anthropic build
- pnpm --filter @anvia/gemini build
- pnpm --filter @anvia/mistral build
- pnpm exec biome check .changeset/harden-provider-response-validation.md packages/providers/anthropic/package.json packages/providers/anthropic/README.md packages/providers/gemini/package.json packages/providers/gemini/README.md packages/providers/gemini/src/gemini/embedding.ts packages/providers/gemini/src/gemini/image-generation.ts packages/providers/gemini/src/gemini/transcription.ts packages/providers/gemini/test/embedding.test.ts packages/providers/gemini/test/multimodal.test.ts packages/providers/mistral/package.json packages/providers/mistral/README.md packages/providers/mistral/src/mistral/embedding.ts packages/providers/mistral/test/embedding.test.ts
- git diff --check