### PR TITLE
Add PromptRequest runtime steering

### DIFF
--- a/.changeset/gentle-prompt-steering.md
+++ b/.changeset/gentle-prompt-steering.md
@@ -1,0 +1,5 @@
+---
+"@anvia/core": patch
+---
+
+Add `PromptRequest.steer()` for enqueueing user messages at safe model-turn boundaries during active prompt runs.

--- a/packages/core/src/agent/request.ts
+++ b/packages/core/src/agent/request.ts
@@ -115,6 +115,8 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
   private concurrency = 1;
   private traceOptions: AgentTraceOptions | undefined;
   private requestMiddlewares: AgentMiddleware[] = [];
+  private readonly steeringMessages: MessageType[] = [];
+  private runState: "idle" | "running" | "completed" | "errored" | "cancelled" = "idle";
   private readonly memoryRecorder: PromptRequestMemory;
 
   private constructor(
@@ -189,7 +191,17 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
     return this;
   }
 
+  steer(input: string | MessageType | MessageType[]): boolean {
+    if (this.isTerminal()) {
+      return false;
+    }
+
+    this.steeringMessages.push(...normalizeSteeringInput(input));
+    return true;
+  }
+
   async send(): Promise<PromptResponse> {
+    this.startRun();
     const runId = globalThis.crypto.randomUUID();
     const newMessages: MessageType[] = [this.promptMessage];
     this.chatHistory = await this.memoryRecorder.prepareRun(runId, newMessages);
@@ -254,6 +266,13 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
           (item): item is ToolCall => item.type === "tool_call",
         );
         if (toolCalls.length === 0) {
+          if (
+            await this.drainSteeringMessages(runId, currentTurns, newMessages, pendingTurnMessages)
+          ) {
+            await this.memoryRecorder.commitCompletedTurn(runId, currentTurns, pendingTurnMessages);
+            continue;
+          }
+
           await this.memoryRecorder.commitCompletedRun(
             runId,
             currentTurns,
@@ -266,6 +285,7 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
             messages: [...newMessages],
             trace: runObservers.trace,
           };
+          this.runState = "completed";
           await this.runRunEndHook(result, newMessages);
           await runObservers.end(result);
           return result;
@@ -290,12 +310,14 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
           [toolMessage],
           pendingTurnMessages,
         );
+        await this.drainSteeringMessages(runId, currentTurns, newMessages, pendingTurnMessages);
         await this.memoryRecorder.commitCompletedTurn(runId, currentTurns, pendingTurnMessages);
       }
 
       throw new MaxTurnsError(this.maxTurnCount, [...this.chatHistory, ...newMessages], lastPrompt);
     } catch (error) {
       const finalError = await this.runRunErrorHook(error, usage, newMessages);
+      this.runState = finalError instanceof PromptCancelledError ? "cancelled" : "errored";
       await runObservers.error({ error: finalError, usage, messages: [...newMessages] });
       await this.memoryRecorder.recordError(runId, finalError, newMessages);
       throw finalError;
@@ -307,6 +329,7 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
       throw new Error("This completion model does not support streaming");
     }
 
+    this.startRun();
     const runId = globalThis.crypto.randomUUID();
     const newMessages: MessageType[] = [this.promptMessage];
     this.chatHistory = await this.memoryRecorder.prepareRun(runId, newMessages);
@@ -419,6 +442,13 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
         yield await emit({ type: "turn_end", turn: currentTurns, response });
 
         if (toolCalls.length === 0) {
+          if (
+            await this.drainSteeringMessages(runId, currentTurns, newMessages, pendingTurnMessages)
+          ) {
+            await this.memoryRecorder.commitCompletedTurn(runId, currentTurns, pendingTurnMessages);
+            continue;
+          }
+
           const output = textFromAssistantContent(response.choice);
           await this.memoryRecorder.commitCompletedRun(
             runId,
@@ -434,6 +464,7 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
             messages: [...newMessages],
             trace: runObservers.trace,
           });
+          this.runState = "completed";
           await this.runRunEndHook({ output, usage, messages: [...newMessages] }, newMessages);
           await runObservers.end({ output, usage, messages: [...newMessages] });
           return;
@@ -471,12 +502,14 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
           [toolMessage],
           pendingTurnMessages,
         );
+        await this.drainSteeringMessages(runId, currentTurns, newMessages, pendingTurnMessages);
         await this.memoryRecorder.commitCompletedTurn(runId, currentTurns, pendingTurnMessages);
       }
 
       throw new MaxTurnsError(this.maxTurnCount, [...this.chatHistory, ...newMessages], lastPrompt);
     } catch (error) {
       const finalError = await this.runRunErrorHook(error, usage, newMessages);
+      this.runState = finalError instanceof PromptCancelledError ? "cancelled" : "errored";
       await runObservers.error({ error: finalError, usage, messages: [...newMessages] });
       await this.memoryRecorder.recordError(runId, finalError, newMessages);
       yield await emit({ type: "error", error: finalError });
@@ -758,6 +791,34 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
     return [...this.agent.middlewares, ...this.requestMiddlewares];
   }
 
+  private async drainSteeringMessages(
+    runId: string,
+    turn: number,
+    newMessages: MessageType[],
+    pendingTurnMessages: MessageType[],
+  ): Promise<boolean> {
+    const messages = this.steeringMessages.splice(0);
+    if (messages.length === 0) {
+      return false;
+    }
+
+    newMessages.push(...messages);
+    await this.memoryRecorder.commitMessages(runId, turn, messages, pendingTurnMessages);
+    return true;
+  }
+
+  private startRun(): void {
+    if (!this.isTerminal()) {
+      this.runState = "running";
+    }
+  }
+
+  private isTerminal(): boolean {
+    return (
+      this.runState === "completed" || this.runState === "errored" || this.runState === "cancelled"
+    );
+  }
+
   private cancelled(newMessages: MessageType[], reason: string): PromptCancelledError {
     return new PromptCancelledError([...this.chatHistory, ...newMessages], reason);
   }
@@ -784,6 +845,13 @@ function normalizePromptInput(prompt: string | MessageType | MessageType[]): {
     prompt: activePrompt,
     history: prompt.slice(0, -1),
   };
+}
+
+function normalizeSteeringInput(input: string | MessageType | MessageType[]): MessageType[] {
+  if (typeof input === "string") {
+    return [Message.user(input)];
+  }
+  return Array.isArray(input) ? [...input] : [input];
 }
 
 function addTurn(turn: number, event: AgentDeltaEvent): AgentStreamEvent {

--- a/packages/core/test/prompt-request.test.ts
+++ b/packages/core/test/prompt-request.test.ts
@@ -83,6 +83,39 @@ describe("PromptRequest", () => {
     expect(model.requests[0]?.chatHistory[0]).toEqual(Message.user("hello"));
   });
 
+  it("send consumes steering queued before no-tool finalization", async () => {
+    const model = new QueueModel([
+      response([AssistantContent.text("first")]),
+      response([AssistantContent.text("second")]),
+    ]);
+    let steer: ((input: string) => boolean) | undefined;
+    const agent = new AgentBuilder("test-agent", model)
+      .hook(
+        createHook({
+          onTurnEnd({ turn }) {
+            if (turn === 1) {
+              expect(steer?.("revise")).toBe(true);
+            }
+          },
+        }),
+      )
+      .build();
+    const request = agent.prompt("hello");
+    steer = request.steer.bind(request);
+
+    const result = await request.send();
+
+    expect(result.output).toBe("second");
+    expect(model.requests).toHaveLength(2);
+    expect(model.requests[1]?.chatHistory.at(-1)).toEqual(Message.user("revise"));
+    expect(result.messages).toEqual([
+      Message.user("hello"),
+      Message.assistant("first"),
+      Message.user("revise"),
+      Message.assistant("second"),
+    ]);
+  });
+
   it("merges repeated instruction blocks", async () => {
     const model = new QueueModel([response([AssistantContent.text("done")])]);
     const agent = new AgentBuilder("test-agent", model)
@@ -721,6 +754,36 @@ describe("PromptRequest", () => {
     await expect(agent.prompt("hello").send()).rejects.toThrow("No queued response");
 
     expect(events).toEqual(["completion_error:No queued response", "run_error:No queued response"]);
+  });
+
+  it("rejects steering after final, error, and cancel", async () => {
+    const finalModel = new QueueModel([response([AssistantContent.text("done")])]);
+    const finalAgent = new AgentBuilder("test-agent", finalModel).build();
+    const finalRequest = finalAgent.prompt("hello");
+
+    const result = await finalRequest.send();
+    const finalMessages = [...result.messages];
+
+    expect(finalRequest.steer("late")).toBe(false);
+    expect(result.messages).toEqual(finalMessages);
+    expect(finalModel.requests).toHaveLength(1);
+
+    const errorRequest = new AgentBuilder("test-agent", new QueueModel([])).build().prompt("hello");
+    await expect(errorRequest.send()).rejects.toThrow("No queued response");
+    expect(errorRequest.steer("late")).toBe(false);
+
+    const cancelRequest = new AgentBuilder("test-agent", new QueueModel([]))
+      .hook(
+        createHook({
+          onRunStart() {
+            return cancelPrompt("stop");
+          },
+        }),
+      )
+      .build()
+      .prompt("hello");
+    await expect(cancelRequest.send()).rejects.toBeInstanceOf(PromptCancelledError);
+    expect(cancelRequest.steer("late")).toBe(false);
   });
 
   it("runs tool error hooks and keeps tool errors as model-visible results", async () => {

--- a/packages/core/test/streaming.test.ts
+++ b/packages/core/test/streaming.test.ts
@@ -32,7 +32,11 @@ class StreamingQueueModel implements StreamingCompletionModel {
   };
   readonly requests: CompletionRequest[] = [];
 
-  constructor(private readonly responses: CompletionStreamEvent[][]) {}
+  constructor(
+    private readonly responses: Array<
+      Iterable<CompletionStreamEvent> | AsyncIterable<CompletionStreamEvent>
+    >,
+  ) {}
 
   async completion(): Promise<CompletionResponse> {
     throw new Error("completion should not be called");
@@ -44,7 +48,9 @@ class StreamingQueueModel implements StreamingCompletionModel {
     if (response === undefined) {
       throw new Error("No queued response");
     }
-    yield* response;
+    for await (const event of response) {
+      yield event;
+    }
   }
 }
 
@@ -99,6 +105,142 @@ describe("PromptRequest streaming", () => {
     expect(events.at(-1)).toMatchObject({ type: "final", output: "hello" });
     expect(model.requests[0]?.instructions).toBe("system");
     expect(model.requests[0]?.chatHistory[0]).toEqual(Message.user("hi"));
+  });
+
+  it("continues when steering arrives before a no-tool response finalizes", async () => {
+    const model = new StreamingQueueModel([
+      [{ type: "text_delta", delta: "first" }],
+      [{ type: "text_delta", delta: "second" }],
+    ]);
+    const agent = new AgentBuilder("test-agent", model).build();
+    const request = agent.prompt("hi");
+    const iterator = request.stream()[Symbol.asyncIterator]();
+
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: "turn_start",
+      turn: 1,
+      prompt: Message.user("hi"),
+    });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: "text_delta",
+      turn: 1,
+      delta: "first",
+    });
+    expect(await nextEvent(iterator)).toMatchObject({ type: "turn_end", turn: 1 });
+
+    expect(request.steer("revise")).toBe(true);
+
+    const rest = await collectIterator(iterator);
+    expect(rest.map((event) => event.type)).toEqual([
+      "turn_start",
+      "text_delta",
+      "turn_end",
+      "final",
+    ]);
+    expect(rest[0]).toMatchObject({
+      type: "turn_start",
+      turn: 2,
+      prompt: Message.user("revise"),
+    });
+    expect(model.requests).toHaveLength(2);
+    expect(model.requests[1]?.chatHistory.at(-1)).toEqual(Message.user("revise"));
+    expect(rest.at(-1)).toMatchObject({
+      type: "final",
+      output: "second",
+      messages: [
+        Message.user("hi"),
+        Message.assistant("first"),
+        Message.user("revise"),
+        Message.assistant("second"),
+      ],
+    });
+  });
+
+  it("appends steering after tool results before the next completion turn", async () => {
+    const toolStarted = deferred<void>();
+    const toolRelease = deferred<number>();
+    const slowAddTool = createTool({
+      name: "slow_add",
+      description: "Add numbers slowly",
+      input: z.object({
+        x: z.number(),
+        y: z.number(),
+      }),
+      output: z.number(),
+      async execute(args) {
+        toolStarted.resolve();
+        await toolRelease.promise;
+        return args.x + args.y;
+      },
+    });
+    const toolCall = AssistantContent.toolCall("call_1", "slow_add", { x: 2, y: 5 });
+    const model = new StreamingQueueModel([
+      [{ type: "tool_call", toolCall }],
+      [{ type: "text_delta", delta: "done" }],
+    ]);
+    const agent = new AgentBuilder("test-agent", model).tool(slowAddTool).build();
+    const request = agent.prompt("add");
+    const eventsPromise = collect(request.stream());
+
+    await toolStarted.promise;
+    expect(request.steer("also explain")).toBe(true);
+    toolRelease.resolve(7);
+
+    const events = await eventsPromise;
+    expect(events.at(-1)).toMatchObject({ type: "final", output: "done" });
+    expect(model.requests).toHaveLength(2);
+    expect(model.requests[1]?.chatHistory.slice(-3)).toEqual([
+      Message.assistant([toolCall]),
+      Message.tool([
+        {
+          type: "tool_result",
+          id: "call_1",
+          content: [{ type: "text", text: "7" }],
+        },
+      ]),
+      Message.user("also explain"),
+    ]);
+  });
+
+  it("consumes multiple steering calls in FIFO order", async () => {
+    const model = new StreamingQueueModel([
+      [{ type: "text_delta", delta: "base" }],
+      [{ type: "text_delta", delta: "done" }],
+    ]);
+    const agent = new AgentBuilder("test-agent", model).build();
+    const request = agent.prompt("start");
+    const iterator = request.stream()[Symbol.asyncIterator]();
+    const firstSteer = Message.user("first steer");
+    const secondSteer = Message.user("second steer");
+
+    expect(await nextEvent(iterator)).toMatchObject({ type: "turn_start", turn: 1 });
+    expect(await nextEvent(iterator)).toMatchObject({ type: "text_delta", turn: 1 });
+    expect(await nextEvent(iterator)).toMatchObject({ type: "turn_end", turn: 1 });
+
+    expect(request.steer(firstSteer)).toBe(true);
+    expect(request.steer([secondSteer])).toBe(true);
+
+    const rest = await collectIterator(iterator);
+    expect(rest[0]).toMatchObject({
+      type: "turn_start",
+      turn: 2,
+      prompt: secondSteer,
+    });
+    expect(model.requests[1]?.chatHistory.slice(-3)).toEqual([
+      Message.assistant("base"),
+      firstSteer,
+      secondSteer,
+    ]);
+    expect(rest.at(-1)).toMatchObject({
+      type: "final",
+      messages: [
+        Message.user("start"),
+        Message.assistant("base"),
+        firstSteer,
+        secondSteer,
+        Message.assistant("done"),
+      ],
+    });
   });
 
   it("merges usage-only final stream responses with accumulated text", async () => {


### PR DESCRIPTION
## Summary
- Add PromptRequest.steer() to enqueue steering messages while a prompt run is active
- Drain steering at safe model-turn boundaries after assistant responses and tool results
- Cover streaming and send() steering behavior, FIFO ordering, and terminal rejection
- Add a patch changeset for @anvia/core

## Verification
- pnpm --dir packages/core exec vitest run test/prompt-request.test.ts test/streaming.test.ts
- pnpm --filter @anvia/core typecheck
- pnpm --dir apps/docs typecheck