### PR TITLE
docs: add Pinecone and Milvus package pages

### DIFF
--- a/apps/docs/content/docs/changelog/index.mdx
+++ b/apps/docs/content/docs/changelog/index.mdx
@@ -36,9 +36,9 @@ Developers should keep writing release notes with `pnpm changeset`. The docs pag
 | Package | Current version | Release notes |
 | --- | --- | --- |
 | `@anvia/chroma` | `0.2.5` | [View changelog](/docs/changelog/chroma) |
-| `@anvia/milvus` | `0.2.5` | [View changelog](/docs/changelog/milvus) |
+| `@anvia/milvus` | `0.3.0` | [View changelog](/docs/changelog/milvus) |
 | `@anvia/pgvector` | `0.2.5` | [View changelog](/docs/changelog/pgvector) |
-| `@anvia/pinecone` | `0.2.5` | [View changelog](/docs/changelog/pinecone) |
+| `@anvia/pinecone` | `0.3.0` | [View changelog](/docs/changelog/pinecone) |
 | `@anvia/qdrant` | `0.2.5` | [View changelog](/docs/changelog/qdrant) |
 
 ## Logger
@@ -59,13 +59,13 @@ Developers should keep writing release notes with `pnpm changeset`. The docs pag
 | Package | Current version | Release notes |
 | --- | --- | --- |
 | `@anvia/sandbox` | `0.2.2` | [View changelog](/docs/changelog/sandbox) |
-| `@anvia/studio` | `0.5.11` | [View changelog](/docs/changelog/studio) |
+| `@anvia/studio` | `0.5.12` | [View changelog](/docs/changelog/studio) |
 
 ## React
 
 | Package | Current version | Release notes |
 | --- | --- | --- |
-| `@anvia/react` | `0.3.1` | [View changelog](/docs/changelog/react) |
+| `@anvia/react` | `0.4.0` | [View changelog](/docs/changelog/react) |
 
 ## Server
 

--- a/apps/docs/content/docs/changelog/milvus.mdx
+++ b/apps/docs/content/docs/changelog/milvus.mdx
@@ -9,9 +9,9 @@ Milvus vector store adapter for Anvia.
 
 Source: [`packages/vector-stores/milvus/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/vector-stores/milvus/CHANGELOG.md)
 
-## No release notes yet
+## 0.3.0
 
-`@anvia/milvus` is public, but `packages/vector-stores/milvus/CHANGELOG.md` does not exist yet.
+### Minor Changes
 
-Release notes will appear here after the next Changesets version bump creates the package changelog.
+- ce25d82: Add Pinecone and Milvus vector store adapters following the existing pattern (Chroma, PgVector, Qdrant). Both implement the `VectorSearchIndex` interface with full filter translation, multi-embedding support, and `asTool()` integration.
 

--- a/apps/docs/content/docs/changelog/pinecone.mdx
+++ b/apps/docs/content/docs/changelog/pinecone.mdx
@@ -9,9 +9,9 @@ Pinecone vector store adapter for Anvia.
 
 Source: [`packages/vector-stores/pinecone/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/vector-stores/pinecone/CHANGELOG.md)
 
-## No release notes yet
+## 0.3.0
 
-`@anvia/pinecone` is public, but `packages/vector-stores/pinecone/CHANGELOG.md` does not exist yet.
+### Minor Changes
 
-Release notes will appear here after the next Changesets version bump creates the package changelog.
+- ce25d82: Add Pinecone and Milvus vector store adapters following the existing pattern (Chroma, PgVector, Qdrant). Both implement the `VectorSearchIndex` interface with full filter translation, multi-embedding support, and `asTool()` integration.
 

--- a/apps/docs/content/docs/changelog/react.mdx
+++ b/apps/docs/content/docs/changelog/react.mdx
@@ -9,6 +9,12 @@ React hooks and client transports for Anvia applications.
 
 Source: [`packages/react/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/react/CHANGELOG.md)
 
+## 0.4.0
+
+### Minor Changes
+
+- da736e9: Add `useCompletion` hook for single-prompt text completion streaming and `createDirectTransport` for in-process transport without HTTP.
+
 ## 0.3.1
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/studio.mdx
+++ b/apps/docs/content/docs/changelog/studio.mdx
@@ -9,6 +9,13 @@ Studio UI and HTTP runtime for Anvia agents.
 
 Source: [`packages/tools/studio/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/tools/studio/CHANGELOG.md)
 
+## 0.5.12
+
+### Patch Changes
+
+- Updated dependencies [da736e9]
+  - @anvia/react@0.4.0
+
 ## 0.5.11
 
 ### Patch Changes

--- a/apps/docs/content/docs/packages/index.mdx
+++ b/apps/docs/content/docs/packages/index.mdx
@@ -35,6 +35,8 @@ Each guide covers one `@anvia/*` package end to end: installation, configuration
 | Package | Purpose |
 | --- | --- |
 | [`@anvia/chroma`](/docs/packages/chroma) | ChromaDB vector store adapter |
+| [`@anvia/milvus`](/docs/packages/milvus) | Milvus vector store adapter |
+| [`@anvia/pinecone`](/docs/packages/pinecone) | Pinecone vector store adapter |
 | [`@anvia/pgvector`](/docs/packages/pgvector) | Postgres pgvector vector store adapter |
 | [`@anvia/qdrant`](/docs/packages/qdrant) | Qdrant vector store adapter |
 

--- a/apps/docs/content/docs/packages/meta.json
+++ b/apps/docs/content/docs/packages/meta.json
@@ -20,6 +20,8 @@
     "transformers",
     "---Vector Stores---",
     "chroma",
+    "milvus",
+    "pinecone",
     "pgvector",
     "qdrant",
     "---Observability---",

--- a/apps/docs/content/docs/packages/milvus.mdx
+++ b/apps/docs/content/docs/packages/milvus.mdx
@@ -1,0 +1,176 @@
+---
+title: "@anvia/milvus"
+description: Milvus vector store adapter for Anvia.
+---
+
+`@anvia/milvus` connects Anvia's vector store interface to Milvus. Use it to store embedded documents in a Milvus collection and search them through Anvia retrieval workflows.
+
+## Install
+
+```sh
+pnpm add @anvia/milvus
+```
+
+The Milvus client (`@zilliz/milvus2-sdk-node`) is a transitive dependency. By default, the adapter connects to `localhost:19530`; pass a custom client when you need a different endpoint.
+
+## Quick Start
+
+```ts
+import { createFastEmbedEmbeddingModel } from "@anvia/fastembed";
+import { MilvusVectorStore } from "@anvia/milvus";
+
+const model = await createFastEmbedEmbeddingModel();
+
+const store = await MilvusVectorStore.connect({
+  collectionName: "documents",
+  vectorSize: 384,  // must match your embedding model's dimensions
+});
+
+await store.upsertDocuments([
+  {
+    id: "doc-1",
+    document: "Anvia is a TypeScript AI agent framework.",
+    embeddings: await model.embedTexts(["Anvia is a TypeScript AI agent framework."]),
+  },
+]);
+
+const index = store.index(model);
+const results = await index.search({ query: "What is Anvia?", topK: 5 });
+console.log(results[0].document);
+```
+
+## Connection Options
+
+```ts
+type MilvusVectorStoreConnectOptions = {
+  client?: MilvusClientLike;   // pre-configured Milvus client
+  collectionName: string;      // required
+  vectorSize: number;          // required: embedding dimensions
+  createIfMissing?: boolean;   // default: true
+  metric?: MilvusMetric;       // default: "COSINE"
+};
+```
+
+```ts
+// Default: creates the collection if missing and loads it
+const store = await MilvusVectorStore.connect({
+  collectionName: "docs",
+  vectorSize: 384,
+});
+
+// Don't create if missing
+const store = await MilvusVectorStore.connect({
+  collectionName: "docs",
+  vectorSize: 384,
+  createIfMissing: false,
+});
+
+// Custom distance metric
+const store = await MilvusVectorStore.connect({
+  collectionName: "docs",
+  vectorSize: 384,
+  metric: "IP",
+});
+```
+
+When `createIfMissing` is `true` (default), the adapter:
+
+1. Checks whether the collection exists
+2. Creates a collection with an `id`, document fields, and a `FloatVector` field
+3. Creates an HNSW index on the vector field
+4. Loads the collection before returning the store
+
+## Upserting Documents
+
+```ts
+await store.upsertDocuments([
+  {
+    id: "doc-1",
+    document: { title: "Getting Started", content: "..." },
+    metadata: { category: "guide", version: 2 },
+    embeddings: await model.embedTexts(["Getting Started content..."]),
+  },
+]);
+```
+
+- Documents are inserted as Milvus rows with document content and metadata fields
+- Documents with multiple embeddings get indexed as `doc-1#embedding:0`, `doc-1#embedding:1`, etc.
+- Row IDs are deterministic SHA-256 hashes of the document ID
+
+## Searching
+
+```ts
+const index = store.index(model);
+
+// Basic search
+const results = await index.search({ query: "agent tools", topK: 5 });
+
+// With threshold
+const results = await index.search({
+  query: "agent tools",
+  topK: 10,
+  threshold: 0.7,
+});
+
+// With metadata filter
+const results = await index.search({
+  query: "agent tools",
+  topK: 5,
+  filter: { type: "eq", key: "category", value: "guide" },
+});
+```
+
+## Metadata Filters
+
+```ts
+// Equality
+{ type: "eq", key: "category", value: "guide" }
+
+// Range
+{ type: "gt", key: "version", value: 2 }
+{ type: "lt", key: "version", value: 5 }
+
+// Logical combinators
+{ type: "and", filters: [...] }
+{ type: "or", filters: [...] }
+```
+
+Filters are translated to Milvus boolean expressions such as `category == "guide"` or `(category == "guide") && (version > 2)`.
+
+## Distance Metrics
+
+| Metric | Milvus value | Notes |
+| --- | --- | --- |
+| Cosine (default) | `"COSINE"` | Best for text embeddings |
+| L2 | `"L2"` | Euclidean distance |
+| Inner product | `"IP"` | Dot product similarity |
+
+## Agent Tool
+
+Expose the vector index as an agent tool:
+
+```ts
+import { AgentBuilder } from "@anvia/core";
+
+const searchTool = index.asTool({
+  name: "search_docs",
+  description: "Search the documentation.",
+});
+
+const agent = new AgentBuilder("support", model)
+  .tool(searchTool)
+  .build();
+```
+
+## Error Handling
+
+- `connect()` throws if Milvus is unreachable
+- `connect({ createIfMissing: false })` throws if the collection does not exist
+- `upsertDocuments()` throws if a document has zero embeddings
+- Metadata keys starting with `__anvia_` are reserved and rejected
+
+## Related
+
+- [Retrieval Guide](/docs/guides/retrieval) for RAG concepts
+- [`@anvia/fastembed`](/docs/packages/fastembed) for local embeddings
+- [`@anvia/transformers`](/docs/packages/transformers) for local Transformers.js embeddings

--- a/apps/docs/content/docs/packages/pinecone.mdx
+++ b/apps/docs/content/docs/packages/pinecone.mdx
@@ -1,0 +1,172 @@
+---
+title: "@anvia/pinecone"
+description: Pinecone vector store adapter for Anvia.
+---
+
+`@anvia/pinecone` connects Anvia's vector store interface to Pinecone. Use it to store embedded documents in a Pinecone index and query them through Anvia retrieval workflows.
+
+## Install
+
+```sh
+pnpm add @anvia/pinecone
+```
+
+The Pinecone client (`@pinecone-database/pinecone`) is a transitive dependency. Configure Pinecone credentials the same way you would for the official client.
+
+## Quick Start
+
+```ts
+import { createFastEmbedEmbeddingModel } from "@anvia/fastembed";
+import { PineconeVectorStore } from "@anvia/pinecone";
+
+const model = await createFastEmbedEmbeddingModel();
+
+const store = await PineconeVectorStore.connect({
+  indexName: "documents",
+  namespace: "support",
+});
+
+await store.upsertDocuments([
+  {
+    id: "doc-1",
+    document: "Anvia is a TypeScript AI agent framework.",
+    embeddings: await model.embedTexts(["Anvia is a TypeScript AI agent framework."]),
+  },
+]);
+
+const index = store.index(model);
+const results = await index.search({ query: "What is Anvia?", topK: 5 });
+console.log(results[0].document);
+```
+
+## Connection Options
+
+```ts
+type PineconeVectorStoreConnectOptions = {
+  client?: PineconeClientLike;      // pre-configured Pinecone client
+  indexName: string;                // required
+  namespace?: string;               // default: ""
+  createIfMissing?: boolean;        // default: true
+  metric?: PineconeMetric;          // default: "cosine"
+};
+```
+
+```ts
+// Default: creates the index if missing and uses the default namespace
+const store = await PineconeVectorStore.connect({
+  indexName: "docs",
+});
+
+// Use a namespace
+const store = await PineconeVectorStore.connect({
+  indexName: "docs",
+  namespace: "production",
+});
+
+// Don't create if missing
+const store = await PineconeVectorStore.connect({
+  indexName: "docs",
+  createIfMissing: false,
+});
+
+// Custom distance metric
+const store = await PineconeVectorStore.connect({
+  indexName: "docs",
+  metric: "dotproduct",
+});
+```
+
+## Upserting Documents
+
+```ts
+await store.upsertDocuments([
+  {
+    id: "doc-1",
+    document: { title: "Getting Started", content: "..." },
+    metadata: { category: "guide", version: 2 },
+    embeddings: await model.embedTexts(["Getting Started content..."]),
+  },
+]);
+```
+
+- Documents are stored as Pinecone vectors with document content and metadata in the vector metadata
+- Documents with multiple embeddings get indexed as `doc-1#embedding:0`, `doc-1#embedding:1`, etc.
+- Vector IDs are deterministic SHA-256 hashes of the document ID
+
+## Searching
+
+```ts
+const index = store.index(model);
+
+// Basic search
+const results = await index.search({ query: "agent tools", topK: 5 });
+
+// With threshold
+const results = await index.search({
+  query: "agent tools",
+  topK: 10,
+  threshold: 0.7,
+});
+
+// With metadata filter
+const results = await index.search({
+  query: "agent tools",
+  topK: 5,
+  filter: { type: "eq", key: "category", value: "guide" },
+});
+```
+
+## Metadata Filters
+
+```ts
+// Equality
+{ type: "eq", key: "category", value: "guide" }
+
+// Range
+{ type: "gt", key: "version", value: 2 }
+{ type: "lt", key: "version", value: 5 }
+
+// Logical combinators
+{ type: "and", filters: [...] }
+{ type: "or", filters: [...] }
+```
+
+Filters are translated to Pinecone's native filter format (`$eq`, `$gt`, `$lt`, `$and`, `$or`).
+
+## Distance Metrics
+
+| Metric | Pinecone value | Notes |
+| --- | --- | --- |
+| Cosine (default) | `"cosine"` | Best for text embeddings |
+| Euclidean | `"euclidean"` | L2 distance |
+| Dot product | `"dotproduct"` | Dot product similarity |
+
+## Agent Tool
+
+Expose the vector index as an agent tool:
+
+```ts
+import { AgentBuilder } from "@anvia/core";
+
+const searchTool = index.asTool({
+  name: "search_docs",
+  description: "Search the documentation.",
+});
+
+const agent = new AgentBuilder("support", model)
+  .tool(searchTool)
+  .build();
+```
+
+## Error Handling
+
+- `connect()` throws if Pinecone credentials or network access fail
+- `connect({ createIfMissing: false })` throws if the index does not exist
+- `upsertDocuments()` throws if a document has zero embeddings
+- Metadata keys starting with `__anvia_` are reserved and rejected
+
+## Related
+
+- [Retrieval Guide](/docs/guides/retrieval) for RAG concepts
+- [`@anvia/fastembed`](/docs/packages/fastembed) for local embeddings
+- [`@anvia/transformers`](/docs/packages/transformers) for local Transformers.js embeddings

--- a/apps/docs/src/routes/index.tsx
+++ b/apps/docs/src/routes/index.tsx
@@ -35,9 +35,9 @@ export const Route = createFileRoute("/")({
 });
 
 const metrics = [
-  { value: "17", label: "Runtime packages", icon: Package },
+  { value: "19", label: "Runtime packages", icon: Package },
   { value: "4", label: "Model adapters", icon: Boxes },
-  { value: "8", label: "Integration packages", icon: BookOpen },
+  { value: "10", label: "Integration packages", icon: BookOpen },
   { value: "1", label: "Core package", icon: Zap },
 ];
 
@@ -118,6 +118,8 @@ const packageGroups = [
       "@anvia/fastembed",
       "@anvia/transformers",
       "@anvia/chroma",
+      "@anvia/milvus",
+      "@anvia/pinecone",
       "@anvia/qdrant",
       "@anvia/pgvector",
     ],


### PR DESCRIPTION
## Summary
- Add package guide pages for @anvia/pinecone and @anvia/milvus
- Include Pinecone and Milvus in package overview, nav metadata, and homepage package counts/list
- Update changelog generation to include pending Pinecone and Milvus changelog pages when package directories are absent, then regenerate changelog docs

## Verification
- pnpm --filter docs typecheck
- pnpm --filter docs build