### PR TITLE
Support Zod schema pipeline inputs

### DIFF
--- a/apps/docs/content/docs/guides/pipelines/pipeline-builder.mdx
+++ b/apps/docs/content/docs/guides/pipelines/pipeline-builder.mdx
@@ -172,7 +172,43 @@ const triage = await ticketPipeline.run({
 });
 ```
 
-## 7. Add Capabilities Gradually
+## 7. Validate Inputs With a Zod Schema
+
+Pass a Zod schema directly to the constructor when you want runtime validation in addition to type inference. The builder infers `Input` and `Output` from the schema with `z.infer<typeof schema>` and parses every call to `pipeline.run(...)`.
+
+```ts
+import { z } from "zod";
+import { PipelineBuilder } from "@anvia/core/pipeline";
+
+const SearchInput = z.object({
+  query: z.string().min(1),
+  limit: z.number().int().positive().default(10),
+});
+
+const searchPipeline = new PipelineBuilder(SearchInput)
+  .step(({ query, limit }) => search(query, limit))
+  .build();
+
+const results = await searchPipeline.run({ query: "anvia" });
+// returns `SearchInput` parsed: { query: "anvia", limit: 10 }
+```
+
+Pass metadata as the second argument when you also want the pipeline to carry a name or description:
+
+```ts
+const searchPipeline = new PipelineBuilder(
+  SearchInput,
+  { name: "Search Pipeline", description: "Validates and runs a search." },
+)
+  .step(({ query, limit }) => search(query, limit))
+  .build();
+
+console.log(searchPipeline.name);
+```
+
+Invalid input throws `ZodError` before any stage runs, so downstream code can assume the schema has already been satisfied.
+
+## 8. Add Capabilities Gradually
 
 Build pipelines in this order:
 

--- a/apps/docs/content/docs/reference/core/pipeline.mdx
+++ b/apps/docs/content/docs/reference/core/pipeline.mdx
@@ -144,6 +144,11 @@ Notable errors: observer errors propagate to the run.
 class PipelineBuilder<Input, Output = Input> {
   constructor();
   constructor(metadata: PipelineMetadata);
+  constructor<S extends z.ZodType>(schema: S): PipelineBuilder<z.infer<S>, z.infer<S>>;
+  constructor<S extends z.ZodType>(
+    schema: S,
+    metadata: PipelineMetadata,
+  ): PipelineBuilder<z.infer<S>, z.infer<S>>;
   step<Next>(
     fn: (input: Awaited<Output>) => Next | Promise<Next>,
     metadata?: PipelineStageMetadata,
@@ -164,8 +169,8 @@ class PipelineBuilder<Input, Output = Input> {
 
 Purpose: typed composition of transform functions, operations, agents, and extractors.
 
-Return behavior: each composition method returns a new builder with the inferred output type.
+Return behavior: each composition method returns a new builder with the inferred output type. The Zod schema overloads parse input at runtime, so the inferred `Input` type flows through the chain and invalid inputs throw `ZodError` before any stage runs.
 
-Notable errors: forwards errors from transform functions, nested operations, agents, or extractors.
+Notable errors: forwards errors from transform functions, nested operations, agents, or extractors. Schema overloads additionally throw `ZodError` on input that does not match the schema.
 
 For workflow guidance, see [Pipeline Builder](/docs/guides/pipelines/pipeline-builder).

--- a/examples/cookbook/05_pipelines/10-zod-schema-input.ts
+++ b/examples/cookbook/05_pipelines/10-zod-schema-input.ts
@@ -1,0 +1,34 @@
+import { PipelineBuilder } from "@anvia/core/pipeline";
+import { z } from "zod";
+
+const SearchInput = z.object({
+  query: z.string().min(1).describe("Search query string"),
+  limit: z.number().int().positive().default(10).describe("Maximum results"),
+});
+
+async function search(query: string, limit: number): Promise<string[]> {
+  await Promise.resolve();
+  return Array.from({ length: limit }, (_, index) => `${query} #${index + 1}`);
+}
+
+const searchPipeline = new PipelineBuilder(SearchInput, {
+  name: "Search Pipeline",
+  description: "Validates input with a Zod schema, then runs a search.",
+})
+  .step(({ query, limit }) => search(query, limit ?? 10))
+  .step((results) => ({ query: results[0]?.split(" #")[0] ?? "", count: results.length }))
+  .build();
+
+const result = await searchPipeline.run({ query: "anvia" });
+
+console.log(result);
+console.log(searchPipeline.name);
+
+try {
+  await searchPipeline.run({ query: "" } as { query: string; limit?: number });
+} catch (error) {
+  console.log(
+    "validation rejected:",
+    error instanceof z.ZodError ? error.issues[0]?.message : error,
+  );
+}

--- a/packages/core/src/pipeline/builder.ts
+++ b/packages/core/src/pipeline/builder.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import type { Agent } from "../agent/agent";
 import type { CompletionModel } from "../completion";
 import type { Extractor } from "../extractor";
@@ -29,18 +30,21 @@ export class PipelineBuilder<Input, Output = Input> {
 
   constructor();
   constructor(metadata: PipelineMetadata);
+  constructor(schema: z.ZodType<unknown, Input>);
+  constructor(schema: z.ZodType<unknown, Input>, metadata: PipelineMetadata);
   constructor(executor: (input: Input) => Output | Promise<Output>);
   constructor(executor: PipelineExecutor<Input, Output>, state: PipelineBuilderState);
   constructor(
     metadataOrExecutor?:
       | PipelineMetadata
+      | z.ZodType
       | ((input: Input) => Output | Promise<Output>)
       | PipelineExecutor<Input, Output>,
-    state?: PipelineBuilderState,
+    stateOrMetadata?: PipelineBuilderState | PipelineMetadata,
   ) {
-    if (state !== undefined) {
+    if (stateOrMetadata !== undefined && isBuilderState(stateOrMetadata)) {
       this.executor = metadataOrExecutor as PipelineExecutor<Input, Output>;
-      this.state = state;
+      this.state = stateOrMetadata;
       return;
     }
 
@@ -51,8 +55,17 @@ export class PipelineBuilder<Input, Output = Input> {
       return;
     }
 
+    if (isZodSchema(metadataOrExecutor)) {
+      const schema = metadataOrExecutor;
+      const metadata: PipelineMetadata =
+        stateOrMetadata !== undefined && isPipelineMetadata(stateOrMetadata) ? stateOrMetadata : {};
+      this.executor = ((input) => schema.parse(input)) as PipelineExecutor<Input, Output>;
+      this.state = initialBuilderState(metadata);
+      return;
+    }
+
     this.executor = identity as PipelineExecutor<Input, Output>;
-    this.state = initialBuilderState(metadataOrExecutor ?? {});
+    this.state = initialBuilderState((metadataOrExecutor as PipelineMetadata | undefined) ?? {});
   }
 
   /** Add a synchronous or asynchronous transform stage. */
@@ -212,4 +225,35 @@ export class PipelineBuilder<Input, Output = Input> {
 
 function identity<T>(input: T): T {
   return input;
+}
+
+function isZodSchema(value: unknown): value is z.ZodType {
+  return value instanceof z.ZodType;
+}
+
+function isBuilderState(value: unknown): value is PipelineBuilderState {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    "graph" in candidate &&
+    "terminalNodeId" in candidate &&
+    "terminalNodeIds" in candidate &&
+    "nextNodeIndex" in candidate &&
+    "nextEdgeIndex" in candidate
+  );
+}
+
+function isPipelineMetadata(value: unknown): value is PipelineMetadata {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    "id" in candidate ||
+    "name" in candidate ||
+    "description" in candidate ||
+    "metadata" in candidate
+  );
 }

--- a/packages/core/test/pipeline.test.ts
+++ b/packages/core/test/pipeline.test.ts
@@ -249,6 +249,55 @@ describe("PipelineBuilder", () => {
       anvia.parallel();
     }
   });
+
+  it("accepts a Zod schema at construction and infers input type", async () => {
+    const op = new PipelineBuilder(z.object({ query: z.string(), limit: z.number() }))
+      .step(({ query, limit }) => `${query}:${limit}`)
+      .build();
+
+    await expect(op.run({ query: "search", limit: 3 })).resolves.toBe("search:3");
+  });
+
+  it("validates input with a Zod schema at runtime", async () => {
+    const op = new PipelineBuilder(z.object({ query: z.string() }))
+      .step(({ query }) => query)
+      .build();
+
+    await expect(op.run({ query: "ok" })).resolves.toBe("ok");
+    await expect(op.run({ query: 42 } as unknown as { query: string })).rejects.toThrow();
+  });
+
+  it("applies Zod defaults when parsing input", async () => {
+    const op = new PipelineBuilder(z.object({ query: z.string(), limit: z.number().default(10) }))
+      .step(({ query, limit }) => `${query}:${limit}`)
+      .build();
+
+    await expect(op.run({ query: "hi" })).resolves.toBe("hi:10");
+  });
+
+  it("accepts a Zod schema with metadata as the second argument", async () => {
+    const op = new PipelineBuilder(z.object({ x: z.string() }), {
+      name: "X Pipeline",
+      description: "desc",
+      metadata: { owner: "test" },
+    })
+      .step(({ x }) => x.toUpperCase())
+      .build();
+
+    await expect(op.run({ x: "ok" })).resolves.toBe("OK");
+    expect(op.name).toBe("X Pipeline");
+    expect(op.description).toBe("desc");
+    expect(op.metadata).toEqual({ owner: "test" });
+  });
+
+  it("keeps existing constructors working alongside the schema overload", async () => {
+    const empty = new PipelineBuilder<string>().step((s: string) => s).build();
+    const metadataOnly = new PipelineBuilder<string>({ name: "M" }).step((s: string) => s).build();
+
+    await expect(empty.run("hi")).resolves.toBe("hi");
+    await expect(metadataOnly.run("hi")).resolves.toBe("hi");
+    expect(metadataOnly.name).toBe("M");
+  });
 });
 
 function unreachable(): boolean {


### PR DESCRIPTION
## Summary
- allow PipelineBuilder to accept a Zod schema as its input parser
- add runtime validation/default handling tests for schema-backed pipelines
- document schema-backed pipeline inputs and add a cookbook example

## Tests
- pnpm --filter @anvia/core test -- pipeline.test.ts
- pnpm --filter @anvia/core typecheck