### PR TITLE
feat(react): add useCompletion hook and createDirectTransport

### DIFF
--- a/.changeset/add-use-completion-and-direct-transport.md
+++ b/.changeset/add-use-completion-and-direct-transport.md
@@ -1,0 +1,5 @@
+---
+"@anvia/react": minor
+---
+
+Add `useCompletion` hook for single-prompt text completion streaming and `createDirectTransport` for in-process transport without HTTP.

--- a/apps/docs/content/docs/reference/react.mdx
+++ b/apps/docs/content/docs/reference/react.mdx
@@ -146,6 +146,58 @@ Purpose: React chat state machine that consumes events from any `EventTransport`
 
 Passing `endpoint` creates a default JSONL fetch transport. Passing `transport` makes the hook independent of HTTP.
 
+## useCompletion
+
+```ts
+type UseCompletionRequest = {
+  prompt: string;
+  stream: true;
+};
+
+type UseCompletionStatus = "idle" | "streaming" | "error";
+
+type UseCompletionOptions<TEvent = unknown> = {
+  transport?: EventTransport<UseCompletionRequest, TEvent>;
+  endpoint?: string | URL;
+  format?: "jsonl" | "sse";
+  initialCompletion?: string;
+  eventToDelta?: (event: TEvent) => string | undefined;
+  eventToFinal?: (event: TEvent) => string | undefined;
+  onEvent?: (event: TEvent) => void;
+  onError?: (error: unknown) => void;
+};
+
+type UseCompletionResult = {
+  completion: string;
+  input: string;
+  setInput(input: string): void;
+  complete(prompt?: string): Promise<void>;
+  stop(): void;
+  reset(completion?: string): void;
+  status: UseCompletionStatus;
+  error: unknown;
+};
+
+function useCompletion<TEvent = unknown>(
+  options?: UseCompletionOptions<TEvent>,
+): UseCompletionResult;
+```
+
+Purpose: React hook for single-prompt text completion streaming. Simpler alternative to `useChat` when you only need prompt-in, text-out without message history.
+
+Default `eventToDelta` matches `{ type: "text_delta", delta: string }` events.
+Default `eventToFinal` matches `{ type: "final", response: { choice: Array<{ type: "text", text: string }> } }` events (compatible with `CompletionStreamEvent` from `@anvia/core`).
+
+## createDirectTransport
+
+```ts
+function createDirectTransport<TRequest, TEvent>(
+  handler: (request: TRequest) => AsyncIterable<TEvent>,
+): EventTransport<TRequest, TEvent>;
+```
+
+Purpose: in-process transport that calls a handler function directly, bypassing HTTP. Works with both `useChat` and `useCompletion`. Useful for SSR, testing, and single-process applications.
+
 ## EventStreamHttpError
 
 ```ts

--- a/packages/react/src/completion-defaults.ts
+++ b/packages/react/src/completion-defaults.ts
@@ -1,0 +1,31 @@
+export function defaultCompletionEventToDelta<TEvent>(event: TEvent): string | undefined {
+  if (!isRecord(event)) {
+    return undefined;
+  }
+
+  return event.type === "text_delta" && typeof event.delta === "string" ? event.delta : undefined;
+}
+
+export function defaultCompletionEventToFinal<TEvent>(event: TEvent): string | undefined {
+  if (!isRecord(event) || event.type !== "final") {
+    return undefined;
+  }
+
+  const response = event.response;
+  if (!isRecord(response) || !Array.isArray(response.choice)) {
+    return undefined;
+  }
+
+  const parts: string[] = [];
+  for (const item of response.choice) {
+    if (isRecord(item) && item.type === "text" && typeof item.text === "string") {
+      parts.push(item.text);
+    }
+  }
+
+  return parts.length > 0 ? parts.join("") : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/packages/react/src/direct.ts
+++ b/packages/react/src/direct.ts
@@ -1,0 +1,28 @@
+import type { EventTransport } from "./types";
+
+export function createDirectTransport<TRequest, TEvent>(
+  handler: (request: TRequest) => AsyncIterable<TEvent>,
+): EventTransport<TRequest, TEvent> {
+  return {
+    async *send(request, options) {
+      const iterable = handler(request);
+      const iterator = iterable[Symbol.asyncIterator]();
+      try {
+        while (true) {
+          if (options?.signal?.aborted) {
+            break;
+          }
+
+          const next = await iterator.next();
+          if (next.done) {
+            break;
+          }
+
+          yield next.value;
+        }
+      } finally {
+        await iterator.return?.();
+      }
+    },
+  };
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,4 @@
+export { createDirectTransport } from "./direct";
 export type { FetchEventStreamOptions } from "./fetch";
 export { EventStreamHttpError, fetchEventStream } from "./fetch";
 export { readJsonlStream, readSseStream } from "./streams";
@@ -15,3 +16,10 @@ export type {
   UseChatStatus,
 } from "./types";
 export { useChat } from "./use-chat";
+export type {
+  UseCompletionOptions,
+  UseCompletionRequest,
+  UseCompletionResult,
+  UseCompletionStatus,
+} from "./use-completion";
+export { useCompletion } from "./use-completion";

--- a/packages/react/src/use-completion.ts
+++ b/packages/react/src/use-completion.ts
@@ -1,0 +1,163 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  defaultCompletionEventToDelta,
+  defaultCompletionEventToFinal,
+} from "./completion-defaults";
+import { createFetchTransport } from "./transport";
+import type { EventStreamFormat, EventTransport } from "./types";
+
+export type UseCompletionRequest = {
+  prompt: string;
+  stream: true;
+};
+
+export type UseCompletionStatus = "idle" | "streaming" | "error";
+
+export type UseCompletionOptions<TEvent = unknown> = {
+  transport?: EventTransport<UseCompletionRequest, TEvent>;
+  endpoint?: string | URL;
+  format?: EventStreamFormat;
+  initialCompletion?: string;
+  eventToDelta?: (event: TEvent) => string | undefined;
+  eventToFinal?: (event: TEvent) => string | undefined;
+  onEvent?: (event: TEvent) => void;
+  onError?: (error: unknown) => void;
+};
+
+export type UseCompletionResult = {
+  completion: string;
+  input: string;
+  setInput(input: string): void;
+  complete(prompt?: string): Promise<void>;
+  stop(): void;
+  reset(completion?: string): void;
+  status: UseCompletionStatus;
+  error: unknown;
+};
+
+export function useCompletion<TEvent = unknown>(
+  options: UseCompletionOptions<TEvent> = {},
+): UseCompletionResult {
+  const [completion, setCompletion] = useState(options.initialCompletion ?? "");
+  const [input, setInput] = useState("");
+  const [status, setStatus] = useState<UseCompletionStatus>("idle");
+  const [error, setError] = useState<unknown>();
+  const abortRef = useRef<AbortController | undefined>(undefined);
+  const completionRef = useRef(completion);
+
+  useEffect(() => {
+    completionRef.current = completion;
+  }, [completion]);
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  const transport = useMemo(() => {
+    if (options.transport !== undefined) {
+      return options.transport;
+    }
+    if (options.endpoint === undefined) {
+      return undefined;
+    }
+
+    return createFetchTransport<UseCompletionRequest, TEvent>({
+      endpoint: options.endpoint,
+      format: options.format ?? "jsonl",
+    });
+  }, [options.transport, options.endpoint, options.format]);
+
+  const eventToDelta = options.eventToDelta ?? defaultCompletionEventToDelta<TEvent>;
+  const eventToFinal = options.eventToFinal ?? defaultCompletionEventToFinal<TEvent>;
+
+  const complete = useCallback(
+    async (nextInput?: string) => {
+      if (transport === undefined) {
+        throw new Error("useCompletion requires either transport or endpoint");
+      }
+
+      const prompt = nextInput ?? input;
+      if (prompt.trim().length === 0) {
+        return;
+      }
+
+      abortRef.current?.abort();
+      const abortController = new AbortController();
+      abortRef.current = abortController;
+
+      const request: UseCompletionRequest = { prompt, stream: true };
+
+      setInput("");
+      setError(undefined);
+      setStatus("streaming");
+      setCompletion("");
+
+      try {
+        for await (const event of transport.send(request, { signal: abortController.signal })) {
+          options.onEvent?.(event);
+
+          const delta = eventToDelta(event);
+          if (delta !== undefined && delta.length > 0) {
+            setCompletion((current) => `${current}${delta}`);
+          }
+
+          const final = eventToFinal(event);
+          if (final !== undefined) {
+            setCompletion(final);
+          }
+        }
+
+        if (!abortController.signal.aborted) {
+          setStatus("idle");
+        }
+      } catch (caught) {
+        if (isAbortError(caught)) {
+          setStatus("idle");
+          return;
+        }
+
+        setError(caught);
+        setStatus("error");
+        options.onError?.(caught);
+      } finally {
+        if (abortRef.current === abortController) {
+          abortRef.current = undefined;
+        }
+      }
+    },
+    [eventToDelta, eventToFinal, input, options, transport],
+  );
+
+  const stop = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = undefined;
+    setStatus("idle");
+  }, []);
+
+  const reset = useCallback((nextCompletion?: string) => {
+    abortRef.current?.abort();
+    abortRef.current = undefined;
+    setCompletion(nextCompletion ?? "");
+    setError(undefined);
+    setInput("");
+    setStatus("idle");
+  }, []);
+
+  return {
+    completion,
+    input,
+    setInput,
+    complete,
+    stop,
+    reset,
+    status,
+    error,
+  };
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}

--- a/packages/react/test/direct.test.ts
+++ b/packages/react/test/direct.test.ts
@@ -1,0 +1,127 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createDirectTransport, useChat, useCompletion } from "../src";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("@anvia/react createDirectTransport", () => {
+  it("yields events from the handler", async () => {
+    const transport = createDirectTransport<{ prompt: string }, { type: string; value: number }>(
+      async function* () {
+        yield { type: "one", value: 1 };
+        yield { type: "two", value: 2 };
+      },
+    );
+
+    const events = await collect(transport.send({ prompt: "hi" }));
+    expect(events).toEqual([
+      { type: "one", value: 1 },
+      { type: "two", value: 2 },
+    ]);
+  });
+
+  it("passes the request to the handler", async () => {
+    const handler = vi.fn(async function* () {
+      yield { type: "ok" };
+    });
+    const transport = createDirectTransport<{ message: string }, { type: string }>(handler);
+
+    await collect(transport.send({ message: "test" }));
+    expect(handler).toHaveBeenCalledWith({ message: "test" });
+  });
+
+  it("supports abort signal", async () => {
+    const controller = new AbortController();
+    const transport = createDirectTransport<unknown, { type: string }>(async function* () {
+      while (true) {
+        yield { type: "item" };
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+    });
+
+    const events: { type: string }[] = [];
+    const iterable = transport.send({}, { signal: controller.signal });
+    const iterator = iterable[Symbol.asyncIterator]();
+
+    const first = await iterator.next();
+    events.push(first.value);
+    controller.abort();
+    const second = await iterator.next();
+    expect(second.done).toBe(true);
+    expect(events).toEqual([{ type: "item" }]);
+  });
+
+  it("calls return on the iterator when done", async () => {
+    let returned = false;
+    const transport = createDirectTransport<unknown, { type: string }>(() => ({
+      [Symbol.asyncIterator]() {
+        return {
+          async next() {
+            return { done: true, value: undefined };
+          },
+          async return() {
+            returned = true;
+            return { done: true, value: undefined };
+          },
+        };
+      },
+    }));
+
+    await collect(transport.send({}));
+    expect(returned).toBe(true);
+  });
+
+  it("works with useCompletion", async () => {
+    const transport = createDirectTransport<
+      { prompt: string; stream: true },
+      { type: string; delta?: string; response?: { choice: { type: string; text: string }[] } }
+    >(async function* (request) {
+      expect(request.prompt).toBe("hello");
+      yield { type: "text_delta", delta: "world" };
+      yield {
+        type: "final",
+        response: { choice: [{ type: "text", text: "world" }] },
+      };
+    });
+
+    const { result } = renderHook(() => useCompletion({ transport }));
+
+    await act(async () => {
+      await result.current.complete("hello");
+    });
+
+    expect(result.current.completion).toBe("world");
+    expect(result.current.status).toBe("idle");
+  });
+
+  it("works with useChat", async () => {
+    const transport = createDirectTransport<
+      { message: string; history: unknown[]; stream: true },
+      { type: string; delta?: string; output?: string }
+    >(async function* (request) {
+      expect(request.message).toBe("hi");
+      yield { type: "text_delta", delta: "Hey" };
+      yield { type: "final", output: "Hey there" };
+    });
+
+    const { result } = renderHook(() => useChat({ transport }));
+
+    await act(async () => {
+      await result.current.send("hi");
+    });
+
+    expect(result.current.text).toBe("Hey there");
+    expect(result.current.status).toBe("idle");
+  });
+});
+
+async function collect<T>(events: AsyncIterable<T>): Promise<T[]> {
+  const items: T[] = [];
+  for await (const event of events) {
+    items.push(event);
+  }
+  return items;
+}

--- a/packages/react/test/use-completion.test.ts
+++ b/packages/react/test/use-completion.test.ts
@@ -1,0 +1,240 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { EventTransport } from "../src";
+import { useCompletion } from "../src";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("@anvia/react useCompletion", () => {
+  it("streams deltas and replaces final output", async () => {
+    const onEvent = vi.fn();
+    const transport: EventTransport<
+      { prompt: string; stream: true },
+      { type: string; delta?: string; response?: { choice: { type: string; text: string }[] } }
+    > = {
+      send: async function* (request) {
+        expect(request).toEqual({ prompt: "hello", stream: true });
+        yield { type: "text_delta", delta: "Hel" };
+        yield { type: "text_delta", delta: "lo" };
+        yield {
+          type: "final",
+          response: { choice: [{ type: "text", text: "Hello, world!" }] },
+        };
+      },
+    };
+
+    const { result } = renderHook(() => useCompletion({ transport, onEvent }));
+
+    await act(async () => {
+      await result.current.complete("hello");
+    });
+
+    expect(result.current.status).toBe("idle");
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.completion).toBe("Hello, world!");
+    expect(onEvent).toHaveBeenCalledTimes(3);
+  });
+
+  it("accumulates text deltas without final event", async () => {
+    const transport: EventTransport<unknown, { type: string; delta?: string }> = {
+      send: async function* () {
+        yield { type: "text_delta", delta: "one" };
+        yield { type: "text_delta", delta: " two" };
+      },
+    };
+
+    const { result } = renderHook(() => useCompletion({ transport }));
+
+    await act(async () => {
+      await result.current.complete("hi");
+    });
+
+    expect(result.current.completion).toBe("one two");
+    expect(result.current.status).toBe("idle");
+  });
+
+  it("does not send empty input", async () => {
+    const transport: EventTransport<unknown, unknown> = {
+      send: vi.fn(async function* () {
+        yield { type: "unexpected" };
+      }),
+    };
+    const { result } = renderHook(() => useCompletion({ transport }));
+
+    await act(async () => {
+      await result.current.complete("   ");
+    });
+
+    expect(transport.send).not.toHaveBeenCalled();
+    expect(result.current.completion).toBe("");
+  });
+
+  it("throws when no transport or endpoint is configured", async () => {
+    const { result } = renderHook(() => useCompletion());
+
+    await expect(
+      act(async () => {
+        await result.current.complete("hi");
+      }),
+    ).rejects.toThrow("useCompletion requires either transport or endpoint");
+  });
+
+  it("creates endpoint-backed transports", async () => {
+    const streamFrom = (text: string): ReadableStream<Uint8Array> =>
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(text));
+          controller.close();
+        },
+      });
+
+    const fetchMock = vi.fn(
+      async () => new Response(streamFrom('{"type":"text_delta","delta":"hi"}\n')),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { result } = renderHook(() =>
+      useCompletion({ endpoint: "https://example.test/completion" }),
+    );
+
+    await act(async () => {
+      await result.current.complete("hello");
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("https://example.test/completion", expect.any(Object));
+    expect(result.current.completion).toBe("hi");
+  });
+
+  it("handles errors and reset", async () => {
+    const error = new Error("failed");
+    const onError = vi.fn();
+    const transport: EventTransport<unknown, unknown> = {
+      send: () => failingEvents(error),
+    };
+    const { result } = renderHook(() =>
+      useCompletion({
+        transport,
+        initialCompletion: "previous",
+        onError,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.complete("hi");
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toBe(error);
+    expect(onError).toHaveBeenCalledWith(error);
+
+    act(() => {
+      result.current.reset("reset value");
+    });
+
+    expect(result.current.status).toBe("idle");
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.completion).toBe("reset value");
+  });
+
+  it("resets to empty string by default", async () => {
+    const { result } = renderHook(() => useCompletion({ initialCompletion: "initial" }));
+
+    expect(result.current.completion).toBe("initial");
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.completion).toBe("");
+    expect(result.current.input).toBe("");
+    expect(result.current.status).toBe("idle");
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it("aborts active streams when stopped", async () => {
+    let signal: AbortSignal | undefined;
+    let completePromise!: Promise<void>;
+    const transport: EventTransport<unknown, unknown> = {
+      send: async function* (_request, options) {
+        signal = options?.signal;
+        yield { type: "text_delta", delta: "hi" };
+        await new Promise<void>((_resolve, reject) => {
+          signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        });
+      },
+    };
+    const { result } = renderHook(() => useCompletion({ transport }));
+
+    await act(async () => {
+      completePromise = result.current.complete("test");
+      await vi.waitFor(() => {
+        expect(signal).toBeDefined();
+      });
+    });
+
+    act(() => {
+      result.current.stop();
+    });
+
+    expect(signal?.aborted).toBe(true);
+    await completePromise;
+    expect(result.current.status).toBe("idle");
+  });
+
+  it("ignores non-object default completion events", async () => {
+    const transport: EventTransport<unknown, unknown> = {
+      send: async function* () {
+        yield "plain";
+        yield null;
+      },
+    };
+    const { result } = renderHook(() => useCompletion({ transport }));
+
+    await act(async () => {
+      await result.current.complete("hi");
+    });
+
+    expect(result.current.completion).toBe("");
+  });
+
+  it("supports controlled input", async () => {
+    const transport: EventTransport<unknown, { type: string; delta?: string }> = {
+      send: async function* () {
+        yield { type: "text_delta", delta: "ok" };
+      },
+    };
+    const { result } = renderHook(() => useCompletion({ transport }));
+
+    act(() => {
+      result.current.setInput("my prompt");
+    });
+
+    expect(result.current.input).toBe("my prompt");
+
+    await act(async () => {
+      await result.current.complete();
+    });
+
+    expect(result.current.completion).toBe("ok");
+    expect(result.current.input).toBe("");
+  });
+});
+
+function failingEvents(error: unknown): AsyncIterable<unknown> {
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        async next() {
+          throw error;
+        },
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Add completion streaming support to `@packages/react`:

- **`useCompletion`** hook for single-prompt text completion streaming (simpler alternative to `useChat`)
- **`createDirectTransport`** for in-process transport (no HTTP round-trip, SSR, testing)
- Default event mappers for `CompletionStreamEvent` from `@anvia/core`

## New public API

```ts
// useCompletion with HTTP endpoint
const { completion, input, complete, stop, status } = useCompletion({
  endpoint: '/api/completion',
});

// useCompletion with in-process transport (no HTTP)
const { completion, complete } = useCompletion({
  transport: createDirectTransport((req) =>
    createCompletionStream(model, { input: req.prompt }),
  ),
});

// createDirectTransport also works with useChat
useChat({
  transport: createDirectTransport((req) => agent.prompt(req.message).stream()),
});
```

## Server handler (already works, no changes needed)

```ts
import { createEventStream } from '@anvia/server';
import { createCompletionStream } from '@anvia/core';

export async function POST(req: Request) {
  const { prompt } = await req.json();
  return createEventStream(createCompletionStream(model, { input: prompt }));
}
```

## Changes

| File | Action |
|---|---|
| `src/use-completion.ts` | New hook |
| `src/completion-defaults.ts` | Default event mappers |
| `src/direct.ts` | In-process transport |
| `src/index.ts` | Updated exports |
| `test/use-completion.test.ts` | 9 tests |
| `test/direct.test.ts` | 6 tests |

All existing APIs untouched. 36 tests pass, 0 failures. Typecheck clean across react, server, core, and docs packages.