### PR TITLE
docs(providers): add Sumopod and Jatevo compatible gateways

### DIFF
--- a/apps/docs/content/docs/models/compatible-gateways/jatevo.mdx
+++ b/apps/docs/content/docs/models/compatible-gateways/jatevo.mdx
@@ -1,0 +1,77 @@
+---
+title: Jatevo
+description: Use Jatevo's OpenAI-compatible multi-model gateway with Anvia.
+---
+
+Jatevo exposes an OpenAI-compatible chat completions surface at `https://2.lb.jatevo.ai/v1`. In Anvia, configure `OpenAIClient` with that `baseUrl`, then pass Jatevo model ids to `completionModel(...)`. The gateway also exposes a `/v1/responses` endpoint for stateful sessions and a `/backend-api/codex` endpoint for Codex CLI compatibility.
+
+## Create the Client
+
+```ts
+import { AgentBuilder } from "@anvia/core";
+import { OpenAIClient } from "@anvia/openai";
+
+const client = new OpenAIClient({
+  baseUrl: "https://2.lb.jatevo.ai/v1",
+  apiKey: process.env.JATEVO_API_KEY,
+});
+
+const model = client.completionModel("auto");
+
+const agent = new AgentBuilder("support", model)
+  .instructions("Answer support questions clearly.")
+  .build();
+
+const response = await agent.prompt("Hello!").send();
+
+console.log(response.output);
+```
+
+`baseUrl` makes Anvia use the OpenAI-compatible chat completion adapter. The model id is the Jatevo id, not an Anvia-specific alias. Pass `"auto"` to let Jatevo route the request across its available models.
+
+## Get the Model List
+
+Jatevo exposes a `/v1/models` endpoint that returns the model ids available to your key. Because the client was created with `baseUrl`, `listModels()` calls Jatevo's `/models` endpoint. The list call is free and does not consume quota.
+
+```ts
+const models = await client.listModels();
+
+console.table(
+  models.data.map((model) => ({
+    id: model.id,
+    name: model.name,
+    contextLength: model.contextLength,
+  })),
+);
+```
+
+Use the `id` field directly with `completionModel(...)`.
+
+## Available Models
+
+Jatevo aggregates models from DeepSeek, Z.AI, NVIDIA, Moonshot, Alibaba, and Cerebras. Sample ids and pricing per 1M tokens:
+
+| Model | Provider | Input | Output |
+| --- | --- | --- | --- |
+| `auto` | Jatevo Router | — | — |
+| `deepseek-v4-pro` | DeepSeek | $1.74 | $3.48 |
+| `glm-5.1` | Z.AI | $1.40 | $4.40 |
+| `nvidia/nemotron-3-ultra-550b-a55b-nvfp4` | NVIDIA | $0.60 | $3.60 |
+| `kimi-k2.7-code` | Moonshot (Jatevo Inference) | $0.75 | $3.50 |
+| `qwen-3.7-max` | Alibaba Cloud | $1.25 | $3.75 |
+| `cerebras-fast-chat` | Cerebras | Low | Low |
+
+Prices shown above were captured on June 15, 2026. Discounts, regional pricing, and available models change frequently, so always confirm the latest rates on [jatevo.ai](https://jatevo.ai/pricing) before quoting or budgeting.
+
+The `auto` model id lets Jatevo's load balancer pick the best available route for the request. Some model routes are request-access only and may not be available to every key.
+
+## Notes
+
+- Jatevo API keys use the `sk-clb-…` prefix and are passed as bearer tokens in the `Authorization` header.
+- Jatevo enforces a daily request quota that resets at 00:00 UTC. Quota size scales with the wallet's `$JTVO` holdings.
+- The gateway host is currently `2.lb.jatevo.ai`. If it moves to `jatevo.ai`, only the `baseUrl` host needs to change.
+- A Codex CLI compatibility endpoint is exposed at `/backend-api/codex` for tools that expect that path.
+- Errors follow the standard OpenAI shape. Common status codes: `401` (invalid or missing key), `403` (key disabled), `429` (daily quota exhausted), `502`/`504` (upstream route unavailable, retry while Jatevo reroutes).
+- Model capabilities still depend on the upstream model. Test the specific model id for tool calling, structured output, streaming, and multimodal support before enabling those features.
+
+For current Jatevo API details, see the [Jatevo documentation](https://jatevo.ai/docs) and the [Jatevo model catalog](https://jatevo.ai/models).

--- a/apps/docs/content/docs/models/compatible-gateways/meta.json
+++ b/apps/docs/content/docs/models/compatible-gateways/meta.json
@@ -12,6 +12,7 @@
     "langdb-ai-gateway",
     "minimax",
     "moonshot-ai",
+    "sumopod",
     "novita-ai",
     "nvidia-nim",
     "ollama",

--- a/apps/docs/content/docs/models/compatible-gateways/meta.json
+++ b/apps/docs/content/docs/models/compatible-gateways/meta.json
@@ -12,6 +12,7 @@
     "langdb-ai-gateway",
     "minimax",
     "moonshot-ai",
+    "jatevo",
     "sumopod",
     "novita-ai",
     "nvidia-nim",

--- a/apps/docs/content/docs/models/compatible-gateways/sumopod.mdx
+++ b/apps/docs/content/docs/models/compatible-gateways/sumopod.mdx
@@ -1,0 +1,108 @@
+---
+title: Sumopod
+description: Use Sumopod's OpenAI-compatible multi-model gateway with Anvia.
+---
+
+Sumopod exposes an OpenAI-compatible chat completions endpoint at `https://ai.sumopod.com/v1`. In Anvia, configure `OpenAIClient` with that `baseUrl`, then pass Sumopod model ids to `completionModel(...)`.
+
+## Create the Client
+
+```ts
+import { AgentBuilder } from "@anvia/core";
+import { OpenAIClient } from "@anvia/openai";
+
+const client = new OpenAIClient({
+  baseUrl: "https://ai.sumopod.com/v1",
+  apiKey: process.env.SUMOPOD_API_KEY,
+});
+
+const model = client.completionModel("gpt-4o-mini");
+
+const agent = new AgentBuilder("support", model)
+  .instructions("Answer support questions clearly.")
+  .build();
+
+const response = await agent.prompt("Say hello in a creative way").send();
+
+console.log(response.output);
+```
+
+`baseUrl` makes Anvia use the OpenAI-compatible chat completion adapter. The model id is the Sumopod id, not an Anvia-specific alias.
+
+## Get the Model List
+
+Sumopod's models API returns the model ids and metadata you can use when choosing a model. Because the client was created with `baseUrl`, `listModels()` calls Sumopod's `/models` endpoint.
+
+```ts
+const models = await client.listModels();
+
+console.table(
+  models.data.map((model) => ({
+    id: model.id,
+    name: model.name,
+    contextLength: model.contextLength,
+  })),
+);
+```
+
+Use the `id` field directly with `completionModel(...)`.
+
+## Available Models
+
+Sumopod aggregates models from Anthropic, OpenAI, Google, DeepSeek, Alibaba, Z.AI, Moonshot, BytePlus, MiniMax, and Mimo. Sample ids and pricing per 1M tokens:
+
+| Model | Provider | Context | Input | Output |
+| --- | --- | --- | --- | --- |
+| `claude-haiku-4-5` | anthropic | 200,000 | $1.00 | $5.00 |
+| `claude-opus-4-7` | anthropic | 1,000,000 | $5.00 | $25.00 |
+| `claude-opus-4-8` | anthropic | 1,000,000 | $5.00 | $25.00 |
+| `claude-sonnet-4-6` | anthropic | 1,000,000 | $3.00 | $15.00 |
+| `deepseek-v4-flash` | deepseek | 1,000,000 | $0.14 | $0.28 |
+| `deepseek-v4-pro` | deepseek | 1,000,000 | $0.43 | $0.87 |
+| `gemini/gemini-2.5-flash` | gemini | 1,048,576 | $0.30 | $2.50 |
+| `gemini/gemini-2.5-flash-lite` | gemini | 1,048,576 | $0.10 | $0.40 |
+| `gemini/gemini-3-flash-preview` | gemini | 1,048,576 | $0.50 | $3.00 |
+| `gemini/gemini-3.1-flash-lite` | gemini | 1,048,576 | $0.25 | $1.50 |
+| `gemini/gemini-3.1-pro-preview` | gemini | 1,048,576 | $2.00 | $12.00 |
+| `gemini/gemini-3.5-flash` | gemini | 1,048,576 | $1.50 | $9.00 |
+| `glm-5` | z.ai | 128,000 | $0.60 | $2.00 |
+| `glm-5-turbo` | z.ai | 128,000 | $1.20 | $4.00 |
+| `glm-5.1` | z.ai | 200,000 | $1.40 | $4.40 |
+| `glm-5.2` | z.ai | 1,000,000 | $1.40 | $4.40 |
+| `gpt-4.1` | openai | 1,047,576 | $2.00 | $8.00 |
+| `gpt-4.1-mini` | openai | 1,047,576 | $0.40 | $1.60 |
+| `gpt-4.1-nano` | openai | 1,047,576 | $0.10 | $0.40 |
+| `gpt-5` | openai | 272,000 | $1.25 | $10.00 |
+| `gpt-5-mini` | openai | 272,000 | $0.25 | $2.00 |
+| `gpt-5-nano` | openai | 272,000 | $0.05 | $0.40 |
+| `gpt-5.4` | openai | 1,050,000 | $2.50 | $15.00 |
+| `gpt-5.4-mini` | openai | 272,000 | $0.75 | $4.50 |
+| `gpt-5.4-nano` | openai | 272,000 | $0.20 | $1.25 |
+| `kimi-k2.6` | moonshoot | 262,100 | $0.67 | $3.39 |
+| `kimi-k2.7` | moonshoot | 262,100 | $0.95 | $4.00 |
+| `mimo-v2.5` | mimo | 1,100,000 | $0.14 | $0.28 |
+| `mimo-v2.5-pro` | mimo | 1,100,000 | $0.43 | $0.87 |
+| `MiniMax-M2.7-highspeed` | sumopod | 204,800 | $0.03 | $0.12 |
+| `MiniMax-M3` | minimax | 1,000,000 | $0.30 | $1.20 |
+| `qwen3.6-flash` | alibaba | 1,000,000 | $0.25 | $1.50 |
+| `qwen3.6-plus` | alibaba | 1,000,000 | $0.50 | $3.00 |
+| `qwen3.7-max` | alibaba | 1,000,000 | $1.25 | $3.75 |
+| `qwen3.7-plus` | alibaba | 1,000,000 | $0.32 | $1.28 |
+| `seed-2-0-code` | byteplus | 256,000 | $0.50 | $3.00 |
+| `seed-2-0-lite` | byteplus | 224,000 | $0.25 | $2.00 |
+| `seed-2-0-mini` | byteplus | 224,000 | $0.10 | $0.40 |
+| `seed-2-0-pro` | byteplus | 256,000 | $0.50 | $3.00 |
+| `text-embedding-3-large` | openai | 8,191 | $0.13 | — |
+| `text-embedding-3-small` | openai | 8,191 | $0.02 | — |
+
+Prices shown above were captured on June 15, 2026. Discounts, regional pricing, and available models change frequently, so always confirm the latest rates on [sumopod.com](https://sumopod.com) before quoting or budgeting.
+
+Embedding models such as `text-embedding-3-small`, `text-embedding-3-large`, and `gemini/gemini-embedding-001` can be retrieved through `embeddingModel(...)` when the gateway exposes them.
+
+## Notes
+
+- Sumopod API keys are passed as bearer tokens in the `Authorization` header.
+- Model capabilities still depend on the upstream model. Test the specific model id for tool calling, structured output, streaming, and multimodal support before enabling those features.
+- Some models on Sumopod are sold at a discount off the upstream list price. The discount is applied by Sumopod, not by Anvia.
+
+For current Sumopod API details, see the [Sumopod documentation](https://sumopod.com).


### PR DESCRIPTION
## Summary

Adds two new OpenAI-compatible gateway pages under `apps/docs/content/docs/models/compatible-gateways/`:

- **Sumopod** (`sumopod.mdx`) — multi-model gateway aggregating Anthropic, OpenAI, Google, DeepSeek, Alibaba, Z.AI, Moonshot, BytePlus, MiniMax, and Mimo. Full model table with pricing snapshot.
- **Jatevo** (`jatevo.mdx`) — multi-model load balancer exposing `auto` routing, the 6 catalog routes (DeepSeek V4 Pro, GLM 5.1, NVIDIA Nemotron 3 Ultra, Kimi K2.7 Code, Qwen 3.7 Max, Cerebras Fast Chat), Codex CLI endpoint, daily quota reset, and `$JTVO` quota scaling.

Both pages follow the existing compatible-gateway pattern (`OpenAIClient` + `baseUrl`) and include a pricing-as-of disclaimer pointing back to each provider's pricing page.

## Files

- `apps/docs/content/docs/models/compatible-gateways/sumopod.mdx` (new)
- `apps/docs/content/docs/models/compatible-gateways/jatevo.mdx` (new)
- `apps/docs/content/docs/models/compatible-gateways/meta.json` (updated)

## Verification

- `pnpm dev` (apps/docs) — both pages return HTTP 200
- biome check — clean

Note: changelog files were left out of this PR because they are regenerated by `pnpm run changelog:generate` on dev start and are not part of the intended change.