### PR TITLE
Improve tool result message helpers

### DIFF
--- a/.changeset/tool-result-api-patch.md
+++ b/.changeset/tool-result-api-patch.md
@@ -1,0 +1,5 @@
+---
+"@anvia/core": patch
+---
+
+Add ergonomic tool result message helpers and export `ToolContent` from the root entrypoint.

--- a/apps/docs/content/docs/guides/sdk-fundamentals/messages-and-history.mdx
+++ b/apps/docs/content/docs/guides/sdk-fundamentals/messages-and-history.mdx
@@ -111,6 +111,12 @@ const historyWithToolCall: Message[] = [
 
 Only create tool-call history yourself when importing an existing transcript or replaying a known run. For live runs, persist `response.messages`.
 
+After manually executing a model-requested tool call, prefer the high-level helper:
+
+```ts
+messages.push(Message.toolResult(toolCall.id, result, { callId: toolCall.callId }));
+```
+
 ## Reasoning In History
 
 Assistant messages can include provider-returned reasoning content. The stable display field is `reasoning.text`; adapters may also include structured `content` blocks for text, summaries, encrypted state, and redacted state.

--- a/apps/docs/content/docs/guides/tools/tool-results.mdx
+++ b/apps/docs/content/docs/guides/tools/tool-results.mdx
@@ -68,6 +68,12 @@ During an agent run, tool results are appended as tool messages.
 
 You usually do not construct this message yourself. Store `response.messages` if you need conversation history.
 
+If you execute a model-requested tool call manually, create the result message with:
+
+```ts
+messages.push(Message.toolResult(toolCall.id, result, { callId: toolCall.callId }));
+```
+
 ## Display Values
 
 Return values should be useful to the model, not necessarily formatted for your UI.

--- a/apps/docs/content/docs/reference/core/completion.mdx
+++ b/apps/docs/content/docs/reference/core/completion.mdx
@@ -76,12 +76,13 @@ const Message: {
   user(content: string | UserContent[]): Message;
   assistant(content: string | AssistantContent[], id?: string): Message;
   tool(content: ToolContent | ToolContent[]): Message;
+  toolResult(id: string, output: unknown, options?: { callId?: string | undefined }): Message;
 };
 ```
 
 Purpose: normalized chat history and prompt shape.
 
-Return behavior: factory methods return message objects with normalized content arrays.
+Return behavior: factory methods return message objects with normalized content arrays. `Message.tool(...)` is the low-level factory for complete tool content. `Message.toolResult(...)` creates the common tool-role message after executing a model-requested tool call, serializing non-string output with JSON and preserving structured `ToolResultContent[]`.
 
 Notable errors: none directly.
 
@@ -117,6 +118,12 @@ const ToolContent: {
 Purpose: helper factories for user, assistant, and tool content.
 
 Return behavior: returns normalized content values.
+
+For normal manual tool execution, prefer:
+
+```ts
+messages.push(Message.toolResult(toolCall.id, result, { callId: toolCall.callId }));
+```
 
 `AssistantContent.reasoning(text, id?)` keeps the legacy shape. Provider adapters can populate `reasoning.content` with structured text, summary, encrypted, or redacted blocks; `reasoning.text` remains the display-safe text made from text and summary blocks.
 

--- a/examples/cli-agent/src/memory.ts
+++ b/examples/cli-agent/src/memory.ts
@@ -4,7 +4,6 @@ import {
   AssistantContent,
   type JsonValue,
   Message,
-  ToolContent,
 } from "@anvia/core/completion";
 import type { AssistantMessage, ChatMessage } from "./types.js";
 
@@ -47,7 +46,7 @@ function assistantHistory(message: AssistantMessage) {
 
     if (part.type === "tool_result") {
       flushAssistantContent();
-      history.push(Message.tool(ToolContent.toolResult(part.id, part.result, part.callId)));
+      history.push(Message.toolResult(part.id, part.result, { callId: part.callId }));
     }
   }
 

--- a/packages/core/src/completion/types.ts
+++ b/packages/core/src/completion/types.ts
@@ -200,6 +200,44 @@ export const ToolContent = {
   },
 };
 
+function serializeToolResultOutput(output: unknown): string {
+  if (typeof output === "string") {
+    return output;
+  }
+
+  try {
+    const serialized = JSON.stringify(output);
+    return serialized === undefined ? String(output) : serialized;
+  } catch {
+    return String(output);
+  }
+}
+
+function isToolResultContentArray(value: unknown): value is ToolResultContent[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every((item) => {
+      if (typeof item !== "object" || item === null || !("type" in item)) {
+        return false;
+      }
+      if (item.type === "text") {
+        return "text" in item && typeof item.text === "string";
+      }
+      if (item.type === "image") {
+        return (
+          "data" in item &&
+          typeof item.data === "string" &&
+          (!("mediaType" in item) ||
+            item.mediaType === undefined ||
+            typeof item.mediaType === "string")
+        );
+      }
+      return false;
+    })
+  );
+}
+
 export const AssistantContent = {
   text(text: string): Text {
     return { type: "text", text };
@@ -291,6 +329,10 @@ export const Message = {
       role: "tool",
       content: Array.isArray(content) ? content : [content],
     };
+  },
+  toolResult(id: string, output: unknown, options: { callId?: string | undefined } = {}): Message {
+    const content = isToolResultContentArray(output) ? output : serializeToolResultOutput(output);
+    return Message.tool(ToolContent.toolResult(id, content, options.callId));
   },
 };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,6 +45,7 @@ export {
   createCompletionStream,
   createParsedCompletion,
   Message,
+  ToolContent,
   Usage,
   UserContent,
 } from "./completion/index";

--- a/packages/core/test/message-content.test.ts
+++ b/packages/core/test/message-content.test.ts
@@ -79,4 +79,63 @@ describe("message attachment content", () => {
     });
     expect(reasoningDisplayText(reasoning)).toBe("Checked the plan.Visible thinking.");
   });
+
+  it("creates a tool result message from string output", () => {
+    expect(Message.toolResult("abc", "hello")).toEqual({
+      role: "tool",
+      content: [
+        {
+          type: "tool_result",
+          id: "abc",
+          content: [{ type: "text", text: "hello" }],
+        },
+      ],
+    });
+  });
+
+  it("creates a tool result message from JSON-serializable output with callId", () => {
+    expect(Message.toolResult("abc", { ok: true }, { callId: "call_123" })).toEqual({
+      role: "tool",
+      content: [
+        {
+          type: "tool_result",
+          id: "abc",
+          callId: "call_123",
+          content: [{ type: "text", text: '{"ok":true}' }],
+        },
+      ],
+    });
+  });
+
+  it("preserves structured tool result content", () => {
+    expect(Message.toolResult("abc", [{ type: "text", text: "hello" }])).toEqual({
+      role: "tool",
+      content: [
+        {
+          type: "tool_result",
+          id: "abc",
+          content: [{ type: "text", text: "hello" }],
+        },
+      ],
+    });
+  });
+
+  it("omits callId when no callId is provided", () => {
+    const message = Message.toolResult("abc", "hello");
+
+    expect(message.role).toBe("tool");
+    if (message.role !== "tool") {
+      throw new Error("Expected tool message");
+    }
+    expect(message).toMatchObject({
+      role: "tool",
+      content: [{ type: "tool_result", id: "abc" }],
+    });
+    const [toolResult] = message.content;
+    expect(toolResult).toBeDefined();
+    if (toolResult === undefined) {
+      throw new Error("Expected tool result content");
+    }
+    expect("callId" in toolResult).toBe(false);
+  });
 });

--- a/packages/core/test/public-exports.test.ts
+++ b/packages/core/test/public-exports.test.ts
@@ -6,7 +6,9 @@ import * as embeddings from "../src/embeddings";
 import * as evals from "../src/evals";
 import * as extractor from "../src/extractor";
 import * as imageGeneration from "../src/image-generation";
+import type { ToolContent as RootToolContentType } from "../src/index";
 import * as publicCore from "../src/index";
+import { Message as RootMessage, ToolContent as RootToolContent } from "../src/index";
 import * as internalAgent from "../src/internal/agent";
 import * as loaders from "../src/loaders";
 import * as mcp from "../src/mcp";
@@ -72,5 +74,22 @@ describe("public exports", () => {
     expect("createCompletion" in publicCore).toBe(true);
     expect("createParsedCompletion" in publicCore).toBe(true);
     expect("createCompletionStream" in publicCore).toBe(true);
+  });
+
+  it("exposes ToolContent from the root entrypoint", () => {
+    expect(publicCore).toHaveProperty("ToolContent");
+    const toolResult: RootToolContentType = RootToolContent.toolResult("abc", "hello", "call_123");
+
+    expect(RootMessage.tool(toolResult)).toMatchObject({
+      role: "tool",
+      content: [
+        {
+          type: "tool_result",
+          id: "abc",
+          callId: "call_123",
+          content: [{ type: "text", text: "hello" }],
+        },
+      ],
+    });
   });
 });

--- a/packages/providers/anthropic/package.json
+++ b/packages/providers/anthropic/package.json
@@ -26,10 +26,10 @@
     }
   },
   "scripts": {
-    "prebuild": "pnpm --filter @anvia/core build",
+    "prebuild": "test -f ../../core/dist/index.d.ts || pnpm --filter @anvia/core build",
     "build": "tsup src/index.ts --format esm --dts --sourcemap --clean",
     "test": "vitest run",
-    "pretypecheck": "pnpm --filter @anvia/core build",
+    "pretypecheck": "test -f ../../core/dist/index.d.ts || pnpm --filter @anvia/core build",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/providers/gemini/package.json
+++ b/packages/providers/gemini/package.json
@@ -26,10 +26,10 @@
     }
   },
   "scripts": {
-    "prebuild": "pnpm --filter @anvia/core build",
+    "prebuild": "test -f ../../core/dist/index.d.ts || pnpm --filter @anvia/core build",
     "build": "tsup src/index.ts --format esm --dts --sourcemap --clean",
     "test": "vitest run",
-    "pretypecheck": "pnpm --filter @anvia/core build",
+    "pretypecheck": "test -f ../../core/dist/index.d.ts || pnpm --filter @anvia/core build",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/providers/mistral/package.json
+++ b/packages/providers/mistral/package.json
@@ -26,10 +26,10 @@
     }
   },
   "scripts": {
-    "prebuild": "pnpm --filter @anvia/core build",
+    "prebuild": "test -f ../../core/dist/index.d.ts || pnpm --filter @anvia/core build",
     "build": "tsup src/index.ts --format esm --dts --sourcemap --clean",
     "test": "vitest run",
-    "pretypecheck": "pnpm --filter @anvia/core build",
+    "pretypecheck": "test -f ../../core/dist/index.d.ts || pnpm --filter @anvia/core build",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/providers/openai/package.json
+++ b/packages/providers/openai/package.json
@@ -26,9 +26,9 @@
     }
   },
   "scripts": {
-    "prebuild": "pnpm --filter @anvia/core build",
+    "prebuild": "test -f ../../core/dist/index.d.ts || pnpm --filter @anvia/core build",
     "build": "tsup src/index.ts --format esm --dts --sourcemap --clean",
-    "pretypecheck": "pnpm --filter @anvia/core build",
+    "pretypecheck": "test -f ../../core/dist/index.d.ts || pnpm --filter @anvia/core build",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/tools/sandbox/package.json
+++ b/packages/tools/sandbox/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "pnpm run build:deps && tsup src/index.ts --format esm --dts --sourcemap --clean",
-    "build:deps": "pnpm --filter @anvia/core build",
+    "build:deps": "test -f ../../core/dist/index.d.ts || pnpm --filter @anvia/core build",
     "test": "pnpm run build:deps && vitest run",
     "typecheck": "pnpm run build:deps && tsc --noEmit"
   },

--- a/packages/tools/studio/package.json
+++ b/packages/tools/studio/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "pnpm run build:deps && tsup && vite build --config vite.config.ts",
-    "build:deps": "pnpm --filter @anvia/core --filter @anvia/server --filter @anvia/react build",
+    "build:deps": "(test -f ../../core/dist/index.d.ts || pnpm --filter @anvia/core build) && pnpm --filter @anvia/server --filter @anvia/react build",
     "test": "pnpm run build:deps && vitest run",
     "typecheck": "pnpm run build:deps && tsc --noEmit"
   },


### PR DESCRIPTION
## Summary
- export ToolContent from the root @anvia/core entrypoint
- add Message.toolResult(...) for ergonomic tool-result message creation
- update tests, docs, and the CLI example to prefer the new helper

## Verification
- pnpm --filter @anvia/core test
- pnpm --filter @anvia/core typecheck
- pnpm exec biome check packages/core/src/completion/types.ts packages/core/src/index.ts packages/core/test/message-content.test.ts packages/core/test/public-exports.test.ts examples/cli-agent/src/memory.ts apps/docs/content/docs/guides/sdk-fundamentals/messages-and-history.mdx apps/docs/content/docs/reference/core/completion.mdx apps/docs/content/docs/guides/tools/tool-results.mdx