### PR TITLE
feat: add sandbox v2 controls

### DIFF
--- a/.changeset/warm-sandboxes-stream.md
+++ b/.changeset/warm-sandboxes-stream.md
@@ -1,0 +1,5 @@
+---
+"@anvia/sandbox": minor
+---
+
+Add sandbox V2 controls for persistent workspaces, lifecycle cleanup, streaming command execution, file-size limits, observability hooks, language presets, and model-facing tool policies.

--- a/apps/docs/content/docs/guides/sandbox/agent-tools.mdx
+++ b/apps/docs/content/docs/guides/sandbox/agent-tools.mdx
@@ -12,9 +12,24 @@ import { createSandboxTools, DockerSandbox } from "@anvia/sandbox";
 const sandbox = new DockerSandbox();
 const session = await sandbox.createSession();
 
+const tools = createSandboxTools(session, {
+  allow: ["exec_command", "read_file", "write_file", "list_files"],
+  exec: {
+    allowedCommands: ["node", "npm"],
+    defaultTimeoutMs: 10_000,
+    maxTimeoutMs: 30_000,
+  },
+  readFile: {
+    maxBytes: 64_000,
+  },
+  writeFile: {
+    maxBytes: 64_000,
+  },
+});
+
 const agent = new AgentBuilder("coder", model)
   .instructions("Use the sandbox for code execution and file operations.")
-  .tools(createSandboxTools(session))
+  .tools(tools)
   .defaultMaxTurns(6)
   .build();
 
@@ -39,3 +54,22 @@ The default bundle exposes:
 | `list_files` | List files and directories under a workspace path |
 
 Keep the session lifetime explicit. Create the session before the agent run and destroy it in a `finally` block.
+
+## Tool Policy
+
+Use `allow` to choose which sandbox tools are exposed. Use `exec.allowedCommands` or `exec.blockedCommands` to keep model-chosen commands inside the product boundary.
+
+```ts
+const tools = createSandboxTools(session, {
+  allow: ["exec_command", "read_file", "list_files"],
+  exec: {
+    allowedCommands: ["node", "npm"],
+    maxTimeoutMs: 30_000,
+  },
+  readFile: {
+    maxBytes: 64_000,
+  },
+});
+```
+
+Tool policy is separate from Docker isolation. Docker limits protect the host; tool policy controls what the model can ask the session to do.

--- a/apps/docs/content/docs/guides/sandbox/docker-sessions.mdx
+++ b/apps/docs/content/docs/guides/sandbox/docker-sessions.mdx
@@ -1,6 +1,6 @@
 ---
 title: Docker Sessions
-description: Create and clean up ephemeral Docker sandbox sessions.
+description: Create, stream, persist, and clean up Docker sandbox sessions.
 ---
 
 Create a `DockerSandbox`, start a session, run commands, then destroy the session when the workflow is done.
@@ -10,11 +10,22 @@ import { DockerSandbox } from "@anvia/sandbox";
 
 const sandbox = new DockerSandbox({
   image: "node:22-bookworm",
+  workspace: {
+    mode: "ephemeral",
+  },
+  lifecycle: {
+    ttlMs: 10 * 60_000,
+    idleTimeoutMs: 60_000,
+  },
   limits: {
     timeoutMs: 30_000,
     maxOutputBytes: 64_000,
+    maxFileBytes: 5_000_000,
     memoryMb: 512,
     cpus: 1,
+  },
+  network: {
+    mode: "none",
   },
 });
 
@@ -43,3 +54,72 @@ try {
 `DockerSandbox` disables network access by default, drops Docker capabilities, enables `no-new-privileges`, rejects unsafe paths, truncates large output, and enforces command timeouts.
 
 Do not bind mount the host project into a sandbox for untrusted code. Stage the files a task needs through `manifest`, `writeFile(...)`, or `write_file`.
+
+## Workspace Modes
+
+The default workspace mode is ephemeral. Each session gets a new Docker volume, and `destroy()` removes it.
+
+```ts
+const sandbox = new DockerSandbox({
+  workspace: {
+    mode: "ephemeral",
+  },
+});
+```
+
+Use a persistent workspace only when continuity is intentional. Persistent workspaces reuse a named Docker volume and keep it after `destroy()` by default.
+
+```ts
+const sandbox = new DockerSandbox({
+  workspace: {
+    mode: "persistent",
+    id: `user-${userId}`,
+  },
+});
+```
+
+You can also choose persistence per session:
+
+```ts
+const session = await sandbox.createSession({
+  workspace: {
+    mode: "persistent",
+    id: `session-${sessionId}`,
+  },
+});
+```
+
+## Streaming Commands
+
+Use `execStream(...)` when command output should appear while the command is still running.
+
+```ts
+for await (const event of session.execStream({
+  command: "npm",
+  args: ["test"],
+  timeoutMs: 60_000,
+})) {
+  if (event.type === "stdout" || event.type === "stderr") {
+    process.stdout.write(event.text);
+  }
+
+  if (event.type === "exit") {
+    console.log(event.result.exitCode);
+  }
+}
+```
+
+## Lifecycle Cleanup
+
+Set lifecycle timers when a session should clean itself up even if application code forgets to call `destroy()`.
+
+```ts
+const sandbox = new DockerSandbox({
+  lifecycle: {
+    ttlMs: 10 * 60_000,
+    idleTimeoutMs: 60_000,
+  },
+});
+```
+
+`ttlMs` is a maximum lifetime. `idleTimeoutMs` starts after the session has no active operations.

--- a/apps/docs/content/docs/guides/sandbox/index.mdx
+++ b/apps/docs/content/docs/guides/sandbox/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sandbox
-description: Run code and file operations inside an ephemeral Docker workspace.
+description: Run code and file operations inside an isolated Docker workspace.
 ---
 
 `@anvia/sandbox` lets an agent work inside an isolated Docker workspace instead of the host filesystem.
@@ -26,6 +26,6 @@ Use a sandbox when an agent needs a scratch workspace for operations such as:
 | Inspect command output | Capture stdout, stderr, exit code, and timeout state |
 | Run multi-step tool flows | Share files between sandbox tools without exposing project files |
 
-V1 sessions are ephemeral. `destroy()` removes the container and workspace volume.
+Sessions are ephemeral by default. `destroy()` removes the container and workspace volume unless you explicitly choose a persistent workspace.
 
 Next, create your first [Docker session](/docs/guides/sandbox/docker-sessions).

--- a/apps/docs/content/docs/packages/sandbox.mdx
+++ b/apps/docs/content/docs/packages/sandbox.mdx
@@ -36,12 +36,15 @@ type DockerSandboxOptions = {
   image?: string;          // Docker image (default: "node:22-bookworm")
   pull?: "missing" | "always" | "never";  // pull policy (default: "missing")
   workdir?: string;        // workspace directory (default: "/workspace")
-  network?: boolean | "none" | "host" | string;  // network mode (default: false/none)
+  workspace?: SandboxWorkspaceOptions;  // ephemeral or persistent volume
+  lifecycle?: SandboxLifecycleOptions;  // ttl and idle cleanup
+  network?: boolean | "none" | "host" | string | { mode: boolean | "none" | "host" | string };
   user?: string;           // container user
   dockerPath?: string;     // path to docker CLI
   labels?: Record<string, string>;  // Docker container labels
   limits?: SandboxLimits;  // resource limits
   security?: DockerSandboxSecurityOptions;
+  hooks?: SandboxHooks;
 };
 ```
 
@@ -49,13 +52,21 @@ type DockerSandboxOptions = {
 // Custom image and limits
 const sandbox = new DockerSandbox({
   image: "python:3.12-slim",
-  limits: { timeoutMs: 30_000, memoryMb: 512, cpus: 1 },
+  limits: { timeoutMs: 30_000, maxFileBytes: 5_000_000, memoryMb: 512, cpus: 1 },
 });
 
 // Network access enabled
 const sandbox = new DockerSandbox({
-  network: "host",
+  network: { mode: "host" },
 });
+```
+
+### Presets
+
+```ts
+const nodeSandbox = DockerSandbox.node();
+const pythonSandbox = DockerSandbox.python();
+const denoSandbox = DockerSandbox.deno();
 ```
 
 ### Security Defaults
@@ -86,6 +97,7 @@ Each session creates one Docker container and one Docker volume mounted at the w
 ```ts
 const session = await sandbox.createSession({
   id: "my-session",           // optional custom ID
+  workspace: { mode: "ephemeral" },
   metadata: { userId: "123" }, // optional metadata
   manifest: {
     files: {
@@ -99,6 +111,17 @@ const session = await sandbox.createSession({
 ```
 
 The manifest seeds the workspace with files and directories before any commands run.
+
+Use a persistent workspace only when continuity is explicit:
+
+```ts
+const session = await sandbox.createSession({
+  workspace: {
+    mode: "persistent",
+    id: `user-${userId}`,
+  },
+});
+```
 
 ### Executing Commands
 
@@ -120,6 +143,16 @@ console.log(result.stderr);
 console.log(result.exitCode);
 console.log(result.durationMs);
 console.log(result.timedOut);
+```
+
+Stream command output with `execStream(...)`:
+
+```ts
+for await (const event of session.execStream({ command: "npm", args: ["test"] })) {
+  if (event.type === "stdout" || event.type === "stderr") {
+    process.stdout.write(event.text);
+  }
+}
 ```
 
 ### File Operations
@@ -155,7 +188,13 @@ import { createSandboxTools } from "@anvia/sandbox";
 import { AgentBuilder } from "@anvia/core";
 
 const session = await sandbox.createSession();
-const tools = createSandboxTools(session);
+const tools = createSandboxTools(session, {
+  allow: ["exec_command", "read_file", "write_file", "list_files"],
+  exec: {
+    allowedCommands: ["node", "npm"],
+    maxTimeoutMs: 30_000,
+  },
+});
 
 const agent = new AgentBuilder("coder", model)
   .instructions("Write and run code to solve problems.")

--- a/apps/docs/content/docs/reference/api-coverage.mdx
+++ b/apps/docs/content/docs/reference/api-coverage.mdx
@@ -16,7 +16,7 @@ Internal source-file exports are outside this check unless they are re-exported 
 | Package | Public entrypoints | Public exports | Reference coverage |
 | --- | ---: | ---: | --- |
 | `@anvia/core` | 19 | 250 | [Core](/docs/reference/core) |
-| `@anvia/sandbox` | 1 | 23 | [Sandbox](/docs/reference/sandbox) |
+| `@anvia/sandbox` | 1 | 36 | [Sandbox](/docs/reference/sandbox) |
 | `@anvia/openai` | 1 | 17 | [OpenAI Provider](/docs/reference/providers/openai) |
 | `@anvia/gemini` | 1 | 13 | [Gemini Provider](/docs/reference/providers/gemini) |
 | `@anvia/anthropic` | 1 | 4 | [Anthropic Provider](/docs/reference/providers/anthropic) |

--- a/apps/docs/content/docs/reference/sandbox.mdx
+++ b/apps/docs/content/docs/reference/sandbox.mdx
@@ -11,6 +11,9 @@ Import from `@anvia/sandbox`.
 class DockerSandbox implements Sandbox {
   readonly provider: "docker";
   constructor(options?: DockerSandboxOptions);
+  static node(options?: DockerSandboxOptions): DockerSandbox;
+  static python(options?: DockerSandboxOptions): DockerSandbox;
+  static deno(options?: DockerSandboxOptions): DockerSandbox;
   createSession(options?: SandboxCreateSessionOptions): Promise<SandboxSession>;
 }
 ```
@@ -34,6 +37,7 @@ interface SandboxSession {
   readonly provider: string;
   readonly workdir: string;
   exec(options: SandboxExecOptions): Promise<SandboxExecResult>;
+  execStream(options: SandboxExecOptions): AsyncIterable<SandboxExecStreamEvent>;
   readFile(path: string): Promise<Uint8Array>;
   readTextFile(path: string): Promise<string>;
   writeFile(path: string, data: string | Uint8Array): Promise<void>;
@@ -52,9 +56,18 @@ Return behavior: file paths are sandbox-relative; absolute paths and traversal o
 ```ts
 type SandboxCreateSessionOptions = {
   id?: string;
+  workspace?: SandboxWorkspaceOptions;
   manifest?: SandboxManifest;
   metadata?: Record<string, string>;
 };
+
+type SandboxWorkspaceOptions =
+  | { mode?: "ephemeral" }
+  | {
+      mode: "persistent";
+      id: string;
+      destroyOnSessionDestroy?: boolean;
+    };
 
 type SandboxManifest = {
   files?: Record<string, string | Uint8Array>;
@@ -65,13 +78,20 @@ type SandboxManifest = {
 type SandboxLimits = {
   timeoutMs?: number;
   maxOutputBytes?: number;
+  maxFileBytes?: number;
   memoryMb?: number;
   cpus?: number;
   pidsLimit?: number;
 };
+
+type SandboxLifecycleOptions = {
+  ttlMs?: number;
+  idleTimeoutMs?: number;
+  autoDestroy?: boolean;
+};
 ```
 
-Purpose: seed files, directories, environment, metadata, and runtime limits for a sandbox session.
+Purpose: seed files, directories, environment, metadata, workspace mode, lifecycle cleanup, and runtime limits for a sandbox session.
 
 ## Docker Options
 
@@ -80,12 +100,15 @@ type DockerSandboxOptions = {
   image?: string;
   pull?: "missing" | "always" | "never";
   workdir?: string;
-  network?: SandboxNetworkMode;
+  workspace?: SandboxWorkspaceOptions;
+  lifecycle?: SandboxLifecycleOptions;
+  network?: SandboxNetworkMode | DockerSandboxNetworkOptions;
   user?: string;
   dockerPath?: string;
   labels?: Record<string, string>;
   limits?: SandboxLimits;
   security?: DockerSandboxSecurityOptions;
+  hooks?: SandboxHooks;
 };
 
 type DockerSandboxSecurityOptions = {
@@ -94,10 +117,16 @@ type DockerSandboxSecurityOptions = {
   dropCapabilities?: string[];
 };
 
+type DockerSandboxNetworkOptions = {
+  mode: SandboxNetworkMode;
+};
+
 type SandboxNetworkMode = boolean | "none" | "host" | string;
 ```
 
 Defaults: `image` is `node:22-bookworm`, `pull` is `missing`, `workdir` is `/workspace`, network access is disabled, `noNewPrivileges` is enabled, and Docker capabilities are dropped with `["ALL"]`.
+
+Static presets: `DockerSandbox.node(...)`, `DockerSandbox.python(...)`, and `DockerSandbox.deno(...)` create sandboxes with language-specific default images.
 
 ## Execution
 
@@ -124,9 +153,14 @@ type SandboxExecResult = {
   stdoutTruncated: boolean;
   stderrTruncated: boolean;
 };
+
+type SandboxExecStreamEvent =
+  | { type: "stdout"; chunk: Uint8Array; text: string }
+  | { type: "stderr"; chunk: Uint8Array; text: string }
+  | { type: "exit"; result: SandboxExecResult };
 ```
 
-Return behavior: non-zero command exits are returned in `SandboxExecResult`; infrastructure failures throw.
+Return behavior: non-zero command exits are returned in `SandboxExecResult`; infrastructure failures throw. `execStream(...)` yields stdout and stderr chunks as they arrive, then yields one `exit` event with the final result.
 
 ## Files
 
@@ -151,8 +185,12 @@ function createSandboxTools(
 ): AnyTool[];
 
 type SandboxToolsOptions = {
+  allow?: SandboxToolName[];
   include?: SandboxToolName[];
   execTimeoutMs?: number;
+  exec?: SandboxExecToolPolicy;
+  readFile?: SandboxFileToolPolicy;
+  writeFile?: SandboxFileToolPolicy;
 };
 
 type SandboxToolName =
@@ -161,13 +199,59 @@ type SandboxToolName =
   | "write_file"
   | "list_files";
 
+type SandboxExecToolPolicy = {
+  allowedCommands?: string[];
+  blockedCommands?: string[];
+  defaultTimeoutMs?: number;
+  maxTimeoutMs?: number;
+};
+
+type SandboxFileToolPolicy = {
+  maxBytes?: number;
+};
+
 type SandboxToolsFactory = (
   session: SandboxSession,
   options?: SandboxToolsOptions,
 ) => AnyTool[];
 ```
 
-Purpose: expose a live sandbox session as Anvia tools. The default bundle includes `exec_command`, `read_file`, `write_file`, and `list_files`.
+Purpose: expose a live sandbox session as Anvia tools. The default bundle includes `exec_command`, `read_file`, `write_file`, and `list_files`. Use `allow` or `include` to select tools and `SandboxExecToolPolicy` or `SandboxFileToolPolicy` to bound model-facing operations.
+
+## Hooks
+
+```ts
+type SandboxHooks = {
+  onSessionCreate?: (event: SandboxSessionEvent) => void | Promise<void>;
+  onExecStart?: (event: SandboxExecEvent) => void | Promise<void>;
+  onExecEnd?: (event: SandboxExecEndEvent) => void | Promise<void>;
+  onFileWrite?: (event: SandboxFileWriteEvent) => void | Promise<void>;
+  onDestroy?: (event: SandboxSessionEvent) => void | Promise<void>;
+};
+
+type SandboxSessionEvent = {
+  sessionId: string;
+  provider: string;
+  workdir: string;
+};
+
+type SandboxExecEvent = SandboxSessionEvent & {
+  command: string;
+  args: string[];
+  cwd?: string;
+};
+
+type SandboxExecEndEvent = SandboxExecEvent & {
+  result: SandboxExecResult;
+};
+
+type SandboxFileWriteEvent = SandboxSessionEvent & {
+  path: string;
+  size: number;
+};
+```
+
+Purpose: observe session creation, command execution, file writes, and cleanup without exposing those details to the model.
 
 For workflow guidance, see [Sandbox](/docs/guides/sandbox) and the `tools:11` cookbook example.
 
@@ -180,6 +264,8 @@ class SandboxDockerCommandError extends SandboxError {}
 class SandboxSessionDestroyedError extends SandboxError {}
 class SandboxPathError extends SandboxError {}
 class SandboxTimeoutError extends SandboxError {}
+class SandboxFileSizeError extends SandboxError {}
+class SandboxToolPolicyError extends SandboxError {}
 ```
 
-Purpose: typed failures for Docker setup, path validation, destroyed sessions, and sandbox operations.
+Purpose: typed failures for Docker setup, path validation, destroyed sessions, file size limits, tool policy limits, and sandbox operations.

--- a/packages/tools/sandbox/src/docker-sandbox.ts
+++ b/packages/tools/sandbox/src/docker-sandbox.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { assertDockerCli, runDockerCli } from "./docker-cli";
 import {
   SandboxDockerCommandError,
+  SandboxFileSizeError,
   SandboxSessionDestroyedError,
   SandboxTimeoutError,
 } from "./errors";
@@ -15,12 +16,16 @@ import type {
   SandboxCreateSessionOptions,
   SandboxExecOptions,
   SandboxExecResult,
+  SandboxExecStreamEvent,
   SandboxFileEntry,
   SandboxFileType,
+  SandboxHooks,
+  SandboxLifecycleOptions,
   SandboxLimits,
   SandboxManifest,
-  SandboxNetworkMode,
   SandboxSession,
+  SandboxSessionEvent,
+  SandboxWorkspaceOptions,
 } from "./types";
 
 const defaultImage = "node:22-bookworm";
@@ -34,17 +39,29 @@ export class DockerSandbox implements Sandbox {
   private readonly image: string;
   private readonly pull: "missing" | "always" | "never";
   private readonly workdir: string;
-  private readonly network: SandboxNetworkMode;
+  private readonly workspace: SandboxWorkspaceOptions;
+  private readonly lifecycle: Required<Pick<SandboxLifecycleOptions, "autoDestroy">> &
+    Omit<SandboxLifecycleOptions, "autoDestroy">;
+  private readonly network: NonNullable<DockerSandboxOptions["network"]>;
   private readonly dockerPath: string;
   private readonly labels: Record<string, string>;
   private readonly limits: SandboxLimits;
   private readonly security: Required<NonNullable<DockerSandboxOptions["security"]>>;
+  private readonly hooks: SandboxHooks;
   private readonly user: string | undefined;
 
   constructor(options: DockerSandboxOptions = {}) {
     this.image = options.image ?? defaultImage;
     this.pull = options.pull ?? "missing";
     this.workdir = options.workdir ?? defaultWorkdir;
+    this.workspace = options.workspace ?? { mode: "ephemeral" };
+    this.lifecycle = {
+      autoDestroy: options.lifecycle?.autoDestroy ?? true,
+      ...(options.lifecycle?.ttlMs === undefined ? {} : { ttlMs: options.lifecycle.ttlMs }),
+      ...(options.lifecycle?.idleTimeoutMs === undefined
+        ? {}
+        : { idleTimeoutMs: options.lifecycle.idleTimeoutMs }),
+    };
     this.network = options.network ?? false;
     this.dockerPath = options.dockerPath ?? "docker";
     this.labels = options.labels ?? {};
@@ -54,23 +71,42 @@ export class DockerSandbox implements Sandbox {
       noNewPrivileges: options.security?.noNewPrivileges ?? true,
       dropCapabilities: options.security?.dropCapabilities ?? ["ALL"],
     };
+    this.hooks = options.hooks ?? {};
     this.user = options.user;
+  }
+
+  static node(options: DockerSandboxOptions = {}): DockerSandbox {
+    return new DockerSandbox({ ...options, image: options.image ?? "node:22-bookworm" });
+  }
+
+  static python(options: DockerSandboxOptions = {}): DockerSandbox {
+    return new DockerSandbox({ ...options, image: options.image ?? "python:3.13-bookworm" });
+  }
+
+  static deno(options: DockerSandboxOptions = {}): DockerSandbox {
+    return new DockerSandbox({ ...options, image: options.image ?? "denoland/deno:debian" });
   }
 
   async createSession(options: SandboxCreateSessionOptions = {}): Promise<SandboxSession> {
     await this.ensureImage();
 
     const id = sanitizeResourceId(options.id ?? randomUUID());
+    const workspace = options.workspace ?? this.workspace;
+    const workspaceId = getWorkspaceId(workspace, id);
     const containerName = `anvia-sandbox-${id}`;
-    const volumeName = `anvia-sandbox-${id}-workspace`;
+    const volumeName = `anvia-sandbox-${workspaceId}-workspace`;
+    const removeVolumeOnDestroy = shouldDestroyWorkspace(workspace);
 
     await assertDockerCli(["volume", "create", volumeName], this.cliOptions());
 
     try {
-      await assertDockerCli(this.createRunArgs(containerName, volumeName, options.metadata), {
-        ...this.cliOptions(),
-        timeoutMs: this.limits.timeoutMs ?? defaultTimeoutMs,
-      });
+      await assertDockerCli(
+        this.createRunArgs(containerName, volumeName, workspace, options.metadata),
+        {
+          ...this.cliOptions(),
+          timeoutMs: this.limits.timeoutMs ?? defaultTimeoutMs,
+        },
+      );
 
       const session = new DockerSandboxSession({
         id,
@@ -79,13 +115,17 @@ export class DockerSandbox implements Sandbox {
         workdir: this.workdir,
         dockerPath: this.dockerPath,
         limits: this.limits,
+        lifecycle: this.lifecycle,
+        removeVolumeOnDestroy,
         env: options.manifest?.env ?? {},
+        hooks: this.hooks,
       });
 
       await session.applyManifest(options.manifest);
+      await this.hooks.onSessionCreate?.(session.event());
       return session;
     } catch (error) {
-      await this.cleanup(containerName, volumeName);
+      await this.cleanup(containerName, removeVolumeOnDestroy ? volumeName : undefined);
       throw error;
     }
   }
@@ -107,6 +147,7 @@ export class DockerSandbox implements Sandbox {
   private createRunArgs(
     containerName: string,
     volumeName: string,
+    workspace: SandboxWorkspaceOptions,
     metadata: Record<string, string> | undefined,
   ): string[] {
     const args = [
@@ -120,6 +161,10 @@ export class DockerSandbox implements Sandbox {
       this.workdir,
       "--label",
       "anvia.sandbox=true",
+      "--label",
+      `anvia.sandbox.workspace.mode=${workspace.mode ?? "ephemeral"}`,
+      "--label",
+      `anvia.sandbox.workspace.volume=${volumeName}`,
     ];
 
     for (const [key, value] of Object.entries(this.labels)) {
@@ -150,13 +195,15 @@ export class DockerSandbox implements Sandbox {
   }
 
   private appendNetworkArgs(args: string[]): void {
-    if (this.network === false || this.network === "none") {
+    const mode = typeof this.network === "object" ? this.network.mode : this.network;
+
+    if (mode === false || mode === "none") {
       args.push("--network", "none");
       return;
     }
 
-    if (this.network !== true) {
-      args.push("--network", this.network);
+    if (mode !== true) {
+      args.push("--network", mode);
     }
   }
 
@@ -195,11 +242,14 @@ export class DockerSandbox implements Sandbox {
     };
   }
 
-  private async cleanup(containerName: string, volumeName: string): Promise<void> {
+  private async cleanup(containerName: string, volumeName: string | undefined): Promise<void> {
     await runDockerCli(["rm", "-f", containerName], this.cliOptions()).catch(() => undefined);
-    await runDockerCli(["volume", "rm", "-f", volumeName], this.cliOptions()).catch(
-      () => undefined,
-    );
+
+    if (volumeName !== undefined) {
+      await runDockerCli(["volume", "rm", "-f", volumeName], this.cliOptions()).catch(
+        () => undefined,
+      );
+    }
   }
 }
 
@@ -212,7 +262,14 @@ class DockerSandboxSession implements SandboxSession {
   private readonly volumeName: string;
   private readonly dockerPath: string;
   private readonly limits: SandboxLimits;
+  private readonly lifecycle: Required<Pick<SandboxLifecycleOptions, "autoDestroy">> &
+    Omit<SandboxLifecycleOptions, "autoDestroy">;
+  private readonly removeVolumeOnDestroy: boolean;
   private readonly env: Record<string, string>;
+  private readonly hooks: SandboxHooks;
+  private ttlTimer: ReturnType<typeof setTimeout> | undefined;
+  private idleTimer: ReturnType<typeof setTimeout> | undefined;
+  private activeOperations = 0;
   private destroyed = false;
 
   constructor(options: {
@@ -222,7 +279,11 @@ class DockerSandboxSession implements SandboxSession {
     workdir: string;
     dockerPath: string;
     limits: SandboxLimits;
+    lifecycle: Required<Pick<SandboxLifecycleOptions, "autoDestroy">> &
+      Omit<SandboxLifecycleOptions, "autoDestroy">;
+    removeVolumeOnDestroy: boolean;
     env: Record<string, string>;
+    hooks: SandboxHooks;
   }) {
     this.id = options.id;
     this.containerName = options.containerName;
@@ -230,24 +291,244 @@ class DockerSandboxSession implements SandboxSession {
     this.workdir = options.workdir;
     this.dockerPath = options.dockerPath;
     this.limits = options.limits;
+    this.lifecycle = options.lifecycle;
+    this.removeVolumeOnDestroy = options.removeVolumeOnDestroy;
     this.env = options.env;
+    this.hooks = options.hooks;
+    this.startLifecycleTimers();
   }
 
   async applyManifest(manifest: SandboxManifest | undefined): Promise<void> {
-    this.assertActive();
+    await this.runOperation(async () => {
+      for (const directory of manifest?.directories ?? []) {
+        await this.mkdir(directory);
+      }
 
-    for (const directory of manifest?.directories ?? []) {
-      await this.mkdir(directory);
-    }
-
-    for (const [filePath, content] of Object.entries(manifest?.files ?? {})) {
-      await this.writeFile(filePath, content);
-    }
+      for (const [filePath, content] of Object.entries(manifest?.files ?? {})) {
+        await this.writeFile(filePath, content);
+      }
+    });
   }
 
   async exec(options: SandboxExecOptions): Promise<SandboxExecResult> {
-    this.assertActive();
+    return this.runOperation(async () => {
+      await this.hooks.onExecStart?.({
+        ...this.event(),
+        command: options.command,
+        args: options.args ?? [],
+        ...(options.cwd === undefined ? {} : { cwd: options.cwd }),
+      });
 
+      const normalizedResult = await this.execCommand(options);
+
+      await this.hooks.onExecEnd?.({
+        ...this.event(),
+        command: options.command,
+        args: options.args ?? [],
+        ...(options.cwd === undefined ? {} : { cwd: options.cwd }),
+        result: normalizedResult,
+      });
+
+      return normalizedResult;
+    });
+  }
+
+  async *execStream(options: SandboxExecOptions): AsyncIterable<SandboxExecStreamEvent> {
+    const events: SandboxExecStreamEvent[] = [];
+    let notify: (() => void) | undefined;
+    let done = false;
+    let error: unknown;
+
+    const push = (event: SandboxExecStreamEvent) => {
+      events.push(event);
+      notify?.();
+      notify = undefined;
+    };
+
+    const wait = () =>
+      new Promise<void>((resolve) => {
+        notify = resolve;
+      });
+
+    const run = this.exec({
+      ...options,
+      onStdout: (chunk) => {
+        options.onStdout?.(chunk);
+        push({ type: "stdout", chunk, text: Buffer.from(chunk).toString("utf8") });
+      },
+      onStderr: (chunk) => {
+        options.onStderr?.(chunk);
+        push({ type: "stderr", chunk, text: Buffer.from(chunk).toString("utf8") });
+      },
+    })
+      .then((result) => {
+        push({ type: "exit", result });
+      })
+      .catch((caught) => {
+        error = caught;
+      })
+      .finally(() => {
+        done = true;
+        notify?.();
+        notify = undefined;
+      });
+
+    try {
+      while (!done || events.length > 0) {
+        const event = events.shift();
+        if (event !== undefined) {
+          yield event;
+          continue;
+        }
+
+        await wait();
+      }
+
+      if (error !== undefined) {
+        throw error;
+      }
+    } finally {
+      await run;
+    }
+  }
+
+  async readFile(filePath: string): Promise<Uint8Array> {
+    return this.runOperation(async () => {
+      const normalized = normalizeSandboxPath(filePath);
+      const tempDir = await mkdtemp(path.join(os.tmpdir(), "anvia-sandbox-read-"));
+      const target = path.join(tempDir, path.basename(normalized));
+
+      try {
+        await assertDockerCli(
+          ["cp", `${this.containerName}:${containerPath(this.workdir, normalized)}`, target],
+          this.cliOptions(),
+        );
+        const { readFile } = await import("node:fs/promises");
+        const bytes = await readFile(target);
+        this.assertFileSize(bytes.byteLength, filePath);
+        return bytes;
+      } finally {
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    });
+  }
+
+  async readTextFile(filePath: string): Promise<string> {
+    const bytes = await this.readFile(filePath);
+    return new TextDecoder().decode(bytes);
+  }
+
+  async writeFile(filePath: string, data: string | Uint8Array): Promise<void> {
+    await this.runOperation(async () => {
+      const size = byteLength(data);
+      this.assertFileSize(size, filePath);
+      const normalized = normalizeSandboxPath(filePath);
+      await this.mkdir(parentSandboxPath(normalized));
+
+      const tempDir = await mkdtemp(path.join(os.tmpdir(), "anvia-sandbox-write-"));
+      const source = path.join(tempDir, path.basename(normalized));
+
+      try {
+        await writeFile(source, data);
+        await assertDockerCli(
+          ["cp", source, `${this.containerName}:${containerPath(this.workdir, normalized)}`],
+          this.cliOptions(),
+        );
+        await this.hooks.onFileWrite?.({ ...this.event(), path: normalized, size });
+      } finally {
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    });
+  }
+
+  async writeTextFile(filePath: string, content: string): Promise<void> {
+    await this.writeFile(filePath, content);
+  }
+
+  async listFiles(filePath = "."): Promise<SandboxFileEntry[]> {
+    return this.runOperation(async () => {
+      const normalized = normalizeSandboxPath(filePath, { allowRoot: true });
+      const target = containerPath(this.workdir, normalized);
+      const result = await this.execCommand({
+        command: "find",
+        args: [target, "-mindepth", "1", "-maxdepth", "1", "-printf", "%p\t%y\t%s\n"],
+      });
+
+      if (result.timedOut) {
+        throw new SandboxTimeoutError(`Listing files timed out for ${filePath}.`);
+      }
+
+      if (result.exitCode !== 0) {
+        throw new SandboxDockerCommandError(`Unable to list sandbox path: ${filePath}`, result);
+      }
+
+      return result.stdout
+        .split("\n")
+        .filter((line) => line.trim().length > 0)
+        .map((line) => this.parseFindEntry(line));
+    });
+  }
+
+  async destroy(): Promise<void> {
+    if (this.destroyed) {
+      return;
+    }
+
+    this.destroyed = true;
+    this.clearLifecycleTimers();
+    await runDockerCli(["rm", "-f", this.containerName], this.cliOptions()).catch(() => undefined);
+
+    if (this.removeVolumeOnDestroy) {
+      await runDockerCli(["volume", "rm", "-f", this.volumeName], this.cliOptions()).catch(
+        () => undefined,
+      );
+    }
+
+    await this.hooks.onDestroy?.(this.event());
+  }
+
+  private async mkdir(directoryPath: string): Promise<void> {
+    const normalized = normalizeSandboxPath(directoryPath, { allowRoot: true });
+    const result = await this.execCommand({
+      command: "mkdir",
+      args: ["-p", containerPath(this.workdir, normalized)],
+    });
+
+    if (result.exitCode !== 0) {
+      throw new SandboxDockerCommandError(
+        `Unable to create sandbox directory: ${directoryPath}`,
+        result,
+      );
+    }
+  }
+
+  private parseFindEntry(line: string): SandboxFileEntry {
+    const [rawPath, rawType, rawSize] = line.split("\t");
+    const absolutePath = rawPath ?? "";
+    const relativePath = absolutePath.startsWith(`${this.workdir}/`)
+      ? absolutePath.slice(this.workdir.length + 1)
+      : absolutePath;
+    const size = rawSize === undefined ? undefined : Number(rawSize);
+    const entry: SandboxFileEntry = {
+      path: relativePath,
+      type: mapFindType(rawType),
+    };
+
+    if (size !== undefined && Number.isFinite(size)) {
+      entry.size = size;
+    }
+
+    return entry;
+  }
+
+  private cliOptions() {
+    return {
+      dockerPath: this.dockerPath,
+      maxOutputBytes: this.limits.maxOutputBytes ?? defaultMaxOutputBytes,
+    };
+  }
+
+  private async execCommand(options: SandboxExecOptions): Promise<SandboxExecResult> {
     if (options.command.trim().length === 0) {
       throw new SandboxDockerCommandError("Sandbox command cannot be empty.", {
         stdout: "",
@@ -293,133 +574,102 @@ class DockerSandboxSession implements SandboxSession {
     return result;
   }
 
-  async readFile(filePath: string): Promise<Uint8Array> {
-    this.assertActive();
-    const normalized = normalizeSandboxPath(filePath);
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "anvia-sandbox-read-"));
-    const target = path.join(tempDir, path.basename(normalized));
-
-    try {
-      await assertDockerCli(
-        ["cp", `${this.containerName}:${containerPath(this.workdir, normalized)}`, target],
-        this.cliOptions(),
-      );
-      const { readFile } = await import("node:fs/promises");
-      return await readFile(target);
-    } finally {
-      await rm(tempDir, { recursive: true, force: true });
-    }
-  }
-
-  async readTextFile(filePath: string): Promise<string> {
-    const bytes = await this.readFile(filePath);
-    return new TextDecoder().decode(bytes);
-  }
-
-  async writeFile(filePath: string, data: string | Uint8Array): Promise<void> {
-    this.assertActive();
-    const normalized = normalizeSandboxPath(filePath);
-    await this.mkdir(parentSandboxPath(normalized));
-
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "anvia-sandbox-write-"));
-    const source = path.join(tempDir, path.basename(normalized));
-
-    try {
-      await writeFile(source, data);
-      await assertDockerCli(
-        ["cp", source, `${this.containerName}:${containerPath(this.workdir, normalized)}`],
-        this.cliOptions(),
-      );
-    } finally {
-      await rm(tempDir, { recursive: true, force: true });
-    }
-  }
-
-  async writeTextFile(filePath: string, content: string): Promise<void> {
-    await this.writeFile(filePath, content);
-  }
-
-  async listFiles(filePath = "."): Promise<SandboxFileEntry[]> {
-    this.assertActive();
-    const normalized = normalizeSandboxPath(filePath, { allowRoot: true });
-    const target = containerPath(this.workdir, normalized);
-    const result = await this.exec({
-      command: "find",
-      args: [target, "-mindepth", "1", "-maxdepth", "1", "-printf", "%p\t%y\t%s\n"],
-    });
-
-    if (result.timedOut) {
-      throw new SandboxTimeoutError(`Listing files timed out for ${filePath}.`);
-    }
-
-    if (result.exitCode !== 0) {
-      throw new SandboxDockerCommandError(`Unable to list sandbox path: ${filePath}`, result);
-    }
-
-    return result.stdout
-      .split("\n")
-      .filter((line) => line.trim().length > 0)
-      .map((line) => this.parseFindEntry(line));
-  }
-
-  async destroy(): Promise<void> {
-    if (this.destroyed) {
-      return;
-    }
-
-    this.destroyed = true;
-    await runDockerCli(["rm", "-f", this.containerName], this.cliOptions()).catch(() => undefined);
-    await runDockerCli(["volume", "rm", "-f", this.volumeName], this.cliOptions()).catch(
-      () => undefined,
-    );
-  }
-
-  private async mkdir(directoryPath: string): Promise<void> {
-    const normalized = normalizeSandboxPath(directoryPath, { allowRoot: true });
-    const result = await this.exec({
-      command: "mkdir",
-      args: ["-p", containerPath(this.workdir, normalized)],
-    });
-
-    if (result.exitCode !== 0) {
-      throw new SandboxDockerCommandError(
-        `Unable to create sandbox directory: ${directoryPath}`,
-        result,
-      );
-    }
-  }
-
-  private parseFindEntry(line: string): SandboxFileEntry {
-    const [rawPath, rawType, rawSize] = line.split("\t");
-    const absolutePath = rawPath ?? "";
-    const relativePath = absolutePath.startsWith(`${this.workdir}/`)
-      ? absolutePath.slice(this.workdir.length + 1)
-      : absolutePath;
-    const size = rawSize === undefined ? undefined : Number(rawSize);
-    const entry: SandboxFileEntry = {
-      path: relativePath,
-      type: mapFindType(rawType),
-    };
-
-    if (size !== undefined && Number.isFinite(size)) {
-      entry.size = size;
-    }
-
-    return entry;
-  }
-
-  private cliOptions() {
-    return {
-      dockerPath: this.dockerPath,
-      maxOutputBytes: this.limits.maxOutputBytes ?? defaultMaxOutputBytes,
-    };
-  }
-
   private assertActive(): void {
     if (this.destroyed) {
       throw new SandboxSessionDestroyedError(`Sandbox session ${this.id} has been destroyed.`);
     }
   }
+
+  event(): SandboxSessionEvent {
+    return {
+      sessionId: this.id,
+      provider: this.provider,
+      workdir: this.workdir,
+    };
+  }
+
+  private async runOperation<T>(operation: () => Promise<T>): Promise<T> {
+    this.assertActive();
+    this.activeOperations += 1;
+    this.clearIdleTimer();
+
+    try {
+      return await operation();
+    } finally {
+      this.activeOperations -= 1;
+      this.scheduleIdleTimer();
+    }
+  }
+
+  private assertFileSize(size: number, filePath: string): void {
+    if (this.limits.maxFileBytes !== undefined && size > this.limits.maxFileBytes) {
+      throw new SandboxFileSizeError(
+        `Sandbox file exceeds maxFileBytes (${size} > ${this.limits.maxFileBytes}): ${filePath}`,
+      );
+    }
+  }
+
+  private startLifecycleTimers(): void {
+    if (!this.lifecycle.autoDestroy) {
+      return;
+    }
+
+    if (this.lifecycle.ttlMs !== undefined) {
+      this.ttlTimer = setTimeout(() => {
+        void this.destroy().catch(() => undefined);
+      }, this.lifecycle.ttlMs);
+      this.ttlTimer.unref?.();
+    }
+
+    this.scheduleIdleTimer();
+  }
+
+  private scheduleIdleTimer(): void {
+    if (!this.lifecycle.autoDestroy || this.lifecycle.idleTimeoutMs === undefined) {
+      return;
+    }
+
+    if (this.destroyed || this.activeOperations > 0) {
+      return;
+    }
+
+    this.clearIdleTimer();
+    this.idleTimer = setTimeout(() => {
+      void this.destroy().catch(() => undefined);
+    }, this.lifecycle.idleTimeoutMs);
+    this.idleTimer.unref?.();
+  }
+
+  private clearLifecycleTimers(): void {
+    if (this.ttlTimer !== undefined) {
+      clearTimeout(this.ttlTimer);
+      this.ttlTimer = undefined;
+    }
+    this.clearIdleTimer();
+  }
+
+  private clearIdleTimer(): void {
+    if (this.idleTimer !== undefined) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = undefined;
+    }
+  }
+}
+
+function getWorkspaceId(workspace: SandboxWorkspaceOptions, sessionId: string): string {
+  if (workspace.mode === "persistent") {
+    return sanitizeResourceId(workspace.id);
+  }
+
+  return sessionId;
+}
+
+function shouldDestroyWorkspace(workspace: SandboxWorkspaceOptions): boolean {
+  if (workspace.mode === "persistent") {
+    return workspace.destroyOnSessionDestroy ?? false;
+  }
+
+  return true;
 }
 
 function sanitizeResourceId(id: string): string {
@@ -428,6 +678,10 @@ function sanitizeResourceId(id: string): string {
     .replaceAll(/[^a-z0-9_.-]/g, "-")
     .replaceAll(/^-+|-+$/g, "");
   return sanitized.length > 0 ? sanitized : randomUUID();
+}
+
+function byteLength(data: string | Uint8Array): number {
+  return typeof data === "string" ? Buffer.byteLength(data) : data.byteLength;
 }
 
 function mapFindType(type: string | undefined): SandboxFileType {

--- a/packages/tools/sandbox/src/errors.ts
+++ b/packages/tools/sandbox/src/errors.ts
@@ -28,3 +28,7 @@ export class SandboxSessionDestroyedError extends SandboxError {}
 export class SandboxPathError extends SandboxError {}
 
 export class SandboxTimeoutError extends SandboxError {}
+
+export class SandboxFileSizeError extends SandboxError {}
+
+export class SandboxToolPolicyError extends SandboxError {}

--- a/packages/tools/sandbox/src/tools.ts
+++ b/packages/tools/sandbox/src/tools.ts
@@ -1,5 +1,6 @@
 import { type AnyTool, createTool } from "@anvia/core/tool";
 import { z } from "zod";
+import { SandboxToolPolicyError } from "./errors";
 import type {
   SandboxExecOptions,
   SandboxExecResult,
@@ -49,7 +50,7 @@ export function createSandboxTools(
   options: SandboxToolsOptions = {},
 ): AnyTool[] {
   const include = new Set<SandboxToolName>(
-    options.include ?? ["exec_command", "read_file", "write_file", "list_files"],
+    options.allow ?? options.include ?? ["exec_command", "read_file", "write_file", "list_files"],
   );
   const tools: AnyTool[] = [];
 
@@ -58,11 +59,11 @@ export function createSandboxTools(
   }
 
   if (include.has("read_file")) {
-    tools.push(createReadFileTool(session));
+    tools.push(createReadFileTool(session, options));
   }
 
   if (include.has("write_file")) {
-    tools.push(createWriteFileTool(session));
+    tools.push(createWriteFileTool(session, options));
   }
 
   if (include.has("list_files")) {
@@ -73,6 +74,8 @@ export function createSandboxTools(
 }
 
 function createExecCommandTool(session: SandboxSession, options: SandboxToolsOptions): AnyTool {
+  const policy = options.exec ?? {};
+
   return createTool({
     name: "exec_command",
     description:
@@ -80,6 +83,8 @@ function createExecCommandTool(session: SandboxSession, options: SandboxToolsOpt
     input: execCommandInput,
     output: textOutput,
     execute: async ({ command, args, cwd, env, timeoutMs, input }) => {
+      assertCommandAllowed(command, options);
+
       const execOptions: SandboxExecOptions = {
         command,
       };
@@ -93,8 +98,9 @@ function createExecCommandTool(session: SandboxSession, options: SandboxToolsOpt
       if (env !== undefined) {
         execOptions.env = env;
       }
-      const effectiveTimeoutMs = timeoutMs ?? options.execTimeoutMs;
+      const effectiveTimeoutMs = timeoutMs ?? policy.defaultTimeoutMs ?? options.execTimeoutMs;
       if (effectiveTimeoutMs !== undefined) {
+        assertTimeoutAllowed(effectiveTimeoutMs, options);
         execOptions.timeoutMs = effectiveTimeoutMs;
       }
       if (input !== undefined) {
@@ -108,23 +114,28 @@ function createExecCommandTool(session: SandboxSession, options: SandboxToolsOpt
   });
 }
 
-function createReadFileTool(session: SandboxSession): AnyTool {
+function createReadFileTool(session: SandboxSession, options: SandboxToolsOptions): AnyTool {
   return createTool({
     name: "read_file",
     description: "Read a text file from the sandbox workspace.",
     input: readFileInput,
     output: textOutput,
-    execute: async ({ path }) => session.readTextFile(path),
+    execute: async ({ path }) => {
+      const content = await session.readTextFile(path);
+      assertReadAllowed(content, options);
+      return content;
+    },
   });
 }
 
-function createWriteFileTool(session: SandboxSession): AnyTool {
+function createWriteFileTool(session: SandboxSession, options: SandboxToolsOptions): AnyTool {
   return createTool({
     name: "write_file",
     description: "Write a text file inside the sandbox workspace. Creates parent directories.",
     input: writeFileInput,
     output: textOutput,
     execute: async ({ path, content }) => {
+      assertContentAllowed(content, options);
       await session.writeTextFile(path, content);
       return `Wrote ${path}`;
     },
@@ -178,4 +189,42 @@ function formatExecResult(result: SandboxExecResult): string {
   }
 
   return parts.join("\n\n");
+}
+
+function assertCommandAllowed(command: string, options: SandboxToolsOptions): void {
+  const policy = options.exec;
+
+  if (policy?.blockedCommands?.includes(command)) {
+    throw new SandboxToolPolicyError(`Command is blocked by sandbox tool policy: ${command}`);
+  }
+
+  if (policy?.allowedCommands !== undefined && !policy.allowedCommands.includes(command)) {
+    throw new SandboxToolPolicyError(`Command is not allowed by sandbox tool policy: ${command}`);
+  }
+}
+
+function assertTimeoutAllowed(timeoutMs: number, options: SandboxToolsOptions): void {
+  const maxTimeoutMs = options.exec?.maxTimeoutMs;
+
+  if (maxTimeoutMs !== undefined && timeoutMs > maxTimeoutMs) {
+    throw new SandboxToolPolicyError(
+      `Command timeout exceeds sandbox tool policy (${timeoutMs} > ${maxTimeoutMs}).`,
+    );
+  }
+}
+
+function assertContentAllowed(content: string, options: SandboxToolsOptions): void {
+  const maxBytes = options.writeFile?.maxBytes;
+
+  if (maxBytes !== undefined && Buffer.byteLength(content) > maxBytes) {
+    throw new SandboxToolPolicyError("File content exceeds sandbox tool policy.");
+  }
+}
+
+function assertReadAllowed(content: string, options: SandboxToolsOptions): void {
+  const maxBytes = options.readFile?.maxBytes;
+
+  if (maxBytes !== undefined && Buffer.byteLength(content) > maxBytes) {
+    throw new SandboxToolPolicyError("File content exceeds sandbox tool policy.");
+  }
 }

--- a/packages/tools/sandbox/src/types.ts
+++ b/packages/tools/sandbox/src/types.ts
@@ -4,6 +4,22 @@ export type SandboxFileType = "file" | "directory" | "symlink" | "other";
 
 export type SandboxNetworkMode = boolean | "none" | "host" | string;
 
+export type SandboxWorkspaceOptions =
+  | {
+      mode?: "ephemeral";
+    }
+  | {
+      mode: "persistent";
+      id: string;
+      destroyOnSessionDestroy?: boolean;
+    };
+
+export interface SandboxLifecycleOptions {
+  ttlMs?: number;
+  idleTimeoutMs?: number;
+  autoDestroy?: boolean;
+}
+
 export interface Sandbox {
   readonly provider: string;
 
@@ -16,6 +32,7 @@ export interface SandboxSession {
   readonly workdir: string;
 
   exec(options: SandboxExecOptions): Promise<SandboxExecResult>;
+  execStream(options: SandboxExecOptions): AsyncIterable<SandboxExecStreamEvent>;
   readFile(path: string): Promise<Uint8Array>;
   readTextFile(path: string): Promise<string>;
   writeFile(path: string, data: string | Uint8Array): Promise<void>;
@@ -26,6 +43,7 @@ export interface SandboxSession {
 
 export interface SandboxCreateSessionOptions {
   id?: string;
+  workspace?: SandboxWorkspaceOptions;
   manifest?: SandboxManifest;
   metadata?: Record<string, string>;
 }
@@ -39,6 +57,7 @@ export interface SandboxManifest {
 export interface SandboxLimits {
   timeoutMs?: number;
   maxOutputBytes?: number;
+  maxFileBytes?: number;
   memoryMb?: number;
   cpus?: number;
   pidsLimit?: number;
@@ -67,6 +86,22 @@ export interface SandboxExecResult {
   stderrTruncated: boolean;
 }
 
+export type SandboxExecStreamEvent =
+  | {
+      type: "stdout";
+      chunk: Uint8Array;
+      text: string;
+    }
+  | {
+      type: "stderr";
+      chunk: Uint8Array;
+      text: string;
+    }
+  | {
+      type: "exit";
+      result: SandboxExecResult;
+    };
+
 export interface SandboxFileEntry {
   path: string;
   type: SandboxFileType;
@@ -79,24 +114,75 @@ export interface DockerSandboxSecurityOptions {
   dropCapabilities?: string[];
 }
 
+export interface DockerSandboxNetworkOptions {
+  mode: SandboxNetworkMode;
+}
+
+export interface SandboxSessionEvent {
+  sessionId: string;
+  provider: string;
+  workdir: string;
+}
+
+export interface SandboxExecEvent extends SandboxSessionEvent {
+  command: string;
+  args: string[];
+  cwd?: string;
+}
+
+export interface SandboxExecEndEvent extends SandboxExecEvent {
+  result: SandboxExecResult;
+}
+
+export interface SandboxFileWriteEvent extends SandboxSessionEvent {
+  path: string;
+  size: number;
+}
+
+export interface SandboxHooks {
+  onSessionCreate?: (event: SandboxSessionEvent) => void | Promise<void>;
+  onExecStart?: (event: SandboxExecEvent) => void | Promise<void>;
+  onExecEnd?: (event: SandboxExecEndEvent) => void | Promise<void>;
+  onFileWrite?: (event: SandboxFileWriteEvent) => void | Promise<void>;
+  onDestroy?: (event: SandboxSessionEvent) => void | Promise<void>;
+}
+
 export interface DockerSandboxOptions {
   image?: string;
   pull?: "missing" | "always" | "never";
   workdir?: string;
-  network?: SandboxNetworkMode;
+  workspace?: SandboxWorkspaceOptions;
+  lifecycle?: SandboxLifecycleOptions;
+  network?: SandboxNetworkMode | DockerSandboxNetworkOptions;
   user?: string;
   dockerPath?: string;
   labels?: Record<string, string>;
   limits?: SandboxLimits;
   security?: DockerSandboxSecurityOptions;
+  hooks?: SandboxHooks;
 }
 
 export interface SandboxToolsOptions {
+  allow?: SandboxToolName[];
   include?: SandboxToolName[];
   execTimeoutMs?: number;
+  exec?: SandboxExecToolPolicy;
+  readFile?: SandboxFileToolPolicy;
+  writeFile?: SandboxFileToolPolicy;
 }
 
 export type SandboxToolName = "exec_command" | "read_file" | "write_file" | "list_files";
+
+export interface SandboxExecToolPolicy {
+  allowedCommands?: string[];
+  blockedCommands?: string[];
+  defaultTimeoutMs?: number;
+  maxTimeoutMs?: number;
+}
+
+export interface SandboxFileToolPolicy {
+  maxBytes?: number;
+}
 
 export type SandboxToolsFactory = (
   session: SandboxSession,

--- a/packages/tools/sandbox/test/docker-sandbox.integration.test.ts
+++ b/packages/tools/sandbox/test/docker-sandbox.integration.test.ts
@@ -62,4 +62,106 @@ describe.skipIf(!runDockerTests)("DockerSandbox integration", () => {
       await session.destroy();
     }
   }, 60_000);
+
+  it("streams command output and enforces file size limits", async () => {
+    const sandbox = new DockerSandbox({
+      image: "node:22-bookworm",
+      pull: "missing",
+      limits: {
+        timeoutMs: 10_000,
+        maxFileBytes: 4,
+      },
+    });
+    const session = await sandbox.createSession({ id: `stream-${Date.now()}` });
+
+    try {
+      const events = [];
+
+      for await (const event of session.execStream({
+        command: "node",
+        args: ["-e", "console.log('one'); console.error('two')"],
+      })) {
+        events.push(event);
+      }
+
+      expect(events.map((event) => event.type)).toEqual(["stdout", "stderr", "exit"]);
+      expect(events.find((event) => event.type === "stdout")?.text.trim()).toBe("one");
+      expect(events.find((event) => event.type === "stderr")?.text.trim()).toBe("two");
+      await expect(session.writeTextFile("too-large.txt", "12345")).rejects.toThrow("maxFileBytes");
+    } finally {
+      await session.destroy();
+    }
+  }, 60_000);
+
+  it("emits hooks for public sandbox operations", async () => {
+    const events: string[] = [];
+    const sandbox = new DockerSandbox({
+      image: "node:22-bookworm",
+      pull: "missing",
+      hooks: {
+        onSessionCreate: (event) => {
+          events.push(`create:${event.sessionId}`);
+        },
+        onExecStart: (event) => {
+          events.push(`exec:start:${event.command}`);
+        },
+        onExecEnd: (event) => {
+          events.push(`exec:end:${event.result.exitCode}`);
+        },
+        onFileWrite: (event) => {
+          events.push(`write:${event.path}:${event.size}`);
+        },
+        onDestroy: (event) => {
+          events.push(`destroy:${event.sessionId}`);
+        },
+      },
+    });
+    const session = await sandbox.createSession({ id: `hooks-${Date.now()}` });
+
+    await session.writeTextFile("out/result.txt", "ok");
+    await session.listFiles("out");
+    await session.exec({ command: "node", args: ["-e", "console.log('hook')"] });
+    await session.destroy();
+
+    expect(events).toEqual([
+      `create:${session.id}`,
+      "write:out/result.txt:2",
+      "exec:start:node",
+      "exec:end:0",
+      `destroy:${session.id}`,
+    ]);
+  }, 60_000);
+
+  it("can reuse an explicit persistent workspace", async () => {
+    const workspaceId = `vitest-persistent-${Date.now()}`;
+    const sandbox = new DockerSandbox({
+      image: "node:22-bookworm",
+      pull: "missing",
+    });
+    const first = await sandbox.createSession({
+      id: `${workspaceId}-first`,
+      workspace: {
+        mode: "persistent",
+        id: workspaceId,
+      },
+    });
+
+    await first.writeTextFile("state.txt", "kept");
+    await first.destroy();
+
+    const second = await sandbox.createSession({
+      id: `${workspaceId}-second`,
+      workspace: {
+        mode: "persistent",
+        id: workspaceId,
+        destroyOnSessionDestroy: true,
+      },
+    });
+
+    try {
+      await expect(second.readTextFile("state.txt")).resolves.toBe("kept");
+    } finally {
+      await second.destroy();
+    }
+  }, 60_000);
 });

--- a/packages/tools/sandbox/test/tools.test.ts
+++ b/packages/tools/sandbox/test/tools.test.ts
@@ -20,6 +20,12 @@ describe("createSandboxTools", () => {
     expect(tools.map((tool) => tool.name)).toEqual(["read_file"]);
   });
 
+  it("supports allow as a tool selection alias", () => {
+    const tools = createSandboxTools(createSession(), { allow: ["list_files"] });
+
+    expect(tools.map((tool) => tool.name)).toEqual(["list_files"]);
+  });
+
   it("exec_command calls the sandbox session with structured args", async () => {
     const session = createSession();
     const [tool] = createSandboxTools(session, { include: ["exec_command"], execTimeoutMs: 1234 });
@@ -43,6 +49,44 @@ describe("createSandboxTools", () => {
     });
     expect(output).toContain("exit_code: 0");
     expect(output).toContain("stdout:");
+  });
+
+  it("enforces exec command policy", async () => {
+    const session = createSession();
+    const [tool] = createSandboxTools(session, {
+      allow: ["exec_command"],
+      exec: {
+        allowedCommands: ["node"],
+        maxTimeoutMs: 1000,
+      },
+    });
+    if (tool === undefined) {
+      throw new Error("Expected exec_command tool.");
+    }
+
+    await expect(tool.call({ command: "python" })).rejects.toThrow(
+      "Command is not allowed by sandbox tool policy",
+    );
+    await expect(tool.call({ command: "node", timeoutMs: 2000 })).rejects.toThrow(
+      "Command timeout exceeds sandbox tool policy",
+    );
+  });
+
+  it("enforces file tool byte policies", async () => {
+    const session = createSession();
+    const tools = Object.fromEntries(
+      createSandboxTools(session, {
+        readFile: { maxBytes: 4 },
+        writeFile: { maxBytes: 4 },
+      }).map((tool) => [tool.name, tool] as const),
+    );
+
+    await expect(tools.read_file?.call({ path: "a.txt" })).rejects.toThrow(
+      "File content exceeds sandbox tool policy",
+    );
+    await expect(tools.write_file?.call({ path: "a.txt", content: "content" })).rejects.toThrow(
+      "File content exceeds sandbox tool policy",
+    );
   });
 
   it("read_file, write_file, and list_files delegate to the session", async () => {
@@ -78,6 +122,21 @@ function createSession(): SandboxSession {
       stdoutTruncated: false,
       stderrTruncated: false,
     })),
+    execStream: vi.fn(async function* () {
+      yield {
+        type: "exit" as const,
+        result: {
+          stdout: "ok\n",
+          stderr: "",
+          exitCode: 0,
+          durationMs: 10,
+          timedOut: false,
+          aborted: false,
+          stdoutTruncated: false,
+          stderrTruncated: false,
+        },
+      };
+    }),
     readFile: vi.fn(async () => new TextEncoder().encode("file content")),
     readTextFile: vi.fn(async () => "file content"),
     writeFile: vi.fn(async () => undefined),


### PR DESCRIPTION
## Summary
- add explicit sandbox workspace modes, lifecycle cleanup, file-size limits, hooks, and language presets
- add streaming command execution via execStream
- add sandbox tool policy controls for allowed tools, commands, timeouts, and file sizes
- update sandbox guides, package docs, reference coverage, and changeset

## Verification
- pnpm exec biome check packages/tools/sandbox/src/types.ts packages/tools/sandbox/src/errors.ts packages/tools/sandbox/src/docker-sandbox.ts packages/tools/sandbox/src/tools.ts packages/tools/sandbox/test/docker-sandbox.integration.test.ts packages/tools/sandbox/test/tools.test.ts .changeset/warm-sandboxes-stream.md
- pnpm --filter @anvia/sandbox typecheck
- ANVIA_SANDBOX_DOCKER_TESTS=1 pnpm --filter @anvia/sandbox test
- pnpm --filter @anvia/sandbox build
- pnpm --filter docs reference-check
- pnpm --filter docs typecheck
- pnpm --filter docs build