### PR TITLE
Remove duplicate tool approvals changeset

### DIFF
--- a/.changeset/tool-approvals.md
+++ b/.changeset/tool-approvals.md
@@ -1,9 +1,0 @@
----
-"@anvia/core": minor
-"@anvia/react": minor
-"@anvia/studio": minor
----
-
-Add centralized tool approval handling with tool-level approval policies and `.approvals(...)` decision handlers.
-
-Add React `useChat` human-input state for tool approvals and `ask_question` prompts, including helpers for approving, rejecting, and answering pending human input.


### PR DESCRIPTION
## Summary
- remove the stale tool approvals changeset after the 0.7.0 release already covered this design
- prevent the Changesets release PR from bumping the same packages again

## Tests
- not run; metadata-only deletion