### PR TITLE
docs: add per-package guides with header navigation

### DIFF
--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -1,4 +1,13 @@
 {
   "title": "Anvia",
-  "pages": ["guides", "best-practices", "frameworks", "models", "studio", "reference", "changelog"]
+  "pages": [
+    "guides",
+    "packages",
+    "best-practices",
+    "frameworks",
+    "models",
+    "studio",
+    "reference",
+    "changelog"
+  ]
 }

--- a/apps/docs/content/docs/packages/anthropic.mdx
+++ b/apps/docs/content/docs/packages/anthropic.mdx
@@ -1,0 +1,141 @@
+---
+title: "@anvia/anthropic"
+description: Anthropic completion models for Anvia.
+---
+
+`@anvia/anthropic` adapts the Anthropic SDK into Anvia's completion model interface. It supports streaming, tool use, and the full Anthropic messages API.
+
+## Install
+
+```sh
+pnpm add @anvia/anthropic
+```
+
+The Anthropic SDK (`@anthropic-ai/sdk`) is a transitive dependency.
+
+## Quick Start
+
+```ts
+import { AgentBuilder } from "@anvia/core";
+import { AnthropicClient } from "@anvia/anthropic";
+
+const client = new AnthropicClient({ apiKey });
+const model = client.completionModel("claude-opus-4-6");
+
+const agent = new AgentBuilder("support", model)
+  .instructions("Answer clearly and concisely.")
+  .build();
+
+const response = await agent.prompt("Explain the agent runtime.").send();
+console.log(response.output);
+```
+
+## Client Configuration
+
+```ts
+type AnthropicClientOptions = {
+  apiKey?: string;     // required unless `client` is provided
+  baseUrl?: string;    // custom endpoint
+  client?: Anthropic;  // pre-configured Anthropic SDK instance
+};
+```
+
+Provider clients only use explicit constructor values. They do not read environment variables.
+
+```ts
+// Standard
+const client = new AnthropicClient({ apiKey });
+
+// Custom base URL (e.g., proxy)
+const client = new AnthropicClient({
+  apiKey,
+  baseUrl: "https://my-proxy.com",
+});
+
+// Pre-configured SDK instance
+const client = new AnthropicClient({ client: existingAnthropicInstance });
+```
+
+## Completion Models
+
+```ts
+// Default model: claude-sonnet-4-20250514
+const model = client.completionModel();
+
+// Specific model
+const model = client.completionModel("claude-opus-4-6");
+```
+
+The model implements `StreamingCompletionModel`:
+
+```ts
+// Non-streaming
+const response = await model.completion(request);
+
+// Streaming
+for await (const event of model.streamCompletion(request)) {
+  console.log(event);
+}
+```
+
+## Model Listing
+
+```ts
+const models = await client.listModels();
+console.log(models.data.map((m) => m.id));
+```
+
+Fetches available Anthropic models and returns a normalized `ModelList`.
+
+## Streaming with Agents
+
+Anthropic streaming works transparently with `AgentBuilder`:
+
+```ts
+const agent = new AgentBuilder("writer", model)
+  .instructions("Write concise technical summaries.")
+  .build();
+
+// Stream events
+for await (const event of agent.prompt("Summarize the runtime.").stream()) {
+  if (event.type === "text_delta") {
+    process.stdout.write(event.text);
+  }
+}
+```
+
+## Tool Use
+
+Anthropic models support tool use through the standard Anvia tool system:
+
+```ts
+import { createTool } from "@anvia/core";
+import { z } from "zod";
+
+const search = createTool({
+  name: "search_docs",
+  description: "Search documentation.",
+  input: z.object({ query: z.string() }),
+  output: z.object({ results: z.array(z.string()) }),
+  async execute({ query }) {
+    return { results: [`Result for: ${query}`] };
+  },
+});
+
+const agent = new AgentBuilder("support", model)
+  .tool(search)
+  .defaultMaxTurns(3)
+  .build();
+```
+
+## Error Handling
+
+- Constructor throws when neither `client` nor `apiKey` is supplied
+- `listModels()` throws `ModelListingError` when the provider request fails
+- Model operations throw Anthropic SDK errors directly
+
+## Related
+
+- [Models](/docs/models) for model name conventions
+- [Anthropic Reference](/docs/reference/providers/anthropic) for full API types
+- [Getting Started](/docs/guides/getting-started) for a first agent walkthrough

--- a/apps/docs/content/docs/packages/chroma.mdx
+++ b/apps/docs/content/docs/packages/chroma.mdx
@@ -1,0 +1,181 @@
+---
+title: "@anvia/chroma"
+description: ChromaDB vector store adapter for Anvia.
+---
+
+`@anvia/chroma` connects Anvia's vector store interface to ChromaDB. Use it to store, search, and retrieve embedded documents through a ChromaDB instance.
+
+## Install
+
+```sh
+pnpm add @anvia/chroma
+```
+
+The ChromaDB client (`chromadb`) is a transitive dependency. You need a running ChromaDB server or use the in-process mode.
+
+## Quick Start
+
+```ts
+import { ChromaVectorStore } from "@anvia/chroma";
+import { createFastEmbedEmbeddingModel } from "@anvia/fastembed";
+
+const model = await createFastEmbedEmbeddingModel();
+
+// Connect (creates collection if missing)
+const store = await ChromaVectorStore.connect({
+  collectionName: "documents",
+});
+
+// Upsert embedded documents
+await store.upsertDocuments([
+  {
+    id: "doc-1",
+    document: "Anvia is a TypeScript AI agent framework.",
+    embeddings: await model.embedTexts(["Anvia is a TypeScript AI agent framework."]),
+  },
+]);
+
+// Search
+const index = store.index(model);
+const results = await index.search({ query: "What is Anvia?", topK: 5 });
+console.log(results[0].document);
+```
+
+## Connection Options
+
+```ts
+type ChromaVectorStoreConnectOptions = {
+  client?: ChromaClientLike;           // pre-configured ChromaDB client
+  collectionName: string;              // required
+  createIfMissing?: boolean;           // default: true
+  metadata?: Record<string, unknown>;  // collection metadata (default: { "hnsw:space": "cosine" })
+  configuration?: Record<string, unknown>;  // ChromaDB collection configuration
+};
+```
+
+```ts
+// Default: creates collection if missing, cosine distance
+const store = await ChromaVectorStore.connect({ collectionName: "docs" });
+
+// Don't create if missing (throws if collection doesn't exist)
+const store = await ChromaVectorStore.connect({
+  collectionName: "docs",
+  createIfMissing: false,
+});
+
+// Custom distance metric
+const store = await ChromaVectorStore.connect({
+  collectionName: "docs",
+  metadata: { "hnsw:space": "l2" },
+});
+
+// Pre-configured client
+const store = await ChromaVectorStore.connect({
+  client: existingChromaClient,
+  collectionName: "docs",
+});
+```
+
+## Upserting Documents
+
+Documents use the `EmbeddedDocument` type from `@anvia/core/embeddings`:
+
+```ts
+await store.upsertDocuments([
+  {
+    id: "doc-1",
+    document: { title: "Getting Started", content: "..." },  // any JSON-serializable value
+    metadata: { category: "guide", version: 2 },
+    embeddings: await model.embedTexts(["Getting Started content..."]),
+  },
+]);
+```
+
+- `id` is the logical document ID
+- `document` is the stored content (string or JSON-serializable object)
+- `metadata` is optional filterable metadata
+- `embeddings` is an array of `Embedding` objects (one per chunk)
+- Documents with multiple embeddings get indexed as `doc-1#embedding:0`, `doc-1#embedding:1`, etc.
+
+## Searching
+
+```ts
+const index = store.index(model);
+
+// Basic search
+const results = await index.search({ query: "agent tools", topK: 5 });
+
+// With threshold
+const results = await index.search({
+  query: "agent tools",
+  topK: 10,
+  threshold: 0.7,  // minimum cosine similarity
+});
+
+// With metadata filter
+const results = await index.search({
+  query: "agent tools",
+  topK: 5,
+  filter: { type: "eq", key: "category", value: "guide" },
+});
+```
+
+## Metadata Filters
+
+```ts
+// Equality
+{ type: "eq", key: "category", value: "guide" }
+
+// Greater than / less than
+{ type: "gt", key: "version", value: 2 }
+{ type: "lt", key: "version", value: 5 }
+
+// Logical combinators
+{ type: "and", filters: [
+  { type: "eq", key: "category", value: "guide" },
+  { type: "gt", key: "version", value: 1 },
+]}
+
+{ type: "or", filters: [
+  { type: "eq", key: "category", value: "guide" },
+  { type: "eq", key: "category", value: "api" },
+]}
+```
+
+## Agent Tool
+
+Expose the vector index as an agent tool:
+
+```ts
+import { AgentBuilder } from "@anvia/core";
+
+const searchTool = index.asTool({
+  name: "search_docs",
+  description: "Search the documentation.",
+});
+
+const agent = new AgentBuilder("support", model)
+  .tool(searchTool)
+  .build();
+```
+
+## Distance Metrics
+
+| Metric | ChromaDB `metadata` value | Notes |
+| --- | --- | --- |
+| Cosine (default) | `"cosine"` | Best for text embeddings |
+| L2 (Euclidean) | `"l2"` | Geometric distance |
+| Inner product | `"ip"` | Dot product similarity |
+
+## Error Handling
+
+- `connect()` throws if ChromaDB is unreachable
+- `connect({ createIfMissing: false })` throws if the collection does not exist
+- `upsertDocuments()` throws if a document has zero embeddings
+- Metadata keys starting with `__anvia_` are reserved and rejected
+
+## Related
+
+- [Retrieval Guide](/docs/guides/retrieval) for RAG concepts
+- [Chroma Reference](/docs/reference/integrations/chroma) for full API types
+- [`@anvia/fastembed`](/docs/packages/fastembed) or [`@anvia/transformers`](/docs/packages/transformers) for local embeddings

--- a/apps/docs/content/docs/packages/core.mdx
+++ b/apps/docs/content/docs/packages/core.mdx
@@ -1,0 +1,122 @@
+---
+title: "@anvia/core"
+description: Provider-neutral runtime for agents, tools, messages, pipelines, and evals.
+---
+
+`@anvia/core` is the central package. Every other `@anvia/*` package depends on it. It provides the agent runtime, tool system, message types, pipeline execution, structured extraction, evals, vector store interfaces, memory, MCP adapters, and observability contracts.
+
+## Install
+
+```sh
+pnpm add @anvia/core
+```
+
+Pair it with a provider package to get a model:
+
+```sh
+pnpm add @anvia/openai
+```
+
+## Quick Start
+
+```ts
+import { AgentBuilder, createTool } from "@anvia/core";
+import { OpenAIClient } from "@anvia/openai";
+import { z } from "zod";
+
+const client = new OpenAIClient({ apiKey });
+const model = client.completionModel("gpt-5.5");
+
+const lookupOrder = createTool({
+  name: "lookup_order",
+  description: "Look up an order by id.",
+  input: z.object({ orderId: z.string() }),
+  output: z.object({ status: z.string() }),
+  async execute({ orderId }) {
+    return { status: orderId === "A-100" ? "shipped" : "unknown" };
+  },
+});
+
+const agent = new AgentBuilder("support", model)
+  .name("Support Agent")
+  .instructions("Answer support questions. Use tools when needed.")
+  .tool(lookupOrder)
+  .defaultMaxTurns(3)
+  .build();
+
+const response = await agent.prompt("Where is order A-100?").send();
+console.log(response.output);
+```
+
+## Root Exports
+
+The root import path covers the most common APIs:
+
+```ts
+import {
+  AgentBuilder,
+  createTool,
+  Message,
+  // ...and many more
+} from "@anvia/core";
+```
+
+Use the root import for small apps, examples, and prototyping.
+
+## Subpath Exports
+
+For larger codebases or narrower dependency boundaries, import from focused subpaths:
+
+| Subpath | Area |
+| --- | --- |
+| `@anvia/core/agent` | Agent builders, hooks, run controls, errors, run events |
+| `@anvia/core/completion` | Completion messages, requests, responses, usage, model contracts |
+| `@anvia/core/tool` | Tool definitions, registries, tool sets, serialization |
+| `@anvia/core/pipeline` | Typed pipelines and batch execution |
+| `@anvia/core/extractor` | Structured extraction builders |
+| `@anvia/core/evals` | Eval suites, metrics, agent targets, reporters |
+| `@anvia/core/embeddings` | Embedding models, documents, vector math |
+| `@anvia/core/vector-store` | In-memory vector store, filters, search tools |
+| `@anvia/core/memory` | Durable session memory interfaces |
+| `@anvia/core/mcp` | MCP connection helpers and normalized types |
+| `@anvia/core/observability` | Observer interfaces, trace options, score contracts |
+| `@anvia/core/skills` | Skill loading, discovery, validation |
+| `@anvia/core/streaming` | Async iterable to ReadableStream conversion |
+| `@anvia/core/loaders` | Node file and PDF loaders |
+| `@anvia/core/model-listing` | Provider-neutral model listing contracts |
+| `@anvia/core/image-generation` | Image generation contracts |
+| `@anvia/core/audio-generation` | Audio generation contracts |
+| `@anvia/core/transcription` | Audio transcription contracts |
+
+```ts
+import { AgentBuilder } from "@anvia/core/agent";
+import { createTool } from "@anvia/core/tool";
+import type { CompletionModel } from "@anvia/core/completion";
+```
+
+`@anvia/core/loaders` is intentionally subpath-only so that normal core imports do not pull in Node filesystem and PDF dependencies.
+
+## Key Concepts
+
+**AgentBuilder** is the primary entry point. It configures an agent with a model, instructions, tools, context, observers, and hooks, then `.build()` produces a reusable agent.
+
+**createTool** defines a tool with Zod-validated input and output schemas. Tools are pure TypeScript functions that the agent can call during a run.
+
+**Messages** are plain objects (`Message.user(...)`, `Message.assistant(...)`, `Message.tool(...)`). History is a `Message[]` array you store wherever your app persists conversations.
+
+**Observers** receive lifecycle events (run start/end, generation, tool calls) without changing runtime behavior. Attach them with `.observe(...)`.
+
+**Hooks** can cancel runs, approve tool calls, or transform requests and responses. Attach them with `.onRunStart(...)`, `.onToolCall(...)`, etc.
+
+## When to Use Subpaths
+
+Start with root imports while learning. Move to subpaths when:
+- You want explicit import boundaries between modules
+- Your bundler benefits from tree-shaking narrower entry points
+- You are building an integration package that only needs tool types, not the full agent runtime
+
+## Related
+
+- [Getting Started](/docs/guides/getting-started) for a step-by-step first agent
+- [SDK Fundamentals](/docs/guides/sdk-fundamentals/runtime-boundaries) for runtime architecture
+- [Core Reference](/docs/reference/core) for full API types

--- a/apps/docs/content/docs/packages/fastembed.mdx
+++ b/apps/docs/content/docs/packages/fastembed.mdx
@@ -1,0 +1,102 @@
+---
+title: "@anvia/fastembed"
+description: Local FastEmbed embedding models for Anvia.
+---
+
+`@anvia/fastembed` runs embedding models locally using ONNX runtime via the FastEmbed library. No API calls, no network latency, no per-token costs. Use it when you want embeddings computed entirely on your machine or CI server.
+
+## Install
+
+```sh
+pnpm add @anvia/fastembed
+```
+
+FastEmbed (`fastembed`) is a transitive dependency. Models are downloaded and cached on first use.
+
+## Quick Start
+
+```ts
+import { createFastEmbedEmbeddingModel } from "@anvia/fastembed";
+
+const model = await createFastEmbedEmbeddingModel();
+
+const embeddings = await model.embedTexts([
+  "Anvia is a TypeScript AI agent framework.",
+  "Agents can use tools and maintain conversation history.",
+]);
+
+console.log(embeddings[0].vector.length); // 384 (for BGESmallENV15)
+```
+
+The `create` call downloads and initializes the model on first run. Subsequent calls use the cached model.
+
+## Configuration
+
+```ts
+type FastEmbedEmbeddingModelOptions = {
+  model?: FastEmbedEmbeddingModelName;  // model name
+  maxBatchSize?: number;                // texts per batch (default: 256)
+  initOptions?: {
+    executionProviders?: ExecutionProvider[];  // ONNX runtime providers
+    maxLength?: number;                        // max token length
+    cacheDir?: string;                         // model cache directory
+    showDownloadProgress?: boolean;            // download progress bar
+    modelName?: string;                        // custom model name
+  };
+};
+```
+
+```ts
+// Custom model
+const model = await createFastEmbedEmbeddingModel({
+  model: "BAAI/bge-base-en-v1.5",
+  maxBatchSize: 128,
+});
+
+// Custom cache directory
+const model = await createFastEmbedEmbeddingModel({
+  initOptions: { cacheDir: "./models", showDownloadProgress: true },
+});
+```
+
+## Available Models
+
+The default model is `BAAI/bge-small-en-v1.5` (384 dimensions, fast).
+
+Other options depend on the FastEmbed version. Check the FastEmbed documentation for the full list of supported models.
+
+## When to Use Local Embeddings
+
+| Scenario | Recommendation |
+| --- | --- |
+| Development and testing | FastEmbed (no API key needed) |
+| CI/CD pipelines | FastEmbed (no network dependency) |
+| Privacy-sensitive data | FastEmbed (data stays local) |
+| High throughput production | Provider embeddings (dedicated infrastructure) |
+| Large model quality | Provider embeddings (bigger models available) |
+
+## Using with Vector Stores
+
+```ts
+import { createFastEmbedEmbeddingModel } from "@anvia/fastembed";
+import { ChromaVectorStore } from "@anvia/chroma";
+
+const model = await createFastEmbedEmbeddingModel();
+const store = await ChromaVectorStore.connect({ collectionName: "docs" });
+
+// Create an index for searching
+const index = store.index(model);
+const results = await index.search({ query: "How do agents work?", topK: 5 });
+```
+
+## Error Handling
+
+- Throws if the model download fails (network issues on first run)
+- Throws if the embedding count does not match the input text count
+- Throws on invalid batch format from the FastEmbed runtime
+
+## Related
+
+- [Embeddings Guide](/docs/guides/retrieval) for embedding concepts
+- [FastEmbed Reference](/docs/reference/integrations/fastembed) for full API types
+- [`@anvia/transformers`](/docs/packages/transformers) for an alternative local embedding package

--- a/apps/docs/content/docs/packages/gemini.mdx
+++ b/apps/docs/content/docs/packages/gemini.mdx
@@ -1,0 +1,159 @@
+---
+title: "@anvia/gemini"
+description: Gemini completion, embedding, image, and transcription models.
+---
+
+`@anvia/gemini` adapts the Google GenAI SDK into Anvia's provider-neutral interfaces. It supports completions, embeddings, image generation (both native and Imagen), and transcription.
+
+## Install
+
+```sh
+pnpm add @anvia/gemini
+```
+
+The Google GenAI SDK (`@google/genai`) is a transitive dependency.
+
+## Quick Start
+
+```ts
+import { AgentBuilder } from "@anvia/core";
+import { GeminiClient } from "@anvia/gemini";
+
+const client = new GeminiClient({ apiKey });
+const model = client.completionModel("gemini-2.5-flash");
+
+const agent = new AgentBuilder("support", model)
+  .instructions("Answer clearly.")
+  .build();
+
+const response = await agent.prompt("What is Anvia?").send();
+console.log(response.output);
+```
+
+## Client Configuration
+
+```ts
+// Google AI API
+const client = new GeminiClient({ apiKey });
+
+// Vertex AI
+const client = new GeminiClient({
+  vertexai: true,
+  project: "my-gcp-project",
+  location: "us-central1",
+});
+
+// Pre-configured SDK instance
+const client = new GeminiClient({ client: existingGoogleGenAIInstance });
+```
+
+| Option | Purpose |
+| --- | --- |
+| `apiKey` | Google AI API key (required for Google AI) |
+| `vertexai` | Set to `true` for Vertex AI |
+| `project` | GCP project ID (required for Vertex AI) |
+| `location` | GCP region (required for Vertex AI) |
+| `client` | Pre-configured `GoogleGenAI` instance |
+
+Provider clients only use explicit constructor values. They do not read environment variables.
+
+## Completion Models
+
+```ts
+// Default: gemini-2.5-flash
+const model = client.completionModel();
+
+// Specific model
+const model = client.completionModel("gemini-3-pro");
+```
+
+Supports streaming and non-streaming through the standard `StreamingCompletionModel` interface.
+
+## Embedding Models
+
+```ts
+const embeddingModel = client.embeddingModel("gemini-embedding-001");
+
+const embeddings = await embeddingModel.embedTexts(["hello", "world"]);
+```
+
+| Option | Default | Purpose |
+| --- | -- | --- |
+| `taskType` | -- | Embedding task type (e.g., `"RETRIEVAL_QUERY"`, `"RETRIEVAL_DOCUMENT"`) |
+| `maxBatchSize` | model default | Texts per API call |
+
+### Task Types
+
+```ts
+type GeminiEmbeddingTaskType =
+  | "RETRIEVAL_QUERY"
+  | "RETRIEVAL_DOCUMENT"
+  | "SEMANTIC_SIMILARITY"
+  | "CLASSIFICATION"
+  | "CLUSTERING"
+  | "QUESTION_ANSWERING"
+  | "FACT_VERIFICATION";
+```
+
+## Image Generation
+
+### Native Gemini Image Generation
+
+```ts
+const imageModel = client.imageGenerationModel("gemini-2.5-flash-preview-image");
+
+const result = await imageModel.generate({
+  prompt: "A diagram of an agent runtime",
+});
+
+// result.images[0] is Uint8Array (PNG)
+```
+
+Model constants: `GEMINI_2_5_FLASH_IMAGE`, `GEMINI_3_PRO_IMAGE_PREVIEW`.
+
+### Imagen Generation
+
+```ts
+const imagenModel = client.imagenGenerationModel("imagen-4-generate");
+
+const result = await imagenModel.generate({
+  prompt: "A watercolor painting of a mountain",
+});
+```
+
+Model constant: `IMAGEN_4_GENERATE`.
+
+## Transcription
+
+```ts
+const transcriptionModel = client.transcriptionModel("gemini-2.5-flash");
+
+const result = await transcriptionModel.transcribe({
+  audio: audioBuffer,
+});
+
+console.log(result.text);
+```
+
+Uses Gemini's multimodal input to process audio.
+
+## Model Listing
+
+```ts
+const models = await client.listModels();
+console.log(models.data.map((m) => m.id));
+```
+
+Fetches available Gemini models and returns a normalized `ModelList`.
+
+## Error Handling
+
+- Constructor throws when required credentials are missing
+- `listModels()` throws `ModelListingError` when the provider request fails
+- Model operations throw Google GenAI SDK errors directly
+
+## Related
+
+- [Models](/docs/models) for model name conventions
+- [Gemini Reference](/docs/reference/providers/gemini) for full API types
+- [Getting Started](/docs/guides/getting-started) for a first agent walkthrough

--- a/apps/docs/content/docs/packages/index.mdx
+++ b/apps/docs/content/docs/packages/index.mdx
@@ -1,0 +1,53 @@
+---
+title: Package Guides
+description: Install, configure, and use every Anvia package.
+---
+
+Each guide covers one `@anvia/*` package end to end: installation, configuration, core usage, working examples, and API highlights. For full type signatures, follow the link to the corresponding reference page.
+
+## Standalone
+
+| Package | Purpose |
+| --- | --- |
+| [`@anvia/core`](/docs/packages/core) | Provider-neutral runtime: agents, tools, messages, pipelines, evals |
+| [`@anvia/react`](/docs/packages/react) | React hooks and client transports |
+| [`@anvia/server`](/docs/packages/server) | Server-side event stream helpers |
+| [`@anvia/logger`](/docs/packages/logger) | Structured logging adapters |
+
+## Providers
+
+| Package | Purpose |
+| --- | --- |
+| [`@anvia/openai`](/docs/packages/openai) | OpenAI completion, embedding, image, audio, and transcription models |
+| [`@anvia/anthropic`](/docs/packages/anthropic) | Anthropic completion models |
+| [`@anvia/gemini`](/docs/packages/gemini) | Gemini completion, embedding, image, and transcription models |
+| [`@anvia/mistral`](/docs/packages/mistral) | Mistral completion and embedding models |
+
+## Embeddings
+
+| Package | Purpose |
+| --- | --- |
+| [`@anvia/fastembed`](/docs/packages/fastembed) | Local FastEmbed embedding models |
+| [`@anvia/transformers`](/docs/packages/transformers) | Local Transformers.js embedding models |
+
+## Vector Stores
+
+| Package | Purpose |
+| --- | --- |
+| [`@anvia/chroma`](/docs/packages/chroma) | ChromaDB vector store adapter |
+| [`@anvia/pgvector`](/docs/packages/pgvector) | Postgres pgvector vector store adapter |
+| [`@anvia/qdrant`](/docs/packages/qdrant) | Qdrant vector store adapter |
+
+## Observability
+
+| Package | Purpose |
+| --- | --- |
+| [`@anvia/langfuse`](/docs/packages/langfuse) | Langfuse tracing and scoring |
+| [`@anvia/otel`](/docs/packages/otel) | OpenTelemetry tracing |
+
+## Tools
+
+| Package | Purpose |
+| --- | --- |
+| [`@anvia/sandbox`](/docs/packages/sandbox) | Docker-backed sandbox sessions |
+| [`@anvia/studio`](/docs/packages/studio) | Studio UI and HTTP runtime |

--- a/apps/docs/content/docs/packages/langfuse.mdx
+++ b/apps/docs/content/docs/packages/langfuse.mdx
@@ -1,0 +1,150 @@
+---
+title: "@anvia/langfuse"
+description: Langfuse tracing and scoring for Anvia agents.
+---
+
+`@anvia/langfuse` sends agent lifecycle events (runs, generations, tool calls, usage, errors) to Langfuse. It also supports scoring traces and reporting eval outcomes.
+
+## Install
+
+```sh
+pnpm add @anvia/langfuse
+```
+
+The package uses OpenTelemetry under the hood via `@langfuse/otel` and `@opentelemetry/sdk-node`.
+
+## Quick Start
+
+```ts
+import { AgentBuilder } from "@anvia/core";
+import { OpenAIClient } from "@anvia/openai";
+import { langfuse } from "@anvia/langfuse";
+
+const tracing = langfuse.create({
+  publicKey,
+  secretKey,
+  baseUrl,       // optional, defaults to https://cloud.langfuse.com
+  environment,   // optional
+  release,       // optional
+});
+
+const client = new OpenAIClient({ apiKey });
+const agent = new AgentBuilder("support", client.completionModel())
+  .instructions("Answer support questions.")
+  .observe(tracing)
+  .build();
+
+const response = await agent
+  .prompt("How do I reset my password?")
+  .withTrace({
+    name: "support-question",
+    userId: "user_123",
+    sessionId: "session_456",
+    metadata: { surface: "docs" },
+    tags: ["support"],
+  })
+  .send();
+```
+
+Every run, model generation, tool call, usage metric, and error is now visible in Langfuse.
+
+## Configuration
+
+```ts
+type LangfuseTracingOptions = {
+  publicKey?: string;    // Langfuse public key
+  secretKey?: string;    // Langfuse secret key
+  baseUrl?: string;      // Langfuse API URL (default: https://cloud.langfuse.com)
+  environment?: string;  // deployment environment label
+  release?: string;      // application release version
+};
+```
+
+## Trace Metadata
+
+Attach metadata to individual requests using `.withTrace(...)`:
+
+```ts
+const response = await agent
+  .prompt("Summarize ticket TICKET-1001.")
+  .withTrace({
+    name: "support-ticket-summary",
+    userId: "user_123",
+    sessionId: "session_456",
+    metadata: { ticketId: "TICKET-1001" },
+    tags: ["support", "anvia"],
+    version: "1.0.0",
+  })
+  .send();
+
+console.log(response.trace?.traceId);
+```
+
+The `traceId` and `observationId` are available on `response.trace` after the run completes.
+
+## Scoring Traces
+
+```ts
+await tracing.score({
+  traceId: response.trace?.traceId,
+  name: "quality",
+  value: 1,
+  comment: "Good answer",
+  metadata: { source: "human-review" },
+});
+```
+
+Scoring requires `publicKey`, `secretKey`, and a trace ID.
+
+## Eval Reporting
+
+Use `createLangfuseEvalReporter(...)` to publish eval outcomes as Langfuse scores:
+
+```ts
+import { agentEvalTarget, contains, runEvalSuite } from "@anvia/core/evals";
+import { createLangfuseEvalReporter } from "@anvia/langfuse";
+
+await runEvalSuite({
+  name: "support-agent-regression",
+  cases: [
+    { id: "refund-window", input: "How long are refunds available?", expected: "30 days" },
+  ],
+  target: agentEvalTarget(agent),
+  metrics: [contains()],
+  reporters: [createLangfuseEvalReporter(tracing)],
+});
+```
+
+The reporter uses the prompt response trace when available. You can also attach `traceId` and `observationId` to eval case metadata.
+
+## Lifecycle Events
+
+The observer captures:
+
+| Event | Data |
+| --- | --- |
+| Run start | agent name, prompt, history, max turns, trace metadata |
+| Generation start/end | turn number, model, tools, input/output, usage, latency |
+| Tool start/end | tool name, arguments, result, skipped status |
+| Run end | output, total usage, all messages |
+| Run error | error message, partial usage |
+
+## Flushing and Shutdown
+
+```ts
+await tracing.flush();
+await tracing.shutdown();
+```
+
+Use `flush()` after short-lived jobs (scripts, CI). Use `shutdown()` when the process is exiting. The OpenTelemetry SDK handles batching automatically for long-running servers.
+
+## Multi-Agent Tracing
+
+When an agent uses another agent as a tool, the observer creates nested traces automatically. Child agent runs appear as sub-spans under the parent tool call.
+
+## Related
+
+- [Langfuse Guide](/docs/guides/observability/langfuse) for setup walkthrough
+- [Observers](/docs/guides/observability/observers) for the observer pattern
+- [Langfuse Reference](/docs/reference/integrations/langfuse) for full API types
+- [`@anvia/otel`](/docs/packages/otel) for raw OpenTelemetry tracing

--- a/apps/docs/content/docs/packages/logger.mdx
+++ b/apps/docs/content/docs/packages/logger.mdx
@@ -1,0 +1,145 @@
+---
+title: "@anvia/logger"
+description: Structured logging adapters for Anvia agent events.
+---
+
+`@anvia/logger` provides console and Pino-based loggers, plus a logger observer that writes agent lifecycle events (runs, generations, tool calls) to your application logs.
+
+## Install
+
+```sh
+pnpm add @anvia/logger
+```
+
+Pino is included as a dependency. No additional installs needed.
+
+## Quick Start
+
+```ts
+import { AgentBuilder } from "@anvia/core";
+import { OpenAIClient } from "@anvia/openai";
+import { createLoggerObserver, createPinoLogger } from "@anvia/logger";
+
+const logger = createPinoLogger({ name: "my-app", level: "info" });
+
+const client = new OpenAIClient({ apiKey });
+const agent = new AgentBuilder("support", client.completionModel())
+  .instructions("Answer support questions.")
+  .observe(createLoggerObserver(logger))
+  .build();
+
+const response = await agent.prompt("How do I reset my password?").send();
+```
+
+Every agent run now produces structured log lines for run start/end, model generations, tool calls, and errors.
+
+## Loggers
+
+### createPinoLogger
+
+Production logger backed by Pino. Outputs structured JSON.
+
+```ts
+import { createPinoLogger } from "@anvia/logger";
+
+const logger = createPinoLogger({
+  name: "my-app",
+  level: "info",
+  bindings: { env: "production" },
+  pinoOptions: { /* pass-through to Pino */ },
+  destination: /* custom Pino destination stream */,
+});
+```
+
+| Option | Default | Purpose |
+| --- | -- | --- |
+| `name` | -- | Logger name field in every log line |
+| `level` | auto | `"trace"` through `"silent"`. Defaults to `ANVIA_LOG_LEVEL`, `LOG_LEVEL`, or `"info"` |
+| `bindings` | `{}` | Default structured fields on every log line |
+| `pinoOptions` | `{}` | Raw Pino options pass-through |
+| `destination` | stdout | Custom Pino destination stream |
+
+### createConsoleLogger
+
+Lightweight JSON logger for development. No Pino dependency at runtime.
+
+```ts
+import { createConsoleLogger } from "@anvia/logger";
+
+const logger = createConsoleLogger({
+  name: "my-app",
+  level: "debug",
+  writer: (line) => console.log(line),  // custom output
+  timestamp: () => new Date(),           // custom timestamps
+});
+```
+
+### Logger Interface
+
+Both loggers implement the same `Logger` interface:
+
+```ts
+interface Logger {
+  trace(message: string, context?: Record<string, unknown>): void;
+  debug(message: string, context?: Record<string, unknown>): void;
+  info(message: string, context?: Record<string, unknown>): void;
+  warn(message: string, context?: Record<string, unknown>): void;
+  error(message: string, context?: Record<string, unknown>): void;
+  fatal(message: string, context?: Record<string, unknown>): void;
+  child(bindings: Record<string, unknown>): Logger;
+}
+```
+
+Use `.child(...)` to add scoped fields (e.g., request ID, user ID) to a subset of logs.
+
+## Logger Observer
+
+`createLoggerObserver` adapts any `Logger` into an agent observer:
+
+```ts
+import { createLoggerObserver } from "@anvia/logger";
+
+const observer = createLoggerObserver(logger, {
+  includeOutput: false,      // log final agent output (default: false)
+  includeRequest: false,     // log full model requests (default: false)
+  includeResponse: false,    // log full model responses (default: false)
+  includeToolResult: false,  // log tool results (default: false)
+});
+```
+
+By default, the observer omits potentially sensitive payloads (final output, full model requests/responses, tool results). Enable these flags when your data policy allows logging those details.
+
+Attach the observer to multiple agents:
+
+```ts
+const agent1 = new AgentBuilder("support", model).observe(observer).build();
+const agent2 = new AgentBuilder("sales", model).observe(observer).build();
+```
+
+## Log Levels
+
+| Level | Use for |
+| --- | --- |
+| `trace` | Extremely verbose internal details |
+| `debug` | Development diagnostics |
+| `info` | Normal operational events (default) |
+| `warn` | Unexpected but recoverable situations |
+| `error` | Failures that need attention |
+| `fatal` | Process-ending failures |
+| `silent` | Disable logging |
+
+## When to Use Which Logger
+
+| Scenario | Logger |
+| --- | --- |
+| Production with log aggregation | `createPinoLogger` |
+| Local development | `createConsoleLogger` |
+| Testing | `createConsoleLogger` with custom `writer` |
+| Custom logging system | Implement the `Logger` interface directly |
+
+## Related
+
+- [Logging Guide](/docs/guides/observability/logging) for logging concepts
+- [Observers](/docs/guides/observability/observers) for the observer pattern
+- [Logger Reference](/docs/reference/integrations/logger) for full API types
+- [`@anvia/langfuse`](/docs/packages/langfuse) and [`@anvia/otel`](/docs/packages/otel) for tracing alternatives

--- a/apps/docs/content/docs/packages/meta.json
+++ b/apps/docs/content/docs/packages/meta.json
@@ -1,0 +1,32 @@
+{
+  "title": "Packages",
+  "description": "Per-package guides",
+  "icon": "Package",
+  "root": true,
+  "pages": [
+    "index",
+    "---Standalone---",
+    "core",
+    "react",
+    "server",
+    "logger",
+    "---Providers---",
+    "openai",
+    "anthropic",
+    "gemini",
+    "mistral",
+    "---Embeddings---",
+    "fastembed",
+    "transformers",
+    "---Vector Stores---",
+    "chroma",
+    "pgvector",
+    "qdrant",
+    "---Observability---",
+    "langfuse",
+    "otel",
+    "---Tools---",
+    "sandbox",
+    "studio"
+  ]
+}

--- a/apps/docs/content/docs/packages/mistral.mdx
+++ b/apps/docs/content/docs/packages/mistral.mdx
@@ -1,0 +1,140 @@
+---
+title: "@anvia/mistral"
+description: Mistral completion and embedding models.
+---
+
+`@anvia/mistral` adapts the Mistral SDK into Anvia's provider-neutral interfaces. It supports completions (streaming and non-streaming) and embeddings.
+
+## Install
+
+```sh
+pnpm add @anvia/mistral
+```
+
+The Mistral SDK (`@mistralai/mistralai`) is a transitive dependency.
+
+## Quick Start
+
+```ts
+import { AgentBuilder } from "@anvia/core";
+import { MistralClient } from "@anvia/mistral";
+
+const client = new MistralClient({ apiKey });
+const model = client.completionModel("mistral-large-latest");
+
+const agent = new AgentBuilder("support", model)
+  .instructions("Answer clearly.")
+  .build();
+
+const response = await agent.prompt("What is Anvia?").send();
+console.log(response.output);
+```
+
+## Client Configuration
+
+```ts
+type MistralClientOptions = {
+  apiKey?: string;        // required unless `client` is provided
+  serverURL?: string;     // custom endpoint
+  client?: Mistral;       // pre-configured Mistral SDK instance
+};
+```
+
+Provider clients only use explicit constructor values. They do not read environment variables.
+
+```ts
+// Standard
+const client = new MistralClient({ apiKey });
+
+// Custom endpoint
+const client = new MistralClient({
+  apiKey,
+  serverURL: "https://my-proxy.com",
+});
+
+// Pre-configured SDK instance
+const client = new MistralClient({ client: existingMistralInstance });
+```
+
+## Completion Models
+
+```ts
+// Default: mistral-large-latest
+const model = client.completionModel();
+
+// Specific model
+const model = client.completionModel("mistral-small-latest");
+```
+
+Supports streaming and non-streaming through the standard `StreamingCompletionModel` interface.
+
+### Streaming with Agents
+
+```ts
+const agent = new AgentBuilder("writer", model)
+  .instructions("Write concise summaries.")
+  .build();
+
+for await (const event of agent.prompt("Summarize this topic.").stream()) {
+  if (event.type === "text_delta") {
+    process.stdout.write(event.text);
+  }
+}
+```
+
+## Embedding Models
+
+```ts
+const embeddingModel = client.embeddingModel("mistral-embed");
+
+const embeddings = await embeddingModel.embedTexts(["hello", "world"]);
+```
+
+| Option | Default | Purpose |
+| --- | -- | --- |
+| `maxBatchSize` | `512` | Texts per API call |
+
+## Tool Use
+
+Mistral models support tool use through the standard Anvia tool system:
+
+```ts
+import { createTool } from "@anvia/core";
+import { z } from "zod";
+
+const search = createTool({
+  name: "search_docs",
+  description: "Search documentation.",
+  input: z.object({ query: z.string() }),
+  output: z.object({ results: z.array(z.string()) }),
+  async execute({ query }) {
+    return { results: [`Result for: ${query}`] };
+  },
+});
+
+const agent = new AgentBuilder("support", model)
+  .tool(search)
+  .defaultMaxTurns(3)
+  .build();
+```
+
+## Model Listing
+
+```ts
+const models = await client.listModels();
+console.log(models.data.map((m) => m.id));
+```
+
+Fetches available Mistral models and returns a normalized `ModelList`.
+
+## Error Handling
+
+- Constructor throws when neither `client` nor `apiKey` is supplied
+- `listModels()` throws `ModelListingError` when the provider request fails
+- Model operations throw Mistral SDK errors directly
+
+## Related
+
+- [Models](/docs/models) for model name conventions
+- [Mistral Reference](/docs/reference/providers/mistral) for full API types
+- [Getting Started](/docs/guides/getting-started) for a first agent walkthrough

--- a/apps/docs/content/docs/packages/openai.mdx
+++ b/apps/docs/content/docs/packages/openai.mdx
@@ -1,0 +1,195 @@
+---
+title: "@anvia/openai"
+description: OpenAI completion, embedding, image, audio, and transcription models.
+---
+
+`@anvia/openai` adapts the OpenAI SDK into Anvia's provider-neutral interfaces. It supports the Responses API (default), Chat Completions API, embeddings, image generation, audio generation, and transcription.
+
+## Install
+
+```sh
+pnpm add @anvia/openai
+```
+
+The OpenAI SDK (`openai`) is a transitive dependency.
+
+## Quick Start
+
+```ts
+import { AgentBuilder } from "@anvia/core";
+import { OpenAIClient } from "@anvia/openai";
+
+const client = new OpenAIClient({ apiKey });
+const model = client.completionModel("gpt-5.5");
+
+const agent = new AgentBuilder("support", model)
+  .instructions("Answer clearly.")
+  .build();
+
+const response = await agent.prompt("What is Anvia?").send();
+console.log(response.output);
+```
+
+## Client Configuration
+
+```ts
+type OpenAIClientOptions = {
+  apiKey?: string;         // required unless `client` is provided
+  baseUrl?: string;        // custom endpoint (OpenAI-compatible proxies)
+  headers?: Record<string, string>;
+  completionApi?: "responses" | "chat";  // default: "responses"
+  client?: OpenAI;         // pre-configured OpenAI SDK instance
+};
+```
+
+Provider clients only use explicit constructor values. They do not read environment variables.
+
+```ts
+// Standard OpenAI
+const client = new OpenAIClient({ apiKey });
+
+// OpenAI-compatible proxy
+const client = new OpenAIClient({
+  baseUrl: "https://my-proxy.com/v1",
+  apiKey,
+});
+
+// Chat Completions API instead of Responses
+const client = new OpenAIClient({
+  apiKey,
+  completionApi: "chat",
+});
+
+// Pre-configured SDK instance
+const client = new OpenAIClient({ client: existingOpenAIInstance });
+```
+
+## Completion Models
+
+### Responses API (default)
+
+```ts
+const model = client.completionModel("gpt-5.5");
+```
+
+Returns an `OpenAIResponsesCompletionModel` that uses the Responses API.
+
+### Chat Completions API
+
+```ts
+const client = new OpenAIClient({ apiKey, completionApi: "chat" });
+const model = client.completionModel("gpt-5.5");
+```
+
+Returns an `OpenAIChatCompletionModel`. Also used automatically when `baseUrl` is set (for OpenAI-compatible proxies that only support chat completions).
+
+### Streaming and Non-Streaming
+
+Both models support:
+
+```ts
+// Non-streaming
+const response = await model.completion(request);
+
+// Streaming
+for await (const event of model.streamCompletion(request)) {
+  console.log(event);
+}
+```
+
+## Embedding Models
+
+```ts
+const embeddingModel = client.embeddingModel("text-embedding-3-small");
+
+// With options
+const embeddingModel = client.embeddingModel("text-embedding-3-large", {
+  dimensions: 1024,
+  maxBatchSize: 512,
+});
+
+const embeddings = await embeddingModel.embedTexts(["hello", "world"]);
+```
+
+| Option | Default | Purpose |
+| --- | -- | --- |
+| `dimensions` | model default | Output embedding dimensions |
+| `maxBatchSize` | `512` | Texts per API call |
+| `user` | -- | End-user identifier for abuse monitoring |
+
+## Image Generation
+
+```ts
+const imageModel = client.imageGenerationModel("gpt-image-1");
+
+const result = await imageModel.generate({
+  prompt: "A diagram of an agent runtime",
+});
+
+// result.images[0] is Uint8Array (PNG)
+```
+
+Model constants: `GPT_IMAGE_1`, `GPT_IMAGE_2`, `DALL_E_2`, `DALL_E_3`.
+
+## Audio Generation (Text-to-Speech)
+
+```ts
+const audioModel = client.audioGenerationModel("tts-1");
+
+const result = await audioModel.generate({
+  text: "Welcome to Anvia.",
+});
+
+// result.audio is Uint8Array
+```
+
+Model constants: `TTS_1`, `TTS_1_HD`.
+
+## Transcription
+
+```ts
+const transcriptionModel = client.transcriptionModel("whisper-1");
+
+const result = await transcriptionModel.transcribe({
+  audio: audioBuffer,
+});
+
+console.log(result.text);
+```
+
+Model constant: `WHISPER_1`.
+
+## Model Listing
+
+```ts
+const models = await client.listModels();
+console.log(models.data.map((m) => m.id));
+```
+
+Fetches the configured `/models` endpoint and returns a normalized `ModelList`.
+
+## Namespaced Exports
+
+All classes are also available under an `openai` namespace:
+
+```ts
+import { openai } from "@anvia/openai";
+
+openai.OpenAIClient;
+openai.OpenAIEmbeddingModel;
+openai.OpenAIImageGenerationModel;
+// etc.
+```
+
+## Error Handling
+
+- Constructor throws when neither `client` nor `apiKey` is supplied
+- `listModels()` throws `ModelListingError` when the provider request fails
+- Model operations throw OpenAI SDK errors directly
+
+## Related
+
+- [Models](/docs/models) for model name conventions
+- [Compatible Gateways](/docs/models/compatible-gateways) for OpenAI-compatible endpoints
+- [OpenAI Reference](/docs/reference/providers/openai) for full API types
+- [Getting Started](/docs/guides/getting-started) for a first agent walkthrough

--- a/apps/docs/content/docs/packages/otel.mdx
+++ b/apps/docs/content/docs/packages/otel.mdx
@@ -1,0 +1,170 @@
+---
+title: "@anvia/otel"
+description: OpenTelemetry tracing for Anvia agents.
+---
+
+`@anvia/otel` sends agent lifecycle events to any OpenTelemetry-compatible backend (Jaeger, Zipkin, Grafana Tempo, Datadog, etc.). Use it when you want full control over your tracing pipeline.
+
+## Install
+
+```sh
+pnpm add @anvia/otel
+```
+
+`@opentelemetry/api` is a transitive dependency. You need to configure an OpenTelemetry exporter separately.
+
+## Quick Start
+
+```ts
+import { AgentBuilder } from "@anvia/core";
+import { OpenAIClient } from "@anvia/openai";
+import { otel } from "@anvia/otel";
+
+const tracing = otel.create({
+  tracerName: "my-app",
+  serviceName: "support-service",
+});
+
+const client = new OpenAIClient({ apiKey });
+const agent = new AgentBuilder("support", client.completionModel())
+  .instructions("Answer support questions.")
+  .observe(tracing)
+  .build();
+
+const response = await agent
+  .prompt("How do I reset my password?")
+  .withTrace({
+    name: "support-question",
+    userId: "user_123",
+    sessionId: "session_456",
+  })
+  .send();
+```
+
+## Configuration
+
+```ts
+type OtelTracingOptions = {
+  tracer?: Tracer;       // pre-configured OpenTelemetry Tracer
+  tracerName?: string;   // tracer name (default: "@anvia/otel")
+  tracerVersion?: string; // tracer version
+  serviceName?: string;  // service.name resource attribute
+};
+```
+
+```ts
+// Minimal
+const tracing = otel.create();
+
+// With service name
+const tracing = otel.create({
+  tracerName: "my-app",
+  serviceName: "support-service",
+});
+
+// Pre-configured tracer
+import { trace } from "@opentelemetry/api";
+const tracing = otel.create({
+  tracer: trace.getTracer("my-app"),
+});
+```
+
+## Setting Up an Exporter
+
+`@anvia/otel` creates spans but does not configure an exporter. You need to set up the OpenTelemetry SDK exporter in your application:
+
+```ts
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+
+const sdk = new NodeSDK({
+  traceExporter: new OTLPTraceExporter({
+    url: "http://localhost:4318/v1/traces",
+  }),
+});
+
+sdk.start();
+```
+
+Or use environment variables:
+
+```sh
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+OTEL_SERVICE_NAME=my-app
+```
+
+## Span Structure
+
+Each agent run produces this span tree:
+
+```
+agent.{name}                          (root span)
+  ├── model.turn.0                    (generation span)
+  ├── tool.{tool_name}                (tool span)
+  │     ├── {child_agent}.run         (child agent span, if applicable)
+  │     │     ├── {child}.model.turn.0
+  │     │     └── {child}.{tool}
+  │     └── {child}.{tool_name}       (child tool span)
+  └── model.turn.1                    (final generation)
+```
+
+## Span Attributes
+
+The observer sets these attributes on spans:
+
+### Run spans (`agent.*`)
+- `anvia.agent.name`, `anvia.agent.description`, `anvia.agent.instructions`
+- `anvia.run.max_turns`, `anvia.run.prompt`, `anvia.run.history`
+- `anvia.run.output`, `anvia.run.messages`
+- `anvia.trace.name`, `anvia.trace.user_id`, `anvia.trace.session_id`, `anvia.trace.tags`
+- `anvia.usage.input_tokens`, `anvia.usage.output_tokens`, `anvia.usage.total_tokens`
+
+### Generation spans (`model.turn.*`)
+- `anvia.generation.turn`, `anvia.generation.model`
+- `anvia.generation.input`, `anvia.generation.output`, `anvia.generation.output_text`
+- `anvia.generation.tool_count`, `anvia.generation.has_output_schema`
+- `anvia.generation.temperature`, `anvia.generation.max_tokens`, `anvia.generation.tool_choice`
+- `anvia.generation.first_delta_ms`
+- `anvia.usage.*` (per-generation usage)
+
+### Tool spans (`tool.*`)
+- `anvia.tool.name`, `anvia.tool.turn`, `anvia.tool.args`, `anvia.tool.result`
+- `anvia.tool.call`, `anvia.tool.call_id`, `anvia.tool.internal_call_id`
+- `anvia.tool.skipped`
+
+## Parent Trace Linking
+
+If a `traceId` is provided via `.withTrace(...)`, the observer creates a remote parent context so the agent run span links to an existing trace. This is useful when the agent is called from within a larger distributed trace.
+
+## Child Agent Tracing
+
+When an agent uses another agent as a tool, the observer creates nested spans under the tool span. Child agent events (generations, tool calls) are automatically captured as sub-spans.
+
+## Error Handling
+
+Observer failures are swallowed by default so tracing does not break application behavior. Use strict mode in tests:
+
+```ts
+const agent = new AgentBuilder("support", model)
+  .observe(tracing, { failOnObserverError: true })
+  .build();
+```
+
+## Langfuse vs OTEL
+
+| Aspect | `@anvia/langfuse` | `@anvia/otel` |
+| --- | --- | --- |
+| Backend | Langfuse only | Any OTEL-compatible backend |
+| Setup | One-line `langfuse.create(...)` | Requires OTEL SDK + exporter config |
+| Scoring | Built-in `tracing.score(...)` | Use your backend's scoring API |
+| Eval reporting | Built-in `createLangfuseEvalReporter` | Custom reporter needed |
+| UI | Langfuse dashboard | Your chosen backend's UI |
+
+Use `@anvia/langfuse` for a batteries-included experience. Use `@anvia/otel` when you already have an OpenTelemetry pipeline or need vendor flexibility.
+
+## Related
+
+- [OTEL Guide](/docs/guides/observability/otel) for setup walkthrough
+- [Observers](/docs/guides/observability/observers) for the observer pattern
+- [OTEL Reference](/docs/reference/integrations/otel) for full API types
+- [`@anvia/langfuse`](/docs/packages/langfuse) for the Langfuse-specific adapter

--- a/apps/docs/content/docs/packages/pgvector.mdx
+++ b/apps/docs/content/docs/packages/pgvector.mdx
@@ -1,0 +1,199 @@
+---
+title: "@anvia/pgvector"
+description: Postgres pgvector vector store adapter for Anvia.
+---
+
+`@anvia/pgvector` connects Anvia's vector store interface to PostgreSQL with the pgvector extension. Use it when you already have Postgres and want to add vector search without a separate database.
+
+## Install
+
+```sh
+pnpm add @anvia/pgvector
+```
+
+The `pg` and `pgvector` packages are transitive dependencies. Your Postgres instance must have the `vector` extension available.
+
+## Quick Start
+
+```ts
+import { PgVectorStore } from "@anvia/pgvector";
+import { createFastEmbedEmbeddingModel } from "@anvia/fastembed";
+
+const model = await createFastEmbedEmbeddingModel();
+
+// Connect (creates table and extension if missing)
+const store = await PgVectorStore.connect({
+  connectionString: "postgresql://user:pass@localhost:5432/mydb",
+  tableName: "documents",
+  vectorSize: 384,  // must match your embedding model's dimensions
+});
+
+// Upsert embedded documents
+await store.upsertDocuments([
+  {
+    id: "doc-1",
+    document: "Anvia is a TypeScript AI agent framework.",
+    embeddings: await model.embedTexts(["Anvia is a TypeScript AI agent framework."]),
+  },
+]);
+
+// Search
+const index = store.index(model);
+const results = await index.search({ query: "What is Anvia?", topK: 5 });
+console.log(results[0].document);
+```
+
+## Connection Options
+
+```ts
+type PgVectorStoreConnectOptions = {
+  client?: PgClientLike;      // pre-configured pg client (Pool, Client, etc.)
+  connectionString?: string;   // Postgres connection string
+  tableName: string;           // required
+  vectorSize: number;          // required: embedding dimensions
+  createIfMissing?: boolean;   // default: true
+  distance?: PgVectorDistance; // default: "cosine"
+};
+```
+
+```ts
+// With connection string
+const store = await PgVectorStore.connect({
+  connectionString: "postgresql://user:pass@localhost:5432/mydb",
+  tableName: "documents",
+  vectorSize: 384,
+});
+
+// With existing pg client
+import pg from "pg";
+const pool = new pg.Pool({ connectionString: "..." });
+
+const store = await PgVectorStore.connect({
+  client: pool,
+  tableName: "documents",
+  vectorSize: 384,
+});
+
+// Schema-qualified table name
+const store = await PgVectorStore.connect({
+  connectionString: "...",
+  tableName: "public.documents",
+  vectorSize: 384,
+});
+```
+
+When `createIfMissing` is `true` (default), the adapter:
+1. Runs `CREATE EXTENSION IF NOT EXISTS vector`
+2. Creates the table with the correct schema if it does not exist
+3. Validates that the existing table's vector dimension matches `vectorSize`
+
+## Table Schema
+
+The auto-created table has this structure:
+
+```sql
+CREATE TABLE IF NOT EXISTS "documents" (
+  id text PRIMARY KEY,
+  document_id text NOT NULL,
+  document jsonb NOT NULL,
+  metadata jsonb,
+  embedding vector(384) NOT NULL
+)
+```
+
+- `id` is a deterministic hash of the logical document ID
+- `document_id` is the original document ID
+- `document` is the JSON-serialized document content
+- `metadata` is optional JSONB metadata
+- `embedding` is the pgvector column
+
+## Upserting Documents
+
+```ts
+await store.upsertDocuments([
+  {
+    id: "doc-1",
+    document: { title: "Getting Started", content: "..." },
+    metadata: { category: "guide", version: 2 },
+    embeddings: await model.embedTexts(["Getting Started content..."]),
+  },
+]);
+```
+
+Uses `INSERT ... ON CONFLICT ... DO UPDATE` so documents are upserted atomically.
+
+## Searching
+
+```ts
+const index = store.index(model);
+
+// Basic search
+const results = await index.search({ query: "agent tools", topK: 5 });
+
+// With threshold
+const results = await index.search({
+  query: "agent tools",
+  topK: 10,
+  threshold: 0.7,
+});
+
+// With metadata filter
+const results = await index.search({
+  query: "agent tools",
+  topK: 5,
+  filter: { type: "eq", key: "category", value: "guide" },
+});
+```
+
+## Metadata Filters
+
+```ts
+// Equality
+{ type: "eq", key: "category", value: "guide" }
+
+// Greater than / less than (numeric values only)
+{ type: "gt", key: "version", value: 2 }
+{ type: "lt", key: "version", value: 5 }
+
+// Logical combinators
+{ type: "and", filters: [...] }
+{ type: "or", filters: [...] }
+```
+
+Filters are translated to Postgres JSONB queries on the `metadata` column. The `gt` and `lt` filters cast the metadata value to numeric, so they require numeric metadata values.
+
+## Distance Metrics
+
+| Metric | Value | SQL Operator |
+| --- | --- | --- |
+| Cosine (default) | `"cosine"` | `<=>` |
+| L2 (Euclidean) | `"l2"` | `<->` |
+| Inner product | `"innerProduct"` | `<#>` |
+
+## Agent Tool
+
+Expose the vector index as an agent tool:
+
+```ts
+const searchTool = index.asTool({
+  name: "search_docs",
+  description: "Search the documentation.",
+});
+
+const agent = new AgentBuilder("support", model)
+  .tool(searchTool)
+  .build();
+```
+
+## Error Handling
+
+- `connect()` throws if Postgres is unreachable or the `vector` extension is unavailable
+- `connect()` throws if the table exists but the vector dimension does not match `vectorSize`
+- `upsertDocuments()` throws if a document has zero embeddings
+- Metadata keys starting with `__anvia_` are reserved and rejected
+
+## Related
+
+- [Retrieval Guide](/docs/guides/retrieval) for RAG concepts
+- [pgvector Reference](/docs/reference/integrations/pgvector) for full API types
+- [`@anvia/fastembed`](/docs/packages/fastembed) for local embeddings

--- a/apps/docs/content/docs/packages/qdrant.mdx
+++ b/apps/docs/content/docs/packages/qdrant.mdx
@@ -1,0 +1,179 @@
+---
+title: "@anvia/qdrant"
+description: Qdrant vector store adapter for Anvia.
+---
+
+`@anvia/qdrant` connects Anvia's vector store interface to Qdrant. Use it for high-performance vector search with Qdrant's filtering and payload features.
+
+## Install
+
+```sh
+pnpm add @anvia/qdrant
+```
+
+The Qdrant client (`@qdrant/js-client-rest`) is a transitive dependency. You need a running Qdrant instance.
+
+## Quick Start
+
+```ts
+import { QdrantVectorStore } from "@anvia/qdrant";
+import { createFastEmbedEmbeddingModel } from "@anvia/fastembed";
+
+const model = await createFastEmbedEmbeddingModel();
+
+// Connect (creates collection if missing)
+const store = await QdrantVectorStore.connect({
+  collectionName: "documents",
+  vectorSize: 384,  // must match your embedding model's dimensions
+});
+
+// Upsert embedded documents
+await store.upsertDocuments([
+  {
+    id: "doc-1",
+    document: "Anvia is a TypeScript AI agent framework.",
+    embeddings: await model.embedTexts(["Anvia is a TypeScript AI agent framework."]),
+  },
+]);
+
+// Search
+const index = store.index(model);
+const results = await index.search({ query: "What is Anvia?", topK: 5 });
+console.log(results[0].document);
+```
+
+## Connection Options
+
+```ts
+type QdrantVectorStoreConnectOptions = {
+  client?: QdrantClientLike;   // pre-configured Qdrant client
+  collectionName: string;      // required
+  vectorSize: number;          // required: embedding dimensions
+  createIfMissing?: boolean;   // default: true
+  distance?: QdrantDistance;   // default: "Cosine"
+};
+```
+
+```ts
+// Default: creates collection if missing, cosine distance
+const store = await QdrantVectorStore.connect({
+  collectionName: "docs",
+  vectorSize: 384,
+});
+
+// Don't create if missing
+const store = await QdrantVectorStore.connect({
+  collectionName: "docs",
+  vectorSize: 384,
+  createIfMissing: false,
+});
+
+// Custom distance metric
+const store = await QdrantVectorStore.connect({
+  collectionName: "docs",
+  vectorSize: 384,
+  distance: "Euclid",
+});
+
+// Pre-configured client
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const store = await QdrantVectorStore.connect({
+  client: new QdrantClient({ url: "http://localhost:6333" }),
+  collectionName: "docs",
+  vectorSize: 384,
+});
+```
+
+## Upserting Documents
+
+```ts
+await store.upsertDocuments([
+  {
+    id: "doc-1",
+    document: { title: "Getting Started", content: "..." },
+    metadata: { category: "guide", version: 2 },
+    embeddings: await model.embedTexts(["Getting Started content..."]),
+  },
+]);
+```
+
+- Documents are stored as Qdrant points with the document content and metadata in the payload
+- Documents with multiple embeddings get indexed as `doc-1#embedding:0`, `doc-1#embedding:1`, etc.
+- Point IDs are deterministic SHA-256 hashes of the document ID
+
+## Searching
+
+```ts
+const index = store.index(model);
+
+// Basic search
+const results = await index.search({ query: "agent tools", topK: 5 });
+
+// With threshold
+const results = await index.search({
+  query: "agent tools",
+  topK: 10,
+  threshold: 0.7,
+});
+
+// With metadata filter
+const results = await index.search({
+  query: "agent tools",
+  topK: 5,
+  filter: { type: "eq", key: "category", value: "guide" },
+});
+```
+
+## Metadata Filters
+
+```ts
+// Equality
+{ type: "eq", key: "category", value: "guide" }
+
+// Range (numeric values)
+{ type: "gt", key: "version", value: 2 }
+{ type: "lt", key: "version", value: 5 }
+
+// Logical combinators
+{ type: "and", filters: [...] }
+{ type: "or", filters: [...] }
+```
+
+Filters are translated to Qdrant's native filter format (`must`, `should`).
+
+## Distance Metrics
+
+| Metric | Qdrant value | Notes |
+| --- | --- | --- |
+| Cosine (default) | `"Cosine"` | Best for text embeddings |
+| Euclid | `"Euclid"` | L2 distance |
+| Dot | `"Dot"` | Dot product similarity |
+
+## Agent Tool
+
+Expose the vector index as an agent tool:
+
+```ts
+const searchTool = index.asTool({
+  name: "search_docs",
+  description: "Search the documentation.",
+});
+
+const agent = new AgentBuilder("support", model)
+  .tool(searchTool)
+  .build();
+```
+
+## Error Handling
+
+- `connect()` throws if Qdrant is unreachable
+- `connect({ createIfMissing: false })` throws if the collection does not exist
+- `upsertDocuments()` throws if a document has zero embeddings
+- Metadata keys starting with `__anvia_` are reserved and rejected
+
+## Related
+
+- [Retrieval Guide](/docs/guides/retrieval) for RAG concepts
+- [Qdrant Reference](/docs/reference/integrations/qdrant) for full API types
+- [`@anvia/fastembed`](/docs/packages/fastembed) for local embeddings

--- a/apps/docs/content/docs/packages/react.mdx
+++ b/apps/docs/content/docs/packages/react.mdx
@@ -1,0 +1,156 @@
+---
+title: "@anvia/react"
+description: React hooks and client transports for Anvia chat applications.
+---
+
+`@anvia/react` provides `useChat`, transport abstractions, and stream parsers for building chat UIs that connect to an Anvia server endpoint.
+
+## Install
+
+```sh
+pnpm add @anvia/react
+```
+
+Peer dependency: `react >= 18`.
+
+## Quick Start
+
+```tsx
+import { useChat } from "@anvia/react";
+
+export function Chat() {
+  const chat = useChat({ endpoint: "/api/chat" });
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        void chat.send();
+      }}
+    >
+      <div>{chat.text}</div>
+      <input
+        value={chat.input}
+        onChange={(event) => chat.setInput(event.target.value)}
+      />
+      <button disabled={chat.status === "streaming"}>Send</button>
+    </form>
+  );
+}
+```
+
+This connects to a server route that returns a JSONL or SSE event stream (see [`@anvia/server`](/docs/packages/server)).
+
+## Configuration
+
+`useChat` accepts these options:
+
+| Option | Type | Default | Purpose |
+| --- | --- | --- | --- |
+| `endpoint` | `string \| URL` | -- | URL for the default fetch transport |
+| `transport` | `EventTransport` | -- | Custom transport (overrides `endpoint`) |
+| `format` | `"jsonl" \| "sse"` | `"jsonl"` | Stream format for the default transport |
+| `initialMessages` | `ChatMessage[]` | `[]` | Pre-populated message history |
+| `createRequest` | function | -- | Custom request builder |
+| `eventToDelta` | function | -- | Extract text delta from an event |
+| `eventToFinal` | function | -- | Extract final text from an event |
+| `onEvent` | function | -- | Callback for each streamed event |
+| `onError` | function | -- | Error callback |
+
+## useChat Return Value
+
+```ts
+type UseChatResult<TEvent, TMessage> = {
+  messages: TMessage[];       // conversation history
+  events: TEvent[];           // raw streamed events
+  input: string;              // current input value
+  setInput(input: string): void;
+  send(input?: string): Promise<void>;
+  stop(): void;               // abort the current stream
+  reset(messages?: TMessage[]): void;
+  status: "idle" | "streaming" | "error";
+  error: unknown;
+  text: string;               // accumulated assistant text
+};
+```
+
+## Transports
+
+The transport layer is the boundary between your UI and the network. The default fetch transport works for most cases.
+
+```ts
+import { createFetchTransport, createChatTransport } from "@anvia/react";
+
+// Generic fetch transport
+const transport = createFetchTransport({
+  endpoint: "/api/chat",
+  format: "jsonl",
+});
+
+// Chat-specific transport (POST JSON by default)
+const transport = createChatTransport({
+  endpoint: "/api/chat",
+  format: "sse",
+});
+```
+
+Pass a custom `transport` to `useChat` when you need WebSocket, local, or other non-HTTP transports.
+
+## Stream Parsers
+
+Use these directly when you need raw stream access without `useChat`:
+
+```ts
+import { readJsonlStream, readSseStream, fetchEventStream } from "@anvia/react";
+
+// Parse a ReadableStream as JSONL
+for await (const event of readJsonlStream(stream)) {
+  console.log(event);
+}
+
+// Fetch and parse a stream in one call
+for await (const event of fetchEventStream("/api/chat", {
+  method: "POST",
+  body: JSON.stringify({ message: "Hello" }),
+  format: "jsonl",
+})) {
+  console.log(event);
+}
+```
+
+## EventTransport Interface
+
+All transports implement this interface:
+
+```ts
+type EventTransport<TRequest, TEvent> = {
+  send(request: TRequest, options?: TransportOptions): AsyncIterable<TEvent>;
+};
+```
+
+This makes `useChat` transport-agnostic: swap JSONL for SSE, HTTP for WebSocket, or a mock for testing without changing the hook.
+
+## Server Pairing
+
+Pair `@anvia/react` with `@anvia/server` on the backend:
+
+```ts
+// Server (Next.js, Hono, Express, etc.)
+import { createEventStream } from "@anvia/server";
+
+return createEventStream(agent.prompt(message).stream(), {
+  format: "jsonl",
+});
+```
+
+```tsx
+// Client
+const chat = useChat({ endpoint: "/api/chat", format: "jsonl" });
+```
+
+## Related
+
+- [Client Transports](/docs/guides/streaming/client-transports) for transport concepts
+- [Readable Streams](/docs/guides/streaming/readable-streams) for stream internals
+- [React Reference](/docs/reference/react) for full API types
+- [`@anvia/server`](/docs/packages/server) for the server-side counterpart

--- a/apps/docs/content/docs/packages/sandbox.mdx
+++ b/apps/docs/content/docs/packages/sandbox.mdx
@@ -1,0 +1,211 @@
+---
+title: "@anvia/sandbox"
+description: Docker-backed sandbox sessions for running untrusted code.
+---
+
+`@anvia/sandbox` provides ephemeral Docker containers for running model-generated or untrusted code outside the host process. It also exposes sandbox operations as agent tools.
+
+## Install
+
+```sh
+pnpm add @anvia/sandbox
+```
+
+Docker must be installed and running on the host machine.
+
+## Quick Start
+
+```ts
+import { DockerSandbox } from "@anvia/sandbox";
+
+const sandbox = new DockerSandbox();
+const session = await sandbox.createSession();
+
+// Run a command
+const result = await session.exec({ command: "node", args: ["-e", "console.log(42)"] });
+console.log(result.stdout); // "42\n"
+
+// Clean up
+await session.destroy();
+```
+
+## Sandbox Configuration
+
+```ts
+type DockerSandboxOptions = {
+  image?: string;          // Docker image (default: "node:22-bookworm")
+  pull?: "missing" | "always" | "never";  // pull policy (default: "missing")
+  workdir?: string;        // workspace directory (default: "/workspace")
+  network?: boolean | "none" | "host" | string;  // network mode (default: false/none)
+  user?: string;           // container user
+  dockerPath?: string;     // path to docker CLI
+  labels?: Record<string, string>;  // Docker container labels
+  limits?: SandboxLimits;  // resource limits
+  security?: DockerSandboxSecurityOptions;
+};
+```
+
+```ts
+// Custom image and limits
+const sandbox = new DockerSandbox({
+  image: "python:3.12-slim",
+  limits: { timeoutMs: 30_000, memoryMb: 512, cpus: 1 },
+});
+
+// Network access enabled
+const sandbox = new DockerSandbox({
+  network: "host",
+});
+```
+
+### Security Defaults
+
+By default, sandboxes run with:
+- Network access disabled
+- `noNewPrivileges` enabled
+- All Linux capabilities dropped (`dropCapabilities: ["ALL"]`)
+
+Override with the `security` option:
+
+```ts
+const sandbox = new DockerSandbox({
+  security: {
+    readonlyRootfs: false,      // allow writes to root filesystem
+    noNewPrivileges: true,
+    dropCapabilities: ["ALL"],
+  },
+});
+```
+
+## Sessions
+
+Each session creates one Docker container and one Docker volume mounted at the workdir.
+
+### Creating Sessions
+
+```ts
+const session = await sandbox.createSession({
+  id: "my-session",           // optional custom ID
+  metadata: { userId: "123" }, // optional metadata
+  manifest: {
+    files: {
+      "main.ts": 'console.log("hello")',
+      "data.json": '{"key": "value"}',
+    },
+    directories: ["src", "tests"],
+    env: { API_KEY: "secret" },
+  },
+});
+```
+
+The manifest seeds the workspace with files and directories before any commands run.
+
+### Executing Commands
+
+```ts
+const result = await session.exec({
+  command: "node",
+  args: ["main.ts"],
+  cwd: "src",                   // working directory (relative to workdir)
+  env: { DEBUG: "true" },       // additional environment variables
+  timeoutMs: 10_000,            // per-command timeout
+  input: "stdin data",          // stdin input
+  signal: abortController.signal,  // abort signal
+  onStdout: (chunk) => {},      // streaming stdout callback
+  onStderr: (chunk) => {},      // streaming stderr callback
+});
+
+console.log(result.stdout);
+console.log(result.stderr);
+console.log(result.exitCode);
+console.log(result.durationMs);
+console.log(result.timedOut);
+```
+
+### File Operations
+
+```ts
+// Write files
+await session.writeTextFile("output.txt", "Hello, world!");
+await session.writeFile("binary.bin", uint8Array);
+
+// Read files
+const content = await session.readTextFile("output.txt");
+const bytes = await session.readFile("binary.bin");
+
+// List files
+const files = await session.listFiles("src");
+// [{ path: "src/index.ts", type: "file", size: 1234 }]
+```
+
+### Cleanup
+
+```ts
+await session.destroy();
+```
+
+This removes both the container and the Docker volume.
+
+## Agent Tools
+
+Expose a sandbox session as agent tools:
+
+```ts
+import { createSandboxTools } from "@anvia/sandbox";
+import { AgentBuilder } from "@anvia/core";
+
+const session = await sandbox.createSession();
+const tools = createSandboxTools(session);
+
+const agent = new AgentBuilder("coder", model)
+  .instructions("Write and run code to solve problems.")
+  .tool(...tools)
+  .defaultMaxTurns(5)
+  .build();
+```
+
+### Available Tools
+
+| Tool | Description |
+| --- | --- |
+| `exec_command` | Run a shell command in the sandbox |
+| `read_file` | Read a file from the workspace |
+| `write_file` | Write a file to the workspace |
+| `list_files` | List files in a directory |
+
+### Tool Options
+
+```ts
+const tools = createSandboxTools(session, {
+  include: ["exec_command", "read_file"],  // only include specific tools
+  execTimeoutMs: 30_000,                   // default timeout for exec_command
+});
+```
+
+## Resource Limits
+
+```ts
+type SandboxLimits = {
+  timeoutMs?: number;      // session-level timeout
+  maxOutputBytes?: number; // max stdout/stderr bytes
+  memoryMb?: number;       // container memory limit
+  cpus?: number;           // container CPU limit
+  pidsLimit?: number;      // max processes
+};
+```
+
+## Error Types
+
+| Error | When |
+| --- | --- |
+| `SandboxDockerUnavailableError` | Docker CLI not found |
+| `SandboxDockerCommandError` | Docker setup command failed |
+| `SandboxSessionDestroyedError` | Using a session after `destroy()` |
+| `SandboxPathError` | Path traversal outside workspace |
+| `SandboxTimeoutError` | Command exceeded timeout |
+
+## Related
+
+- [Sandbox Guide](/docs/guides/sandbox/docker-sessions) for setup walkthrough
+- [Sandbox Reference](/docs/reference/sandbox) for full API types
+- [Sandbox Testing](/docs/guides/sandbox/testing) for testing patterns

--- a/apps/docs/content/docs/packages/server.mdx
+++ b/apps/docs/content/docs/packages/server.mdx
@@ -1,0 +1,155 @@
+---
+title: "@anvia/server"
+description: Server-side event stream helpers for Anvia applications.
+---
+
+`@anvia/server` converts an async iterable of agent events into a streaming HTTP `Response`. It supports both JSONL and Server-Sent Events (SSE) formats.
+
+## Install
+
+```sh
+pnpm add @anvia/server
+```
+
+No peer dependencies. Works with any framework that returns a `Response` object (Next.js, Hono, Express, Bun, Deno, etc.).
+
+## Quick Start
+
+```ts
+import { createEventStream } from "@anvia/server";
+
+// In a route handler:
+return createEventStream(agent.prompt("Draft a reply.").stream(), {
+  format: "jsonl",
+});
+```
+
+This produces a `Response` with `content-type: application/x-ndjson`, `cache-control: no-cache, no-transform`, and `connection: keep-alive`.
+
+## createEventStream
+
+The primary export. Converts an async iterable into a streaming `Response`.
+
+```ts
+function createEventStream<TEvent>(
+  events: AsyncIterable<TEvent>,
+  options?: {
+    format?: "jsonl" | "sse";
+    headers?: HeadersInit;
+    status?: number;
+    statusText?: string;
+    jsonl?: JsonlStreamOptions;
+    sse?: SseStreamOptions;
+  },
+): Response;
+```
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `format` | `"jsonl"` | Stream format: JSONL or SSE |
+| `headers` | -- | Additional response headers |
+| `status` | `200` | HTTP status code |
+| `statusText` | -- | HTTP status text |
+
+## JSONL vs SSE
+
+**JSONL** (default): one JSON object per line, `content-type: application/x-ndjson`. Best for most Anvia client transports.
+
+**SSE**: Server-Sent Events with `data:` fields, `content-type: text/event-stream`. Use when you need browser `EventSource` compatibility or SSE-specific tooling.
+
+```ts
+// JSONL (default)
+createEventStream(events);
+
+// SSE
+createEventStream(events, { format: "sse" });
+```
+
+## Low-Level Streams
+
+Use these when you need a `ReadableStream<Uint8Array>` instead of a full `Response`:
+
+### createJsonlStream
+
+```ts
+function createJsonlStream<TEvent>(
+  events: AsyncIterable<TEvent>,
+  options?: {
+    serialize?: (event: TEvent | { type: "error"; error: unknown }) => string;
+  },
+): ReadableStream<Uint8Array>;
+```
+
+Each event becomes one JSON line. If the iterable throws, the stream emits `{ type: "error", error }` and closes.
+
+### createSseStream
+
+```ts
+function createSseStream<TEvent>(
+  events: AsyncIterable<TEvent>,
+  options?: {
+    eventName?: string | ((event: TEvent | { type: "error"; error: unknown }) => string | undefined);
+    serialize?: (event: TEvent | { type: "error"; error: unknown }) => string;
+    retry?: number;
+  },
+): ReadableStream<Uint8Array>;
+```
+
+Each event becomes a `data:` field in an SSE message. Use `eventName` to set custom event types.
+
+## Framework Examples
+
+### Next.js App Router
+
+```ts
+// app/api/chat/route.ts
+import { createEventStream } from "@anvia/server";
+
+export async function POST(request: Request) {
+  const { message } = await request.json();
+  return createEventStream(agent.prompt(message).stream());
+}
+```
+
+### Hono
+
+```ts
+import { createEventStream } from "@anvia/server";
+
+app.post("/api/chat", async (c) => {
+  const { message } = await c.req.json();
+  return createEventStream(agent.prompt(message).stream());
+});
+```
+
+### Express
+
+```ts
+import { createEventStream } from "@anvia/server";
+
+app.post("/api/chat", async (req, res) => {
+  const response = createEventStream(agent.prompt(req.body.message).stream());
+  res.status(response.status);
+  response.headers.forEach((value, key) => res.setHeader(key, value));
+  const body = response.body!;
+  const reader = body.getReader();
+  const pump = async () => {
+    const { done, value } = await reader.read();
+    if (done) { res.end(); return; }
+    res.write(value);
+    await pump();
+  };
+  await pump();
+});
+```
+
+## Error Handling
+
+If the async iterable throws, both JSONL and SSE streams emit an error event and close gracefully. The client receives a structured error rather than a broken connection.
+
+## Related
+
+- [Streaming Events](/docs/guides/streaming/streaming-events) for event types
+- [Readable Streams](/docs/guides/streaming/readable-streams) for stream internals
+- [Server Reference](/docs/reference/server) for full API types
+- [`@anvia/react`](/docs/packages/react) for the client-side counterpart

--- a/apps/docs/content/docs/packages/studio.mdx
+++ b/apps/docs/content/docs/packages/studio.mdx
@@ -1,0 +1,169 @@
+---
+title: "@anvia/studio"
+description: Studio UI and HTTP runtime for Anvia agents.
+---
+
+`@anvia/studio` provides a local playground for testing agents, browsing sessions and traces, approving tool calls, and inspecting agent context. It runs as an HTTP server with a React-based UI.
+
+## Install
+
+```sh
+pnpm add @anvia/studio
+```
+
+Studio depends on `@anvia/core`, `@anvia/react`, and `@anvia/server`. It bundles a Hono HTTP server and a React UI.
+
+## Quick Start
+
+```ts
+import { AgentBuilder } from "@anvia/core";
+import { OpenAIClient } from "@anvia/openai";
+import { Studio } from "@anvia/studio";
+
+const client = new OpenAIClient({ apiKey });
+const agent = new AgentBuilder("support", client.completionModel())
+  .instructions("Answer support questions.")
+  .build();
+
+const studio = new Studio({ agents: [agent] });
+await studio.start();  // starts on http://localhost:3456
+```
+
+Open the URL in your browser to access the Studio UI.
+
+## Configuration
+
+```ts
+type StudioConfig = {
+  agents: Agent[];              // agents to register
+  port?: number;                // HTTP port (default: 3456)
+  host?: string;                // bind address (default: "localhost")
+  sessionStore?: StudioSessionStore;  // custom session persistence
+  traceStore?: StudioTraceStore;      // custom trace persistence
+};
+```
+
+```ts
+const studio = new Studio({
+  agents: [supportAgent, salesAgent],
+  port: 8080,
+  host: "0.0.0.0",
+});
+```
+
+## Studio Observer
+
+`StudioTraceObserver` captures traces for the Studio UI:
+
+```ts
+import { StudioTraceObserver } from "@anvia/studio";
+
+const observer = new StudioTraceObserver();
+
+const agent = new AgentBuilder("support", model)
+  .observe(observer)
+  .build();
+```
+
+The observer stores traces in memory by default. Pass a custom `traceStore` to `Studio` for persistence.
+
+## Sessions
+
+Studio tracks conversation sessions. Each session stores message history, agent configuration, and metadata.
+
+### Session Store
+
+```ts
+import { createSqliteSessionStore } from "@anvia/studio";
+
+const sessionStore = createSqliteSessionStore("./studio.db");
+
+const studio = new Studio({
+  agents: [agent],
+  sessionStore,
+});
+```
+
+The default session store is in-memory (sessions are lost when the server restarts).
+
+## Traces
+
+Studio captures and displays:
+- Agent run start/end with full prompt and history
+- Model generations with input/output, token usage, and latency
+- Tool calls with arguments, results, and timing
+- Errors with stack traces and partial context
+
+### Trace Store
+
+```ts
+import type { StudioTraceStore } from "@anvia/studio";
+
+const traceStore: StudioTraceStore = {
+  async save(trace) { /* persist */ },
+  async load(traceId) { /* retrieve */ },
+  async list(options) { /* list with filters */ },
+};
+
+const studio = new Studio({ agents: [agent], traceStore });
+```
+
+## Approvals
+
+Studio supports human-in-the-loop approval for tool calls. When an agent tool requires approval, Studio pauses the run and shows an approval UI.
+
+```ts
+import { AgentBuilder } from "@anvia/core";
+
+const agent = new AgentBuilder("support", model)
+  .tool(deleteAccountTool)
+  .onToolCall(async ({ toolName }) => {
+    if (toolName === "delete_account") {
+      return { type: "approve" as const };  // or "reject"
+    }
+    return { type: "auto" as const };
+  })
+  .build();
+```
+
+When running in Studio, approval requests appear in the UI. When running outside Studio, the hook resolves immediately.
+
+## HTTP API
+
+Studio exposes these endpoints:
+
+| Endpoint | Method | Purpose |
+| --- | --- | --- |
+| `/api/chat` | POST | Send a message to an agent |
+| `/api/sessions` | GET/POST | List/create sessions |
+| `/api/sessions/:id` | GET | Get session details |
+| `/api/traces` | GET | List traces |
+| `/api/traces/:id` | GET | Get trace details |
+| `/api/health` | GET | Health check |
+
+The chat endpoint returns a JSONL event stream compatible with `@anvia/react`'s `useChat`.
+
+## Programmatic Runtime
+
+Use `Studio` programmatically (without the UI) for testing:
+
+```ts
+import { Studio } from "@anvia/studio";
+
+const studio = new Studio({ agents: [agent] });
+const runtime = studio.runtime;
+
+// Send a message programmatically
+const events = runtime.chat({
+  agentId: "support",
+  message: "Hello",
+  sessionId: "test-session",
+});
+```
+
+## Related
+
+- [Studio Overview](/docs/studio/overview) for feature walkthrough
+- [Run Studio](/docs/studio/run-studio) for setup guide
+- [Studio Reference](/docs/reference/studio) for full API types
+- [Human-in-the-Loop](/docs/studio/human-in-the-loop) for approval workflows

--- a/apps/docs/content/docs/packages/transformers.mdx
+++ b/apps/docs/content/docs/packages/transformers.mdx
@@ -1,0 +1,113 @@
+---
+title: "@anvia/transformers"
+description: Local Transformers.js embedding models for Anvia.
+---
+
+`@anvia/transformers` runs Hugging Face embedding models locally using Transformers.js. No API calls, no network latency, no per-token costs. It supports a wide range of sentence transformer models from the Hugging Face Hub.
+
+## Install
+
+```sh
+pnpm add @anvia/transformers
+```
+
+`@huggingface/transformers` is a transitive dependency. Models are downloaded and cached on first use.
+
+## Quick Start
+
+```ts
+import { createTransformersEmbeddingModel } from "@anvia/transformers";
+
+const model = await createTransformersEmbeddingModel();
+
+const embeddings = await model.embedTexts([
+  "Anvia is a TypeScript AI agent framework.",
+  "Agents can use tools and maintain conversation history.",
+]);
+
+console.log(embeddings[0].vector.length); // 384 (for all-MiniLM-L6-v2)
+```
+
+The `create` call downloads and initializes the model on first run. Subsequent calls use the cached model.
+
+## Configuration
+
+```ts
+type TransformersEmbeddingModelOptions = {
+  model?: string;           // Hugging Face model name (default: "Xenova/all-MiniLM-L6-v2")
+  pooling?: "mean" | "cls"; // pooling strategy (default: "mean")
+  normalize?: boolean;      // normalize vectors (default: true)
+  maxBatchSize?: number;    // texts per batch (default: 16)
+};
+```
+
+```ts
+// Custom model
+const model = await createTransformersEmbeddingModel({
+  model: "Xenova/all-mpnet-base-v2",
+  maxBatchSize: 32,
+});
+
+// CLS pooling instead of mean
+const model = await createTransformersEmbeddingModel({
+  pooling: "cls",
+  normalize: false,
+});
+```
+
+## Pooling Strategies
+
+| Strategy | Description |
+| --- | --- |
+| `mean` (default) | Average all token embeddings. Best for general-purpose similarity. |
+| `cls` | Use the [CLS] token embedding. Some models are trained specifically for this. |
+
+## Model Selection
+
+The default `Xenova/all-MiniLM-L6-v2` is a good general-purpose model (384 dimensions, fast). For higher quality:
+
+- `Xenova/all-mpnet-base-v2` -- 768 dimensions, better accuracy
+- `Xenova/multi-qa-MiniLM-L6-cos-v1` -- optimized for semantic search
+- `Xenova/paraphrase-multilingual-MiniLM-L12-v2` -- multilingual support
+
+Any model compatible with the `feature-extraction` pipeline from `@huggingface/transformers` will work.
+
+## FastEmbed vs Transformers.js
+
+| Aspect | `@anvia/fastembed` | `@anvia/transformers` |
+| --- | --- | --- |
+| Runtime | ONNX Runtime | Transformers.js (ONNX in browser/Node) |
+| Model library | FastEmbed curated list | Any HF `feature-extraction` model |
+| Default model | BGE-small-en-v1.5 | all-MiniLM-L6-v2 |
+| Browser support | No | Yes |
+| Batch size default | 256 | 16 |
+
+Choose FastEmbed for a curated, optimized experience. Choose Transformers.js when you need specific Hugging Face models or browser compatibility.
+
+## Using with Vector Stores
+
+```ts
+import { createTransformersEmbeddingModel } from "@anvia/transformers";
+import { QdrantVectorStore } from "@anvia/qdrant";
+
+const model = await createTransformersEmbeddingModel();
+const store = await QdrantVectorStore.connect({
+  collectionName: "docs",
+  vectorSize: 384,
+});
+
+const index = store.index(model);
+const results = await index.search({ query: "How do agents work?", topK: 5 });
+```
+
+## Error Handling
+
+- Throws if the model download fails (network issues on first run)
+- Throws if the embedding count does not match the input text count
+- Throws on invalid vector format from the Transformers.js runtime
+
+## Related
+
+- [Embeddings Guide](/docs/guides/retrieval) for embedding concepts
+- [Transformers Reference](/docs/reference/integrations/transformers) for full API types
+- [`@anvia/fastembed`](/docs/packages/fastembed) for an alternative local embedding package

--- a/apps/docs/src/components/docs-route.tsx
+++ b/apps/docs/src/components/docs-route.tsx
@@ -4,19 +4,29 @@ import browserCollections from "collections/browser";
 import { useFumadocsLoader } from "fumadocs-core/source/client";
 import { DocsLayout, useDocsLayout } from "fumadocs-ui/layouts/docs";
 import { DocsBody, DocsDescription, DocsPage, DocsTitle } from "fumadocs-ui/layouts/docs/page";
-import { SidebarIcon } from "lucide-react";
+import {
+  BookCheck,
+  BookOpen,
+  Code,
+  Cpu,
+  Layers,
+  Monitor,
+  Package,
+  SidebarIcon,
+} from "lucide-react";
 import { Suspense } from "react";
 import { getMDXComponents } from "@/components/mdx";
 import { baseOptions } from "@/lib/layout.shared";
 import { source } from "@/lib/source";
 
 const docsSections = [
-  { title: "Docs", href: "/docs/guides" },
-  { title: "Best Practices", href: "/docs/best-practices" },
-  { title: "Frameworks", href: "/docs/frameworks" },
-  { title: "Models", href: "/docs/models" },
-  { title: "Studio", href: "/docs/studio/overview" },
-  { title: "Reference", href: "/docs/reference" },
+  { title: "Docs", href: "/docs/guides", icon: BookOpen },
+  { title: "Packages", href: "/docs/packages", icon: Package },
+  { title: "Best Practices", href: "/docs/best-practices", icon: BookCheck },
+  { title: "Frameworks", href: "/docs/frameworks", icon: Layers },
+  { title: "Models", href: "/docs/models", icon: Cpu },
+  { title: "Studio", href: "/docs/studio/overview", icon: Monitor },
+  { title: "Reference", href: "/docs/reference", icon: Code },
 ];
 
 const bestPracticeRedirects: Record<string, string> = {
@@ -138,8 +148,11 @@ function DocsSectionTabs() {
       {docsSections.map((section) => {
         const active = pathname === section.href || pathname.startsWith(`${section.href}/`);
 
+        const Icon = section.icon;
+
         return (
           <Link aria-current={active ? "page" : undefined} key={section.href} to={section.href}>
+            <Icon className="size-3.5" />
             {section.title}
           </Link>
         );


### PR DESCRIPTION
Add a top-level Packages section to the docs site with full guides for all 17 @anvia/* packages.

### What changed

**New section: /docs/packages** with 17 package guides plus an index page. Each guide covers install, configuration, core usage, working examples, and API highlights.

**Header navigation:** Added Packages tab and icons to all docs header section tabs.

**Packages covered:** @anvia/core, @anvia/react, @anvia/server, @anvia/logger, @anvia/openai, @anvia/anthropic, @anvia/gemini, @anvia/mistral, @anvia/fastembed, @anvia/transformers, @anvia/chroma, @anvia/pgvector, @anvia/qdrant, @anvia/langfuse, @anvia/otel, @anvia/sandbox, @anvia/studio