### PR TITLE
feat(studio): add multi-provider model config

### DIFF
--- a/.changeset/studio-multi-provider-models.md
+++ b/.changeset/studio-multi-provider-models.md
@@ -1,0 +1,5 @@
+---
+"@anvia/studio": minor
+---
+
+Add multi-provider model selection and multimodal attachment support to Studio, including cookbook documentation and assistant loading feedback in the playground.

--- a/apps/docs/content/docs/reference/api-coverage.mdx
+++ b/apps/docs/content/docs/reference/api-coverage.mdx
@@ -28,7 +28,7 @@ Internal source-file exports are outside this check unless they are re-exported 
 | `@anvia/qdrant` | 1 | 5 | [Qdrant](/docs/reference/integrations/qdrant) |
 | `@anvia/langfuse` | 1 | 6 | [Langfuse](/docs/reference/integrations/langfuse) |
 | `@anvia/otel` | 1 | 3 | [OpenTelemetry](/docs/reference/integrations/otel) |
-| `@anvia/studio` | 1 | 61 | [Studio](/docs/reference/studio) |
+| `@anvia/studio` | 1 | 128 | [Studio](/docs/reference/studio) |
 
 The check must report:
 

--- a/apps/docs/content/docs/reference/studio/types.mdx
+++ b/apps/docs/content/docs/reference/studio/types.mdx
@@ -95,7 +95,9 @@ type StudioConfig = {
   description?: string;
   version?: string;
   agents: StudioAgentConfig[];
+  models?: StudioModelsConfig;
   pipelines: StudioPipelineConfig[];
+  evals: StudioEvalSuiteConfig[];
   chat: { quickPrompts: Record<string, string[]> };
   capabilities: Partial<Record<StudioCapability, StudioCapabilityConfig>>;
   unsupportedCapabilities: StudioCapability[];
@@ -107,6 +109,88 @@ Purpose: configuration returned by Studio runtime and HTTP config endpoints.
 Return behavior: `Studio.config()` returns `StudioConfig`. Pipelines are top-level Studio targets beside agents.
 
 Notable errors: none directly.
+
+## Model Configuration Types
+
+```ts
+type StudioModelRef = string | { provider: string; model: string };
+
+type StudioModelModality = "text" | "image" | "document" | "audio" | "video";
+
+type StudioModelModalities = {
+  input: StudioModelModality[];
+  output?: StudioModelModality[];
+};
+
+type StudioModelDefinition = {
+  id: string;
+  name?: string;
+  description?: string;
+  modalities?: StudioModelModalities;
+  capabilities?: Partial<CompletionModelCapabilities>;
+  metadata?: JsonObject;
+};
+
+type StudioModelProvider = {
+  id: string;
+  name?: string;
+  defaultModel?: string;
+  models?: StudioModelDefinition[];
+  createCompletionModel(model: string): CompletionModel | StreamingCompletionModel;
+  listModels?: () => Promise<ModelList>;
+  metadata?: JsonObject;
+};
+
+type StudioAgentModelPolicy = {
+  default?: StudioModelRef;
+  allowed?: Array<StudioModelRef | `${string}:*`>;
+};
+
+type StudioModelConfig = {
+  providers: StudioModelProvider[];
+  default?: StudioModelRef;
+  agents?: Record<string, StudioAgentModelPolicy>;
+};
+
+type StudioModelSummary = StudioModelDefinition & {
+  ref: string;
+  providerId: string;
+  providerName?: string;
+};
+
+type StudioModelProviderConfig = {
+  id: string;
+  name?: string;
+  defaultModel?: string;
+  models: StudioModelSummary[];
+  metadata?: JsonObject;
+  warning?: string;
+};
+
+type StudioAgentModelPolicyConfig = {
+  default?: string;
+  allowed?: string[];
+};
+
+type StudioModelsConfig = {
+  providers: StudioModelProviderConfig[];
+  default?: string;
+  agents: Record<string, StudioAgentModelPolicyConfig>;
+};
+
+type StudioAgentModelsSummary = {
+  agentId: string;
+  defaultModel?: string;
+  models: StudioModelSummary[];
+  warnings?: JsonObject[];
+};
+```
+
+Purpose: configure the provider/model menu Studio exposes for agent runs. `StudioModelProvider` bridges human-facing model metadata to runtime `CompletionModel` instances. `StudioModelModalities` records whether a model accepts text, image, document, audio, or video input and which output modalities it can produce.
+
+Return behavior: `StudioModelConfig` is accepted through `new Studio(targets, { models })`. `StudioModelsConfig` appears on `GET /config`; `StudioAgentModelsSummary` appears on `GET /agents/:agentId/models`; `StudioModelSummary` values use canonical `provider:model` refs for UI selection and HTTP run requests.
+
+Notable errors: run requests that select a model outside an agent's `StudioAgentModelPolicy` return `bad_request`. Unsupported modality selections are reported as warnings when metadata is available.
 
 ## Tool Metadata Types
 
@@ -167,6 +251,14 @@ type StudioAgentMcpServerMetadata = {
 type StudioAgentMcpsSummary = {
   agentId: string;
   servers: StudioAgentMcpServerMetadata[];
+};
+
+type StudioTranscriptAttachment = {
+  kind: "image" | "document";
+  name?: string;
+  mediaType?: string;
+  data?: string;
+  url?: string;
 };
 ```
 
@@ -288,6 +380,7 @@ type AgentRunRequest = {
   message: string | Message;
   history?: Message[];
   sessionId?: string;
+  model?: StudioModelRef;
   stream?: boolean;
   maxTurns?: number;
   toolConcurrency?: number;

--- a/apps/docs/content/docs/studio/configure/meta.json
+++ b/apps/docs/content/docs/studio/configure/meta.json
@@ -2,5 +2,12 @@
   "title": "Configure Studio",
   "defaultOpen": false,
   "collapsible": true,
-  "pages": ["serve-options", "quick-prompts", "storage-and-persistence", "capabilities", "status"]
+  "pages": [
+    "serve-options",
+    "quick-prompts",
+    "model-providers",
+    "storage-and-persistence",
+    "capabilities",
+    "status"
+  ]
 }

--- a/apps/docs/content/docs/studio/configure/model-providers.mdx
+++ b/apps/docs/content/docs/studio/configure/model-providers.mdx
@@ -1,0 +1,160 @@
+---
+title: Model Providers
+description: Configure Studio to select models across providers per run.
+---
+
+Studio can expose a model selector for each agent. Use it when you want the same agent instructions, tools, sessions, and traces to run against multiple provider models.
+
+The agent still needs a normal default model at build time. The Studio `models` option adds runtime model choices for Studio runs.
+
+```ts
+import { AnthropicClient } from "@anvia/anthropic";
+import { AgentBuilder } from "@anvia/core/agent";
+import { OpenAIClient } from "@anvia/openai";
+import { Studio } from "@anvia/studio";
+
+const openai = new OpenAIClient({ apiKey: process.env.OPENAI_API_KEY });
+const anthropic = new AnthropicClient({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+const agent = new AgentBuilder("assistant", openai.completionModel("gpt-5.5"))
+  .name("Assistant")
+  .instructions("You are a helpful general-purpose assistant.")
+  .build();
+
+new Studio([agent], {
+  models: {
+    default: "openai:gpt-5.5",
+    providers: [
+      {
+        id: "openai",
+        name: "OpenAI",
+        defaultModel: "gpt-5.5",
+        createCompletionModel: (model) => openai.completionModel(model),
+        listModels: () => openai.listModels(),
+        models: [
+          {
+            id: "gpt-5.5",
+            name: "GPT-5.5",
+            modalities: {
+              input: ["text", "image", "document"],
+              output: ["text"],
+            },
+          },
+        ],
+      },
+      {
+        id: "anthropic",
+        name: "Anthropic",
+        defaultModel: "claude-opus-4-8",
+        createCompletionModel: (model) => anthropic.completionModel(model),
+        listModels: () => anthropic.listModels(),
+        models: [
+          {
+            id: "claude-opus-4-8",
+            name: "Claude Opus 4.8",
+            modalities: {
+              input: ["text", "image", "document"],
+              output: ["text"],
+            },
+          },
+        ],
+      },
+    ],
+    agents: {
+      assistant: {
+        default: "openai:gpt-5.5",
+        allowed: ["openai:gpt-5.5", "anthropic:claude-opus-4-8"],
+      },
+    },
+  },
+}).start({ port: 4021 });
+```
+
+## Provider Config
+
+Each provider entry describes how Studio should create a runtime model from a selected model id.
+
+| Field | Purpose |
+| --- | --- |
+| `id` | Stable provider id used in model refs, such as `openai` |
+| `name` | Human label shown in Studio |
+| `defaultModel` | Provider-local fallback model id |
+| `createCompletionModel` | Factory that returns a `CompletionModel` or `StreamingCompletionModel` |
+| `listModels` | Optional dynamic model catalog from the provider |
+| `models` | Optional static metadata for labels, modalities, capabilities, and custom metadata |
+
+Static `models` metadata is useful when the provider's model list does not include all the display or modality information you want Studio to show.
+
+## Model Refs
+
+Studio identifies configured models with `provider:model` refs.
+
+```ts
+models: {
+  default: "openai:gpt-5.5",
+  agents: {
+    assistant: {
+      default: "anthropic:claude-opus-4-8",
+      allowed: ["openai:*", "anthropic:claude-opus-4-8"],
+    },
+  },
+}
+```
+
+Use an object ref when constructing config programmatically:
+
+```ts
+default: { provider: "openai", model: "gpt-5.5" }
+```
+
+The `allowed` list can include exact refs or provider wildcards such as `openai:*`.
+
+## Multimodal Metadata
+
+Use `modalities` to tell Studio which file inputs a model can accept.
+
+```ts
+{
+  id: "gpt-5.5",
+  modalities: {
+    input: ["text", "image", "document"],
+    output: ["text"],
+  },
+  capabilities: {
+    streaming: true,
+    tools: true,
+    imageInput: true,
+    documentInput: true,
+  },
+}
+```
+
+When a user attaches images or documents, Studio sends a structured `Message` to the selected model. Attachments are read in the browser and sent with the run request; Studio does not upload them to a standalone file store.
+
+## HTTP API
+
+Inspect the resolved Studio-wide model config:
+
+```bash
+curl http://localhost:4021/models
+```
+
+Inspect the model choices allowed for one agent:
+
+```bash
+curl http://localhost:4021/agents/assistant/models
+```
+
+Run an agent with a selected model:
+
+```bash
+curl -X POST http://localhost:4021/agents/assistant/runs \
+  -H 'content-type: application/json' \
+  -d '{"message":"Draft a short project update.","model":"anthropic:claude-opus-4-8"}'
+```
+
+Studio persists the selected model ref in session metadata so continued sessions can keep using the same model unless the user changes it.
+
+## Cookbook
+
+See `examples/cookbook/09_studio/13-multi-provider-models.ts` for a complete runnable OpenAI and Anthropic setup.

--- a/examples/cookbook/09_studio/13-multi-provider-models.ts
+++ b/examples/cookbook/09_studio/13-multi-provider-models.ts
@@ -1,0 +1,99 @@
+import { AnthropicClient } from "@anvia/anthropic";
+import { AgentBuilder } from "@anvia/core/agent";
+import { OpenAIClient } from "@anvia/openai";
+import { Studio } from "@anvia/studio";
+
+const openai = new OpenAIClient({
+  baseUrl: process.env.OPENAI_BASEURL,
+  apiKey: process.env.OPENAI_API_KEY,
+});
+
+const anthropic = new AnthropicClient({
+  baseUrl: process.env.ANTHROPIC_BASEURL,
+  apiKey: process.env.ANTHROPIC_API_KEY,
+});
+
+const agent = new AgentBuilder("studio-model-router", openai.completionModel("gpt-5.5"))
+  .name("Studio Model Router")
+  .description("Demonstrates Studio model selection across multiple providers.")
+  .instructions(
+    [
+      "You are a helpful general-purpose assistant used to compare provider behavior in Anvia Studio.",
+      "Answer clearly and concisely. Adapt your tone and depth to the user's request.",
+    ].join("\n"),
+  )
+  .build();
+
+new Studio([agent], {
+  models: {
+    default: "openai:gpt-5.5",
+    providers: [
+      {
+        id: "openai",
+        name: "OpenAI",
+        defaultModel: "gpt-5.5",
+        createCompletionModel: (model) => openai.completionModel(model),
+        listModels: () => openai.listModels(),
+        models: [
+          {
+            id: "gpt-5.5",
+            name: "GPT-5.5",
+            modalities: {
+              input: ["text", "image", "document"],
+              output: ["text"],
+            },
+            capabilities: {
+              streaming: true,
+              tools: true,
+              imageInput: true,
+              documentInput: true,
+              outputSchema: true,
+              reasoning: true,
+            },
+          },
+        ],
+      },
+      {
+        id: "anthropic",
+        name: "Anthropic",
+        defaultModel: "claude-opus-4-8",
+        createCompletionModel: (model) => anthropic.completionModel(model),
+        listModels: () => anthropic.listModels(),
+        models: [
+          {
+            id: "claude-opus-4-8",
+            name: "Claude Sonnet 4",
+            modalities: {
+              input: ["text", "image", "document"],
+              output: ["text"],
+            },
+            capabilities: {
+              streaming: true,
+              tools: true,
+              imageInput: true,
+              documentInput: true,
+              reasoning: true,
+            },
+          },
+        ],
+      },
+    ],
+    agents: {
+      "studio-model-router": {
+        default: "openai:gpt-5.5",
+        allowed: ["openai:gpt-5.5", "anthropic:claude-opus-4-8"],
+      },
+    },
+  },
+  quickPrompts: {
+    "studio-model-router": [
+      "Explain the difference between latency, quality, and cost when choosing a model.",
+      "Draft a short project update for a weekly team check-in.",
+      "What should I consider before routing multimodal work to a model?",
+    ],
+  },
+}).start({ port: 4021 });
+
+console.log("Open http://localhost:4021/ui/playground");
+console.log("Use the model selector in the message composer to switch providers per run.");
+console.log("Open http://localhost:4021/agents/studio-model-router/models for the model catalog.");

--- a/examples/cookbook/README.md
+++ b/examples/cookbook/README.md
@@ -28,7 +28,7 @@ Legacy script names such as `cookbook:basic:01`, `cookbook:intermediate:14`, `co
 | `06_retrieval` | Embeddings, in-memory search, metadata filters, RAG context, document loaders, vector stores, and embedding provider variants. |
 | `07_multi_agent` | Basic agent-tools, pipeline-backed parallel specialists, streaming agent-tools, and event stores. |
 | `08_evals` | Deterministic metrics, semantic similarity, custom metrics, agent eval targets, and LLM judge/score. |
-| `09_studio` | Single-agent, multi-agent, pipeline, eval, and subagent Studio runners, pipeline replay, realtime observability, tool approvals, human feedback, Knowledge, Memory, Status, tool inspection, SQLite persistence, and UI route options. |
+| `09_studio` | Single-agent, multi-agent, pipeline, eval, and subagent Studio runners, pipeline replay, realtime observability, tool approvals, human feedback, Knowledge, Memory, Status, tool inspection, SQLite persistence, multi-provider model selection, and UI route options. |
 | `10_integrations` | MCP tools, local skills, Langfuse tracing, logging, and eval reporting. |
 
 ## Environment
@@ -70,7 +70,7 @@ Not every example needs every variable. Pure pipeline, dynamic tool, and core ev
 - `retrieval:13` uses a hosted Pinecone index. Create a 384-dimension index first, then set `PINECONE_API_KEY`, `PINECONE_INDEX_NAME`, and optionally `PINECONE_NAMESPACE`.
 - Langfuse examples need Langfuse credentials and live in `10_integrations`.
 - `integrations:06` logs agent lifecycle events with Pino through `@anvia/logger`; `integrations:07` shows the built-in console logger.
-- Studio examples start a local HTTP server and keep Studio state in memory by default. `studio:10` shows explicit SQLite store wiring for sessions, traces, pipeline logs, and pipeline run history.
+- Studio examples start a local HTTP server and keep Studio state in memory by default. `studio:10` shows explicit SQLite store wiring for sessions, traces, pipeline logs, and pipeline run history. `studio:13` shows the Studio message-composer model selector across OpenAI and Anthropic.
 - Tool history and loader examples write sample files under `.memory`.
 - Image and audio generation examples write generated media files in the current working directory.
 - `providers:09` uses the bundled `assets/audio/voice.wav` sample by default. Set `ANVIA_AUDIO_FILE` to transcribe a different local audio file.

--- a/examples/cookbook/package.json
+++ b/examples/cookbook/package.json
@@ -90,6 +90,7 @@
     "studio:10": "tsx -r dotenv/config 09_studio/10-persistent-store.ts dotenv_config_path=../../.env",
     "studio:11": "tsx -r dotenv/config 09_studio/11-eval-runner.ts dotenv_config_path=../../.env",
     "studio:12": "tsx -r dotenv/config 09_studio/12-ui-options.ts dotenv_config_path=../../.env",
+    "studio:13": "tsx -r dotenv/config 09_studio/13-multi-provider-models.ts dotenv_config_path=../../.env",
     "integrations": "tsx -r dotenv/config 10_integrations/01-mcp-tools.ts dotenv_config_path=../../.env",
     "integrations:01": "tsx -r dotenv/config 10_integrations/01-mcp-tools.ts dotenv_config_path=../../.env",
     "integrations:02": "tsx -r dotenv/config 10_integrations/02-local-skills.ts dotenv_config_path=../../.env",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "cookbook:studio:10": "pnpm --filter cookbook studio:10",
     "cookbook:studio:11": "pnpm --filter cookbook studio:11",
     "cookbook:studio:12": "pnpm --filter cookbook studio:12",
+    "cookbook:studio:13": "pnpm --filter cookbook studio:13",
     "cookbook:integrations": "pnpm --filter cookbook integrations",
     "cookbook:integrations:01": "pnpm --filter cookbook integrations:01",
     "cookbook:integrations:02": "pnpm --filter cookbook integrations:02",

--- a/packages/tool-studio/README.md
+++ b/packages/tool-studio/README.md
@@ -44,6 +44,68 @@ Then open:
 http://localhost:4021/ui/playground
 ```
 
+## Multi-Provider Models
+
+Studio can expose a shared model catalog and let each agent choose from registered providers:
+
+```ts
+import { AgentBuilder } from "@anvia/core";
+import { AnthropicClient } from "@anvia/anthropic";
+import { OpenAIClient } from "@anvia/openai";
+import { Studio } from "@anvia/studio";
+
+const openai = new OpenAIClient({ apiKey: process.env.OPENAI_API_KEY });
+const anthropic = new AnthropicClient({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+const agent = new AgentBuilder("support", openai.completionModel("gpt-5"))
+  .name("Support")
+  .instructions("Answer support questions clearly.")
+  .build();
+
+new Studio([agent], {
+  models: {
+    providers: [
+      {
+        id: "openai",
+        name: "OpenAI",
+        defaultModel: "gpt-5",
+        createCompletionModel: (model) => openai.completionModel(model),
+        listModels: () => openai.listModels(),
+        models: [
+          {
+            id: "gpt-5",
+            modalities: { input: ["text", "image", "document"], output: ["text"] },
+          },
+        ],
+      },
+      {
+        id: "anthropic",
+        name: "Anthropic",
+        defaultModel: "claude-sonnet-4-20250514",
+        createCompletionModel: (model) => anthropic.completionModel(model),
+      },
+    ],
+    agents: {
+      support: {
+        default: "openai:gpt-5",
+        allowed: ["openai:*", "anthropic:claude-sonnet-4-20250514"],
+      },
+    },
+  },
+}).start();
+```
+
+The playground message composer shows the allowed models for the selected agent. API callers can
+also select a model per run:
+
+```json
+{
+  "message": "Summarize this ticket",
+  "model": "anthropic:claude-sonnet-4-20250514",
+  "stream": true
+}
+```
+
 ## Browser UI
 
 Studio exposes:

--- a/packages/tool-studio/src/runtime/models.ts
+++ b/packages/tool-studio/src/runtime/models.ts
@@ -1,0 +1,468 @@
+import type { CompletionModel, JsonObject, Message } from "@anvia/core/completion";
+import type { Hono } from "hono";
+import type {
+  AgentRunRequest,
+  StudioAgent,
+  StudioAgentModelPolicy,
+  StudioAgentModelPolicyConfig,
+  StudioAgentModelsSummary,
+  StudioModelConfig,
+  StudioModelDefinition,
+  StudioModelModality,
+  StudioModelProvider,
+  StudioModelProviderConfig,
+  StudioModelRef,
+  StudioModelSummary,
+  StudioModelsConfig,
+} from "../types";
+import { errorResponse, serializeError } from "./shared";
+
+export const STUDIO_MODEL_METADATA_KEY = "studioModel";
+
+type RuntimeProvider = StudioModelProvider & {
+  staticModels: Map<string, StudioModelDefinition>;
+};
+
+export type StudioModelRegistry = {
+  readonly defaultModel?: string;
+  readonly providers: Map<string, RuntimeProvider>;
+  readonly agentPolicies: Map<string, NormalizedAgentModelPolicy>;
+  readonly modelCache: Map<string, CompletionModel>;
+};
+
+type NormalizedAgentModelPolicy = {
+  default?: string;
+  allowed?: string[];
+};
+
+type ResolveModelInput = {
+  agent: StudioAgent;
+  request: AgentRunRequest;
+  sessionMetadata?: JsonObject | undefined;
+};
+
+export type StudioResolvedModel = {
+  ref?: string;
+  model?: CompletionModel;
+  warnings: JsonObject[];
+};
+
+export function createStudioModelRegistry(
+  config: StudioModelConfig | undefined,
+): StudioModelRegistry | undefined {
+  if (config === undefined) {
+    return undefined;
+  }
+
+  const providers = new Map<string, RuntimeProvider>();
+  for (const provider of config.providers) {
+    const id = normalizeProviderId(provider.id);
+    if (providers.has(id)) {
+      throw new Error(`Duplicate Studio model provider id: ${id}`);
+    }
+    const staticModels = new Map<string, StudioModelDefinition>();
+    for (const model of provider.models ?? []) {
+      const modelId = normalizeModelId(model.id);
+      if (staticModels.has(modelId)) {
+        throw new Error(`Duplicate Studio model id for provider ${id}: ${modelId}`);
+      }
+      staticModels.set(modelId, { ...model, id: modelId });
+    }
+    providers.set(id, {
+      ...provider,
+      id,
+      ...(provider.defaultModel === undefined
+        ? {}
+        : { defaultModel: normalizeModelId(provider.defaultModel) }),
+      staticModels,
+    });
+  }
+
+  return {
+    ...(config.default === undefined ? {} : { defaultModel: normalizeModelRef(config.default) }),
+    providers,
+    agentPolicies: normalizeAgentPolicies(config.agents ?? {}),
+    modelCache: new Map(),
+  };
+}
+
+export function studioModelsConfig(
+  registry: StudioModelRegistry | undefined,
+  agents: StudioAgent[],
+): StudioModelsConfig | undefined {
+  if (registry === undefined) {
+    return undefined;
+  }
+
+  const providers = [...registry.providers.values()].map((provider): StudioModelProviderConfig => {
+    const models = [...provider.staticModels.values()].map((model) =>
+      modelSummary(provider, model.id, model),
+    );
+    return {
+      id: provider.id,
+      ...(provider.name === undefined ? {} : { name: provider.name }),
+      ...(provider.defaultModel === undefined ? {} : { defaultModel: provider.defaultModel }),
+      models,
+      ...(provider.metadata === undefined ? {} : { metadata: provider.metadata }),
+    };
+  });
+
+  const agentIds = new Set(agents.map((agent) => agent.id));
+  const agentsConfig = Object.fromEntries(
+    [...registry.agentPolicies.entries()]
+      .filter(([agentId]) => agentIds.has(agentId))
+      .map(([agentId, policy]) => [agentId, publicPolicy(policy)]),
+  );
+
+  return {
+    providers,
+    ...(registry.defaultModel === undefined ? {} : { default: registry.defaultModel }),
+    agents: agentsConfig,
+  };
+}
+
+export function registerModelRoutes(
+  app: Hono,
+  props: { registry?: StudioModelRegistry | undefined; agentMap: Map<string, StudioAgent> },
+): void {
+  app.get("/models", async (c) => {
+    if (props.registry === undefined) {
+      return errorResponse(c, 404, "not_found", "Model registry not configured");
+    }
+    const providers = await Promise.all(
+      [...props.registry.providers.values()].map((provider) => providerCatalog(provider)),
+    );
+    return c.json({
+      providers,
+      ...(props.registry.defaultModel === undefined
+        ? {}
+        : { defaultModel: props.registry.defaultModel }),
+    });
+  });
+
+  app.get("/models/:providerId", async (c) => {
+    if (props.registry === undefined) {
+      return errorResponse(c, 404, "not_found", "Model registry not configured");
+    }
+    const provider = props.registry.providers.get(c.req.param("providerId"));
+    if (provider === undefined) {
+      return errorResponse(c, 404, "not_found", "Model provider not found");
+    }
+    return c.json(await providerCatalog(provider));
+  });
+
+  app.get("/agents/:agentId/models", async (c) => {
+    const agentId = c.req.param("agentId");
+    const agent = props.agentMap.get(agentId);
+    if (agent === undefined) {
+      return errorResponse(c, 404, "not_found", "Agent not found");
+    }
+    if (props.registry === undefined) {
+      return c.json({
+        agentId,
+        models: [],
+      } satisfies StudioAgentModelsSummary);
+    }
+    return c.json(await agentModelsCatalog(props.registry, agent));
+  });
+}
+
+export function resolveStudioModel(
+  registry: StudioModelRegistry | undefined,
+  input: ResolveModelInput,
+): StudioResolvedModel {
+  if (registry === undefined) {
+    return { warnings: [] };
+  }
+
+  const selectedRef =
+    normalizeOptionalModelRef(input.request.model) ??
+    sessionModelRef(input.sessionMetadata) ??
+    registry.agentPolicies.get(input.agent.id)?.default ??
+    registry.defaultModel;
+  if (selectedRef === undefined) {
+    return { warnings: [] };
+  }
+
+  ensureModelAllowed(registry, input.agent.id, selectedRef);
+  const { providerId, modelId } = parseModelRef(selectedRef);
+  const provider = registry.providers.get(providerId);
+  if (provider === undefined) {
+    throw new ModelSelectionError(`Unknown model provider: ${providerId}`);
+  }
+
+  let model = registry.modelCache.get(selectedRef);
+  if (model === undefined) {
+    model = provider.createCompletionModel(modelId);
+    registry.modelCache.set(selectedRef, model);
+  }
+
+  const metadata = provider.staticModels.get(modelId);
+  return {
+    ref: selectedRef,
+    model,
+    warnings: modelWarnings(selectedRef, metadata, input.request),
+  };
+}
+
+export function sessionModelRef(metadata: JsonObject | undefined): string | undefined {
+  const value = metadata?.[STUDIO_MODEL_METADATA_KEY];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+export function normalizeOptionalModelRef(ref: StudioModelRef | undefined): string | undefined {
+  return ref === undefined ? undefined : normalizeModelRef(ref);
+}
+
+export function normalizeModelRef(ref: StudioModelRef): string {
+  if (typeof ref === "string") {
+    const trimmed = ref.trim();
+    const parsed = parseModelRef(trimmed);
+    return `${parsed.providerId}:${parsed.modelId}`;
+  }
+  return `${normalizeProviderId(ref.provider)}:${normalizeModelId(ref.model)}`;
+}
+
+export function parseModelRef(ref: string): { providerId: string; modelId: string } {
+  const index = ref.indexOf(":");
+  if (index <= 0 || index === ref.length - 1) {
+    throw new ModelSelectionError(`Model ref must use provider:model format: ${ref}`);
+  }
+  return {
+    providerId: normalizeProviderId(ref.slice(0, index)),
+    modelId: normalizeModelId(ref.slice(index + 1)),
+  };
+}
+
+export class ModelSelectionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ModelSelectionError";
+  }
+}
+
+async function agentModelsCatalog(
+  registry: StudioModelRegistry,
+  agent: StudioAgent,
+): Promise<StudioAgentModelsSummary> {
+  const policy = registry.agentPolicies.get(agent.id);
+  const catalogs = await Promise.all([...registry.providers.values()].map(providerCatalog));
+  const warnings = catalogs.flatMap((catalog) =>
+    catalog.warning === undefined
+      ? []
+      : [{ providerId: catalog.id, warning: catalog.warning } satisfies JsonObject],
+  );
+  const models = catalogs
+    .flatMap((catalog) => catalog.models)
+    .filter((model) => {
+      if (policy?.allowed === undefined) {
+        return true;
+      }
+      return allowedByPolicy(policy.allowed, model.ref);
+    });
+  const exactPolicyModels = (policy?.allowed ?? [])
+    .filter((allowed) => !allowed.endsWith(":*"))
+    .filter((allowed) => models.every((model) => model.ref !== allowed))
+    .flatMap((ref) => {
+      try {
+        const { providerId, modelId } = parseModelRef(ref);
+        const provider = registry.providers.get(providerId);
+        return provider === undefined
+          ? []
+          : [
+              modelSummary(provider, modelId, {
+                id: modelId,
+              }),
+            ];
+      } catch {
+        return [];
+      }
+    });
+
+  const defaultModel = policy?.default ?? registry.defaultModel;
+  return {
+    agentId: agent.id,
+    ...(defaultModel === undefined ? {} : { defaultModel }),
+    models: [...models, ...exactPolicyModels],
+    ...(warnings.length === 0 ? {} : { warnings }),
+  };
+}
+
+async function providerCatalog(provider: RuntimeProvider): Promise<StudioModelProviderConfig> {
+  const models = new Map<string, StudioModelSummary>();
+  for (const model of provider.staticModels.values()) {
+    models.set(model.id, modelSummary(provider, model.id, model));
+  }
+
+  let warning: string | undefined;
+  if (provider.listModels !== undefined) {
+    try {
+      const listed = await provider.listModels();
+      for (const model of listed.data) {
+        const staticModel = provider.staticModels.get(model.id);
+        models.set(
+          model.id,
+          modelSummary(provider, model.id, {
+            id: model.id,
+            ...(model.name === undefined ? {} : { name: model.name }),
+            ...(model.description === undefined ? {} : { description: model.description }),
+            ...(staticModel ?? {}),
+            metadata: {
+              ...(model.type === undefined ? {} : { type: model.type }),
+              ...(model.createdAt === undefined ? {} : { createdAt: model.createdAt }),
+              ...(model.ownedBy === undefined ? {} : { ownedBy: model.ownedBy }),
+              ...(model.contextLength === undefined ? {} : { contextLength: model.contextLength }),
+              ...(staticModel?.metadata ?? {}),
+            },
+          }),
+        );
+      }
+    } catch (error) {
+      const serialized = serializeError(error);
+      warning =
+        typeof serialized === "object" && serialized !== null && "message" in serialized
+          ? String(serialized.message)
+          : String(error);
+    }
+  }
+
+  return {
+    id: provider.id,
+    ...(provider.name === undefined ? {} : { name: provider.name }),
+    ...(provider.defaultModel === undefined ? {} : { defaultModel: provider.defaultModel }),
+    models: [...models.values()].sort((left, right) => left.ref.localeCompare(right.ref)),
+    ...(provider.metadata === undefined ? {} : { metadata: provider.metadata }),
+    ...(warning === undefined ? {} : { warning }),
+  };
+}
+
+function modelSummary(
+  provider: RuntimeProvider,
+  modelId: string,
+  model: StudioModelDefinition,
+): StudioModelSummary {
+  return {
+    ...model,
+    id: modelId,
+    ref: `${provider.id}:${modelId}`,
+    providerId: provider.id,
+    ...(provider.name === undefined ? {} : { providerName: provider.name }),
+  };
+}
+
+function ensureModelAllowed(registry: StudioModelRegistry, agentId: string, ref: string): void {
+  const { providerId } = parseModelRef(ref);
+  if (!registry.providers.has(providerId)) {
+    throw new ModelSelectionError(`Unknown model provider: ${providerId}`);
+  }
+  const policy = registry.agentPolicies.get(agentId);
+  if (policy?.allowed !== undefined && !allowedByPolicy(policy.allowed, ref)) {
+    throw new ModelSelectionError(`Model ${ref} is not allowed for agent ${agentId}`);
+  }
+}
+
+function allowedByPolicy(allowed: string[], ref: string): boolean {
+  return allowed.some((entry) =>
+    entry.endsWith(":*") ? ref.startsWith(entry.slice(0, -1)) : entry === ref,
+  );
+}
+
+function normalizeAgentPolicies(
+  policies: Record<string, StudioAgentModelPolicy>,
+): Map<string, NormalizedAgentModelPolicy> {
+  return new Map(
+    Object.entries(policies).map(([agentId, policy]) => [
+      agentId.trim(),
+      {
+        ...(policy.default === undefined ? {} : { default: normalizeModelRef(policy.default) }),
+        ...(policy.allowed === undefined
+          ? {}
+          : {
+              allowed: policy.allowed.map((entry) =>
+                typeof entry === "string" && entry.trim().endsWith(":*")
+                  ? `${normalizeProviderId(entry.trim().slice(0, -2))}:*`
+                  : normalizeModelRef(entry),
+              ),
+            }),
+      },
+    ]),
+  );
+}
+
+function publicPolicy(policy: NormalizedAgentModelPolicy): StudioAgentModelPolicyConfig {
+  return {
+    ...(policy.default === undefined ? {} : { default: policy.default }),
+    ...(policy.allowed === undefined ? {} : { allowed: policy.allowed }),
+  };
+}
+
+function modelWarnings(
+  ref: string,
+  model: StudioModelDefinition | undefined,
+  request: AgentRunRequest,
+): JsonObject[] {
+  const warnings: JsonObject[] = [];
+  const modalities = requestModalities(request);
+  const missingModalities = [...modalities].filter(
+    (modality) => !model?.modalities?.input.includes(modality),
+  );
+  if (model?.modalities !== undefined && missingModalities.length > 0) {
+    warnings.push({
+      model: ref,
+      kind: "modality",
+      message: `Model ${ref} does not declare input support for ${missingModalities.join(", ")}`,
+      missing: missingModalities,
+    });
+  }
+
+  if (request.stream === true && model?.capabilities?.streaming === false) {
+    warnings.push({
+      model: ref,
+      kind: "capability",
+      message: `Model ${ref} is configured as non-streaming but the run requested streaming`,
+      capability: "streaming",
+    });
+  }
+
+  return warnings;
+}
+
+function requestModalities(request: AgentRunRequest): Set<StudioModelModality> {
+  const modalities = new Set<StudioModelModality>(["text"]);
+  for (const message of requestMessages(request)) {
+    if (typeof message === "string") {
+      continue;
+    }
+    if (message.role === "user" || message.role === "assistant") {
+      for (const content of message.content) {
+        if (content.type === "image") {
+          modalities.add("image");
+        }
+        if (content.type === "document") {
+          modalities.add("document");
+        }
+      }
+    }
+  }
+  return modalities;
+}
+
+function requestMessages(request: AgentRunRequest): Array<string | Message> {
+  return [...(request.history ?? []), request.message];
+}
+
+function normalizeProviderId(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.length === 0 || trimmed.includes(":")) {
+    throw new ModelSelectionError("Model provider id must be non-empty and cannot contain ':'");
+  }
+  return trimmed;
+}
+
+function normalizeModelId(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.length === 0) {
+    throw new ModelSelectionError("Model id cannot be empty");
+  }
+  return trimmed;
+}

--- a/packages/tool-studio/src/runtime/runs.ts
+++ b/packages/tool-studio/src/runtime/runs.ts
@@ -7,6 +7,7 @@ import type {
   AgentRunStreamEvent,
   StudioSession,
   StudioSessionStore,
+  StudioTranscriptAttachment,
   StudioTranscriptChildAgentEvent,
   StudioTranscriptEntry,
 } from "../types";
@@ -476,6 +477,7 @@ function messageToTranscriptEntry(
     kind: "message",
     role,
     text: extractMessageText(message),
+    ...(role === "user" ? optionalTranscriptAttachments(message) : {}),
   };
 }
 
@@ -595,6 +597,44 @@ function extractMessageText(message: string | Message): string {
     .join("\n");
 }
 
+function optionalTranscriptAttachments(message: string | Message): {
+  attachments?: StudioTranscriptAttachment[];
+} {
+  if (typeof message === "string" || message.role !== "user") {
+    return {};
+  }
+  const attachments = message.content.flatMap((content): StudioTranscriptAttachment[] => {
+    if (content.type === "image") {
+      return [
+        {
+          kind: "image",
+          ...(content.source.type === "base64"
+            ? { data: content.source.data, mediaType: content.source.mediaType }
+            : { url: content.source.url }),
+        },
+      ];
+    }
+    if (content.type === "document") {
+      return [
+        {
+          kind: "document",
+          ...(content.source.filename === undefined ? {} : { name: content.source.filename }),
+          ...(content.source.mediaType === undefined
+            ? {}
+            : { mediaType: content.source.mediaType }),
+          ...(content.source.type === "base64"
+            ? { data: content.source.data }
+            : content.source.type === "url"
+              ? { url: content.source.url }
+              : {}),
+        },
+      ];
+    }
+    return [];
+  });
+  return attachments.length === 0 ? {} : { attachments };
+}
+
 function formatJson(value: unknown): string {
   try {
     return JSON.stringify(value, null, 2);
@@ -667,6 +707,30 @@ export async function parseRunRequest(c: Context): Promise<AgentRunRequest | { e
       };
     }
     request.toolConcurrency = body.toolConcurrency;
+  }
+
+  if ("model" in body) {
+    if (typeof body.model === "string") {
+      request.model = body.model;
+    } else if (
+      isObject(body.model) &&
+      typeof body.model.provider === "string" &&
+      typeof body.model.model === "string"
+    ) {
+      request.model = {
+        provider: body.model.provider,
+        model: body.model.model,
+      };
+    } else {
+      return {
+        error: errorResponse(
+          c,
+          400,
+          "bad_request",
+          "model must be a provider:model string or { provider, model } object",
+        ),
+      };
+    }
   }
 
   if ("metadata" in body) {

--- a/packages/tool-studio/src/runtime/shared.ts
+++ b/packages/tool-studio/src/runtime/shared.ts
@@ -13,6 +13,7 @@ import type {
   StudioErrorResponse,
   StudioEvalSuite,
   StudioEvalSuiteConfig,
+  StudioModelConfig,
   StudioPipeline,
   StudioPipelineConfig,
   StudioPipelineLogStore,
@@ -24,6 +25,7 @@ import type {
   StudioUiOptions,
 } from "../types";
 import { serializeUnknown, toJsonValue } from "./json";
+import { createStudioModelRegistry, studioModelsConfig } from "./models";
 import { agentHasMcpTools, agentToolItems, mcpServerName } from "./tool-metadata";
 
 export type ResolvedStores = {
@@ -41,6 +43,7 @@ export type StudioRuntimeOptions = {
   agents: StudioAgent[];
   pipelines: StudioPipeline[];
   evals: StudioEvalSuite[];
+  models?: StudioModelConfig;
   stores?: StudioStores;
   ui?: boolean | StudioUiOptions;
 };
@@ -206,12 +209,17 @@ export function buildConfig(
   pipelines: StudioPipeline[],
   stores: ResolvedStores,
 ): StudioConfig {
+  const models =
+    options.models === undefined
+      ? undefined
+      : studioModelsConfig(createStudioModelRegistry(options.models), agents);
   return {
     id: runnerId(options),
     ...(options.name === undefined ? {} : { name: options.name }),
     ...(options.description === undefined ? {} : { description: options.description }),
     ...(options.version === undefined ? {} : { version: options.version }),
     agents: agents.map(agentConfig),
+    ...(models === undefined ? {} : { models }),
     pipelines: pipelines.map(pipelineConfig),
     evals: options.evals.map(evalConfig),
     chat: {

--- a/packages/tool-studio/src/runtime/studio.ts
+++ b/packages/tool-studio/src/runtime/studio.ts
@@ -39,6 +39,14 @@ import { registerKnowledgeRoutes } from "./knowledge";
 import { registerMcpRoutes } from "./mcps";
 import { registerMemoryRoutes } from "./memory";
 import {
+  createStudioModelRegistry,
+  ModelSelectionError,
+  registerModelRoutes,
+  resolveStudioModel,
+  STUDIO_MODEL_METADATA_KEY,
+  sessionModelRef,
+} from "./models";
+import {
   observeStores,
   registerObservabilityRoutes,
   StudioObservabilityHub,
@@ -173,6 +181,7 @@ function studioOptionsFromTargets(
     agents: inferStudioAgents(agents, options.quickPrompts ?? {}),
     pipelines: inferStudioPipelines(pipelines),
     evals: options.evals ?? [],
+    ...(options.models === undefined ? {} : { models: options.models }),
     ...(options.stores === undefined ? {} : { stores: options.stores }),
     ...(options.ui === undefined ? {} : { ui: options.ui }),
   };
@@ -236,6 +245,7 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
   const agents = normalizeAgents(options.agents).map((agent) =>
     withStudioTraceObserver(agent, stores.traces),
   );
+  const modelRegistry = createStudioModelRegistry(options.models);
   const pipelines = normalizePipelines(options.pipelines);
   const agentMap = new Map(agents.map((agent) => [agent.id, agent]));
   const pipelineMap = new Map(pipelines.map((pipeline) => [pipeline.id, pipeline]));
@@ -287,6 +297,7 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
     return c.json(agentRuntimeSummary(agent));
   });
 
+  registerModelRoutes(app, { registry: modelRegistry, agentMap });
   registerMcpRoutes(app, { agentMap });
   registerToolRoutes(app, { agentMap });
   registerApprovalRoutes(app, approvalRuntime);
@@ -332,6 +343,24 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
       return errorResponse(c, 400, "bad_request", "Session belongs to another agent");
     }
 
+    let selectedModel: ReturnType<typeof resolveStudioModel>;
+    try {
+      selectedModel = resolveStudioModel(modelRegistry, {
+        agent,
+        request: body,
+        sessionMetadata: session?.metadata,
+      });
+    } catch (error) {
+      if (error instanceof ModelSelectionError) {
+        return errorResponse(c, 400, "bad_request", error.message);
+      }
+      throw error;
+    }
+    const runAgent =
+      selectedModel.model === undefined
+        ? agent.agent
+        : cloneAgent(agent.agent, { model: selectedModel.model });
+
     const runId = globalThis.crypto.randomUUID();
     const runStartedAt = Date.now();
     if (session !== undefined) {
@@ -346,13 +375,44 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
           ...(body.maxTurns === undefined ? {} : { maxTurns: body.maxTurns }),
           ...(body.toolConcurrency === undefined ? {} : { toolConcurrency: body.toolConcurrency }),
           hasTrace: body.trace !== undefined,
-          ...(body.metadata === undefined ? {} : { metadata: body.metadata }),
+          ...(body.metadata === undefined && selectedModel.ref === undefined
+            ? {}
+            : {
+                metadata: {
+                  ...(body.metadata ?? {}),
+                  ...(selectedModel.ref === undefined
+                    ? {}
+                    : { [STUDIO_MODEL_METADATA_KEY]: selectedModel.ref }),
+                },
+              }),
         }),
       );
+    }
+    if (session !== undefined && selectedModel.ref !== undefined) {
+      for (const warning of selectedModel.warnings) {
+        await appendSessionLog(stores.sessions, {
+          sessionId: session.id,
+          runId,
+          level: "warn",
+          category: "model",
+          event: "model.warning",
+          message: typeof warning.message === "string" ? warning.message : "Model warning",
+          metadata: warning,
+        });
+      }
+      if (sessionModelRef(session.metadata) !== selectedModel.ref) {
+        await stores.sessions?.updateSessionMetadata?.(session.id, {
+          ...(session.metadata ?? {}),
+          [STUDIO_MODEL_METADATA_KEY]: selectedModel.ref,
+        });
+      }
     }
     const memoryMetadata = {
       agentId,
       ...(body.metadata ?? {}),
+      ...(selectedModel.ref === undefined
+        ? {}
+        : { [STUDIO_MODEL_METADATA_KEY]: selectedModel.ref }),
       studioRunId: runId,
     };
     const promptMessage = normalizePromptMessage(body.message);
@@ -360,7 +420,7 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
     const shouldPersistSessionMessages =
       session !== undefined &&
       sessionStore !== undefined &&
-      !usesStoreAsAgentMemory(agent.agent, sessionStore);
+      !usesStoreAsAgentMemory(runAgent, sessionStore);
     if (shouldPersistSessionMessages) {
       await sessionStore.append({
         context: { sessionId: session.id, metadata: memoryMetadata },
@@ -371,10 +431,10 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
     }
     const request =
       session !== undefined
-        ? agent.agent.memory === undefined
-          ? agent.agent.prompt([...session.messages, promptMessage])
-          : agent.agent.session(session.id, { metadata: memoryMetadata }).prompt(body.message)
-        : agent.agent.prompt(
+        ? runAgent.memory === undefined
+          ? runAgent.prompt([...session.messages, promptMessage])
+          : runAgent.session(session.id, { metadata: memoryMetadata }).prompt(body.message)
+        : runAgent.prompt(
             body.history !== undefined ? [...body.history, promptMessage] : body.message,
           );
     if (body.maxTurns !== undefined) {
@@ -393,13 +453,13 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
       const runtimeEvents = new AsyncEventQueue<AgentRunStreamEvent>();
       const effectiveHook = composeHooks(
         composeHooks(
-          agent.agent.hook,
+          runAgent.hook,
           approvalRuntime.createHook({
             runId,
             agentId,
             ...(session?.id === undefined ? {} : { sessionId: session.id }),
             ...(body.metadata === undefined ? {} : { metadata: body.metadata }),
-            getTool: (toolName) => agent.agent.getTool(toolName),
+            getTool: (toolName) => runAgent.getTool(toolName),
             emit: (event) => runtimeEvents.push(event),
           }),
         ),
@@ -442,13 +502,13 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
       }
       const effectiveHook = composeHooks(
         composeHooks(
-          agent.agent.hook,
+          runAgent.hook,
           approvalRuntime.createHook({
             runId,
             agentId,
             ...(session?.id === undefined ? {} : { sessionId: session.id }),
             ...(body.metadata === undefined ? {} : { metadata: body.metadata }),
-            getTool: (toolName) => agent.agent.getTool(toolName),
+            getTool: (toolName) => runAgent.getTool(toolName),
           }),
         ),
         questionRuntime.createHook({

--- a/packages/tool-studio/src/runtime/transcript.ts
+++ b/packages/tool-studio/src/runtime/transcript.ts
@@ -1,5 +1,5 @@
 import type { Message } from "@anvia/core/completion";
-import type { StudioTranscriptEntry } from "../types";
+import type { StudioTranscriptAttachment, StudioTranscriptEntry } from "../types";
 
 export function renumberTranscript(entries: StudioTranscriptEntry[]): StudioTranscriptEntry[] {
   return entries.map((entry, entryId) => ({ ...entry, entryId }));
@@ -12,6 +12,8 @@ export function transcriptFromMessages(messages: Message[]): StudioTranscriptEnt
       continue;
     }
     if (message.role === "user") {
+      const attachments = attachmentsFromMessage(message);
+      let textEntryAdded = false;
       for (const content of message.content) {
         if (content.type === "text") {
           transcript.push({
@@ -19,8 +21,19 @@ export function transcriptFromMessages(messages: Message[]): StudioTranscriptEnt
             kind: "message",
             role: "user",
             text: content.text,
+            ...(attachments.length === 0 ? {} : { attachments }),
           });
+          textEntryAdded = true;
         }
+      }
+      if (!textEntryAdded && attachments.length > 0) {
+        transcript.push({
+          entryId: transcript.length,
+          kind: "message",
+          role: "user",
+          text: "",
+          attachments,
+        });
       }
       continue;
     }
@@ -64,6 +77,41 @@ export function transcriptFromMessages(messages: Message[]): StudioTranscriptEnt
     }
   }
   return transcript;
+}
+
+function attachmentsFromMessage(message: Message): StudioTranscriptAttachment[] {
+  if (message.role !== "user" && message.role !== "assistant") {
+    return [];
+  }
+  return message.content.flatMap((content): StudioTranscriptAttachment[] => {
+    if (content.type === "image") {
+      return [
+        {
+          kind: "image",
+          ...(content.source.type === "base64"
+            ? { data: content.source.data, mediaType: content.source.mediaType }
+            : { url: content.source.url }),
+        },
+      ];
+    }
+    if (content.type === "document") {
+      return [
+        {
+          kind: "document",
+          ...(content.source.filename === undefined ? {} : { name: content.source.filename }),
+          ...(content.source.mediaType === undefined
+            ? {}
+            : { mediaType: content.source.mediaType }),
+          ...(content.source.type === "base64"
+            ? { data: content.source.data }
+            : content.source.type === "url"
+              ? { url: content.source.url }
+              : {}),
+        },
+      ];
+    }
+    return [];
+  });
 }
 
 function appendAssistantTranscriptText(transcript: StudioTranscriptEntry[], text: string): void {

--- a/packages/tool-studio/src/storage/memory-store.ts
+++ b/packages/tool-studio/src/storage/memory-store.ts
@@ -79,6 +79,20 @@ class InMemoryStudioStore
     return session === undefined ? undefined : materializeSession(session);
   }
 
+  updateSessionMetadata(id: string, metadata: JsonObject | undefined): StudioSession | undefined {
+    const session = this.sessions.get(id);
+    if (session === undefined) {
+      return undefined;
+    }
+    if (metadata === undefined) {
+      delete session.metadata;
+    } else {
+      session.metadata = metadata;
+    }
+    session.updatedAt = new Date().toISOString();
+    return materializeSession(session);
+  }
+
   load(context: MemoryContext): Promise<Message[]> {
     return Promise.resolve(this.sessions.get(context.sessionId)?.messages ?? []);
   }

--- a/packages/tool-studio/src/storage/sqlite-store.ts
+++ b/packages/tool-studio/src/storage/sqlite-store.ts
@@ -220,6 +220,27 @@ class SqliteSessionStore
       : toSession(row, this.listSessionMessages(id), this.listSessionRunRows(id));
   }
 
+  updateSessionMetadata(id: string, metadata: JsonObject | undefined): StudioSession | undefined {
+    const db = this.database();
+    const now = new Date().toISOString();
+    const result = db
+      .prepare(
+        `UPDATE anvia_studio_sessions
+         SET metadata_json = $metadata,
+             updated_at = $now
+         WHERE id = $id`,
+      )
+      .run({
+        $id: id,
+        $metadata: metadata === undefined ? null : JSON.stringify(metadata),
+        $now: now,
+      });
+    if (result.changes === 0) {
+      return undefined;
+    }
+    return this.getSession(id);
+  }
+
   load(context: MemoryContext): Promise<Message[]> {
     const session = this.getSession(context.sessionId);
     return Promise.resolve(session?.messages ?? []);

--- a/packages/tool-studio/src/types.ts
+++ b/packages/tool-studio/src/types.ts
@@ -1,14 +1,18 @@
 import type { AgentStreamEvent, PromptResponse } from "@anvia/core/agent";
 import type {
+  CompletionModel,
+  CompletionModelCapabilities,
   JsonObject,
   JsonValue,
   Message,
+  StreamingCompletionModel,
   ToolResultContent,
   Usage,
 } from "@anvia/core/completion";
 import type { RunEvalSuiteOptions } from "@anvia/core/evals";
 import type { Agent } from "@anvia/core/internal/agent";
 import type { MemoryStore } from "@anvia/core/memory";
+import type { ModelList } from "@anvia/core/model-listing";
 import type { AgentTraceInfo, AgentTraceOptions } from "@anvia/core/observability";
 import type { Pipeline, PipelineGraph } from "@anvia/core/pipeline";
 import type { Hono } from "hono";
@@ -26,6 +30,78 @@ export type StudioCapability =
   | "status"
   | "tools"
   | "traces";
+
+export type StudioModelRef = string | { provider: string; model: string };
+
+export type StudioModelModality = "text" | "image" | "document" | "audio" | "video";
+
+export type StudioModelModalities = {
+  input: StudioModelModality[];
+  output?: StudioModelModality[];
+};
+
+export type StudioModelDefinition = {
+  id: string;
+  name?: string;
+  description?: string;
+  modalities?: StudioModelModalities;
+  capabilities?: Partial<CompletionModelCapabilities>;
+  metadata?: JsonObject;
+};
+
+export type StudioModelProvider = {
+  id: string;
+  name?: string;
+  defaultModel?: string;
+  models?: StudioModelDefinition[];
+  createCompletionModel(model: string): CompletionModel | StreamingCompletionModel;
+  listModels?: () => Promise<ModelList>;
+  metadata?: JsonObject;
+};
+
+export type StudioAgentModelPolicy = {
+  default?: StudioModelRef;
+  allowed?: Array<StudioModelRef | `${string}:*`>;
+};
+
+export type StudioModelConfig = {
+  providers: StudioModelProvider[];
+  default?: StudioModelRef;
+  agents?: Record<string, StudioAgentModelPolicy>;
+};
+
+export type StudioModelSummary = StudioModelDefinition & {
+  ref: string;
+  providerId: string;
+  providerName?: string;
+};
+
+export type StudioModelProviderConfig = {
+  id: string;
+  name?: string;
+  defaultModel?: string;
+  models: StudioModelSummary[];
+  metadata?: JsonObject;
+  warning?: string;
+};
+
+export type StudioAgentModelPolicyConfig = {
+  default?: string;
+  allowed?: string[];
+};
+
+export type StudioModelsConfig = {
+  providers: StudioModelProviderConfig[];
+  default?: string;
+  agents: Record<string, StudioAgentModelPolicyConfig>;
+};
+
+export type StudioAgentModelsSummary = {
+  agentId: string;
+  defaultModel?: string;
+  models: StudioModelSummary[];
+  warnings?: JsonObject[];
+};
 
 export type StudioAgent = {
   id: string;
@@ -137,6 +213,7 @@ export type StudioConfig = {
   description?: string;
   version?: string;
   agents: StudioAgentConfig[];
+  models?: StudioModelsConfig;
   pipelines: StudioPipelineConfig[];
   evals: StudioEvalSuiteConfig[];
   chat: {
@@ -211,6 +288,15 @@ export type StudioTranscriptChatEntry = {
   text: string;
   tone?: "error";
   traceId?: string;
+  attachments?: StudioTranscriptAttachment[];
+};
+
+export type StudioTranscriptAttachment = {
+  kind: "image" | "document";
+  name?: string;
+  mediaType?: string;
+  data?: string;
+  url?: string;
 };
 
 export type StudioTranscriptReasoningEntry = {
@@ -354,6 +440,10 @@ export type StudioSessionStore = MemoryStore & {
   getSession(id: string): StudioSession | undefined | Promise<StudioSession | undefined>;
   saveSessionRunTranscript(
     input: StudioSessionRunTranscriptInput,
+  ): StudioSession | undefined | Promise<StudioSession | undefined>;
+  updateSessionMetadata?(
+    id: string,
+    metadata: JsonObject | undefined,
   ): StudioSession | undefined | Promise<StudioSession | undefined>;
   appendSessionLog?(
     input: StudioSessionLogAppendInput,
@@ -605,6 +695,7 @@ export type StudioOptions = {
   quickPrompts?: Record<string, string[]>;
   stores?: StudioStores;
   ui?: boolean | StudioUiOptions;
+  models?: StudioModelConfig;
 };
 
 export type StudioServeOptions = {
@@ -848,6 +939,7 @@ export type AgentRunRequest = {
   stream?: boolean;
   maxTurns?: number;
   toolConcurrency?: number;
+  model?: StudioModelRef;
   metadata?: JsonObject;
   trace?: AgentTraceOptions;
 };

--- a/packages/tool-studio/src/ui/app/app.tsx
+++ b/packages/tool-studio/src/ui/app/app.tsx
@@ -1,6 +1,15 @@
-import type { Message, ToolResultContent } from "@anvia/core/completion";
+import type { Message, ToolResultContent, UserContent } from "@anvia/core/completion";
 import { createChatTransport, EventStreamHttpError, useChat } from "@anvia/react";
-import { Archive, ArrowSquareOut, ArrowUp, Moon, Plus, Sun } from "@phosphor-icons/react";
+import {
+  Archive,
+  ArrowSquareOut,
+  ArrowUp,
+  Moon,
+  Paperclip,
+  Plus,
+  Sun,
+  X,
+} from "@phosphor-icons/react";
 import {
   type ChangeEvent,
   type KeyboardEvent,
@@ -15,10 +24,12 @@ import {
 import type {
   AgentRunStreamEvent,
   StudioAgentMcpsSummary,
+  StudioAgentModelsSummary,
   StudioAgentToolsSummary,
   StudioConfig,
   StudioEvalRunResponse,
   StudioKnowledgeSummary,
+  StudioModelSummary,
   StudioPipelineDetail,
   StudioPipelineLogEntry,
   StudioPipelineRunRecord,
@@ -151,13 +162,27 @@ type StudioTheme = "light" | "dark";
 
 type StudioAgentRunRequest = {
   agentId: string;
-  message: string;
+  message: string | Message;
   sessionId?: string;
   history?: Message[];
+  model?: string;
   stream: true;
   metadata: {
     source: string;
+    studioModel?: string;
   };
+};
+
+const studioModelMetadataKey = "studioModel";
+const supportedAttachmentTypes = ".png,.jpg,.jpeg,.webp,.gif,.pdf,.txt,.md,.csv,.json";
+
+type PromptAttachment = {
+  id: string;
+  name: string;
+  mediaType: string;
+  kind: "image" | "document";
+  data: string;
+  size: number;
 };
 
 const studioThemeStorageKey = "anvia-studio-theme";
@@ -251,6 +276,7 @@ export function StudioConsole() {
   const [pipelineRuns, setPipelineRuns] = useState<StudioPipelineRunRecord[]>([]);
   const [messages, setMessages] = useState<TranscriptEntry[]>([]);
   const [prompt, setPrompt] = useState("");
+  const [attachments, setAttachments] = useState<PromptAttachment[]>([]);
   const [pipelineRunInput, setPipelineRunInput] = useState('"Hello from Studio"');
   const [pipelineRunOutput, setPipelineRunOutput] = useState("");
   const [evalRunResult, setEvalRunResult] = useState<StudioEvalRunResponse | undefined>();
@@ -279,6 +305,8 @@ export function StudioConsole() {
   const [mcpsLoadState, setMcpsLoadState] = useState<"idle" | "loading">("idle");
   const [tools, setTools] = useState<StudioAgentToolsSummary | undefined>();
   const [toolsLoadState, setToolsLoadState] = useState<"idle" | "loading">("idle");
+  const [agentModels, setAgentModels] = useState<StudioAgentModelsSummary | undefined>();
+  const [selectedModelRef, setSelectedModelRef] = useState("");
   const [pipelineDetailLoadState, setPipelineDetailLoadState] = useState<"idle" | "loading">(
     "idle",
   );
@@ -287,6 +315,7 @@ export function StudioConsole() {
   const [pipelineRunState, setPipelineRunState] = useState<RunState>("idle");
   const [evalRunState, setEvalRunState] = useState<RunState>("idle");
   const promptRef = useRef<HTMLTextAreaElement | null>(null);
+  const attachmentInputRef = useRef<HTMLInputElement | null>(null);
   const transcriptScrollerRef = useRef<HTMLElement | null>(null);
   const transcriptStickToBottomRef = useRef(true);
   const playgroundRunRequestRef = useRef<StudioAgentRunRequest | undefined>(undefined);
@@ -392,8 +421,53 @@ export function StudioConsole() {
   );
   const selectedAgent =
     agents.find((agent) => agent.id === selectedAgentId) ?? agents[0] ?? undefined;
+  const selectedAgentModelId = selectedAgent?.id;
   const selectedAgentQuickPrompts = selectedAgent?.quickPrompts ?? [];
+  const selectedAgentModels =
+    agentModels !== undefined && agentModels.agentId === selectedAgent?.id
+      ? agentModels.models
+      : [];
   const hasMessages = messages.length > 0;
+
+  useEffect(() => {
+    if (config?.models === undefined || selectedAgentModelId === undefined) {
+      setAgentModels(undefined);
+      setSelectedModelRef("");
+      return;
+    }
+
+    const agentId = selectedAgentModelId;
+    let cancelled = false;
+    async function loadAgentModels() {
+      try {
+        const response = await fetch(`/agents/${encodeURIComponent(agentId)}/models`);
+        if (!response.ok) {
+          throw new Error(`Agent models failed with HTTP ${response.status}`);
+        }
+        const body = (await response.json()) as StudioAgentModelsSummary;
+        if (cancelled) {
+          return;
+        }
+        setAgentModels(body);
+        setSelectedModelRef((current) =>
+          modelRefAvailable(body.models, current)
+            ? current
+            : (body.defaultModel ?? body.models[0]?.ref ?? ""),
+        );
+      } catch (loadError) {
+        if (!cancelled) {
+          setAgentModels(undefined);
+          setError(errorMessage(loadError));
+        }
+      }
+    }
+
+    void loadAgentModels();
+    return () => {
+      cancelled = true;
+    };
+  }, [config?.models, selectedAgentModelId]);
+
   const playgroundChat = useChat<StudioAgentRunRequest, AgentRunStreamEvent>({
     transport: createChatTransport<StudioAgentRunRequest, AgentRunStreamEvent>({
       endpoint: (request) => `/agents/${encodeURIComponent(request.agentId)}/runs`,
@@ -502,6 +576,7 @@ export function StudioConsole() {
         title,
         metadata: {
           source: "anvia-studio",
+          ...(selectedModelRef.length === 0 ? {} : { [studioModelMetadataKey]: selectedModelRef }),
         },
       }),
     });
@@ -830,8 +905,10 @@ export function StudioConsole() {
         ]);
         setTranscriptSequence(nextSequence(session.transcript));
         setSelectedAgentId(session.agentId);
+        setSelectedModelRef(sessionModelRef(session));
         setSelectedSessionId(session.id);
         setMessages(enrichTranscriptWithTraceIds(session.transcript, traceSummaries));
+        setAttachments([]);
         if (options.updatePath !== false) {
           setActivePage("playground");
           updateSessionPath(session.id);
@@ -856,6 +933,7 @@ export function StudioConsole() {
       setSessionLogs([]);
       setMessages([]);
       setPrompt("");
+      setAttachments([]);
       setActivePage("playground");
       setError("");
       if (options.updatePath !== false) {
@@ -873,11 +951,13 @@ export function StudioConsole() {
       }
 
       setSelectedAgentId(agentId);
+      setSelectedModelRef("");
       resetTranscriptSequence();
       setSelectedSessionId("");
       setSessionLogs([]);
       setMessages([]);
       setPrompt("");
+      setAttachments([]);
       setActivePage("playground");
       setError("");
       updateSessionPath(undefined);
@@ -908,6 +988,7 @@ export function StudioConsole() {
         setSessionLogs([]);
         setMessages([]);
         setPrompt("");
+        setAttachments([]);
         if (activePage === "playground") {
           updateSessionPath(undefined);
         }
@@ -971,9 +1052,10 @@ export function StudioConsole() {
 
   async function runPrompt(text: string) {
     const trimmed = text.trim();
+    const promptAttachments = attachments;
     const agentId = selectedAgent?.id ?? selectedAgentId;
     if (
-      trimmed.length === 0 ||
+      (trimmed.length === 0 && promptAttachments.length === 0) ||
       agentId.length === 0 ||
       runState === "running" ||
       playgroundChat.status === "streaming"
@@ -985,11 +1067,24 @@ export function StudioConsole() {
     setActivePage("playground");
     setError("");
     setPrompt("");
+    setAttachments([]);
     transcriptStickToBottomRef.current = true;
     requestAnimationFrame(() => resizeTextarea(promptRef.current));
+    const promptMessage =
+      promptAttachments.length === 0
+        ? trimmed
+        : userMessageWithAttachments(trimmed, promptAttachments);
     setMessages((current) => [
       ...current,
-      { entryId: nextTranscriptId(), kind: "message", role: "user", text: trimmed },
+      {
+        entryId: nextTranscriptId(),
+        kind: "message",
+        role: "user",
+        text: trimmed,
+        ...(promptAttachments.length === 0
+          ? {}
+          : { attachments: transcriptAttachmentsForPrompt(promptAttachments) }),
+      },
     ]);
 
     try {
@@ -1002,12 +1097,14 @@ export function StudioConsole() {
       playgroundVisibleEventRef.current = Promise.resolve();
       playgroundRunRequestRef.current = {
         agentId,
-        message: trimmed,
+        message: promptMessage,
         ...(sessionId.length === 0 ? {} : { sessionId }),
         ...(history === undefined ? {} : { history }),
+        ...(selectedModelRef.length === 0 ? {} : { model: selectedModelRef }),
         stream: true,
         metadata: {
           source: "anvia-studio",
+          ...(selectedModelRef.length === 0 ? {} : { studioModel: selectedModelRef }),
         },
       };
 
@@ -1675,6 +1772,25 @@ export function StudioConsole() {
     resizeTextarea(event.currentTarget);
   }
 
+  async function addPromptAttachments(event: ChangeEvent<HTMLInputElement>) {
+    const files = Array.from(event.currentTarget.files ?? []);
+    event.currentTarget.value = "";
+    if (files.length === 0) {
+      return;
+    }
+
+    try {
+      const nextAttachments = await Promise.all(files.map(fileToAttachment));
+      setAttachments((current) => [...current, ...nextAttachments]);
+    } catch (attachmentError) {
+      setError(errorMessage(attachmentError));
+    }
+  }
+
+  function removePromptAttachment(id: string) {
+    setAttachments((current) => current.filter((attachment) => attachment.id !== id));
+  }
+
   function handlePromptKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
     if (event.key !== "Enter" || event.shiftKey || event.nativeEvent.isComposing) {
       return;
@@ -1738,6 +1854,7 @@ export function StudioConsole() {
     setSessionLogs([]);
     setMessages([]);
     setPrompt("");
+    setAttachments([]);
     setActivePage(nextPage);
     updatePagePath(nextPage);
 
@@ -2050,9 +2167,74 @@ export function StudioConsole() {
                       onKeyDown={handlePromptKeyDown}
                       placeholder="Ask anything..."
                     />
+                    {attachments.length === 0 ? null : (
+                      <div className="flex min-w-0 flex-wrap gap-1.5 px-2">
+                        {attachments.map((attachment) => (
+                          <span
+                            className="inline-flex max-w-full items-center gap-1.5 rounded-lg border border-border/80 bg-muted/55 px-2 py-1 font-mono text-[11px] font-medium text-muted-foreground"
+                            key={attachment.id}
+                          >
+                            <span className="min-w-0 truncate">
+                              {attachment.kind === "image" ? "Image" : "Doc"} / {attachment.name}
+                            </span>
+                            <Button
+                              aria-label={`Remove ${attachment.name}`}
+                              className="h-5 min-h-5 w-5 rounded-md border-0 bg-transparent p-0 text-muted-foreground shadow-none hover:bg-accent hover:text-foreground [&_svg]:h-3 [&_svg]:w-3"
+                              size="icon"
+                              type="button"
+                              variant="ghost"
+                              onClick={() => removePromptAttachment(attachment.id)}
+                            >
+                              <X aria-hidden="true" />
+                            </Button>
+                          </span>
+                        ))}
+                      </div>
+                    )}
                     <div className="flex min-w-0 items-center justify-between gap-2">
-                      <div />
                       <div className="flex min-w-0 items-center gap-2">
+                        <input
+                          ref={attachmentInputRef}
+                          className="hidden"
+                          type="file"
+                          multiple
+                          accept={supportedAttachmentTypes}
+                          onChange={(event) => void addPromptAttachments(event)}
+                        />
+                        <Button
+                          aria-label="Attach image or document"
+                          className="h-8 min-h-8 w-8 border-0 bg-transparent p-0 text-muted-foreground shadow-none hover:bg-accent hover:text-accent-foreground"
+                          size="icon"
+                          type="button"
+                          variant="ghost"
+                          disabled={runState === "running"}
+                          onClick={() => attachmentInputRef.current?.click()}
+                        >
+                          <Paperclip aria-hidden="true" />
+                        </Button>
+                      </div>
+                      <div className="flex min-w-0 items-center gap-2">
+                        {selectedAgentModels.length === 0 ? null : (
+                          <Select
+                            value={selectedModelRef}
+                            onValueChange={setSelectedModelRef}
+                            disabled={runState === "running"}
+                          >
+                            <SelectTrigger
+                              aria-label="Select model"
+                              className="flex h-8 min-h-8 w-auto max-w-44 gap-2 border-0 bg-transparent px-2 py-1 font-mono text-xs font-medium text-muted-foreground shadow-none hover:bg-accent hover:text-accent-foreground sm:max-w-72"
+                            >
+                              <SelectValue placeholder="Model" />
+                            </SelectTrigger>
+                            <SelectContent align="end">
+                              {selectedAgentModels.map((model) => (
+                                <SelectItem value={model.ref} key={model.ref}>
+                                  {modelSelectLabel(model)}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        )}
                         {agents.length > 1 ? (
                           <Select
                             value={selectedAgent?.id ?? selectedAgentId}
@@ -2348,4 +2530,116 @@ function enrichTranscriptWithTraceIds(
 function withoutTraceId(entry: Extract<TranscriptEntry, { kind: "message" }>): TranscriptEntry {
   const { traceId: _traceId, ...rest } = entry;
   return rest;
+}
+
+function sessionModelRef(session: StudioSession): string {
+  const value = session.metadata?.[studioModelMetadataKey];
+  return typeof value === "string" ? value : "";
+}
+
+function modelRefAvailable(models: StudioModelSummary[], ref: string): boolean {
+  return ref.length > 0 && models.some((model) => model.ref === ref);
+}
+
+function modelSelectLabel(model: StudioModelSummary): string {
+  const provider = model.providerName ?? model.providerId;
+  const name = model.name ?? model.id;
+  const modalities = model.modalities?.input
+    .filter((modality) => modality !== "text")
+    .map((modality) => modality.slice(0, 3))
+    .join("/");
+  return modalities === undefined || modalities.length === 0
+    ? `${provider} / ${name}`
+    : `${provider} / ${name} (${modalities})`;
+}
+
+async function fileToAttachment(file: File): Promise<PromptAttachment> {
+  const mediaType = file.type || mediaTypeFromName(file.name);
+  const kind = mediaType.startsWith("image/") ? "image" : "document";
+  if (!isSupportedAttachment(mediaType, file.name)) {
+    throw new Error(`Unsupported attachment type: ${file.name}`);
+  }
+  return {
+    id: globalThis.crypto.randomUUID(),
+    name: file.name,
+    mediaType,
+    kind,
+    data: await fileToBase64(file),
+    size: file.size,
+  };
+}
+
+function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error ?? new Error(`Failed to read ${file.name}`));
+    reader.onload = () => {
+      const value = reader.result;
+      if (typeof value !== "string") {
+        reject(new Error(`Failed to read ${file.name}`));
+        return;
+      }
+      resolve(value.slice(value.indexOf(",") + 1));
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+function userMessageWithAttachments(text: string, attachments: PromptAttachment[]): Message {
+  const content: UserContent[] = [];
+  if (text.length > 0) {
+    content.push({ type: "text", text });
+  }
+  for (const attachment of attachments) {
+    if (attachment.kind === "image") {
+      content.push({
+        type: "image",
+        source: {
+          type: "base64",
+          data: attachment.data,
+          mediaType: attachment.mediaType,
+        },
+      });
+      continue;
+    }
+    content.push({
+      type: "document",
+      source: {
+        type: "base64",
+        data: attachment.data,
+        mediaType: attachment.mediaType,
+        filename: attachment.name,
+      },
+    });
+  }
+  return { role: "user", content };
+}
+
+function transcriptAttachmentsForPrompt(
+  attachments: PromptAttachment[],
+): NonNullable<Extract<TranscriptEntry, { kind: "message" }>["attachments"]> {
+  return attachments.map((attachment) => ({
+    kind: attachment.kind,
+    name: attachment.name,
+    mediaType: attachment.mediaType,
+    data: attachment.data,
+  }));
+}
+
+function isSupportedAttachment(mediaType: string, name: string): boolean {
+  return (
+    mediaType.startsWith("image/") ||
+    mediaType === "application/pdf" ||
+    mediaType.startsWith("text/") ||
+    ["application/json", "text/markdown", "text/csv"].includes(mediaType) ||
+    /\.(md|csv|json|txt)$/i.test(name)
+  );
+}
+
+function mediaTypeFromName(name: string): string {
+  if (/\.pdf$/i.test(name)) return "application/pdf";
+  if (/\.md$/i.test(name)) return "text/markdown";
+  if (/\.csv$/i.test(name)) return "text/csv";
+  if (/\.json$/i.test(name)) return "application/json";
+  return "text/plain";
 }

--- a/packages/tool-studio/src/ui/app/app.tsx
+++ b/packages/tool-studio/src/ui/app/app.tsx
@@ -1085,6 +1085,13 @@ export function StudioConsole() {
           ? {}
           : { attachments: transcriptAttachmentsForPrompt(promptAttachments) }),
       },
+      {
+        entryId: nextTranscriptId(),
+        kind: "message",
+        role: "assistant",
+        text: "",
+        tone: "pending",
+      },
     ]);
 
     try {
@@ -1325,8 +1332,11 @@ export function StudioConsole() {
       appendSessionLogEntry(event.log);
       return true;
     }
-    if (event.type === "final" && event.trace?.traceId !== undefined) {
-      assignAssistantTraceId(event.trace.traceId);
+    if (event.type === "final") {
+      if (event.trace?.traceId !== undefined) {
+        assignAssistantTraceId(event.trace.traceId);
+      }
+      clearPendingAssistant();
       return true;
     }
     if (event.type === "error") {
@@ -1362,7 +1372,12 @@ export function StudioConsole() {
       const next = [...current];
       const last = next.at(-1);
       if (last?.kind === "message" && last.role === "assistant") {
-        next[next.length - 1] = { ...last, text: `${last.text}${delta}` };
+        if (last.tone === "pending") {
+          const { tone: _tone, ...readyMessage } = last;
+          next[next.length - 1] = { ...readyMessage, text: delta };
+        } else {
+          next[next.length - 1] = { ...last, text: `${last.text}${delta}` };
+        }
       } else {
         next.push({
           entryId: nextTranscriptId(),
@@ -1376,16 +1391,25 @@ export function StudioConsole() {
   }
 
   function appendAssistantError(message: string) {
-    setMessages((current) => [
-      ...current,
-      {
-        entryId: nextTranscriptId(),
-        kind: "message",
-        role: "assistant",
+    setMessages((current) => {
+      const next = [...current];
+      const last = next.at(-1);
+      const entry = {
+        entryId:
+          last?.kind === "message" && last.role === "assistant" && last.tone === "pending"
+            ? last.entryId
+            : nextTranscriptId(),
+        kind: "message" as const,
+        role: "assistant" as const,
         text: message,
-        tone: "error",
-      },
-    ]);
+        tone: "error" as const,
+      };
+      if (last?.kind === "message" && last.role === "assistant" && last.tone === "pending") {
+        next[next.length - 1] = entry;
+        return next;
+      }
+      return [...next, entry];
+    });
   }
 
   function assignAssistantTraceId(traceId: string) {
@@ -1402,9 +1426,28 @@ export function StudioConsole() {
     });
   }
 
+  function clearPendingAssistant() {
+    setMessages((current) => withoutPendingAssistant(current));
+  }
+
+  function withoutPendingAssistant(entries: TranscriptEntry[]): TranscriptEntry[] {
+    for (let index = entries.length - 1; index >= 0; index -= 1) {
+      const entry = entries[index];
+      if (
+        entry?.kind === "message" &&
+        entry.role === "assistant" &&
+        entry.tone === "pending" &&
+        entry.text.trim().length === 0
+      ) {
+        return entries.filter((_, itemIndex) => itemIndex !== index);
+      }
+    }
+    return [...entries];
+  }
+
   function updateToolApproval(approval: ToolApprovalUpdate) {
     setMessages((current) => {
-      const next = [...current];
+      const next = withoutPendingAssistant(current);
       const matchedIndex = findMatchingToolIndexByCall(next, approval.toolName, approval.callId);
       if (matchedIndex < 0) {
         next.push({
@@ -1442,7 +1485,7 @@ export function StudioConsole() {
 
   function updateToolQuestion(question: ToolQuestionUpdate) {
     setMessages((current) => {
-      const next = [...current];
+      const next = withoutPendingAssistant(current);
       const matchedIndex = findMatchingToolIndexByCall(next, question.toolName, question.callId);
       if (matchedIndex < 0) {
         next.push({
@@ -1543,7 +1586,7 @@ export function StudioConsole() {
 
   function appendReasoningText(delta: string, reasoningId: string | undefined) {
     setMessages((current) => {
-      const next = [...current];
+      const next = withoutPendingAssistant(current);
       const last = next.at(-1);
       if (last?.kind === "reasoning" && (last.reasoningId ?? "") === (reasoningId ?? "")) {
         next[next.length - 1] = { ...last, text: `${last.text}${delta}` };
@@ -1561,7 +1604,7 @@ export function StudioConsole() {
 
   function appendToolCall(toolName: string, args: string, callId: string | undefined) {
     setMessages((current) => [
-      ...current,
+      ...withoutPendingAssistant(current),
       {
         entryId: nextTranscriptId(),
         kind: "tool",
@@ -1580,7 +1623,7 @@ export function StudioConsole() {
     structuredResult?: ToolResultContent[];
   }) {
     setMessages((current) => {
-      const next = [...current];
+      const next = withoutPendingAssistant(current);
       const matchedIndex = findMatchingToolIndex(next, props.toolName, props.callId);
       if (matchedIndex >= 0) {
         const existing = next[matchedIndex];
@@ -1618,7 +1661,7 @@ export function StudioConsole() {
       return;
     }
     setMessages((current) => {
-      const next = [...current];
+      const next = withoutPendingAssistant(current);
       const matchedIndex = findMatchingToolIndex(next, event.toolName, event.toolCallId);
       if (matchedIndex < 0) {
         next.push({

--- a/packages/tool-studio/src/ui/app/modules/playground/transcript-item.tsx
+++ b/packages/tool-studio/src/ui/app/modules/playground/transcript-item.tsx
@@ -48,6 +48,24 @@ export function TranscriptItem(props: {
   const isError =
     props.entry.role === "assistant" && "tone" in props.entry && props.entry.tone === "error";
 
+  if (props.entry.role === "user") {
+    return (
+      <article
+        className="grid w-fit max-w-[min(64ch,82%)] justify-items-end justify-self-end self-start text-foreground"
+        data-entry-id={String(props.entry.entryId)}
+      >
+        {props.entry.text.trim().length === 0 ? null : (
+          <div className="rounded-2xl bg-primary/10 px-4 py-2.5 shadow-sm shadow-primary/10">
+            <MarkdownText text={props.entry.text} />
+          </div>
+        )}
+        {props.entry.attachments !== undefined ? (
+          <MessageAttachments attachments={props.entry.attachments} />
+        ) : null}
+      </article>
+    );
+  }
+
   return (
     <article
       className={cn(
@@ -55,12 +73,10 @@ export function TranscriptItem(props: {
         hasTable ? "w-full max-w-full" : "max-w-[min(82ch,100%)]",
         props.entry.role === "assistant" &&
           cn("justify-self-start text-foreground", isError && "text-destructive"),
-        props.entry.role === "user" &&
-          "w-fit max-w-[min(64ch,82%)] justify-self-end rounded-2xl bg-primary/10 px-4 py-2.5 text-foreground shadow-sm shadow-primary/10",
       )}
       data-entry-id={String(props.entry.entryId)}
     >
-      <MarkdownText text={props.entry.text} />
+      {props.entry.text.trim().length === 0 ? null : <MarkdownText text={props.entry.text} />}
       {traceId !== undefined ? (
         <Button
           className="group mt-3 h-7 min-h-7 max-w-full gap-1.5 rounded-lg border border-primary/25 bg-primary/10 px-2 py-1 font-mono text-xs font-semibold text-muted-foreground shadow-none transition duration-200 hover:border-primary/45 hover:bg-primary/15 hover:text-primary"
@@ -81,6 +97,53 @@ export function TranscriptItem(props: {
         </Button>
       ) : null}
     </article>
+  );
+}
+
+function MessageAttachments(props: {
+  attachments: NonNullable<Extract<TranscriptEntry, { kind: "message" }>["attachments"]>;
+}) {
+  return (
+    <div className="mt-2 flex max-w-full flex-wrap gap-2">
+      {props.attachments.map((attachment, index) => {
+        const key = `${attachment.kind}-${attachment.name ?? attachment.mediaType ?? index}-${index}`;
+        if (attachment.kind === "image") {
+          const src =
+            attachment.url ??
+            (attachment.data === undefined
+              ? undefined
+              : `data:${attachment.mediaType ?? "image/png"};base64,${attachment.data}`);
+          return (
+            <div
+              className="overflow-hidden rounded-lg border border-border/80 bg-card/80"
+              key={key}
+            >
+              {src === undefined ? (
+                <div className="grid h-20 w-24 place-items-center px-2 text-center font-mono text-[10px] text-muted-foreground">
+                  Image
+                </div>
+              ) : (
+                <img
+                  alt={attachment.name ?? "Attached image"}
+                  className="h-20 w-24 object-cover"
+                  src={src}
+                />
+              )}
+            </div>
+          );
+        }
+        return (
+          <span
+            className="inline-flex max-w-full items-center gap-1.5 rounded-lg border border-border/80 bg-card/80 px-2 py-1 font-mono text-[11px] font-medium text-muted-foreground"
+            key={key}
+          >
+            <span className="min-w-0 truncate">
+              {attachment.name ?? attachment.mediaType ?? "Document"}
+            </span>
+          </span>
+        );
+      })}
+    </div>
   );
 }
 

--- a/packages/tool-studio/src/ui/app/modules/playground/transcript-item.tsx
+++ b/packages/tool-studio/src/ui/app/modules/playground/transcript-item.tsx
@@ -47,6 +47,8 @@ export function TranscriptItem(props: {
   const hasTable = props.entry.role === "assistant" && hasMarkdownTable(props.entry.text);
   const isError =
     props.entry.role === "assistant" && "tone" in props.entry && props.entry.tone === "error";
+  const isPending =
+    props.entry.role === "assistant" && "tone" in props.entry && props.entry.tone === "pending";
 
   if (props.entry.role === "user") {
     return (
@@ -76,6 +78,7 @@ export function TranscriptItem(props: {
       )}
       data-entry-id={String(props.entry.entryId)}
     >
+      {isPending ? <AssistantLoadingIndicator /> : null}
       {props.entry.text.trim().length === 0 ? null : <MarkdownText text={props.entry.text} />}
       {traceId !== undefined ? (
         <Button
@@ -97,6 +100,25 @@ export function TranscriptItem(props: {
         </Button>
       ) : null}
     </article>
+  );
+}
+
+function AssistantLoadingIndicator() {
+  return (
+    <div
+      aria-label="Assistant is responding"
+      className="inline-flex h-9 min-h-9 items-center gap-2 rounded-xl border border-border/70 bg-muted/35 px-3 text-muted-foreground shadow-sm"
+      role="status"
+    >
+      <span className="flex items-center gap-1" aria-hidden="true">
+        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-primary" />
+        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-primary [animation-delay:150ms]" />
+        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-primary [animation-delay:300ms]" />
+      </span>
+      <span className="font-mono text-[11px] font-semibold uppercase text-muted-foreground">
+        Thinking
+      </span>
+    </div>
   );
 }
 

--- a/packages/tool-studio/src/ui/app/modules/shared/types.ts
+++ b/packages/tool-studio/src/ui/app/modules/shared/types.ts
@@ -1,6 +1,15 @@
-import type { StudioTrace, StudioTranscriptEntry } from "../../../../types";
+import type {
+  StudioTrace,
+  StudioTranscriptChatEntry,
+  StudioTranscriptEntry,
+} from "../../../../types";
 
-export type TranscriptEntry = StudioTranscriptEntry;
+export type PendingAssistantMessage = Omit<StudioTranscriptChatEntry, "role" | "text" | "tone"> & {
+  role: "assistant";
+  text: "";
+  tone: "pending";
+};
+export type TranscriptEntry = StudioTranscriptEntry | PendingAssistantMessage;
 export type ChatMessage = Extract<TranscriptEntry, { kind: "message" }>;
 export type ToolMessage = Extract<TranscriptEntry, { kind: "tool" }>;
 export type ToolApproval = NonNullable<ToolMessage["approval"]>;

--- a/packages/tool-studio/test/runner.test.ts
+++ b/packages/tool-studio/test/runner.test.ts
@@ -413,6 +413,228 @@ describe("Anvia studio", () => {
     });
   });
 
+  it("exposes configured and listed provider models", async () => {
+    const agent = new AgentBuilder("support", new QueueModel([])).name("Support").build();
+    const runner = new Studio([agent], {
+      models: {
+        default: "openai:gpt-5",
+        providers: [
+          {
+            id: "openai",
+            name: "OpenAI",
+            defaultModel: "gpt-5",
+            models: [
+              {
+                id: "gpt-5",
+                name: "GPT-5",
+                modalities: { input: ["text", "image", "document"], output: ["text"] },
+                capabilities: { streaming: true, tools: true },
+              },
+            ],
+            createCompletionModel: () => new QueueModel([]),
+            listModels: async () => ({
+              data: [{ id: "gpt-5-mini", name: "GPT-5 mini", ownedBy: "provider" }],
+            }),
+          },
+        ],
+        agents: {
+          support: {
+            default: "openai:gpt-5",
+            allowed: ["openai:*"],
+          },
+        },
+      },
+    });
+
+    expect(runner.config().models).toMatchObject({
+      default: "openai:gpt-5",
+      providers: [
+        {
+          id: "openai",
+          name: "OpenAI",
+          defaultModel: "gpt-5",
+          models: [
+            {
+              ref: "openai:gpt-5",
+              providerId: "openai",
+              providerName: "OpenAI",
+              modalities: { input: ["text", "image", "document"], output: ["text"] },
+            },
+          ],
+        },
+      ],
+      agents: {
+        support: {
+          default: "openai:gpt-5",
+          allowed: ["openai:*"],
+        },
+      },
+    });
+
+    const models = await runner.fetch(new Request("http://runner.test/agents/support/models"));
+    await expect(models.json()).resolves.toMatchObject({
+      agentId: "support",
+      defaultModel: "openai:gpt-5",
+      models: [
+        { ref: "openai:gpt-5", name: "GPT-5" },
+        { ref: "openai:gpt-5-mini", name: "GPT-5 mini", metadata: { ownedBy: "provider" } },
+      ],
+    });
+  });
+
+  it("uses the selected provider model for runs and persists the session default", async () => {
+    const baseModel = new QueueModel([]);
+    const selectedModel = new QueueModel([
+      response([AssistantContent.text("First answer")]),
+      response([AssistantContent.text("Second answer")]),
+    ]);
+    const agent = new AgentBuilder("support", baseModel).build();
+    const runner = new Studio([agent], {
+      models: {
+        providers: [
+          {
+            id: "test",
+            defaultModel: "primary",
+            models: [{ id: "secondary", modalities: { input: ["text"], output: ["text"] } }],
+            createCompletionModel: (model) => {
+              if (model !== "secondary") {
+                throw new Error(`Unexpected model: ${model}`);
+              }
+              return selectedModel;
+            },
+          },
+        ],
+        agents: {
+          support: {
+            allowed: ["test:secondary"],
+          },
+        },
+      },
+    });
+    const created = await runner.fetch(
+      new Request("http://runner.test/sessions", {
+        method: "POST",
+        body: JSON.stringify({ agentId: "support", title: "Support" }),
+      }),
+    );
+    const session = (await created.json()) as { id: string };
+
+    const firstRun = await runner.fetch(
+      new Request("http://runner.test/agents/support/runs", {
+        method: "POST",
+        body: JSON.stringify({
+          sessionId: session.id,
+          message: "first",
+          model: "test:secondary",
+        }),
+      }),
+    );
+    expect(firstRun.status).toBe(200);
+
+    const secondRun = await runner.fetch(
+      new Request("http://runner.test/agents/support/runs", {
+        method: "POST",
+        body: JSON.stringify({
+          sessionId: session.id,
+          message: "second",
+        }),
+      }),
+    );
+    expect(secondRun.status).toBe(200);
+    expect(baseModel.requests).toHaveLength(0);
+    expect(selectedModel.requests).toHaveLength(2);
+
+    const loaded = await runner.fetch(new Request(`http://runner.test/sessions/${session.id}`));
+    await expect(loaded.json()).resolves.toMatchObject({
+      metadata: {
+        studioModel: "test:secondary",
+      },
+    });
+  });
+
+  it("rejects models outside the agent policy", async () => {
+    const agent = new AgentBuilder("support", new QueueModel([])).build();
+    const runner = new Studio([agent], {
+      models: {
+        providers: [
+          {
+            id: "test",
+            createCompletionModel: () => new QueueModel([]),
+          },
+        ],
+        agents: {
+          support: {
+            allowed: ["test:allowed"],
+          },
+        },
+      },
+    });
+
+    const run = await runner.fetch(
+      new Request("http://runner.test/agents/support/runs", {
+        method: "POST",
+        body: JSON.stringify({
+          message: "hello",
+          model: "test:blocked",
+        }),
+      }),
+    );
+
+    expect(run.status).toBe(400);
+    await expect(run.json()).resolves.toMatchObject({
+      error: {
+        code: "bad_request",
+        message: "Model test:blocked is not allowed for agent support",
+      },
+    });
+  });
+
+  it("accepts multimodal message payloads from Studio runs", async () => {
+    const model = new QueueModel([response([AssistantContent.text("image noted")])]);
+    const agent = new AgentBuilder("support", model).build();
+    const runner = new Studio([agent]);
+
+    const run = await runner.fetch(
+      new Request("http://runner.test/agents/support/runs", {
+        method: "POST",
+        body: JSON.stringify({
+          message: {
+            role: "user",
+            content: [
+              { type: "text", text: "Describe this image." },
+              {
+                type: "image",
+                source: {
+                  type: "base64",
+                  data: "aW1hZ2U=",
+                  mediaType: "image/png",
+                },
+              },
+            ],
+          },
+        }),
+      }),
+    );
+
+    expect(run.status).toBe(200);
+    expect(model.requests[0]?.chatHistory.at(-1)).toMatchObject({
+      role: "user",
+      content: [
+        { type: "text", text: "Describe this image." },
+        { type: "image", source: { type: "base64", mediaType: "image/png" } },
+      ],
+    });
+
+    const body = (await run.json()) as { messages: Message[] };
+    expect(body.messages[0]).toMatchObject({
+      role: "user",
+      content: [
+        { type: "text", text: "Describe this image." },
+        { type: "image", source: { type: "base64", mediaType: "image/png" } },
+      ],
+    });
+  });
+
   it("registers pipelines separately from agents", async () => {
     const agent = new AgentBuilder("support", new QueueModel([])).name("Support").build();
     const pipeline = new PipelineBuilder<string>({


### PR DESCRIPTION
## Summary
- add multi-provider Studio model configuration and per-agent model policies
- support multimodal model metadata plus image/document attachments in Studio runs
- add OpenAI/Anthropic cookbook example and assistant loading feedback in the playground
- add a minor changeset for @anvia/studio

## Validation
- pnpm --filter @anvia/studio build
- pnpm --filter @anvia/studio test
- pnpm --filter cookbook typecheck