### PR TITLE
Fix core peer dependency compatibility

### DIFF
--- a/.changeset/core-peer-dependencies.md
+++ b/.changeset/core-peer-dependencies.md
@@ -1,0 +1,23 @@
+---
+"@anvia/anthropic": patch
+"@anvia/chroma": patch
+"@anvia/fastembed": patch
+"@anvia/gemini": patch
+"@anvia/langfuse": patch
+"@anvia/lancedb": patch
+"@anvia/logger": patch
+"@anvia/milvus": patch
+"@anvia/mistral": patch
+"@anvia/openai": patch
+"@anvia/otel": patch
+"@anvia/pgvector": patch
+"@anvia/pinecone": patch
+"@anvia/qdrant": patch
+"@anvia/redis": patch
+"@anvia/sandbox": patch
+"@anvia/studio": patch
+"@anvia/transformers": patch
+"@anvia/weaviate": patch
+---
+
+Move @anvia/core to peer dependencies for packages that expose or consume core types, preventing duplicate private-type incompatibilities in consumer apps.

--- a/examples/peer-core-compat/package.json
+++ b/examples/peer-core-compat/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "peer-core-compat",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "pretypecheck": "pnpm --filter @anvia/openai --filter @anvia/studio build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@anvia/core": "workspace:*",
+    "@anvia/openai": "workspace:*",
+    "@anvia/studio": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.9.1",
+    "typescript": "^5.9.3"
+  }
+}

--- a/examples/peer-core-compat/src/index.ts
+++ b/examples/peer-core-compat/src/index.ts
@@ -1,0 +1,13 @@
+import { AgentBuilder } from "@anvia/core";
+import { OpenAIClient } from "@anvia/openai";
+import { Studio } from "@anvia/studio";
+
+const openaiModel = new OpenAIClient({ apiKey: "test" }).completionModel("gpt-5");
+
+const agent = new AgentBuilder("assistant", openaiModel)
+  .name("assistant")
+  .description("An assistant that can answer questions.")
+  .instructions("You are a helpful assistant.")
+  .build();
+
+new Studio([agent]).start();

--- a/examples/peer-core-compat/tsconfig.json
+++ b/examples/peer-core-compat/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/embedding-fastembed/package.json
+++ b/packages/embedding-fastembed/package.json
@@ -31,13 +31,16 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
     "fastembed": "^2.1.0"
   },
   "devDependencies": {
+    "@anvia/core": "workspace:*",
     "@types/node": "^24.9.1",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.8"
+  },
+  "peerDependencies": {
+    "@anvia/core": "^0.7.0"
   }
 }

--- a/packages/embedding-transformers/package.json
+++ b/packages/embedding-transformers/package.json
@@ -31,13 +31,16 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
     "@huggingface/transformers": "^4.2.0"
   },
   "devDependencies": {
+    "@anvia/core": "workspace:*",
     "@types/node": "^24.9.1",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.8"
+  },
+  "peerDependencies": {
+    "@anvia/core": "^0.7.0"
   }
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -31,13 +31,16 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
     "pino": "^10.3.1"
   },
   "devDependencies": {
+    "@anvia/core": "workspace:*",
     "@types/node": "^24.9.1",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.8"
+  },
+  "peerDependencies": {
+    "@anvia/core": "^0.7.0"
   }
 }

--- a/packages/observability-langfuse/package.json
+++ b/packages/observability-langfuse/package.json
@@ -31,15 +31,18 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "^0.7.0",
     "@langfuse/otel": "^5.4.1",
     "@langfuse/tracing": "^5.4.1",
     "@opentelemetry/sdk-node": "^0.219.0"
   },
   "devDependencies": {
+    "@anvia/core": "workspace:*",
     "@types/node": "^24.9.1",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.8"
+  },
+  "peerDependencies": {
+    "@anvia/core": "^0.7.0"
   }
 }

--- a/packages/observability-otel/package.json
+++ b/packages/observability-otel/package.json
@@ -31,13 +31,16 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
     "@opentelemetry/api": "^1.9.1"
   },
   "devDependencies": {
+    "@anvia/core": "workspace:*",
     "@types/node": "^24.9.1",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.8"
+  },
+  "peerDependencies": {
+    "@anvia/core": "^0.7.0"
   }
 }

--- a/packages/provider-anthropic/package.json
+++ b/packages/provider-anthropic/package.json
@@ -33,13 +33,16 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.104.1",
-    "@anvia/core": "^0.7.0"
+    "@anthropic-ai/sdk": "^0.104.1"
   },
   "devDependencies": {
+    "@anvia/core": "workspace:*",
     "@types/node": "^24.9.1",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.8"
+  },
+  "peerDependencies": {
+    "@anvia/core": "^0.7.0"
   }
 }

--- a/packages/provider-gemini/package.json
+++ b/packages/provider-gemini/package.json
@@ -33,13 +33,16 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "^0.7.0",
     "@google/genai": "^2.8.0"
   },
   "devDependencies": {
+    "@anvia/core": "workspace:*",
     "@types/node": "^24.9.1",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.8"
+  },
+  "peerDependencies": {
+    "@anvia/core": "^0.7.0"
   }
 }

--- a/packages/provider-mistral/package.json
+++ b/packages/provider-mistral/package.json
@@ -33,13 +33,16 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
     "@mistralai/mistralai": "^2.2.5"
   },
   "devDependencies": {
+    "@anvia/core": "workspace:*",
     "@types/node": "^24.9.1",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.8"
+  },
+  "peerDependencies": {
+    "@anvia/core": "^0.7.0"
   }
 }

--- a/packages/provider-openai/package.json
+++ b/packages/provider-openai/package.json
@@ -33,13 +33,16 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
     "openai": "^6.42.0"
   },
   "devDependencies": {
+    "@anvia/core": "workspace:*",
     "@types/node": "^24.9.1",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.8"
+  },
+  "peerDependencies": {
+    "@anvia/core": "^0.7.0"
   }
 }

--- a/packages/tool-sandbox/package.json
+++ b/packages/tool-sandbox/package.json
@@ -32,13 +32,16 @@
     "typecheck": "pnpm run build:deps && tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@anvia/core": "workspace:*",
     "@types/node": "^24.9.1",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.8"
+  },
+  "peerDependencies": {
+    "@anvia/core": "^0.7.0"
   }
 }

--- a/packages/tool-studio/package.json
+++ b/packages/tool-studio/package.json
@@ -32,7 +32,6 @@
     "typecheck": "pnpm run build:deps && tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
     "@anvia/react": "workspace:*",
     "@anvia/server": "workspace:*",
     "@hono/node-server": "^2.0.4",
@@ -53,6 +52,7 @@
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
+    "@anvia/core": "workspace:*",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.4",
     "@types/node": "^24.9.1",
@@ -65,5 +65,8 @@
     "typescript": "^5.9.3",
     "vite": "^8.0.10",
     "vitest": "^4.0.8"
+  },
+  "peerDependencies": {
+    "@anvia/core": "^0.7.0"
   }
 }

--- a/packages/vector-chroma/package.json
+++ b/packages/vector-chroma/package.json
@@ -31,13 +31,16 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
     "chromadb": "^3.4.3"
   },
   "devDependencies": {
+    "@anvia/core": "workspace:*",
     "@types/node": "^24.9.1",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.8"
+  },
+  "peerDependencies": {
+    "@anvia/core": "^0.7.0"
   }
 }

--- a/packages/vector-lancedb/package.json
+++ b/packages/vector-lancedb/package.json
@@ -31,13 +31,16 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
     "@lancedb/lancedb": "^0.13.0"
   },
   "devDependencies": {
+    "@anvia/core": "workspace:*",
     "@types/node": "^24.9.1",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.8"
+  },
+  "peerDependencies": {
+    "@anvia/core": "^0.7.0"
   }
 }

--- a/packages/vector-milvus/package.json
+++ b/packages/vector-milvus/package.json
@@ -31,13 +31,16 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
     "@zilliz/milvus2-sdk-node": "^2.5.0"
   },
   "devDependencies": {
+    "@anvia/core": "workspace:*",
     "@types/node": "^24.9.1",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.8"
+  },
+  "peerDependencies": {
+    "@anvia/core": "^0.7.0"
   }
 }

--- a/packages/vector-pgvector/package.json
+++ b/packages/vector-pgvector/package.json
@@ -31,15 +31,18 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
     "pg": "^8.21.0",
     "pgvector": "^0.3.0"
   },
   "devDependencies": {
+    "@anvia/core": "workspace:*",
     "@types/node": "^24.9.1",
     "@types/pg": "^8.15.6",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.8"
+  },
+  "peerDependencies": {
+    "@anvia/core": "^0.7.0"
   }
 }

--- a/packages/vector-pinecone/package.json
+++ b/packages/vector-pinecone/package.json
@@ -31,13 +31,16 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
     "@pinecone-database/pinecone": "^5.1.0"
   },
   "devDependencies": {
+    "@anvia/core": "workspace:*",
     "@types/node": "^24.9.1",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.8"
+  },
+  "peerDependencies": {
+    "@anvia/core": "^0.7.0"
   }
 }

--- a/packages/vector-qdrant/package.json
+++ b/packages/vector-qdrant/package.json
@@ -31,13 +31,16 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
     "@qdrant/js-client-rest": "^1.18.0"
   },
   "devDependencies": {
+    "@anvia/core": "workspace:*",
     "@types/node": "^24.9.1",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.8"
+  },
+  "peerDependencies": {
+    "@anvia/core": "^0.7.0"
   }
 }

--- a/packages/vector-redis/package.json
+++ b/packages/vector-redis/package.json
@@ -31,13 +31,16 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
     "redis": "^4.7.0"
   },
   "devDependencies": {
+    "@anvia/core": "workspace:*",
     "@types/node": "^24.9.1",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.8"
+  },
+  "peerDependencies": {
+    "@anvia/core": "^0.7.0"
   }
 }

--- a/packages/vector-weaviate/package.json
+++ b/packages/vector-weaviate/package.json
@@ -31,13 +31,16 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anvia/core": "workspace:*",
     "weaviate-client": "^3.5.0"
   },
   "devDependencies": {
+    "@anvia/core": "workspace:*",
     "@types/node": "^24.9.1",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.8"
+  },
+  "peerDependencies": {
+    "@anvia/core": "^0.7.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,6 +237,25 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  examples/peer-core-compat:
+    dependencies:
+      '@anvia/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@anvia/openai':
+        specifier: workspace:*
+        version: link:../../packages/provider-openai
+      '@anvia/studio':
+        specifier: workspace:*
+        version: link:../../packages/tool-studio
+    devDependencies:
+      '@types/node':
+        specifier: ^24.9.1
+        version: 24.12.2
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/core:
     dependencies:
       '@modelcontextprotocol/sdk':
@@ -270,13 +289,13 @@ importers:
 
   packages/embedding-fastembed:
     dependencies:
-      '@anvia/core':
-        specifier: workspace:*
-        version: link:../core
       fastembed:
         specifier: ^2.1.0
         version: 2.1.0
     devDependencies:
+      '@anvia/core':
+        specifier: workspace:*
+        version: link:../core
       '@types/node':
         specifier: ^24.9.1
         version: 24.12.2
@@ -292,13 +311,13 @@ importers:
 
   packages/embedding-transformers:
     dependencies:
-      '@anvia/core':
-        specifier: workspace:*
-        version: link:../core
       '@huggingface/transformers':
         specifier: ^4.2.0
         version: 4.2.0
     devDependencies:
+      '@anvia/core':
+        specifier: workspace:*
+        version: link:../core
       '@types/node':
         specifier: ^24.9.1
         version: 24.12.2
@@ -314,13 +333,13 @@ importers:
 
   packages/logger:
     dependencies:
-      '@anvia/core':
-        specifier: workspace:*
-        version: link:../core
       pino:
         specifier: ^10.3.1
         version: 10.3.1
     devDependencies:
+      '@anvia/core':
+        specifier: workspace:*
+        version: link:../core
       '@types/node':
         specifier: ^24.9.1
         version: 24.12.2
@@ -336,9 +355,6 @@ importers:
 
   packages/observability-langfuse:
     dependencies:
-      '@anvia/core':
-        specifier: workspace:*
-        version: link:../core
       '@langfuse/otel':
         specifier: ^5.4.1
         version: 5.4.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
@@ -349,6 +365,9 @@ importers:
         specifier: ^0.219.0
         version: 0.219.0(@opentelemetry/api@1.9.1)
     devDependencies:
+      '@anvia/core':
+        specifier: workspace:*
+        version: link:../core
       '@types/node':
         specifier: ^24.9.1
         version: 24.12.2
@@ -364,13 +383,13 @@ importers:
 
   packages/observability-otel:
     dependencies:
-      '@anvia/core':
-        specifier: workspace:*
-        version: link:../core
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
     devDependencies:
+      '@anvia/core':
+        specifier: workspace:*
+        version: link:../core
       '@types/node':
         specifier: ^24.9.1
         version: 24.12.2
@@ -389,10 +408,10 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.104.1
         version: 0.104.1(zod@4.4.3)
+    devDependencies:
       '@anvia/core':
         specifier: workspace:*
         version: link:../core
-    devDependencies:
       '@types/node':
         specifier: ^24.9.1
         version: 24.12.2
@@ -408,13 +427,13 @@ importers:
 
   packages/provider-gemini:
     dependencies:
-      '@anvia/core':
-        specifier: workspace:*
-        version: link:../core
       '@google/genai':
         specifier: ^2.8.0
         version: 2.8.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
     devDependencies:
+      '@anvia/core':
+        specifier: workspace:*
+        version: link:../core
       '@types/node':
         specifier: ^24.9.1
         version: 24.12.2
@@ -430,13 +449,13 @@ importers:
 
   packages/provider-mistral:
     dependencies:
-      '@anvia/core':
-        specifier: workspace:*
-        version: link:../core
       '@mistralai/mistralai':
         specifier: ^2.2.5
         version: 2.2.5
     devDependencies:
+      '@anvia/core':
+        specifier: workspace:*
+        version: link:../core
       '@types/node':
         specifier: ^24.9.1
         version: 24.12.2
@@ -452,13 +471,13 @@ importers:
 
   packages/provider-openai:
     dependencies:
-      '@anvia/core':
-        specifier: workspace:*
-        version: link:../core
       openai:
         specifier: ^6.42.0
         version: 6.42.0(ws@8.21.0)(zod@4.4.3)
     devDependencies:
+      '@anvia/core':
+        specifier: workspace:*
+        version: link:../core
       '@types/node':
         specifier: ^24.9.1
         version: 24.12.2
@@ -528,13 +547,13 @@ importers:
 
   packages/tool-sandbox:
     dependencies:
-      '@anvia/core':
-        specifier: workspace:*
-        version: link:../core
       zod:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@anvia/core':
+        specifier: workspace:*
+        version: link:../core
       '@types/node':
         specifier: ^24.9.1
         version: 24.12.2
@@ -550,9 +569,6 @@ importers:
 
   packages/tool-studio:
     dependencies:
-      '@anvia/core':
-        specifier: workspace:*
-        version: link:../core
       '@anvia/react':
         specifier: workspace:*
         version: link:../react
@@ -608,6 +624,9 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0
     devDependencies:
+      '@anvia/core':
+        specifier: workspace:*
+        version: link:../core
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@4.2.4)
@@ -647,13 +666,13 @@ importers:
 
   packages/vector-chroma:
     dependencies:
-      '@anvia/core':
-        specifier: workspace:*
-        version: link:../core
       chromadb:
         specifier: ^3.4.3
         version: 3.4.3
     devDependencies:
+      '@anvia/core':
+        specifier: workspace:*
+        version: link:../core
       '@types/node':
         specifier: ^24.9.1
         version: 24.12.2
@@ -669,13 +688,13 @@ importers:
 
   packages/vector-lancedb:
     dependencies:
-      '@anvia/core':
-        specifier: workspace:*
-        version: link:../core
       '@lancedb/lancedb':
         specifier: ^0.13.0
         version: 0.13.0(apache-arrow@17.0.0)
     devDependencies:
+      '@anvia/core':
+        specifier: workspace:*
+        version: link:../core
       '@types/node':
         specifier: ^24.9.1
         version: 24.12.2
@@ -691,13 +710,13 @@ importers:
 
   packages/vector-milvus:
     dependencies:
-      '@anvia/core':
-        specifier: workspace:*
-        version: link:../core
       '@zilliz/milvus2-sdk-node':
         specifier: ^2.5.0
         version: 2.6.17
     devDependencies:
+      '@anvia/core':
+        specifier: workspace:*
+        version: link:../core
       '@types/node':
         specifier: ^24.9.1
         version: 24.12.2
@@ -713,9 +732,6 @@ importers:
 
   packages/vector-pgvector:
     dependencies:
-      '@anvia/core':
-        specifier: workspace:*
-        version: link:../core
       pg:
         specifier: ^8.21.0
         version: 8.21.0
@@ -723,6 +739,9 @@ importers:
         specifier: ^0.3.0
         version: 0.3.0
     devDependencies:
+      '@anvia/core':
+        specifier: workspace:*
+        version: link:../core
       '@types/node':
         specifier: ^24.9.1
         version: 24.12.2
@@ -741,13 +760,13 @@ importers:
 
   packages/vector-pinecone:
     dependencies:
-      '@anvia/core':
-        specifier: workspace:*
-        version: link:../core
       '@pinecone-database/pinecone':
         specifier: ^5.1.0
         version: 5.1.2
     devDependencies:
+      '@anvia/core':
+        specifier: workspace:*
+        version: link:../core
       '@types/node':
         specifier: ^24.9.1
         version: 24.12.2
@@ -763,13 +782,13 @@ importers:
 
   packages/vector-qdrant:
     dependencies:
-      '@anvia/core':
-        specifier: workspace:*
-        version: link:../core
       '@qdrant/js-client-rest':
         specifier: ^1.18.0
         version: 1.18.0(typescript@5.9.3)
     devDependencies:
+      '@anvia/core':
+        specifier: workspace:*
+        version: link:../core
       '@types/node':
         specifier: ^24.9.1
         version: 24.12.2
@@ -785,13 +804,13 @@ importers:
 
   packages/vector-redis:
     dependencies:
-      '@anvia/core':
-        specifier: workspace:*
-        version: link:../core
       redis:
         specifier: ^4.7.0
         version: 4.7.1
     devDependencies:
+      '@anvia/core':
+        specifier: workspace:*
+        version: link:../core
       '@types/node':
         specifier: ^24.9.1
         version: 24.12.2
@@ -807,13 +826,13 @@ importers:
 
   packages/vector-weaviate:
     dependencies:
-      '@anvia/core':
-        specifier: workspace:*
-        version: link:../core
       weaviate-client:
         specifier: ^3.5.0
         version: 3.13.1
     devDependencies:
+      '@anvia/core':
+        specifier: workspace:*
+        version: link:../core
       '@types/node':
         specifier: ^24.9.1
         version: 24.12.2


### PR DESCRIPTION
## Summary
- Move @anvia/core from runtime dependencies to peer dependencies for packages that expose or consume core types
- Keep @anvia/core as a workspace dev dependency for local package builds and tests
- Add a consumer-style peer compatibility fixture covering @anvia/core + @anvia/openai + @anvia/studio and new Studio([agent])
- Add a changeset for affected packages

## Verification
- pnpm --filter peer-core-compat typecheck
- pnpm --filter @anvia/openai --filter @anvia/studio typecheck
- pnpm --filter './packages/*' typecheck
- Packed @anvia/openai and @anvia/studio manifests to confirm @anvia/core publishes as peerDependency ^0.7.0, not as a runtime dependency