### PR TITLE
Add direct completion helpers

### DIFF
--- a/.changeset/bright-pandas-parse.md
+++ b/.changeset/bright-pandas-parse.md
@@ -1,0 +1,7 @@
+---
+"@anvia/core": minor
+---
+
+Add direct completion helpers for non-streaming, streaming, and parsed structured output flows.
+
+`createCompletion` now always returns a final completion result, `createCompletionStream` exposes raw normalized model stream events, and `createParsedCompletion` returns schema-validated data from direct completions.

--- a/apps/docs/content/docs/guides/completions/index.mdx
+++ b/apps/docs/content/docs/guides/completions/index.mdx
@@ -1,0 +1,51 @@
+---
+title: Direct Completions
+description: Call a provider model directly without agent turns or tool execution.
+---
+
+Direct completions are for one model request when you do not need an agent runtime. Use them for small transformations, classifiers, summaries, or infrastructure code that already owns the prompt shape and does not need Anvia to execute tools.
+
+If you need reusable agent configuration, automatic context loading, tool execution, memory, hooks, tracing, turn limits, or approval handling around the model, use `agent.prompt(...).send()` instead.
+
+## Create a Final Completion
+
+```ts
+import { createCompletion } from "@anvia/core";
+import { OpenAIClient } from "@anvia/openai";
+
+const model = new OpenAIClient({ apiKey }).completionModel("gpt-5.5");
+
+const result = await createCompletion(model, {
+  input: "Summarize this ticket in one sentence: password reset link expired.",
+  instructions: "Write for an internal support handoff.",
+  maxTokens: 120,
+});
+
+console.log(result.text);
+```
+
+`createCompletion` always waits for the final provider response.
+
+It returns:
+
+| Field | Meaning |
+| --- | --- |
+| `text` | Joined assistant text content |
+| `content` | Normalized assistant content parts |
+| `usage` | Normalized token usage |
+| `response` | Full normalized `CompletionResponse`, including the raw provider response |
+
+## When to Use Agents Instead
+
+Direct completions do not run tools or own a multi-turn workflow. Use an agent when the run needs:
+
+- reusable instructions and context setup
+- dynamic context or retrieval
+- tool execution
+- memory or sessions
+- hooks, approvals, or tracing
+- turn limits and tool loops
+
+## Next
+
+Read [Messages and Multimodal Input](/docs/guides/completions/messages) to pass transcripts, images, and documents, or [Structured Output](/docs/guides/completions/structured-output) to return schema-validated data.

--- a/apps/docs/content/docs/guides/completions/messages.mdx
+++ b/apps/docs/content/docs/guides/completions/messages.mdx
@@ -1,0 +1,94 @@
+---
+title: Messages and Multimodal Input
+description: Pass transcripts, text, images, and documents into direct completions.
+---
+
+Use `messages` when your application already owns the transcript. If you also pass `input`, Anvia appends it as the final message.
+
+## Transcript Messages
+
+```ts
+import { Message, createCompletion } from "@anvia/core";
+
+const result = await createCompletion(model, {
+  messages: [
+    Message.system("You classify support tickets."),
+    Message.user("My invoice is wrong."),
+    Message.assistant("billing"),
+  ],
+  input: "I cannot log in.",
+});
+```
+
+`Message.user("...")` and `Message.assistant("...")` create Anvia's normalized content arrays for you.
+
+## Multimodal User Messages
+
+User messages can contain multiple content parts, including text, images, and documents:
+
+```ts
+import { Message, UserContent, createCompletion } from "@anvia/core";
+
+const result = await createCompletion(model, {
+  messages: [
+    Message.system("Inspect the user-provided materials."),
+    Message.user([
+      UserContent.text("Summarize what is shown here."),
+      UserContent.imageUrl("https://example.com/screenshot.png", {
+        detail: "auto",
+      }),
+      UserContent.documentUrl(
+        "https://example.com/spec.pdf",
+        "application/pdf",
+        { filename: "spec.pdf" },
+      ),
+    ]),
+  ],
+});
+```
+
+Provider support still matters. If the selected model does not support image or document input, Anvia rejects before calling the provider.
+
+## Raw Normalized Shape
+
+Raw objects are also valid when they match Anvia's normalized message shape:
+
+```ts
+const message = {
+  role: "user",
+  content: [
+    { type: "text", text: "Summarize what is shown here." },
+    {
+      type: "image",
+      source: { type: "url", url: "https://example.com/screenshot.png" },
+    },
+  ],
+};
+```
+
+This is different from plain OpenAI-style user messages with string content:
+
+```ts
+// Not the normalized Anvia user message shape.
+const message = { role: "user", content: "Summarize this." };
+```
+
+Use the factory helpers unless you need to construct content arrays manually.
+
+## Static Documents
+
+Use `documents` for text context that should be attached to the request rather than stored in the transcript:
+
+```ts
+const result = await createCompletion(model, {
+  input: "Answer using the attached policy.",
+  documents: [
+    {
+      id: "refund-policy",
+      text: "Refunds are available within 30 days for annual plans.",
+    },
+  ],
+});
+```
+
+`documents` are text context. File-like document inputs belong in `UserContent.documentUrl(...)` or `UserContent.documentBase64(...)`.

--- a/apps/docs/content/docs/guides/completions/meta.json
+++ b/apps/docs/content/docs/guides/completions/meta.json
@@ -1,0 +1,6 @@
+{
+  "title": "Completions",
+  "defaultOpen": false,
+  "collapsible": true,
+  "pages": ["index", "messages", "structured-output", "streaming", "options"]
+}

--- a/apps/docs/content/docs/guides/completions/options.mdx
+++ b/apps/docs/content/docs/guides/completions/options.mdx
@@ -1,0 +1,96 @@
+---
+title: Options and Validation
+description: Configure direct completion requests and understand validation behavior.
+---
+
+`createCompletion` and `createCompletionStream` use the same option shape.
+
+```ts
+type CreateCompletionBaseOptions = {
+  input?: string | Message | Message[];
+  messages?: Message[];
+  instructions?: string;
+  documents?: Document[];
+  tools?: ToolDefinition[];
+  temperature?: number;
+  maxTokens?: number;
+  toolChoice?: ToolChoice;
+  outputSchema?: JsonObject;
+  params?: JsonValue;
+};
+```
+
+`createParsedCompletion` uses the same shape, but replaces `outputSchema` with `schema`:
+
+```ts
+type CreateParsedCompletionOptions<T> =
+  Omit<CreateCompletionBaseOptions, "outputSchema"> & {
+    schema: ZodSchema<T>;
+  };
+```
+
+## Provider Params
+
+Use `params` for provider-specific request options. Anvia forwards it to `CompletionRequest.additionalParams`.
+
+```ts
+const result = await createCompletion(model, {
+  input: "Classify this ticket: I cannot reset my password.",
+  params: {
+    reasoning: { effort: "low" },
+  },
+});
+```
+
+Keep `params` provider-aware. A value accepted by one provider can be ignored or rejected by another provider.
+
+## Tool Definitions
+
+Direct completions can send tool definitions to the model, but they do not execute tools. Tool calls are returned as assistant content or stream events for your application to handle.
+
+```ts
+const result = await createCompletion(model, {
+  input: "Check order A123.",
+  tools: [
+    {
+      name: "lookup_order",
+      description: "Look up an order by id.",
+      parameters: {
+        type: "object",
+        properties: {
+          orderId: { type: "string" },
+        },
+        required: ["orderId"],
+      },
+    },
+  ],
+  toolChoice: "auto",
+});
+```
+
+Use an agent when Anvia should execute tools and continue the model loop.
+
+## Capability Validation
+
+Both helpers validate request features against `model.capabilities` before calling the provider. Unsupported tools, tool choice, image input, file document input, output schemas, and streaming fail before the provider request is made.
+
+`createCompletion` rejects through the returned promise:
+
+```ts
+try {
+  await createCompletion(model, {
+    input: "Use this screenshot.",
+    tools: [
+      {
+        name: "lookup_order",
+        description: "Look up an order by id.",
+        parameters: { type: "object" },
+      },
+    ],
+  });
+} catch (error) {
+  console.error(error);
+}
+```
+
+`createCompletionStream` throws before returning the stream when validation fails.

--- a/apps/docs/content/docs/guides/completions/streaming.mdx
+++ b/apps/docs/content/docs/guides/completions/streaming.mdx
@@ -1,0 +1,68 @@
+---
+title: Streaming Completions
+description: Stream normalized raw model events from a direct completion.
+---
+
+Use `createCompletionStream` when you want normalized provider stream events without agent runtime events.
+
+```ts
+import { createCompletionStream } from "@anvia/core";
+
+for await (const event of createCompletionStream(model, {
+  input: "Write a short launch note.",
+})) {
+  if (event.type === "text_delta") {
+    process.stdout.write(event.delta);
+  }
+
+  if (event.type === "final") {
+    console.log(event.response.usage);
+  }
+}
+```
+
+`createCompletionStream` returns the model's `CompletionStreamEvent` values directly.
+
+## Event Types
+
+Direct completion streams can include:
+
+| Event | Meaning |
+| --- | --- |
+| `text_delta` | Assistant text arrived |
+| `reasoning_delta` | Reasoning text or summary arrived from a provider that exposes it |
+| `tool_call_delta` | Partial tool call data arrived |
+| `tool_call` | The model emitted a complete tool call |
+| `message_id` | The provider emitted a message id |
+| `final` | The model stream completed with a normalized response |
+| `error` | The stream failed |
+
+## Raw Model Stream, Not Agent Stream
+
+Direct completion streams do not execute tools and do not emit agent stream events such as:
+
+- `turn_start`
+- `turn_end`
+- `tool_result`
+- `agent_tool_event`
+- agent `final` output
+
+For streams with tool execution and turn events, use `agent.prompt(...).stream()`.
+
+## Capability Validation
+
+`createCompletionStream` throws before returning the model stream if streaming or another requested feature is unsupported:
+
+```ts
+try {
+  const stream = createCompletionStream(model, {
+    input: "Write a live status update.",
+  });
+
+  for await (const event of stream) {
+    console.log(event.type);
+  }
+} catch (error) {
+  console.error(error);
+}
+```

--- a/apps/docs/content/docs/guides/completions/structured-output.mdx
+++ b/apps/docs/content/docs/guides/completions/structured-output.mdx
@@ -1,0 +1,90 @@
+---
+title: Structured Output
+description: Parse direct completion responses into typed schema data.
+---
+
+Use `createParsedCompletion` when you want one direct model call to return validated data.
+
+```ts
+import { createParsedCompletion } from "@anvia/core";
+import { OpenAIClient } from "@anvia/openai";
+import { z } from "zod";
+
+const eventSchema = z.object({
+  name: z.string(),
+  date: z.string(),
+  participants: z.array(z.string()),
+});
+
+const model = new OpenAIClient({ apiKey }).completionModel("gpt-5.5");
+
+const result = await createParsedCompletion(model, {
+  schema: eventSchema,
+  input: "Alice and Bob are going to a science fair on Friday.",
+});
+
+console.log(result.data.participants);
+```
+
+`createParsedCompletion` converts the Zod schema to the provider `outputSchema`, waits for the final response, parses the assistant text as JSON, and validates the parsed value with the same schema.
+
+It returns the parsed data plus the normal completion fields:
+
+| Field | Meaning |
+| --- | --- |
+| `data` | Parsed and schema-validated value |
+| `text` | Joined assistant text content |
+| `content` | Normalized assistant content parts |
+| `usage` | Normalized token usage |
+| `response` | Full normalized `CompletionResponse`, including the raw provider response |
+
+## Messages and Multimodal Input
+
+Parsed completions use the same prompt shape as `createCompletion`. You can pass `messages`, `input`, text, images, and documents:
+
+```ts
+import { Message, UserContent, createParsedCompletion } from "@anvia/core";
+
+const result = await createParsedCompletion(model, {
+  schema: eventSchema,
+  messages: [
+    Message.system("Extract event details."),
+    Message.user([
+      UserContent.text("Read this flyer and extract the event."),
+      UserContent.imageUrl("https://example.com/flyer.png"),
+    ]),
+  ],
+});
+```
+
+If `input` is also provided, Anvia appends it after `messages`.
+
+## Provider Params
+
+Use `params` the same way you would with `createCompletion`:
+
+```ts
+const result = await createParsedCompletion(model, {
+  schema: eventSchema,
+  input: "Alice and Bob are going to a science fair on Friday.",
+  params: {
+    reasoning: { effort: "low" },
+  },
+});
+```
+
+## Compared With Extractors
+
+`createParsedCompletion` is a direct completion helper. It does not execute tools, create a submit tool, or retry validation failures.
+
+Use `ExtractorBuilder` when you want the higher-level extraction workflow: required `submit` tool semantics, retries, usage/history helpers, and pipeline integration.
+
+## Validation Errors
+
+The helper rejects if:
+
+- the request uses model features the provider adapter does not support
+- the model does not return valid JSON text
+- the parsed JSON does not match the schema
+
+Provider support for structured output still matters. If the model does not support output schemas, Anvia rejects before calling the provider.

--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -13,6 +13,7 @@
     "learning-paths",
     "---Guide---",
     "sdk-fundamentals",
+    "completions",
     "agents",
     "memory",
     "tools",

--- a/apps/docs/content/docs/reference/core/completion.mdx
+++ b/apps/docs/content/docs/reference/core/completion.mdx
@@ -255,6 +255,73 @@ Return behavior: returns `void` when the request is supported.
 
 Notable errors: throws `CompletionCapabilityError` for unsupported tools, tool choice, image input, file document input, output schema, or streaming. Static `CompletionRequest.documents` context and `UserContent.documentText(...)` are treated as text, not file document input.
 
+## Direct Completion Helpers
+
+```ts
+type CreateCompletionInput = string | Message | Message[];
+
+type CreateCompletionBaseOptions = {
+  input?: CreateCompletionInput;
+  messages?: Message[];
+  instructions?: string;
+  documents?: Document[];
+  tools?: ToolDefinition[];
+  temperature?: number;
+  maxTokens?: number;
+  toolChoice?: ToolChoice;
+  outputSchema?: JsonObject;
+  params?: JsonValue;
+};
+
+type CreateCompletionOptions = CreateCompletionBaseOptions;
+type CreateCompletionStreamOptions = CreateCompletionBaseOptions;
+type CreateParsedCompletionOptions<T> =
+  Omit<CreateCompletionBaseOptions, "outputSchema"> & {
+    schema: ZodSchema<T>;
+  };
+
+type CreateCompletionResult<RawResponse = unknown> = {
+  text: string;
+  content: AssistantContent[];
+  usage: Usage;
+  response: CompletionResponse<RawResponse>;
+};
+
+type CreateParsedCompletionResult<T, RawResponse = unknown> =
+  CreateCompletionResult<RawResponse> & {
+    data: T;
+  };
+
+function createCompletion<Model extends CompletionModel>(
+  model: Model,
+  options: CreateCompletionOptions,
+): Promise<CreateCompletionResult>;
+
+function createCompletionStream<Model extends StreamingCompletionModel>(
+  model: Model,
+  options: CreateCompletionStreamOptions,
+): AsyncIterable<CompletionStreamEvent>;
+
+function createParsedCompletion<T, Model extends CompletionModel>(
+  model: Model,
+  options: CreateParsedCompletionOptions<T>,
+): Promise<CreateParsedCompletionResult<T>>;
+```
+
+Purpose: call a completion model directly without building an agent or executing tools.
+
+Return behavior: `createCompletion(...)` always returns a promise for the final response. `createCompletionStream(...)` returns the model's normalized `CompletionStreamEvent` iterable directly.
+
+`createParsedCompletion(...)` converts `schema` to `outputSchema`, calls the model once, parses the assistant text as JSON, validates it with the same schema, and returns `data` plus the normal completion result fields.
+
+`messages` supplies an existing transcript. `input` accepts a string, one message, or multiple messages and is appended after `messages`. At least one of `input` or `messages` is required.
+
+`params` maps to `CompletionRequest.additionalParams` for provider-specific options.
+
+Notable errors: `createCompletion(...)` rejects if input is empty or the request uses unsupported model features. `createCompletionStream(...)` throws before returning the stream when validation fails or when the model does not support streaming. `createParsedCompletion(...)` also rejects when the response text is not valid JSON or does not match `schema`.
+
+Direct completion streams are raw model streams. They can include text deltas, reasoning deltas, tool call deltas, tool calls, message ids, final responses, and errors. They do not execute tools and do not emit agent stream events such as `turn_start`, `tool_result`, `agent_tool_event`, or agent `final` output.
+
 ## CompletionRequestBuilder
 
 ```ts

--- a/apps/docs/src/routeTree.gen.ts
+++ b/apps/docs/src/routeTree.gen.ts
@@ -208,3 +208,12 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
+declare module '@tanstack/react-start' {
+  interface Register {
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+  }
+}

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -47,6 +47,74 @@ const response = await agent.prompt("What is happening with order A123?").send()
 console.log(response.output);
 ```
 
+## Direct Completions
+
+Use `createCompletion` when you want a single provider call without agent turns, memory, or
+tool execution:
+
+```ts
+import { createCompletion } from "@anvia/core";
+import { OpenAIClient } from "@anvia/openai";
+
+const model = new OpenAIClient({ apiKey }).completionModel("gpt-5");
+
+const result = await createCompletion(model, {
+  input: "Summarize Anvia in one sentence.",
+  instructions: "Answer clearly and concisely.",
+});
+
+console.log(result.text);
+```
+
+Use `messages` when you already own the transcript. If `input` is also provided, it is appended as
+the final message:
+
+```ts
+import { Message, createCompletion } from "@anvia/core";
+
+const result = await createCompletion(model, {
+  messages: [
+    Message.system("You are concise."),
+    Message.user("Explain Anvia."),
+  ],
+  maxTokens: 300,
+  params: {
+    reasoning: { effort: "low" },
+  },
+});
+```
+
+Use `createCompletionStream` to receive raw completion stream events from the model:
+
+```ts
+import { createCompletionStream } from "@anvia/core";
+
+for await (const event of createCompletionStream(model, {
+  input: "Write a short launch note.",
+})) {
+  if (event.type === "text_delta") process.stdout.write(event.delta);
+}
+```
+
+Use `createParsedCompletion` when you want a direct completion to return schema-validated data:
+
+```ts
+import { createParsedCompletion } from "@anvia/core";
+import { z } from "zod";
+
+const eventSchema = z.object({
+  name: z.string(),
+  date: z.string(),
+});
+
+const event = await createParsedCompletion(model, {
+  schema: eventSchema,
+  input: "Alice and Bob are going to a science fair on Friday.",
+});
+
+console.log(event.data);
+```
+
 ## Prompts and Memory
 
 Use a plain prompt for stateless calls:

--- a/packages/core/src/completion/create-completion.ts
+++ b/packages/core/src/completion/create-completion.ts
@@ -1,0 +1,172 @@
+import { toProviderJsonSchema, type ZodSchema } from "../schema/zod-schema";
+import type {
+  AssistantContent,
+  CompletionModel,
+  CompletionRequest,
+  CompletionResponse,
+  CompletionStreamEvent,
+  Document,
+  JsonObject,
+  JsonValue,
+  Message as MessageType,
+  StreamingCompletionModel,
+  ToolChoice,
+  ToolDefinition,
+  Usage,
+} from "./types";
+import { assertCompletionRequestSupported, Message, textFromAssistantContent } from "./types";
+
+export type CreateCompletionInput = string | MessageType | MessageType[];
+
+export type CreateCompletionBaseOptions = {
+  input?: CreateCompletionInput | undefined;
+  messages?: MessageType[] | undefined;
+  instructions?: string | undefined;
+  documents?: Document[] | undefined;
+  tools?: ToolDefinition[] | undefined;
+  temperature?: number | undefined;
+  maxTokens?: number | undefined;
+  toolChoice?: ToolChoice | undefined;
+  outputSchema?: JsonObject | undefined;
+  params?: JsonValue | undefined;
+};
+
+export type CreateCompletionOptions = CreateCompletionBaseOptions;
+
+export type CreateCompletionStreamOptions = CreateCompletionBaseOptions;
+
+export type CreateParsedCompletionOptions<T> = Omit<CreateCompletionBaseOptions, "outputSchema"> & {
+  schema: ZodSchema<T>;
+};
+
+export type CreateCompletionResult<RawResponse = unknown> = {
+  text: string;
+  content: AssistantContent[];
+  usage: Usage;
+  response: CompletionResponse<RawResponse>;
+};
+
+export type CreateParsedCompletionResult<
+  T,
+  RawResponse = unknown,
+> = CreateCompletionResult<RawResponse> & {
+  data: T;
+};
+
+type RawResponseOf<Model> =
+  Model extends CompletionModel<infer RawResponse> ? RawResponse : unknown;
+
+export function createCompletion<Model extends CompletionModel>(
+  model: Model,
+  options: CreateCompletionOptions,
+): Promise<CreateCompletionResult<RawResponseOf<Model>>> {
+  return sendCompletion(model, options);
+}
+
+export function createCompletionStream<Model extends StreamingCompletionModel>(
+  model: Model,
+  options: CreateCompletionStreamOptions,
+): AsyncIterable<CompletionStreamEvent<RawResponseOf<Model>>> {
+  const request = toCompletionRequest(options);
+  if (!isStreamingCompletionModel(model) || !model.capabilities.streaming) {
+    throw new Error("This completion model does not support streaming");
+  }
+  assertCompletionRequestSupported(model, request, { streaming: true });
+  return model.streamCompletion(request) as AsyncIterable<
+    CompletionStreamEvent<RawResponseOf<Model>>
+  >;
+}
+
+export async function createParsedCompletion<T, Model extends CompletionModel>(
+  model: Model,
+  options: CreateParsedCompletionOptions<T>,
+): Promise<CreateParsedCompletionResult<T, RawResponseOf<Model>>> {
+  const { schema, ...completionOptions } = options;
+  const request = toCompletionRequest(
+    {
+      ...completionOptions,
+      outputSchema: toProviderJsonSchema(schema),
+    },
+    "createParsedCompletion",
+  );
+  assertCompletionRequestSupported(model, request);
+  const response = (await model.completion(request)) as CompletionResponse<RawResponseOf<Model>>;
+  const text = textFromAssistantContent(response.choice);
+  return {
+    data: parseCompletionData(text, schema),
+    text,
+    content: response.choice,
+    usage: response.usage,
+    response,
+  };
+}
+
+async function sendCompletion<Model extends CompletionModel>(
+  model: Model,
+  options: CreateCompletionOptions,
+): Promise<CreateCompletionResult<RawResponseOf<Model>>> {
+  const request = toCompletionRequest(options);
+  assertCompletionRequestSupported(model, request);
+  const response = (await model.completion(request)) as CompletionResponse<RawResponseOf<Model>>;
+  return {
+    text: textFromAssistantContent(response.choice),
+    content: response.choice,
+    usage: response.usage,
+    response,
+  };
+}
+
+function toCompletionRequest(
+  options: CreateCompletionBaseOptions,
+  helperName = "createCompletion",
+): CompletionRequest {
+  const chatHistory = [...(options.messages ?? []), ...messagesFromInput(options.input)];
+
+  if (chatHistory.length === 0) {
+    throw new Error(`${helperName} requires input or messages.`);
+  }
+
+  const request: CompletionRequest = {
+    chatHistory,
+    documents: [...(options.documents ?? [])],
+    tools: [...(options.tools ?? [])],
+  };
+
+  if (options.instructions !== undefined && options.instructions.length > 0) {
+    request.instructions = options.instructions;
+  }
+  if (options.temperature !== undefined) request.temperature = options.temperature;
+  if (options.maxTokens !== undefined) request.maxTokens = options.maxTokens;
+  if (options.toolChoice !== undefined) request.toolChoice = options.toolChoice;
+  if (options.outputSchema !== undefined) request.outputSchema = options.outputSchema;
+  if (options.params !== undefined) request.additionalParams = options.params;
+
+  return request;
+}
+
+function messagesFromInput(input: CreateCompletionInput | undefined): MessageType[] {
+  if (input === undefined) {
+    return [];
+  }
+  if (typeof input === "string") {
+    return [Message.user(input)];
+  }
+  return Array.isArray(input) ? [...input] : [input];
+}
+
+function isStreamingCompletionModel(model: CompletionModel): model is StreamingCompletionModel {
+  return typeof (model as { streamCompletion?: unknown }).streamCompletion === "function";
+}
+
+function parseCompletionData<T>(text: string, schema: ZodSchema<T>): T {
+  let json: unknown;
+  try {
+    json = JSON.parse(text);
+  } catch (error) {
+    throw new Error("createParsedCompletion expected the model response to be valid JSON.", {
+      cause: error,
+    });
+  }
+
+  return schema.parse(json);
+}

--- a/packages/core/src/completion/index.ts
+++ b/packages/core/src/completion/index.ts
@@ -1,3 +1,4 @@
+export * from "./create-completion";
 export * from "./documents";
 export * from "./request";
 export * from "./types";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,13 @@ export type {
   CompletionModel,
   CompletionRequest,
   CompletionResponse,
+  CreateCompletionBaseOptions,
+  CreateCompletionInput,
+  CreateCompletionOptions,
+  CreateCompletionResult,
+  CreateCompletionStreamOptions,
+  CreateParsedCompletionOptions,
+  CreateParsedCompletionResult,
   Document,
   ImageContent,
   JsonObject,
@@ -34,6 +41,9 @@ export type {
 } from "./completion/index";
 export {
   AssistantContent,
+  createCompletion,
+  createCompletionStream,
+  createParsedCompletion,
   Message,
   Usage,
   UserContent,

--- a/packages/core/test/completion-capabilities.test.ts
+++ b/packages/core/test/completion-capabilities.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
 import {
   AgentBuilder,
   AssistantContent,
@@ -10,6 +11,9 @@ import {
   CompletionRequestBuilder,
   type CompletionResponse,
   type CompletionStreamEvent,
+  createCompletion,
+  createCompletionStream,
+  createParsedCompletion,
   Message,
   type StreamingCompletionModel,
   Usage,
@@ -32,14 +36,17 @@ class QueueModel implements CompletionModel {
   readonly capabilities: CompletionModelCapabilities;
   readonly requests: CompletionRequest[] = [];
 
-  constructor(capabilities: Partial<CompletionModelCapabilities> = {}) {
+  constructor(
+    capabilities: Partial<CompletionModelCapabilities> = {},
+    private readonly choice = [AssistantContent.text("ok")],
+  ) {
     this.capabilities = { ...fullCapabilities, streaming: false, ...capabilities };
   }
 
   async completion(request: CompletionRequest): Promise<CompletionResponse> {
     this.requests.push(request);
     return {
-      choice: [AssistantContent.text("ok")],
+      choice: this.choice,
       usage: Usage.empty(),
       rawResponse: {},
     };
@@ -170,6 +177,182 @@ describe("completion model capabilities", () => {
       "This completion model does not support streaming",
     );
     expect(model.requests).toHaveLength(0);
+  });
+});
+
+describe("createCompletion", () => {
+  it("creates a non-streaming completion with ergonomic result fields", async () => {
+    const model = new QueueModel();
+    const response = await createCompletion(model, {
+      input: "hello",
+      instructions: "system",
+      documents: [{ id: "policy", text: "Policy text." }],
+      tools: [{ name: "lookup", description: "Lookup", parameters: { type: "object" } }],
+      temperature: 0.2,
+      maxTokens: 128,
+      toolChoice: "auto",
+      outputSchema: { type: "object" },
+      params: { reasoning: { effort: "low" } },
+    });
+
+    expect(response).toMatchObject({
+      text: "ok",
+      content: [AssistantContent.text("ok")],
+      usage: Usage.empty(),
+    });
+    expect(response.response).toBeDefined();
+    expect(model.requests).toEqual([
+      {
+        chatHistory: [Message.user("hello")],
+        instructions: "system",
+        documents: [{ id: "policy", text: "Policy text." }],
+        tools: [{ name: "lookup", description: "Lookup", parameters: { type: "object" } }],
+        temperature: 0.2,
+        maxTokens: 128,
+        toolChoice: "auto",
+        outputSchema: { type: "object" },
+        additionalParams: { reasoning: { effort: "low" } },
+      },
+    ]);
+  });
+
+  it("appends input after transcript messages", async () => {
+    const model = new QueueModel();
+    await createCompletion(model, {
+      messages: [Message.user("My project is named Anvia."), Message.assistant("Noted.")],
+      input: "What is my project named?",
+    });
+
+    expect(model.requests[0]?.chatHistory).toEqual([
+      Message.user("My project is named Anvia."),
+      Message.assistant("Noted."),
+      Message.user("What is my project named?"),
+    ]);
+  });
+
+  it("requires input or messages", async () => {
+    const model = new QueueModel();
+
+    await expect(createCompletion(model, {})).rejects.toThrow(
+      "createCompletion requires input or messages.",
+    );
+    expect(model.requests).toHaveLength(0);
+  });
+
+  it("streams completion events with createCompletionStream", async () => {
+    const model = new StreamingQueueModel();
+
+    const events = await collect(
+      createCompletionStream(model, {
+        input: "hello",
+      }),
+    );
+
+    expect(events).toEqual([
+      {
+        type: "final",
+        response: {
+          choice: [AssistantContent.text("ok")],
+          usage: Usage.empty(),
+          rawResponse: {},
+        },
+      },
+    ]);
+    expect(model.requests).toEqual([
+      {
+        chatHistory: [Message.user("hello")],
+        documents: [],
+        tools: [],
+      },
+    ]);
+  });
+
+  it("rejects unsupported streaming before model calls", async () => {
+    const model = new StreamingQueueModel({ streaming: false });
+
+    expect(() =>
+      createCompletionStream(model, {
+        input: "hello",
+      }),
+    ).toThrow("This completion model does not support streaming");
+    expect(model.requests).toHaveLength(0);
+  });
+
+  it("enforces capabilities before model calls", async () => {
+    const model = new QueueModel({ tools: false });
+
+    await expect(
+      createCompletion(model, {
+        input: "hello",
+        tools: [{ name: "lookup", description: "Lookup", parameters: { type: "object" } }],
+      }),
+    ).rejects.toThrow("test:test-model does not support tool definitions.");
+    expect(model.requests).toHaveLength(0);
+  });
+
+  it("creates a parsed completion with schema validation", async () => {
+    const schema = z.object({
+      title: z.string(),
+      priority: z.enum(["low", "medium", "high"]),
+    });
+    const model = new QueueModel({}, [
+      AssistantContent.text(JSON.stringify({ title: "Checkout failure", priority: "high" })),
+    ]);
+
+    const response = await createParsedCompletion(model, {
+      schema,
+      messages: [Message.system("Extract ticket fields.")],
+      input: "Acme has an urgent checkout failure.",
+      instructions: "Return only structured ticket data.",
+      params: { reasoning: { effort: "low" } },
+    });
+
+    expect(response.data).toEqual({ title: "Checkout failure", priority: "high" });
+    expect(response.text).toBe('{"title":"Checkout failure","priority":"high"}');
+    expect(model.requests).toEqual([
+      {
+        chatHistory: [
+          Message.system("Extract ticket fields."),
+          Message.user("Acme has an urgent checkout failure."),
+        ],
+        instructions: "Return only structured ticket data.",
+        documents: [],
+        tools: [],
+        outputSchema: {
+          type: "object",
+          properties: {
+            title: { type: "string" },
+            priority: { type: "string", enum: ["low", "medium", "high"] },
+          },
+          required: ["title", "priority"],
+          additionalProperties: false,
+        },
+        additionalParams: { reasoning: { effort: "low" } },
+      },
+    ]);
+  });
+
+  it("rejects parsed completion when output schemas are unsupported", async () => {
+    const model = new QueueModel({ outputSchema: false });
+
+    await expect(
+      createParsedCompletion(model, {
+        input: "hello",
+        schema: z.object({ title: z.string() }),
+      }),
+    ).rejects.toThrow("test:test-model does not support output schemas.");
+    expect(model.requests).toHaveLength(0);
+  });
+
+  it("rejects parsed completion when model text is invalid JSON", async () => {
+    const model = new QueueModel({}, [AssistantContent.text("not json")]);
+
+    await expect(
+      createParsedCompletion(model, {
+        input: "hello",
+        schema: z.object({ title: z.string() }),
+      }),
+    ).rejects.toThrow("createParsedCompletion expected the model response to be valid JSON.");
   });
 });
 

--- a/packages/core/test/public-exports.test.ts
+++ b/packages/core/test/public-exports.test.ts
@@ -47,6 +47,9 @@ describe("public exports", () => {
     expect(audioGeneration).toHaveProperty("AudioGenerationRequestBuilder");
     expect(audioGeneration).toHaveProperty("audioGenerationRequest");
     expect(completion).toHaveProperty("CompletionRequestBuilder");
+    expect(completion).toHaveProperty("createCompletion");
+    expect(completion).toHaveProperty("createParsedCompletion");
+    expect(completion).toHaveProperty("createCompletionStream");
     expect(completion).toHaveProperty("Message");
     expect(embeddings).toHaveProperty("embedText");
     expect(evals).toHaveProperty("runEvalSuite");
@@ -63,5 +66,11 @@ describe("public exports", () => {
     expect(tool).toHaveProperty("createTool");
     expect(transcription).toHaveProperty("TranscriptionRequestBuilder");
     expect(vectorStore).toHaveProperty("InMemoryVectorStore");
+  });
+
+  it("exposes createCompletion from the root entrypoint", () => {
+    expect("createCompletion" in publicCore).toBe(true);
+    expect("createParsedCompletion" in publicCore).toBe(true);
+    expect("createCompletionStream" in publicCore).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add explicit direct completion helpers: `createCompletion`, `createCompletionStream`, and `createParsedCompletion`
- export the new helpers and option/result types from root and completion entrypoints
- add Completions docs pages plus core reference coverage
- add a changeset for `@anvia/core`

## Verification
- `pnpm --filter @anvia/core test`
- `pnpm --filter @anvia/core typecheck`
- `pnpm --filter docs typecheck`