### PR TITLE
fix: preserve Studio agent memory

### DIFF
--- a/.changeset/calm-studio-memory.md
+++ b/.changeset/calm-studio-memory.md
@@ -1,0 +1,5 @@
+---
+"@anvia/studio": patch
+---
+
+Keep Studio's default session store in memory only, remove legacy Studio DB env defaults, and preserve agent-configured memory stores during Studio session runs.

--- a/apps/docs/content/docs/reference/studio/stores.mdx
+++ b/apps/docs/content/docs/reference/studio/stores.mdx
@@ -33,7 +33,7 @@ function createInMemoryStudioStore(): StudioSessionStore &
 
 Purpose: create a process-local Studio store for sessions, traces, pipeline logs, and pipeline run history.
 
-Return behavior: this is the default Studio store when `ANVIA_STUDIO_DB` is not set and no explicit store is provided.
+Return behavior: this is the default Studio store when no explicit store is provided.
 
 Notable errors: none directly.
 

--- a/apps/docs/content/docs/studio/configure/storage-and-persistence.mdx
+++ b/apps/docs/content/docs/studio/configure/storage-and-persistence.mdx
@@ -7,17 +7,7 @@ Studio uses an in-memory store by default. It stores sessions, runtime messages,
 
 ## Optional SQLite
 
-Set `ANVIA_STUDIO_DB` when you want Studio state to survive process restarts.
-
-```bash
-ANVIA_STUDIO_DB=.data/studio.sqlite pnpm tsx studio.ts
-```
-
-`AION_STUDIO_DB` is also read as a compatibility fallback.
-
-SQLite storage uses dedicated `anvia_studio_*` tables, including `anvia_studio_sessions`, `anvia_studio_traces`, `anvia_studio_pipeline_logs`, and `anvia_studio_pipeline_runs`. That makes it safe to point Studio at a shared application database without writing into production product tables.
-
-You can also pass a store explicitly:
+Pass a SQLite store explicitly when you want Studio state to survive process restarts:
 
 ```ts
 import { Studio, createSqliteSessionStore } from "@anvia/studio";
@@ -28,6 +18,8 @@ new Studio([agent], {
   },
 }).start();
 ```
+
+SQLite storage uses dedicated `anvia_studio_*` tables, including `anvia_studio_sessions`, `anvia_studio_traces`, `anvia_studio_pipeline_logs`, and `anvia_studio_pipeline_runs`. That makes it safe to point Studio at a shared application database without writing into production product tables.
 
 ## What Gets Stored
 

--- a/apps/docs/content/docs/studio/inspect-context/memory.mdx
+++ b/apps/docs/content/docs/studio/inspect-context/memory.mdx
@@ -33,4 +33,4 @@ Filter conversations by agent or user:
 curl 'http://localhost:4021/memory/conversations?agentId=support-operations&userId=dev_1'
 ```
 
-The Memory page does not edit or delete stored data. Use the Sessions page or `DELETE /sessions/:sessionId` when you need to remove a conversation. By default this data is in memory only; set `ANVIA_STUDIO_DB` or pass an explicit store when you need persistence.
+The Memory page does not edit or delete stored data. Use the Sessions page or `DELETE /sessions/:sessionId` when you need to remove a conversation. By default this data is in memory only; pass an explicit store when you need persistence.

--- a/examples/cookbook/05_pipelines/09-financial-market-analysis.ts
+++ b/examples/cookbook/05_pipelines/09-financial-market-analysis.ts
@@ -120,7 +120,7 @@ const marketPipeline = new PipelineBuilder<string>()
   .prompt(marketAnalyst)
   .build();
 
-const analysis = await marketPipeline.run("AION");
+const analysis = await marketPipeline.run("ACME");
 
 console.log(analysis);
 

--- a/examples/cookbook/06_retrieval/05-rag-search-tool.ts
+++ b/examples/cookbook/06_retrieval/05-rag-search-tool.ts
@@ -30,7 +30,7 @@ const embedded = await embedDocuments(embeddingModel, runbooks, {
   content: (runbook) => runbook.text,
 });
 const store = await ChromaVectorStore.connect<Runbook>({
-  collectionName: "aion_runbooks",
+  collectionName: "anvia_runbooks",
 });
 await store.upsertDocuments(embedded);
 

--- a/examples/cookbook/06_retrieval/06-chromadb-vector-store.ts
+++ b/examples/cookbook/06_retrieval/06-chromadb-vector-store.ts
@@ -29,7 +29,7 @@ const embedded = await embedDocuments(embeddingModel, notes, {
 });
 
 const store = await ChromaVectorStore.connect<MarketNote>({
-  collectionName: "aion_market_notes",
+  collectionName: "anvia_market_notes",
 });
 await store.upsertDocuments(embedded);
 

--- a/examples/cookbook/09_studio/10-persistent-store.ts
+++ b/examples/cookbook/09_studio/10-persistent-store.ts
@@ -7,7 +7,7 @@ import { OpenAIClient } from "@anvia/openai";
 import { createSqliteSessionStore, Studio } from "@anvia/studio";
 import { z } from "zod";
 
-const dbPath = process.env.ANVIA_STUDIO_DB ?? ".anvia-studio/cookbook-studio.sqlite";
+const dbPath = ".anvia-studio/cookbook-studio.sqlite";
 mkdirSync(dirname(dbPath), { recursive: true });
 
 const store = createSqliteSessionStore({ path: dbPath });

--- a/examples/cookbook/README.md
+++ b/examples/cookbook/README.md
@@ -63,7 +63,7 @@ Not every example needs every variable. Pure pipeline, dynamic tool, and core ev
 - `retrieval:08` uses the compose pgvector connection on host port `5439` by default. Set `DATABASE_URL` to point it at another Postgres database.
 - Langfuse examples need Langfuse credentials and live in `10_integrations`.
 - `integrations:06` logs agent lifecycle events with `@anvia/logger`.
-- Studio examples start a local HTTP server and keep Studio state in memory unless `ANVIA_STUDIO_DB` is set. `studio:10` shows explicit SQLite store wiring for sessions, traces, pipeline logs, and pipeline run history.
+- Studio examples start a local HTTP server and keep Studio state in memory by default. `studio:10` shows explicit SQLite store wiring for sessions, traces, pipeline logs, and pipeline run history.
 - Tool history and loader examples write sample files under `.memory`.
 - Image and audio generation examples write generated media files in the current working directory.
 - `providers:09` uses the bundled `assets/audio/voice.wav` sample by default. Set `ANVIA_AUDIO_FILE` to transcribe a different local audio file.

--- a/packages/tools/studio/README.md
+++ b/packages/tools/studio/README.md
@@ -60,12 +60,18 @@ Studio exposes:
 
 ## Session Storage
 
-Studio uses an in-memory store by default. Sessions, traces, and pipeline run history are available while the process is running, but they do not create local files unless you opt in to SQLite. If you omit the port, Studio uses `RUNNER_PORT` and then falls back to `4021`.
+Studio uses an in-memory store by default. Sessions, traces, and pipeline run history are available while the process is running, but they do not create local files unless you pass an explicit SQLite store. If you omit the port, Studio uses `RUNNER_PORT` and then falls back to `4021`.
 
-Set `ANVIA_STUDIO_DB` to persist Studio data in SQLite:
+Pass `createSqliteSessionStore` to persist Studio data in SQLite:
 
-```sh
-ANVIA_STUDIO_DB=.anvia/studio.sqlite node ./dist/server.js
+```ts
+import { Studio, createSqliteSessionStore } from "@anvia/studio";
+
+new Studio([agent], {
+  stores: {
+    sessions: createSqliteSessionStore({ path: ".anvia/studio.sqlite" }),
+  },
+}).start();
 ```
 
 SQLite storage uses dedicated `anvia_studio_*` tables so it can share an application database without writing into product tables.

--- a/packages/tools/studio/src/runtime/runs.ts
+++ b/packages/tools/studio/src/runtime/runs.ts
@@ -146,6 +146,7 @@ export async function* persistStreamingSessionTranscript(props: {
   session: StudioSession;
   message: string | Message;
   runId: string;
+  persistGeneratedMessages?: boolean;
 }): AsyncIterable<AgentRunStreamEvent> {
   const transcript: StudioTranscriptEntry[] = [messageToTranscriptEntry(props.message, 0)];
   const title = optionalTitle(props.message);
@@ -172,6 +173,15 @@ export async function* persistStreamingSessionTranscript(props: {
       });
       if (nextSession === undefined) {
         throw new Error("Session not found");
+      }
+      const generatedMessages = event.type === "final" ? event.messages.slice(1) : [];
+      if (props.persistGeneratedMessages === true && generatedMessages.length > 0) {
+        await props.store.append({
+          context: { sessionId: props.session.id },
+          runId: props.runId,
+          turn: 1,
+          messages: generatedMessages,
+        });
       }
 
       yield event;

--- a/packages/tools/studio/src/runtime/shared.ts
+++ b/packages/tools/studio/src/runtime/shared.ts
@@ -2,7 +2,6 @@ import type { JsonObject, JsonValue, Message } from "@anvia/core/completion";
 import type { AgentTraceOptions } from "@anvia/core/observability";
 import type { Context } from "hono";
 import { createInMemoryStudioStore } from "../storage/memory-store";
-import { createSqliteSessionStore } from "../storage/sqlite-store";
 import type {
   StudioAgent,
   StudioAgentConfig,
@@ -64,10 +63,7 @@ function defaultStudioStore(): StudioSessionStore &
   StudioTraceStore &
   StudioPipelineLogStore &
   StudioPipelineRunStore {
-  const sqlitePath = process.env.ANVIA_STUDIO_DB ?? process.env.AION_STUDIO_DB;
-  return sqlitePath === undefined
-    ? createInMemoryStudioStore()
-    : createSqliteSessionStore({ path: sqlitePath });
+  return createInMemoryStudioStore();
 }
 
 function resolveSessionStore(

--- a/packages/tools/studio/src/runtime/studio.ts
+++ b/packages/tools/studio/src/runtime/studio.ts
@@ -6,7 +6,6 @@ import {
 } from "@anvia/core/agent";
 import { type Message as CoreMessage, type JsonObject, Message } from "@anvia/core/completion";
 import { Agent } from "@anvia/core/internal/agent";
-import { resolveMemoryOptions } from "@anvia/core/memory";
 import { Pipeline } from "@anvia/core/pipeline";
 import { serve } from "@hono/node-server";
 import type { Hono } from "hono";
@@ -234,9 +233,9 @@ function agentMetadata(agent: Agent): JsonObject {
 function createStudioApp(options: StudioRuntimeOptions): StudioApp {
   const observabilityHub = new StudioObservabilityHub();
   const stores = observeStores(resolveStores(options), observabilityHub);
-  const agents = normalizeAgents(options.agents)
-    .map((agent) => withStudioSessionMemory(agent, stores.sessions))
-    .map((agent) => withStudioTraceObserver(agent, stores.traces));
+  const agents = normalizeAgents(options.agents).map((agent) =>
+    withStudioTraceObserver(agent, stores.traces),
+  );
   const pipelines = normalizePipelines(options.pipelines);
   const agentMap = new Map(agents.map((agent) => [agent.id, agent]));
   const pipelineMap = new Map(pipelines.map((pipeline) => [pipeline.id, pipeline]));
@@ -356,13 +355,27 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
       ...(body.metadata ?? {}),
       studioRunId: runId,
     };
+    const promptMessage = normalizePromptMessage(body.message);
+    const sessionStore = stores.sessions;
+    const shouldPersistSessionMessages =
+      session !== undefined &&
+      sessionStore !== undefined &&
+      !usesStoreAsAgentMemory(agent.agent, sessionStore);
+    if (shouldPersistSessionMessages) {
+      await sessionStore.append({
+        context: { sessionId: session.id, metadata: memoryMetadata },
+        runId,
+        turn: 1,
+        messages: [promptMessage],
+      });
+    }
     const request =
       session !== undefined
-        ? agent.agent.session(session.id, { metadata: memoryMetadata }).prompt(body.message)
+        ? agent.agent.memory === undefined
+          ? agent.agent.prompt([...session.messages, promptMessage])
+          : agent.agent.session(session.id, { metadata: memoryMetadata }).prompt(body.message)
         : agent.agent.prompt(
-            body.history !== undefined
-              ? [...body.history, normalizePromptMessage(body.message)]
-              : body.message,
+            body.history !== undefined ? [...body.history, promptMessage] : body.message,
           );
     if (body.maxTurns !== undefined) {
       request.maxTurns(body.maxTurns);
@@ -403,28 +416,29 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
       }
       const runStream = mergeRunAndApprovalEvents(request.stream(), runtimeEvents);
       const stream =
-        session === undefined || stores.sessions === undefined
+        session === undefined || sessionStore === undefined
           ? runStream
           : persistStreamingSessionTranscript({
               stream: streamSessionRunLogs({
                 stream: runStream,
-                store: stores.sessions,
+                store: sessionStore,
                 session,
                 runId,
                 startedAt: runStartedAt,
               }),
-              store: stores.sessions,
+              store: sessionStore,
               session,
               message: body.message,
               runId,
+              persistGeneratedMessages: shouldPersistSessionMessages,
             });
       return streamAgentRunEvents(c, stream);
     }
 
     try {
       if (session !== undefined) {
-        await appendSessionLog(stores.sessions, runStartedLog(session, runId));
-        await appendSessionLog(stores.sessions, memoryLoadedLog(session, runId));
+        await appendSessionLog(sessionStore, runStartedLog(session, runId));
+        await appendSessionLog(sessionStore, memoryLoadedLog(session, runId));
       }
       const effectiveHook = composeHooks(
         composeHooks(
@@ -448,8 +462,19 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
         request.requestHook(effectiveHook);
       }
       const response = await request.send();
-      if (session !== undefined && stores.sessions !== undefined) {
-        await stores.sessions.saveSessionRunTranscript({
+      if (session !== undefined && sessionStore !== undefined) {
+        if (shouldPersistSessionMessages) {
+          const generatedMessages = response.messages.slice(1);
+          if (generatedMessages.length > 0) {
+            await sessionStore.append({
+              context: { sessionId: session.id, metadata: memoryMetadata },
+              runId,
+              turn: 1,
+              messages: generatedMessages,
+            });
+          }
+        }
+        await sessionStore.saveSessionRunTranscript({
           id: session.id,
           runId,
           ...optionalTitle(body.message),
@@ -457,7 +482,7 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
           status: "success",
         });
         await appendSessionLog(
-          stores.sessions,
+          sessionStore,
           runCompletedLog({
             sessionId: session.id,
             runId,
@@ -468,7 +493,7 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
           }),
         );
         await appendSessionLog(
-          stores.sessions,
+          sessionStore,
           memorySavedLog({
             sessionId: session.id,
             runId,
@@ -478,12 +503,12 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
       }
       return c.json(response);
     } catch (error) {
-      if (session !== undefined && stores.sessions !== undefined) {
-        const messages = await stores.sessions.load({
+      if (session !== undefined && sessionStore !== undefined) {
+        const messages = await sessionStore.load({
           sessionId: session.id,
           metadata: memoryMetadata,
         });
-        await stores.sessions.saveSessionRunTranscript({
+        await sessionStore.saveSessionRunTranscript({
           id: session.id,
           runId,
           ...optionalTitle(body.message),
@@ -491,10 +516,7 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
           status: "error",
           error: serializeError(error),
         });
-        await appendSessionLog(
-          stores.sessions,
-          runFailedLog(session.id, runId, error, runStartedAt),
-        );
+        await appendSessionLog(sessionStore, runFailedLog(session.id, runId, error, runStartedAt));
       }
       return errorResponse(c, 500, "internal_error", "Agent run failed", serializeError(error));
     }
@@ -538,23 +560,8 @@ function normalizePromptMessage(message: string | CoreMessage): CoreMessage {
   return typeof message === "string" ? Message.user(message) : message;
 }
 
-function withStudioSessionMemory(
-  studioAgent: StudioAgent,
-  sessionStore: StudioSessionStore | undefined,
-): StudioAgent {
-  if (sessionStore === undefined) {
-    return studioAgent;
-  }
-
-  return {
-    ...studioAgent,
-    agent: cloneAgent(studioAgent.agent, {
-      memory: {
-        store: sessionStore,
-        options: resolveMemoryOptions({ savePolicy: "message" }),
-      },
-    }),
-  };
+function usesStoreAsAgentMemory(agent: Agent, store: StudioSessionStore): boolean {
+  return agent.memory?.store === store;
 }
 
 function withStudioTraceObserver(

--- a/packages/tools/studio/src/ui/routes.tsx
+++ b/packages/tools/studio/src/ui/routes.tsx
@@ -164,7 +164,7 @@ function renderLegacyStudioUiShell(props: {
     '<meta charset="utf-8">',
     '<meta name="viewport" content="width=device-width, initial-scale=1">',
     `<title>${title}</title>`,
-    '<script>(()=>{try{if((localStorage.getItem("anvia-studio-theme")??localStorage.getItem("aion-studio-theme"))==="light"){document.documentElement.classList.remove("dark")}}catch{}})();</script>',
+    '<script>(()=>{try{if(localStorage.getItem("anvia-studio-theme")==="light"){document.documentElement.classList.remove("dark")}}catch{}})();</script>',
     `<link rel="icon" type="image/png" href="${escapeHtml(props.compatUiPath)}/assets/logo.png">`,
     `<link rel="stylesheet" href="${escapeHtml(props.stylesheet)}">`,
     "</head>",

--- a/packages/tools/studio/test/runner.test.ts
+++ b/packages/tools/studio/test/runner.test.ts
@@ -8,6 +8,7 @@ import {
   type CompletionRequest,
   type CompletionResponse,
   type CompletionStreamEvent,
+  type Message as CoreMessage,
   type JsonObject,
   Message,
   type StreamingCompletionModel,
@@ -18,6 +19,12 @@ import {
 import { type Embedding, type EmbeddingModel, embedDocuments } from "@anvia/core/embeddings";
 import { type EvalMetric, EvalOutcome } from "@anvia/core/evals";
 import { connectMcp, type McpClient } from "@anvia/core/mcp";
+import type {
+  MemoryAppendInput,
+  MemoryContext,
+  MemoryErrorInput,
+  MemoryStore,
+} from "@anvia/core/memory";
 import type { AgentObserver, AgentRunObserver, AgentRunStartArgs } from "@anvia/core/observability";
 import { PipelineBuilder } from "@anvia/core/pipeline";
 import { createToolIndex, type Tool } from "@anvia/core/tool";
@@ -137,6 +144,30 @@ class GatedReasoningModel implements StreamingCompletionModel {
       this.releaseText = resolve;
     });
     yield { type: "text_delta", delta: "done" };
+  }
+}
+
+class RecordingMemoryStore implements MemoryStore {
+  readonly appendCalls: MemoryAppendInput[] = [];
+  readonly errorCalls: MemoryErrorInput[] = [];
+  private readonly sessions = new Map<string, CoreMessage[]>();
+
+  async load(context: MemoryContext): Promise<CoreMessage[]> {
+    return [...(this.sessions.get(context.sessionId) ?? [])];
+  }
+
+  async append(input: MemoryAppendInput): Promise<void> {
+    this.appendCalls.push({ ...input, messages: [...input.messages] });
+    const current = this.sessions.get(input.context.sessionId) ?? [];
+    this.sessions.set(input.context.sessionId, [...current, ...input.messages]);
+  }
+
+  async clear(context: MemoryContext): Promise<void> {
+    this.sessions.delete(context.sessionId);
+  }
+
+  async recordError(input: MemoryErrorInput): Promise<void> {
+    this.errorCalls.push({ ...input, messages: [...input.messages] });
   }
 }
 
@@ -934,7 +965,7 @@ describe("Anvia studio", () => {
       dynamicToolCount: 0,
       approvalToolCount: 0,
       mcpToolCount: 0,
-      hasMemory: true,
+      hasMemory: false,
       hasHook: false,
       hasOutputSchema: false,
       defaultMaxTurns: 4,
@@ -2206,6 +2237,65 @@ describe("Anvia studio", () => {
         { kind: "message", role: "assistant", text: "First answer" },
         { kind: "message", role: "user", text: "Follow up" },
         { kind: "message", role: "assistant", text: "Second answer" },
+      ],
+    });
+  });
+
+  it("preserves agent memory stores during Studio session runs", async () => {
+    const model = new QueueModel([
+      response([AssistantContent.text("First answer")]),
+      response([AssistantContent.text("Second answer")]),
+    ]);
+    const memory = new RecordingMemoryStore();
+    const agent = new AgentBuilder("support", model).memory(memory).build();
+    const runner = new Studio([agent]);
+
+    const created = await runner.fetch(
+      new Request("http://runner.test/sessions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ agentId: "support", title: "Memory session" }),
+      }),
+    );
+    const session = (await created.json()) as { id: string };
+
+    const firstRun = await runner.fetch(
+      new Request("http://runner.test/agents/support/runs", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ message: "First question", sessionId: session.id }),
+      }),
+    );
+    expect(firstRun.status).toBe(200);
+
+    const secondRun = await runner.fetch(
+      new Request("http://runner.test/agents/support/runs", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ message: "Follow up", sessionId: session.id }),
+      }),
+    );
+    expect(secondRun.status).toBe(200);
+
+    expect(memory.appendCalls.map((call) => call.messages.map((message) => message.role))).toEqual([
+      ["user"],
+      ["assistant"],
+      ["user"],
+      ["assistant"],
+    ]);
+    expect(model.requests[1]?.chatHistory).toEqual([
+      Message.user("First question"),
+      Message.assistant("First answer"),
+      Message.user("Follow up"),
+    ]);
+
+    const loaded = await runner.fetch(new Request(`http://runner.test/sessions/${session.id}`));
+    await expect(loaded.json()).resolves.toMatchObject({
+      messages: [
+        Message.user("First question"),
+        Message.assistant("First answer"),
+        Message.user("Follow up"),
+        Message.assistant("Second answer"),
       ],
     });
   });

--- a/packages/tools/studio/test/runner.test.ts
+++ b/packages/tools/studio/test/runner.test.ts
@@ -209,21 +209,13 @@ const addTool = {
   },
 } satisfies Tool<{ x: number; y: number }, number>;
 
-let previousStudioDb: string | undefined;
 let studioDbDir: string | undefined;
 
 beforeEach(() => {
-  previousStudioDb = process.env.ANVIA_STUDIO_DB;
   studioDbDir = mkdtempSync(join(tmpdir(), "anvia-studio-test-"));
-  delete process.env.ANVIA_STUDIO_DB;
 });
 
 afterEach(() => {
-  if (previousStudioDb === undefined) {
-    delete process.env.ANVIA_STUDIO_DB;
-  } else {
-    process.env.ANVIA_STUDIO_DB = previousStudioDb;
-  }
   if (studioDbDir !== undefined) {
     rmSync(studioDbDir, { force: true, recursive: true });
     studioDbDir = undefined;


### PR DESCRIPTION
## Summary
- keep Studio's implicit default session store in memory only and remove automatic SQLite env defaults
- remove legacy AION/AION_STUDIO_DB references and old theme migration fallback
- preserve agent-configured memory stores during Studio session runs while mirroring session history for Studio UI inspection

## Validation
- pnpm --filter @anvia/studio test
- pnpm --filter @anvia/studio typecheck
- rg -n "ANVIA_STUDIO_DB|AION_|AION|aion" . -g '!node_modules' -g '!**/dist/**' -g '!**/.git/**'
