### PR TITLE
Update pipeline schemas and upstream dependencies

### DIFF
--- a/.changeset/schema-pipeline-deps.md
+++ b/.changeset/schema-pipeline-deps.md
@@ -1,0 +1,17 @@
+---
+"@anvia/core": patch
+"@anvia/anthropic": patch
+"@anvia/gemini": patch
+"@anvia/mistral": patch
+"@anvia/openai": patch
+"@anvia/langfuse": patch
+"@anvia/studio": patch
+"@anvia/lancedb": patch
+"@anvia/milvus": patch
+"@anvia/pgvector": patch
+"@anvia/pinecone": patch
+"@anvia/redis": patch
+"@anvia/weaviate": patch
+---
+
+Refresh upstream runtime dependencies and make pipeline construction schema-first.

--- a/apps/docs/content/docs/best-practices/common-patterns/pipeline.mdx
+++ b/apps/docs/content/docs/best-practices/common-patterns/pipeline.mdx
@@ -74,7 +74,7 @@ Keep nested agents narrow. A broad agent calling another broad agent usually mak
 Use a pipeline when the job has explicit typed stages that should be tested, reused, or observed independently.
 
 ```ts
-const pipeline = new PipelineBuilder<string>()
+const pipeline = new PipelineBuilder(z.string())
   .step((input) => input.trim())
   .prompt(triageAgent)
   .extract(ticketExtractor)

--- a/apps/docs/content/docs/best-practices/long-process-pipelines/run-pipeline-workers.mdx
+++ b/apps/docs/content/docs/best-practices/long-process-pipelines/run-pipeline-workers.mdx
@@ -10,9 +10,9 @@ The worker owns execution. It should mark jobs running, call `pipeline.run(...)`
 ```ts
 import { PipelineBuilder } from "@anvia/core/pipeline";
 import { ticketAgent, ticketExtractor } from "./ai";
-import type { TicketJobData } from "./schema";
+import { ticketInputSchema } from "./schema";
 
-export const ticketPipeline = new PipelineBuilder<TicketJobData>({
+export const ticketPipeline = new PipelineBuilder(ticketInputSchema, {
   id: "ticket-triage-pipeline",
   name: "Ticket triage pipeline",
 })

--- a/apps/docs/content/docs/best-practices/real-cases/research-agent.mdx
+++ b/apps/docs/content/docs/best-practices/real-cases/research-agent.mdx
@@ -74,7 +74,7 @@ const briefSchema = z.object({
 
 const briefExtractor = new ExtractorBuilder(model, briefSchema).build();
 
-export const researchWorkflow = new PipelineBuilder<string>()
+export const researchWorkflow = new PipelineBuilder(z.string())
   .step((question) => question.trim())
   .prompt(researchAgent)
   .extract(briefExtractor)

--- a/apps/docs/content/docs/guides/design-philosophy.mdx
+++ b/apps/docs/content/docs/guides/design-philosophy.mdx
@@ -164,7 +164,7 @@ const lookupCustomer = createTool({
 
 const extractor = new ExtractorBuilder(model, ticketSchema).build();
 
-const pipeline = new PipelineBuilder<string>()
+const pipeline = new PipelineBuilder(z.string())
   .step((input) => input.trim())
   .extract(extractor)
   .step((ticket) => ({
@@ -198,7 +198,7 @@ const supportAgent = new AgentBuilder("support", model)
   )
   .build();
 
-const workflow = new PipelineBuilder<string>()
+const workflow = new PipelineBuilder(z.string())
   .prompt(supportAgent)
   .extract(extractor)
   .build();

--- a/apps/docs/content/docs/guides/learning-paths/build-a-pipeline.mdx
+++ b/apps/docs/content/docs/guides/learning-paths/build-a-pipeline.mdx
@@ -41,14 +41,15 @@ Do not use a pipeline just to send one prompt. Start with an agent and add a pip
 
 ```ts
 import { PipelineBuilder } from "@anvia/core/pipeline";
+import { z } from "zod";
 
-type TicketInput = {
-  customer: string;
-  subject: string;
-  body: string;
-};
+const TicketInput = z.object({
+  customer: z.string(),
+  subject: z.string(),
+  body: z.string(),
+});
 
-const pipeline = new PipelineBuilder<TicketInput>()
+const pipeline = new PipelineBuilder(TicketInput)
   .step((ticket) => ({
     customer: ticket.customer.trim(),
     subject: ticket.subject.trim(),
@@ -93,7 +94,7 @@ const extractor = new ExtractorBuilder(
   }),
 ).build();
 
-const pipeline = new PipelineBuilder<TicketInput>()
+const pipeline = new PipelineBuilder(TicketInput)
   .step(
     (ticket) =>
       [
@@ -120,16 +121,16 @@ For object inputs, format the prompt in a step before `.prompt(...)` or `.extrac
 ## Parallel Branch Shape
 
 ```ts
-const checks = new PipelineBuilder<TicketInput>()
+const checks = new PipelineBuilder(TicketInput)
   .step((ticket) => ticket.body)
   .parallel({
-    uppercase: new PipelineBuilder<string>()
+    uppercase: new PipelineBuilder(z.string())
       .step((value) => value.toUpperCase())
       .build(),
-    length: new PipelineBuilder<string>()
+    length: new PipelineBuilder(z.string())
       .step((value) => value.length)
       .build(),
-    urgent: new PipelineBuilder<string>()
+    urgent: new PipelineBuilder(z.string())
       .step((value) => value.toLowerCase().includes("failing"))
       .build(),
   })

--- a/apps/docs/content/docs/guides/pipelines/agents-in-pipelines.mdx
+++ b/apps/docs/content/docs/guides/pipelines/agents-in-pipelines.mdx
@@ -17,7 +17,7 @@ const triageAgent = new AgentBuilder("triage", model)
 ## 2. Format the Prompt in a Step
 
 ```ts
-const pipeline = new PipelineBuilder<string>()
+const pipeline = new PipelineBuilder(z.string())
   .step((ticket) => `Classify this ticket:\n\n${ticket}`)
   .prompt(triageAgent)
   .build();
@@ -34,7 +34,7 @@ const supportAgent = new AgentBuilder("support", model)
   .defaultMaxTurns(3)
   .build();
 
-const pipeline = new PipelineBuilder<string>()
+const pipeline = new PipelineBuilder(z.string())
   .step((ticket) => `Answer this support ticket:\n\n${ticket}`)
   .prompt(supportAgent)
   .build();
@@ -45,10 +45,10 @@ The agent can call tools during the prompt step. The pipeline receives the final
 ## 4. Use Separate Agents for Separate Jobs
 
 ```ts
-const pipeline = new PipelineBuilder<string>()
+const pipeline = new PipelineBuilder(z.string())
   .parallel({
-    customerReply: new PipelineBuilder<string>().prompt(replyAgent).build(),
-    internalSummary: new PipelineBuilder<string>().prompt(summaryAgent).build(),
+    customerReply: new PipelineBuilder(z.string()).prompt(replyAgent).build(),
+    internalSummary: new PipelineBuilder(z.string()).prompt(summaryAgent).build(),
   })
   .build();
 ```

--- a/apps/docs/content/docs/guides/pipelines/batch-runs.mdx
+++ b/apps/docs/content/docs/guides/pipelines/batch-runs.mdx
@@ -8,7 +8,7 @@ Use `batch(...)` when the same pipeline should process many inputs with a concur
 ## 1. Build a Normal Pipeline
 
 ```ts
-const normalizeTicket = new PipelineBuilder<string>()
+const normalizeTicket = new PipelineBuilder(z.string())
   .step((ticket) => ticket.trim())
   .step((ticket) => ticket.replace(/\s+/g, " "))
   .build();

--- a/apps/docs/content/docs/guides/pipelines/composition-patterns.mdx
+++ b/apps/docs/content/docs/guides/pipelines/composition-patterns.mdx
@@ -8,12 +8,12 @@ Once the basic flow works, split reusable stages into small pipeline operations 
 ## Reuse a Pipeline Operation
 
 ```ts
-const normalizeTicket = new PipelineBuilder<string>()
+const normalizeTicket = new PipelineBuilder(z.string())
   .step((ticket) => ticket.trim())
   .step((ticket) => ticket.replace(/\s+/g, " "))
   .build();
 
-const supportPipeline = new PipelineBuilder<string>()
+const supportPipeline = new PipelineBuilder(z.string())
   .use(normalizeTicket)
   .prompt(supportAgent)
   .build();
@@ -24,7 +24,7 @@ Use `.use(...)` when a whole stage is useful in more than one workflow.
 ## Normalize, Prompt, Extract
 
 ```ts
-const triagePipeline = new PipelineBuilder<string>()
+const triagePipeline = new PipelineBuilder(z.string())
   .use(normalizeTicket)
   .step((ticket) => `Summarize and classify:\n\n${ticket}`)
   .prompt(triageAgent)
@@ -37,11 +37,11 @@ This is the default shape for many production workflows: deterministic preproces
 ## Branch, Then Merge
 
 ```ts
-const pipeline = new PipelineBuilder<string>()
+const pipeline = new PipelineBuilder(z.string())
   .use(normalizeTicket)
   .parallel({
-    reply: new PipelineBuilder<string>().prompt(replyAgent).build(),
-    triage: new PipelineBuilder<string>().prompt(triageAgent).extract(triageExtractor).build(),
+    reply: new PipelineBuilder(z.string()).prompt(replyAgent).build(),
+    triage: new PipelineBuilder(z.string()).prompt(triageAgent).extract(triageExtractor).build(),
   })
   .step(({ reply, triage }) => ({
     reply,
@@ -57,7 +57,7 @@ Use this when the branches do not depend on each other but the final result shou
 Prefer a pipeline that reads like the workflow:
 
 ```ts
-const pipeline = new PipelineBuilder<string>()
+const pipeline = new PipelineBuilder(z.string())
   .use(loadTicket)
   .use(addRetrievalContext)
   .prompt(agent)

--- a/apps/docs/content/docs/guides/pipelines/extractor-steps.mdx
+++ b/apps/docs/content/docs/guides/pipelines/extractor-steps.mdx
@@ -26,7 +26,7 @@ const extractor = new ExtractorBuilder(model, triageSchema)
 ## 2. Extract Inside the Pipeline
 
 ```ts
-const pipeline = new PipelineBuilder<string>()
+const pipeline = new PipelineBuilder(z.string())
   .step((ticket) => `Summarize this ticket:\n\n${ticket}`)
   .prompt(summarizer)
   .extract(extractor)
@@ -44,7 +44,7 @@ console.log(triage.priority);
 ## 3. Add Application Logic After Extraction
 
 ```ts
-const pipeline = new PipelineBuilder<string>()
+const pipeline = new PipelineBuilder(z.string())
   .prompt(summarizer)
   .extract(extractor)
   .step((triage) => ({

--- a/apps/docs/content/docs/guides/pipelines/parallel-branches.mdx
+++ b/apps/docs/content/docs/guides/pipelines/parallel-branches.mdx
@@ -8,12 +8,12 @@ Use `.parallel(...)` when independent work can run from the same input. Each bra
 ## 1. Create Branches
 
 ```ts
-const summaryBranch = new PipelineBuilder<string>()
+const summaryBranch = new PipelineBuilder(z.string())
   .step((ticket) => `Summarize:\n\n${ticket}`)
   .prompt(summarizer)
   .build();
 
-const priorityBranch = new PipelineBuilder<string>()
+const priorityBranch = new PipelineBuilder(z.string())
   .step((ticket) => `Classify priority:\n\n${ticket}`)
   .prompt(priorityAgent)
   .build();
@@ -22,7 +22,7 @@ const priorityBranch = new PipelineBuilder<string>()
 ## 2. Run Them in Parallel
 
 ```ts
-const pipeline = new PipelineBuilder<string>()
+const pipeline = new PipelineBuilder(z.string())
   .parallel({
     summary: summaryBranch,
     priority: priorityBranch,
@@ -44,7 +44,7 @@ The branch names become the output keys.
 ## 4. Continue After Branching
 
 ```ts
-const pipeline = new PipelineBuilder<string>()
+const pipeline = new PipelineBuilder(z.string())
   .parallel({
     summary: summaryBranch,
     priority: priorityBranch,

--- a/apps/docs/content/docs/guides/pipelines/pipeline-builder.mdx
+++ b/apps/docs/content/docs/guides/pipelines/pipeline-builder.mdx
@@ -5,27 +5,30 @@ description: Compose multi-step workflows with Anvia pipelines.
 
 Use `PipelineBuilder` when a workflow should be explicit, testable, and made from named stages instead of one large prompt.
 
-## 1. Start With Input and Output Types
+## 1. Start With an Input Schema
 
 ```ts
+import { z } from "zod";
 import { PipelineBuilder } from "@anvia/core/pipeline";
 
-const pipeline = new PipelineBuilder<string>();
+const pipeline = new PipelineBuilder(z.string());
 ```
 
-`PipelineBuilder<Input, Output = Input>` tracks two types:
+Pass a Zod schema to `PipelineBuilder`. The schema defines the input accepted by `run(...)`, validates every run at runtime, and gives TypeScript the parsed value type for the first stage.
+
+`PipelineBuilder` tracks two types from that schema:
 
 | Type | Meaning |
 | --- | --- |
-| `Input` | The value accepted by `run(...)` after `.build()`. |
-| `Output` | The current value after the latest stage. It starts as `Input` and changes as stages return new values. |
+| `Input` | The value accepted by `run(...)`. This is the schema input type. |
+| `Output` | The current value after the latest stage. It starts as the parsed schema output and changes as stages return new values. |
 
-Most pipelines only set the first generic. TypeScript infers the output after every `.step(...)`, `.use(...)`, `.parallel(...)`, `.prompt(...)`, and `.extract(...)`.
+TypeScript infers the output after every `.step(...)`, `.use(...)`, `.parallel(...)`, `.prompt(...)`, and `.extract(...)`.
 
 ## 2. Build, Then Run
 
 ```ts
-const normalizeTicket = new PipelineBuilder<string>()
+const normalizeTicket = new PipelineBuilder(z.string())
   .step((input) => input.trim())
   .step((input) => input.replace(/\s+/g, " "))
   .build();
@@ -55,11 +58,11 @@ The builder describes the pipeline. `.build()` returns the runnable `Pipeline<In
 Pipelines are not limited to strings. A step can return an object, array, number, or any other TypeScript value.
 
 ```ts
-type SupportTicketInput = {
-  customer: string;
-  subject: string;
-  body: string;
-};
+const SupportTicketInput = z.object({
+  customer: z.string(),
+  subject: z.string(),
+  body: z.string(),
+});
 
 type NormalizedTicket = {
   customer: string;
@@ -67,7 +70,7 @@ type NormalizedTicket = {
   words: number;
 };
 
-const normalizeTicket = new PipelineBuilder<SupportTicketInput>()
+const normalizeTicket = new PipelineBuilder(SupportTicketInput)
   .step((ticket): NormalizedTicket => ({
     customer: ticket.customer.trim(),
     title: ticket.subject.trim().toLowerCase(),
@@ -84,12 +87,12 @@ const ticket = await normalizeTicket.run({
 console.log(ticket.title);
 ```
 
-The first step receives `SupportTicketInput`. The built pipeline returns `NormalizedTicket`.
+The first step receives the parsed `SupportTicketInput` value. The built pipeline returns `NormalizedTicket`.
 
 ## 4. Use Arrays and Numbers
 
 ```ts
-const executiveNotes = new PipelineBuilder<string[]>()
+const executiveNotes = new PipelineBuilder(z.array(z.string()))
   .step((notes) => notes.map((note) => `- ${note}`).join("\n"))
   .build();
 
@@ -100,7 +103,7 @@ const notes = await executiveNotes.run([
 ```
 
 ```ts
-const formatPrice = new PipelineBuilder<number>()
+const formatPrice = new PipelineBuilder(z.number())
   .step((dollars) => Math.round(dollars * 100))
   .step((cents) => ({
     cents,
@@ -116,15 +119,15 @@ console.log(price.formatted);
 ## 5. Branch Into Different Output Types
 
 ```ts
-const ticketSignals = new PipelineBuilder<string>()
+const ticketSignals = new PipelineBuilder(z.string())
   .parallel({
-    title: new PipelineBuilder<string>()
+    title: new PipelineBuilder(z.string())
       .step((ticket) => ticket.split(".")[0] ?? ticket)
       .build(),
-    wordCount: new PipelineBuilder<string>()
+    wordCount: new PipelineBuilder(z.string())
       .step((ticket) => ticket.trim().split(/\s+/).length)
       .build(),
-    urgent: new PipelineBuilder<string>()
+    urgent: new PipelineBuilder(z.string())
       .step((ticket) => ticket.toLowerCase().includes("outage"))
       .build(),
   })
@@ -152,7 +155,7 @@ The result is typed as:
 `.prompt(agent)` and `.extract(extractor)` call `String(input)` internally. For strings, that is usually fine. For objects, add a formatting step first so the model receives intentional text instead of `[object Object]`.
 
 ```ts
-const ticketPipeline = new PipelineBuilder<SupportTicketInput>()
+const ticketPipeline = new PipelineBuilder(SupportTicketInput)
   .step(
     (ticket) =>
       [
@@ -172,14 +175,11 @@ const triage = await ticketPipeline.run({
 });
 ```
 
-## 7. Validate Inputs With a Zod Schema
+## 7. Use Defaults and Metadata
 
-Pass a Zod schema directly to the constructor when you want runtime validation in addition to type inference. The builder infers `Input` and `Output` from the schema with `z.infer<typeof schema>` and parses every call to `pipeline.run(...)`.
+Schemas can apply defaults, transforms, and validation before any stage runs. The first stage receives the parsed schema output.
 
 ```ts
-import { z } from "zod";
-import { PipelineBuilder } from "@anvia/core/pipeline";
-
 const SearchInput = z.object({
   query: z.string().min(1),
   limit: z.number().int().positive().default(10),
@@ -222,7 +222,7 @@ Build pipelines in this order:
 ## Minimal End-to-End Shape
 
 ```ts
-const ticketPipeline = new PipelineBuilder<string>()
+const ticketPipeline = new PipelineBuilder(z.string())
   .step((ticket) => ticket.trim())
   .step((ticket) => `Summarize this ticket:\n\n${ticket}`)
   .prompt(summarizer)

--- a/apps/docs/content/docs/guides/pipelines/prompt-steps.mdx
+++ b/apps/docs/content/docs/guides/pipelines/prompt-steps.mdx
@@ -16,7 +16,7 @@ const summarizer = new AgentBuilder("summarizer", model)
 ## 2. Prepare the Prompt
 
 ```ts
-const pipeline = new PipelineBuilder<string>()
+const pipeline = new PipelineBuilder(z.string())
   .step((ticket) => `Summarize this support ticket:\n\n${ticket}`)
   .prompt(summarizer)
   .build();
@@ -27,7 +27,7 @@ const pipeline = new PipelineBuilder<string>()
 ## 3. Continue After the Prompt
 
 ```ts
-const pipeline = new PipelineBuilder<string>()
+const pipeline = new PipelineBuilder(z.string())
   .step((ticket) => `Summarize this support ticket:\n\n${ticket}`)
   .prompt(summarizer)
   .step((summary) => summary.trim())
@@ -45,7 +45,7 @@ const agent = new AgentBuilder("triage", model)
   .instructions("Classify support urgency using the company policy.")
   .build();
 
-const pipeline = new PipelineBuilder<string>()
+const pipeline = new PipelineBuilder(z.string())
   .step((ticket) => `Ticket:\n${ticket}`)
   .prompt(agent)
   .build();

--- a/apps/docs/content/docs/guides/pipelines/research-example.mdx
+++ b/apps/docs/content/docs/guides/pipelines/research-example.mdx
@@ -94,7 +94,7 @@ The summarizer creates readable synthesis. The extractor turns that synthesis in
 ## 4. Compose the Pipeline
 
 ```ts
-const researchPipeline = new PipelineBuilder<string>()
+const researchPipeline = new PipelineBuilder(z.string())
   .step(async (query): Promise<ResearchPacket> => ({
     query,
     results: await searchWeb(query),

--- a/apps/docs/content/docs/guides/pipelines/steps.mdx
+++ b/apps/docs/content/docs/guides/pipelines/steps.mdx
@@ -8,13 +8,13 @@ Steps are the basic unit of a pipeline. Use them for parsing, normalization, enr
 ## 1. Transform the Input
 
 ```ts
-type TicketInput = {
-  customer: string;
-  subject: string;
-  body: string;
-};
+const TicketInput = z.object({
+  customer: z.string(),
+  subject: z.string(),
+  body: z.string(),
+});
 
-const pipeline = new PipelineBuilder<TicketInput>()
+const pipeline = new PipelineBuilder(TicketInput)
   .step((ticket) => ({
     ...ticket,
     customer: ticket.customer.trim(),
@@ -39,7 +39,7 @@ The first step receives the `run(...)` input.
 ## 2. Return a New Shape
 
 ```ts
-const pipeline = new PipelineBuilder<number>()
+const pipeline = new PipelineBuilder(z.number())
   .step((dollars) => Math.round(dollars * 100))
   .step((cents) => ({
     cents,
@@ -55,7 +55,12 @@ Each next step receives the value returned by the previous step. In this example
 ## 3. Use Async Steps
 
 ```ts
-const pipeline = new PipelineBuilder<{ email: string; subject: string }>()
+const PipelineInput = z.object({
+  email: z.email(),
+  subject: z.string(),
+});
+
+const pipeline = new PipelineBuilder(PipelineInput)
   .step(async (input) => ({
     user: await users.findByEmail(input.email),
     subject: input.subject,
@@ -75,7 +80,7 @@ Async steps are awaited before the next stage runs.
 Prefer several simple steps over one large function:
 
 ```ts
-const pipeline = new PipelineBuilder<string>()
+const pipeline = new PipelineBuilder(z.string())
   .step(parseInboundEmail)
   .step(normalizeTicketFields)
   .step(loadCustomerContext)

--- a/apps/docs/content/docs/guides/testing/tools-and-pipelines.mdx
+++ b/apps/docs/content/docs/guides/testing/tools-and-pipelines.mdx
@@ -37,7 +37,7 @@ Throw only when the workflow should fail or be retried. That keeps tool behavior
 Pipeline steps are ordinary functions. Keep deterministic steps small enough to test before adding model calls:
 
 ```ts
-const pipeline = new PipelineBuilder<string>()
+const pipeline = new PipelineBuilder(z.string())
   .step((input) => input.trim())
   .step((input) => ({ query: input, limit: 5 }))
   .build();

--- a/apps/docs/content/docs/studio/pipelines/inspect-pipelines.mdx
+++ b/apps/docs/content/docs/studio/pipelines/inspect-pipelines.mdx
@@ -12,7 +12,7 @@ import { Studio } from "@anvia/studio";
 
 const supportAgent = new AgentBuilder("support", model).build();
 
-const ticketPipeline = new PipelineBuilder<string>({
+const ticketPipeline = new PipelineBuilder(z.string(), {
   id: "ticket-pipeline",
   name: "Ticket Pipeline",
 })

--- a/apps/docs/src/routes/llms[.]txt.ts
+++ b/apps/docs/src/routes/llms[.]txt.ts
@@ -272,14 +272,15 @@ Minimal shape:
 
 \`\`\`ts
 import { PipelineBuilder } from "@anvia/core/pipeline";
+import { z } from "zod";
 
-type TicketInput = {
-  customer: string;
-  subject: string;
-  body: string;
-};
+const TicketInput = z.object({
+  customer: z.string(),
+  subject: z.string(),
+  body: z.string(),
+});
 
-const pipeline = new PipelineBuilder<TicketInput>()
+const pipeline = new PipelineBuilder(TicketInput)
   .step((ticket) => ({
     customer: ticket.customer.trim(),
     subject: ticket.subject.trim(),
@@ -302,7 +303,7 @@ const result = await pipeline.run({
 Agent and extractor pipeline shape:
 
 \`\`\`ts
-const pipeline = new PipelineBuilder<TicketInput>()
+const pipeline = new PipelineBuilder(TicketInput)
   .step((ticket) =>
     [
       "Customer: " + ticket.customer,

--- a/examples/cookbook/05_pipelines/01-step-transform.ts
+++ b/examples/cookbook/05_pipelines/01-step-transform.ts
@@ -1,6 +1,7 @@
 import { PipelineBuilder } from "@anvia/core/pipeline";
+import { z } from "zod";
 
-const normalizeIncident = new PipelineBuilder<string>()
+const normalizeIncident = new PipelineBuilder(z.string())
   .step((input) => input.trim())
   .step((input) => input.replace(/\s+/g, " "))
   .step((input) => ({

--- a/examples/cookbook/05_pipelines/02-async-step.ts
+++ b/examples/cookbook/05_pipelines/02-async-step.ts
@@ -1,6 +1,7 @@
 import { PipelineBuilder } from "@anvia/core/pipeline";
+import { z } from "zod";
 
-const fetchCustomerProfile = new PipelineBuilder<string>()
+const fetchCustomerProfile = new PipelineBuilder(z.string())
   .step(async (customerId) => {
     await delay(10);
     return {

--- a/examples/cookbook/05_pipelines/03-compose-pipelines.ts
+++ b/examples/cookbook/05_pipelines/03-compose-pipelines.ts
@@ -1,6 +1,7 @@
 import { PipelineBuilder } from "@anvia/core/pipeline";
+import { z } from "zod";
 
-const parseTicket = new PipelineBuilder<string>()
+const parseTicket = new PipelineBuilder(z.string())
   .step((raw) => raw.split("\n"))
   .step((lines) =>
     Object.fromEntries(lines.map((line) => line.split(":").map((part) => part.trim()))),
@@ -12,7 +13,13 @@ const parseTicket = new PipelineBuilder<string>()
   }))
   .build();
 
-const scoreTicket = new PipelineBuilder<{ customer: string; issue: string; impact: string }>()
+const TicketInput = z.object({
+  customer: z.string(),
+  issue: z.string(),
+  impact: z.string(),
+});
+
+const scoreTicket = new PipelineBuilder(TicketInput)
   .step((ticket) => ({
     ...ticket,
     severity:
@@ -24,7 +31,7 @@ const scoreTicket = new PipelineBuilder<{ customer: string; issue: string; impac
   .step((ticket) => `[${ticket.severity.toUpperCase()}] ${ticket.customer}: ${ticket.issue}`)
   .build();
 
-const ticketSummary = new PipelineBuilder<string>().use(parseTicket).use(scoreTicket).build();
+const ticketSummary = new PipelineBuilder(z.string()).use(parseTicket).use(scoreTicket).build();
 
 const summary = await ticketSummary.run(
   [

--- a/examples/cookbook/05_pipelines/04-named-parallel.ts
+++ b/examples/cookbook/05_pipelines/04-named-parallel.ts
@@ -1,19 +1,20 @@
 import { PipelineBuilder } from "@anvia/core/pipeline";
+import { z } from "zod";
 
-const classifyText = new PipelineBuilder<string>()
+const classifyText = new PipelineBuilder(z.string())
   .step((text) => ({
     topic: text.toLowerCase().includes("payment") ? "billing" : "operations",
   }))
   .build();
 
-const extractSignals = new PipelineBuilder<string>()
+const extractSignals = new PipelineBuilder(z.string())
   .step((text) => ({
     hasOutage: text.toLowerCase().includes("outage"),
     hasEnterpriseCustomer: text.toLowerCase().includes("enterprise"),
   }))
   .build();
 
-const estimatePriority = new PipelineBuilder<string>()
+const estimatePriority = new PipelineBuilder(z.string())
   .step((text) => ({
     priority:
       text.toLowerCase().includes("outage") || text.toLowerCase().includes("missed orders")
@@ -22,7 +23,7 @@ const estimatePriority = new PipelineBuilder<string>()
   }))
   .build();
 
-const triage = new PipelineBuilder<string>()
+const triage = new PipelineBuilder(z.string())
   .parallel({
     classification: classifyText,
     signals: extractSignals,

--- a/examples/cookbook/05_pipelines/05-batch-run.ts
+++ b/examples/cookbook/05_pipelines/05-batch-run.ts
@@ -1,6 +1,7 @@
 import { PipelineBuilder } from "@anvia/core/pipeline";
+import { z } from "zod";
 
-const normalizeIncident = new PipelineBuilder<string>()
+const normalizeIncident = new PipelineBuilder(z.string())
   .step((input) => input.trim().replace(/\s+/g, " "))
   .step((input) => ({
     normalized: input,

--- a/examples/cookbook/05_pipelines/06-agent-pipeline.ts
+++ b/examples/cookbook/05_pipelines/06-agent-pipeline.ts
@@ -1,6 +1,7 @@
 import { AgentBuilder } from "@anvia/core/agent";
 import { PipelineBuilder } from "@anvia/core/pipeline";
 import { OpenAIClient } from "@anvia/openai";
+import { z } from "zod";
 
 const client = new OpenAIClient({
   baseUrl: process.env.OPENAI_BASEURL,
@@ -19,7 +20,7 @@ const analyst = new AgentBuilder("analyst", analystModel)
   )
   .build();
 
-const executiveUpdate = new PipelineBuilder<string[]>()
+const executiveUpdate = new PipelineBuilder(z.array(z.string()))
   .step((notes) => notes.map((note) => `- ${note}`).join("\n"))
   .step((notes) => `Prepare an executive update from these notes:\n\n${notes}`)
   .prompt(analyst)

--- a/examples/cookbook/05_pipelines/07-extractor-pipeline.ts
+++ b/examples/cookbook/05_pipelines/07-extractor-pipeline.ts
@@ -19,7 +19,7 @@ const ticketExtractor = new ExtractorBuilder(model, ticketSchema)
   .instructions("Extract a support ticket from the provided operational note.")
   .build();
 
-const ticketPipeline = new PipelineBuilder<string>()
+const ticketPipeline = new PipelineBuilder(z.string())
   .step((note) => `Extract a support ticket from this note:\n\n${note}`)
   .extract(ticketExtractor)
   .build();

--- a/examples/cookbook/05_pipelines/08-research-pipeline.ts
+++ b/examples/cookbook/05_pipelines/08-research-pipeline.ts
@@ -45,11 +45,11 @@ const researchTools = ToolSet.fromTools([
   }),
 ]);
 
-const searchNotes = new PipelineBuilder<string>()
+const searchNotes = new PipelineBuilder(z.string())
   .step((topic) => researchTools.call("search_notes", JSON.stringify({ topic })))
   .build();
 
-const sourceQuality = new PipelineBuilder<string>()
+const sourceQuality = new PipelineBuilder(z.string())
   .step((topic) => researchTools.call("source_quality", JSON.stringify({ topic })))
   .build();
 
@@ -65,7 +65,7 @@ const synthesizer = new AgentBuilder("synthesizer", synthesizerModel)
   )
   .build();
 
-const researchPipeline = new PipelineBuilder<string>()
+const researchPipeline = new PipelineBuilder(z.string())
   .parallel({
     notesJson: searchNotes,
     qualityJson: sourceQuality,

--- a/examples/cookbook/05_pipelines/09-financial-market-analysis.ts
+++ b/examples/cookbook/05_pipelines/09-financial-market-analysis.ts
@@ -62,15 +62,15 @@ const marketTools = ToolSet.fromTools([
   }),
 ]);
 
-const quoteSnapshot = new PipelineBuilder<string>()
+const quoteSnapshot = new PipelineBuilder(z.string())
   .step((ticker) => marketTools.call("quote_snapshot", JSON.stringify({ ticker })))
   .build();
 
-const marketNews = new PipelineBuilder<string>()
+const marketNews = new PipelineBuilder(z.string())
   .step((ticker) => marketTools.call("market_news", JSON.stringify({ ticker })))
   .build();
 
-const riskFlags = new PipelineBuilder<string>()
+const riskFlags = new PipelineBuilder(z.string())
   .step((ticker) => marketTools.call("risk_flags", JSON.stringify({ ticker })))
   .build();
 
@@ -86,7 +86,7 @@ const marketAnalyst = new AgentBuilder("market-analyst", marketAnalystModel)
   )
   .build();
 
-const marketPipeline = new PipelineBuilder<string>()
+const marketPipeline = new PipelineBuilder(z.string())
   .step((ticker) => ticker.trim().toUpperCase())
   .parallel({
     quoteJson: quoteSnapshot,

--- a/examples/cookbook/07_multi_agent/02-parallel-specialists.ts
+++ b/examples/cookbook/07_multi_agent/02-parallel-specialists.ts
@@ -1,6 +1,7 @@
 import { AgentBuilder } from "@anvia/core/agent";
 import { PipelineBuilder } from "@anvia/core/pipeline";
 import { OpenAIClient } from "@anvia/openai";
+import { z } from "zod";
 
 const client = new OpenAIClient({
   baseUrl: process.env.OPENAI_BASEURL,
@@ -58,22 +59,22 @@ const synthesizerAgent = new AgentBuilder("synthesizer", model)
   )
   .build();
 
-const supportNotesPipeline = new PipelineBuilder<string>()
+const supportNotesPipeline = new PipelineBuilder(z.string())
   .step((input) => `Triage this incident for support:\n\n${input}`)
   .prompt(supportAgent)
   .build();
 
-const engineeringNotesPipeline = new PipelineBuilder<string>()
+const engineeringNotesPipeline = new PipelineBuilder(z.string())
   .step((input) => `Triage this incident for engineering:\n\n${input}`)
   .prompt(engineeringAgent)
   .build();
 
-const commsNotesPipeline = new PipelineBuilder<string>()
+const commsNotesPipeline = new PipelineBuilder(z.string())
   .step((input) => `Draft customer communication for this incident:\n\n${input}`)
   .prompt(commsAgent)
   .build();
 
-const incidentBrief = new PipelineBuilder<string>()
+const incidentBrief = new PipelineBuilder(z.string())
   .parallel({
     support: supportNotesPipeline,
     engineering: engineeringNotesPipeline,

--- a/examples/cookbook/09_studio/07-pipeline-inspector.ts
+++ b/examples/cookbook/09_studio/07-pipeline-inspector.ts
@@ -2,6 +2,7 @@ import { AgentBuilder } from "@anvia/core/agent";
 import { PipelineBuilder } from "@anvia/core/pipeline";
 import { OpenAIClient } from "@anvia/openai";
 import { Studio } from "@anvia/studio";
+import { z } from "zod";
 
 const client = new OpenAIClient({
   baseUrl: process.env.OPENAI_BASEURL,
@@ -21,7 +22,7 @@ const replyAgent = new AgentBuilder("studio-reply-drafter", replyModel)
   )
   .build();
 
-const ticketPipeline = new PipelineBuilder<string>({
+const ticketPipeline = new PipelineBuilder(z.string(), {
   id: "ticket-triage-pipeline",
   name: "Ticket Triage Pipeline",
   description: "Normalizes a ticket, computes metadata, then drafts a reply.",
@@ -35,12 +36,12 @@ const ticketPipeline = new PipelineBuilder<string>({
   })
   .parallel(
     {
-      classification: new PipelineBuilder<string>()
+      classification: new PipelineBuilder(z.string())
         .step((ticket) => ({
           topic: ticket.toLowerCase().includes("payment") ? "billing" : "operations",
         }))
         .build(),
-      priority: new PipelineBuilder<string>()
+      priority: new PipelineBuilder(z.string())
         .step((ticket) => ({
           priority:
             ticket.toLowerCase().includes("outage") || ticket.toLowerCase().includes("enterprise")

--- a/examples/cookbook/09_studio/08-multiple-pipelines.ts
+++ b/examples/cookbook/09_studio/08-multiple-pipelines.ts
@@ -1,5 +1,6 @@
 import { PipelineBuilder } from "@anvia/core/pipeline";
 import { Studio } from "@anvia/studio";
+import { z } from "zod";
 
 type OrderSnapshot = {
   id: string;
@@ -29,7 +30,7 @@ const orders: Record<string, OrderSnapshot> = {
   },
 };
 
-const orderStatusPipeline = new PipelineBuilder<string>({
+const orderStatusPipeline = new PipelineBuilder(z.string(), {
   id: "order-status-pipeline",
   name: "Order Status Pipeline",
   description:
@@ -78,7 +79,7 @@ const orderStatusPipeline = new PipelineBuilder<string>({
   )
   .build();
 
-const ticketRoutingPipeline = new PipelineBuilder<string>({
+const ticketRoutingPipeline = new PipelineBuilder(z.string(), {
   id: "ticket-routing-pipeline",
   name: "Ticket Routing Pipeline",
   description: "Classifies a pasted support ticket and recommends an operational route.",
@@ -93,12 +94,12 @@ const ticketRoutingPipeline = new PipelineBuilder<string>({
   })
   .parallel(
     {
-      classification: new PipelineBuilder<string>()
+      classification: new PipelineBuilder(z.string())
         .step((ticket) => ({
           topic: ticket.toLowerCase().includes("payment") ? "billing" : "operations",
         }))
         .build(),
-      priority: new PipelineBuilder<string>()
+      priority: new PipelineBuilder(z.string())
         .step((ticket) => ({
           priority:
             ticket.toLowerCase().includes("outage") ||
@@ -108,7 +109,7 @@ const ticketRoutingPipeline = new PipelineBuilder<string>({
               : "normal",
         }))
         .build(),
-      routing: new PipelineBuilder<string>()
+      routing: new PipelineBuilder(z.string())
         .step((ticket) => ({
           team: ticket.toLowerCase().includes("payment") ? "billing-ops" : "support-ops",
         }))

--- a/examples/cookbook/09_studio/10-persistent-store.ts
+++ b/examples/cookbook/09_studio/10-persistent-store.ts
@@ -60,7 +60,7 @@ const agent = new AgentBuilder("studio-persistent-ops", model)
   .defaultMaxTurns(4)
   .build();
 
-const escalationPipeline = new PipelineBuilder<string>({
+const escalationPipeline = new PipelineBuilder(z.string(), {
   id: "persistent-escalation-pipeline",
   name: "Persistent Escalation Pipeline",
   description: "Creates pipeline logs and replayable run history in the same SQLite store.",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -195,8 +195,9 @@ const ticket = await extractor.extract(
 
 ```ts
 import { PipelineBuilder } from "@anvia/core/pipeline";
+import { z } from "zod";
 
-const pipeline = new PipelineBuilder<string>()
+const pipeline = new PipelineBuilder(z.string())
   .step((input) => `Extract this support ticket:\n\n${input}`)
   .prompt(agent)
   .extract(extractor)

--- a/packages/core/src/pipeline/builder.ts
+++ b/packages/core/src/pipeline/builder.ts
@@ -28,10 +28,8 @@ export class PipelineBuilder<Input, Output = Input> {
   private readonly executor: PipelineExecutor<Input, Output>;
   private readonly state: PipelineBuilderState;
 
-  constructor();
-  constructor(metadata: PipelineMetadata);
-  constructor(schema: z.ZodType<unknown, Input>);
-  constructor(schema: z.ZodType<unknown, Input>, metadata: PipelineMetadata);
+  constructor(schema: z.ZodType<Output, Input>);
+  constructor(schema: z.ZodType<Output, Input>, metadata: PipelineMetadata);
   constructor(executor: (input: Input) => Output | Promise<Output>);
   constructor(executor: PipelineExecutor<Input, Output>, state: PipelineBuilderState);
   constructor(

--- a/packages/core/test/pipeline.test.ts
+++ b/packages/core/test/pipeline.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import { z } from "zod";
 import * as anvia from "./helpers/imports";
 import {
@@ -49,7 +49,7 @@ function response(choice: CompletionResponse["choice"]): CompletionResponse {
 
 describe("PipelineBuilder", () => {
   it("composes sync steps", async () => {
-    const op = new PipelineBuilder<number>()
+    const op = new PipelineBuilder(z.number())
       .step((value) => value + 1)
       .step((value) => `value:${value}`)
       .build();
@@ -58,7 +58,7 @@ describe("PipelineBuilder", () => {
   });
 
   it("composes async steps", async () => {
-    const op = new PipelineBuilder<string>()
+    const op = new PipelineBuilder(z.string())
       .step(async (value) => value.trim())
       .step(async (value) => value.toUpperCase())
       .build();
@@ -67,8 +67,8 @@ describe("PipelineBuilder", () => {
   });
 
   it("uses another pipeline op", async () => {
-    const suffix = new PipelineBuilder<string>().step((value) => `${value}!`).build();
-    const op = new PipelineBuilder<string>()
+    const suffix = new PipelineBuilder(z.string()).step((value) => `${value}!`).build();
+    const op = new PipelineBuilder(z.string())
       .step((value) => value.toUpperCase())
       .use(suffix)
       .build();
@@ -79,7 +79,7 @@ describe("PipelineBuilder", () => {
   it("batches with a concurrency limit and preserves order", async () => {
     let active = 0;
     let maxActive = 0;
-    const op = new PipelineBuilder<number>()
+    const op = new PipelineBuilder(z.number())
       .step(async (value) => {
         active += 1;
         maxActive = Math.max(maxActive, active);
@@ -95,11 +95,11 @@ describe("PipelineBuilder", () => {
   });
 
   it("runs named parallel branches and returns object output", async () => {
-    const op = new PipelineBuilder<string>()
+    const op = new PipelineBuilder(z.string())
       .parallel({
-        upper: new PipelineBuilder<string>().step((value) => value.toUpperCase()).build(),
-        length: new PipelineBuilder<string>().step(async (value) => value.length).build(),
-        includesA: new PipelineBuilder<string>().step((value) => value.includes("a")).build(),
+        upper: new PipelineBuilder(z.string()).step((value) => value.toUpperCase()).build(),
+        length: new PipelineBuilder(z.string()).step(async (value) => value.length).build(),
+        includesA: new PipelineBuilder(z.string()).step((value) => value.includes("a")).build(),
       })
       .build();
 
@@ -113,7 +113,7 @@ describe("PipelineBuilder", () => {
   it("prompts an agent and returns output", async () => {
     const model = new QueueModel([response([AssistantContent.text("answer")])]);
     const agent = new AgentBuilder("test-agent", model).build();
-    const op = new PipelineBuilder<string>()
+    const op = new PipelineBuilder(z.string())
       .step((value) => `Question: ${value}`)
       .prompt(agent)
       .build();
@@ -133,7 +133,7 @@ describe("PipelineBuilder", () => {
       model,
       z.object({ priority: z.enum(["low", "high"]) }),
     ).build();
-    const op = new PipelineBuilder<string>()
+    const op = new PipelineBuilder(z.string())
       .step((value) => `Extract priority: ${value}`)
       .extract(extractor)
       .build();
@@ -142,7 +142,7 @@ describe("PipelineBuilder", () => {
   });
 
   it("rejects run and batch when a step throws", async () => {
-    const op = new PipelineBuilder<number>()
+    const op = new PipelineBuilder(z.number())
       .step((value) => {
         if (value === 2) {
           throw new Error("boom");
@@ -156,7 +156,7 @@ describe("PipelineBuilder", () => {
   });
 
   it("can use a custom pipeline op", async () => {
-    const op = new PipelineBuilder<number>().use(createPipelineOp((value) => value + 10)).build();
+    const op = new PipelineBuilder(z.number()).use(createPipelineOp((value) => value + 10)).build();
 
     await expect(op.run(5)).resolves.toBe(15);
   });
@@ -164,7 +164,7 @@ describe("PipelineBuilder", () => {
   it("exposes an automatic graph", () => {
     const model = new QueueModel([response([AssistantContent.text("answer")])]);
     const agent = new AgentBuilder("support", model).name("Support").build();
-    const op = new PipelineBuilder<string>({
+    const op = new PipelineBuilder(z.string(), {
       id: "ticket_triage",
       name: "Ticket triage",
       description: "Prepare a support answer.",
@@ -172,8 +172,8 @@ describe("PipelineBuilder", () => {
     })
       .step((value) => value.trim())
       .parallel({
-        upper: new PipelineBuilder<string>().step((value) => value.toUpperCase()).build(),
-        length: new PipelineBuilder<string>().step((value) => value.length).build(),
+        upper: new PipelineBuilder(z.string()).step((value) => value.toUpperCase()).build(),
+        length: new PipelineBuilder(z.string()).step((value) => value.length).build(),
       })
       .prompt(agent)
       .build();
@@ -208,7 +208,7 @@ describe("PipelineBuilder", () => {
 
   it("emits pipeline stage run events without changing output", async () => {
     const events: string[] = [];
-    const op = new PipelineBuilder<number>()
+    const op = new PipelineBuilder(z.number())
       .step((value) => value + 1)
       .step((value) => value * 2)
       .build();
@@ -231,10 +231,14 @@ describe("PipelineBuilder", () => {
   });
 
   it("does not expose the old helper-first methods at type level", () => {
-    const builder = new PipelineBuilder<number>();
+    const builder = new PipelineBuilder(z.number());
     const op = builder.step((value) => value + 1).build();
 
     if (unreachable()) {
+      // @ts-expect-error - pass a Zod schema instead.
+      new PipelineBuilder<number>();
+      // @ts-expect-error - pass metadata as the second argument after a Zod schema.
+      new PipelineBuilder<number>({ name: "M" });
       // @ts-expect-error - use step(...) instead of map(...).
       builder.map((value: number) => value);
       // @ts-expect-error - use step(...) instead of then(...).
@@ -252,7 +256,10 @@ describe("PipelineBuilder", () => {
 
   it("accepts a Zod schema at construction and infers input type", async () => {
     const op = new PipelineBuilder(z.object({ query: z.string(), limit: z.number() }))
-      .step(({ query, limit }) => `${query}:${limit}`)
+      .step((input) => {
+        expectTypeOf(input).toEqualTypeOf<{ query: string; limit: number }>();
+        return `${input.query}:${input.limit}`;
+      })
       .build();
 
     await expect(op.run({ query: "search", limit: 3 })).resolves.toBe("search:3");
@@ -269,7 +276,10 @@ describe("PipelineBuilder", () => {
 
   it("applies Zod defaults when parsing input", async () => {
     const op = new PipelineBuilder(z.object({ query: z.string(), limit: z.number().default(10) }))
-      .step(({ query, limit }) => `${query}:${limit}`)
+      .step((input) => {
+        expectTypeOf(input).toEqualTypeOf<{ query: string; limit: number }>();
+        return `${input.query}:${input.limit}`;
+      })
       .build();
 
     await expect(op.run({ query: "hi" })).resolves.toBe("hi:10");
@@ -290,11 +300,11 @@ describe("PipelineBuilder", () => {
     expect(op.metadata).toEqual({ owner: "test" });
   });
 
-  it("keeps existing constructors working alongside the schema overload", async () => {
-    const empty = new PipelineBuilder<string>().step((s: string) => s).build();
-    const metadataOnly = new PipelineBuilder<string>({ name: "M" }).step((s: string) => s).build();
+  it("accepts metadata as the second argument after a Zod schema", async () => {
+    const metadataOnly = new PipelineBuilder(z.string(), { name: "M" })
+      .step((s: string) => s)
+      .build();
 
-    await expect(empty.run("hi")).resolves.toBe("hi");
     await expect(metadataOnly.run("hi")).resolves.toBe("hi");
     expect(metadataOnly.name).toBe("M");
   });

--- a/packages/observability-langfuse/package.json
+++ b/packages/observability-langfuse/package.json
@@ -31,8 +31,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@langfuse/otel": "^5.4.1",
-    "@langfuse/tracing": "^5.4.1",
+    "@langfuse/otel": "^5.5.3",
+    "@langfuse/tracing": "^5.5.3",
     "@opentelemetry/sdk-node": "^0.219.0"
   },
   "devDependencies": {

--- a/packages/provider-anthropic/package.json
+++ b/packages/provider-anthropic/package.json
@@ -33,7 +33,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.104.1"
+    "@anthropic-ai/sdk": "^0.105.0"
   },
   "devDependencies": {
     "@anvia/core": "workspace:*",

--- a/packages/provider-gemini/package.json
+++ b/packages/provider-gemini/package.json
@@ -33,7 +33,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@google/genai": "^2.8.0"
+    "@google/genai": "^2.9.0"
   },
   "devDependencies": {
     "@anvia/core": "workspace:*",

--- a/packages/provider-mistral/package.json
+++ b/packages/provider-mistral/package.json
@@ -33,7 +33,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mistralai/mistralai": "^2.2.5"
+    "@mistralai/mistralai": "^2.2.6"
   },
   "devDependencies": {
     "@anvia/core": "workspace:*",

--- a/packages/provider-openai/package.json
+++ b/packages/provider-openai/package.json
@@ -33,7 +33,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "openai": "^6.42.0"
+    "openai": "^6.44.0"
   },
   "devDependencies": {
     "@anvia/core": "workspace:*",

--- a/packages/tool-studio/package.json
+++ b/packages/tool-studio/package.json
@@ -34,18 +34,18 @@
   "dependencies": {
     "@anvia/react": "workspace:*",
     "@anvia/server": "workspace:*",
-    "@hono/node-server": "^2.0.4",
+    "@hono/node-server": "^2.0.5",
     "@phosphor-icons/react": "^2.1.10",
-    "@radix-ui/react-alert-dialog": "^1.1.16",
-    "@radix-ui/react-dialog": "^1.1.16",
-    "@radix-ui/react-scroll-area": "^1.2.11",
-    "@radix-ui/react-select": "^2.3.0",
-    "@radix-ui/react-separator": "^1.1.9",
-    "@radix-ui/react-slot": "^1.2.5",
+    "@radix-ui/react-alert-dialog": "^1.1.17",
+    "@radix-ui/react-dialog": "^1.1.17",
+    "@radix-ui/react-scroll-area": "^1.2.12",
+    "@radix-ui/react-select": "^2.3.1",
+    "@radix-ui/react-separator": "^1.1.10",
+    "@radix-ui/react-slot": "^1.3.0",
     "@xyflow/react": "^12.11.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "hono": "^4.12.25",
+    "hono": "^4.12.26",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-markdown": "^10.1.0",
@@ -64,7 +64,8 @@
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
     "vite": "^8.0.10",
-    "vitest": "^4.0.8"
+    "vitest": "^4.0.8",
+    "zod": "^4.4.3"
   },
   "peerDependencies": {
     "@anvia/core": "^0.7.0"

--- a/packages/tool-studio/test/runner.test.ts
+++ b/packages/tool-studio/test/runner.test.ts
@@ -36,6 +36,7 @@ import {
 } from "@anvia/core/vector-store";
 import { Hono } from "hono";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
 import { createInMemoryStudioStore, Studio } from "../src/index";
 import { registerObservabilityRoutes, StudioObservabilityHub } from "../src/runtime/observability";
 import { createSqliteSessionStore } from "../src/sqlite";
@@ -637,7 +638,7 @@ describe("Anvia studio", () => {
 
   it("registers pipelines separately from agents", async () => {
     const agent = new AgentBuilder("support", new QueueModel([])).name("Support").build();
-    const pipeline = new PipelineBuilder<string>({
+    const pipeline = new PipelineBuilder(z.string(), {
       id: "ticket-pipeline",
       name: "Ticket Pipeline",
       description: "Prepare support tickets",
@@ -689,7 +690,7 @@ describe("Anvia studio", () => {
   });
 
   it("runs pipelines over HTTP and persists runs plus metadata-only pipeline logs", async () => {
-    const pipeline = new PipelineBuilder<string>({ id: "audit-pipeline" })
+    const pipeline = new PipelineBuilder(z.string(), { id: "audit-pipeline" })
       .step((input) => input.trim(), { id: "normalize", name: "Normalize" })
       .step((input) => ({ reply: input.toUpperCase() }), { id: "shape", name: "Shape" })
       .build();
@@ -857,7 +858,7 @@ describe("Anvia studio", () => {
   });
 
   it("replays persisted pipeline runs outside the first runs page", async () => {
-    const pipeline = new PipelineBuilder<string>({ id: "audit-pipeline" })
+    const pipeline = new PipelineBuilder(z.string(), { id: "audit-pipeline" })
       .step((input) => ({ reply: input.toUpperCase() }), { id: "shape", name: "Shape" })
       .build();
     const store = createSqliteSessionStore({

--- a/packages/vector-lancedb/package.json
+++ b/packages/vector-lancedb/package.json
@@ -31,7 +31,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@lancedb/lancedb": "^0.13.0"
+    "@lancedb/lancedb": "^0.30.0"
   },
   "devDependencies": {
     "@anvia/core": "workspace:*",

--- a/packages/vector-milvus/package.json
+++ b/packages/vector-milvus/package.json
@@ -31,7 +31,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@zilliz/milvus2-sdk-node": "^2.5.0"
+    "@zilliz/milvus2-sdk-node": "^3.0.3"
   },
   "devDependencies": {
     "@anvia/core": "workspace:*",

--- a/packages/vector-pgvector/package.json
+++ b/packages/vector-pgvector/package.json
@@ -31,7 +31,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "pg": "^8.21.0",
+    "pg": "^8.22.0",
     "pgvector": "^0.3.0"
   },
   "devDependencies": {

--- a/packages/vector-pinecone/package.json
+++ b/packages/vector-pinecone/package.json
@@ -31,7 +31,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@pinecone-database/pinecone": "^5.1.0"
+    "@pinecone-database/pinecone": "^8.0.0"
   },
   "devDependencies": {
     "@anvia/core": "workspace:*",

--- a/packages/vector-redis/package.json
+++ b/packages/vector-redis/package.json
@@ -31,7 +31,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "redis": "^4.7.0"
+    "redis": "^6.0.0"
   },
   "devDependencies": {
     "@anvia/core": "workspace:*",

--- a/packages/vector-redis/src/types.ts
+++ b/packages/vector-redis/src/types.ts
@@ -1,9 +1,16 @@
-import { SchemaFieldTypes, VectorAlgorithms } from "redis";
-
 export const documentIdField = "__anvia_document_id";
 export const documentField = "__anvia_document";
 export const vectorField = "__anvia_vector";
 export const reservedFieldPrefix = "__anvia_";
+
+export const SchemaFieldTypes = {
+  TEXT: "TEXT",
+  VECTOR: "VECTOR",
+} as const;
+
+export const VectorAlgorithms = {
+  HNSW: "HNSW",
+} as const;
 
 export type RedisDistance = "COSINE" | "L2" | "IP";
 
@@ -30,5 +37,3 @@ export type RedisVectorStoreConnectOptions = {
   createIfMissing?: boolean | undefined;
   distance?: RedisDistance | undefined;
 };
-
-export { SchemaFieldTypes, VectorAlgorithms };

--- a/packages/vector-weaviate/package.json
+++ b/packages/vector-weaviate/package.json
@@ -31,7 +31,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "weaviate-client": "^3.5.0"
+    "weaviate-client": "^3.13.1"
   },
   "devDependencies": {
     "@anvia/core": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -356,11 +356,11 @@ importers:
   packages/observability-langfuse:
     dependencies:
       '@langfuse/otel':
-        specifier: ^5.4.1
-        version: 5.4.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
+        specifier: ^5.5.3
+        version: 5.5.3(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
       '@langfuse/tracing':
-        specifier: ^5.4.1
-        version: 5.4.1(@opentelemetry/api@1.9.1)
+        specifier: ^5.5.3
+        version: 5.5.3(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-node':
         specifier: ^0.219.0
         version: 0.219.0(@opentelemetry/api@1.9.1)
@@ -406,8 +406,8 @@ importers:
   packages/provider-anthropic:
     dependencies:
       '@anthropic-ai/sdk':
-        specifier: ^0.104.1
-        version: 0.104.1(zod@4.4.3)
+        specifier: ^0.105.0
+        version: 0.105.0(zod@4.4.3)
     devDependencies:
       '@anvia/core':
         specifier: workspace:*
@@ -428,8 +428,8 @@ importers:
   packages/provider-gemini:
     dependencies:
       '@google/genai':
-        specifier: ^2.8.0
-        version: 2.8.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
+        specifier: ^2.9.0
+        version: 2.9.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
     devDependencies:
       '@anvia/core':
         specifier: workspace:*
@@ -450,8 +450,8 @@ importers:
   packages/provider-mistral:
     dependencies:
       '@mistralai/mistralai':
-        specifier: ^2.2.5
-        version: 2.2.5
+        specifier: ^2.2.6
+        version: 2.2.6(@opentelemetry/api@1.9.1)
     devDependencies:
       '@anvia/core':
         specifier: workspace:*
@@ -472,8 +472,8 @@ importers:
   packages/provider-openai:
     dependencies:
       openai:
-        specifier: ^6.42.0
-        version: 6.42.0(ws@8.21.0)(zod@4.4.3)
+        specifier: ^6.44.0
+        version: 6.44.0(ws@8.21.0)(zod@4.4.3)
     devDependencies:
       '@anvia/core':
         specifier: workspace:*
@@ -576,29 +576,29 @@ importers:
         specifier: workspace:*
         version: link:../server
       '@hono/node-server':
-        specifier: ^2.0.4
-        version: 2.0.4(hono@4.12.25)
+        specifier: ^2.0.5
+        version: 2.0.5(hono@4.12.26)
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-alert-dialog':
-        specifier: ^1.1.16
-        version: 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^1.1.17
+        version: 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-dialog':
-        specifier: ^1.1.16
-        version: 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^1.1.17
+        version: 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-scroll-area':
-        specifier: ^1.2.11
-        version: 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^1.2.12
+        version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-select':
-        specifier: ^2.3.0
-        version: 2.3.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^2.3.1
+        version: 2.3.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-separator':
-        specifier: ^1.1.9
-        version: 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^1.1.10
+        version: 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-slot':
-        specifier: ^1.2.5
-        version: 1.2.5(@types/react@19.2.14)(react@19.2.7)
+        specifier: ^1.3.0
+        version: 1.3.0(@types/react@19.2.14)(react@19.2.7)
       '@xyflow/react':
         specifier: ^12.11.0
         version: 12.11.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -609,8 +609,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       hono:
-        specifier: ^4.12.25
-        version: 4.12.25
+        specifier: ^4.12.26
+        version: 4.12.26
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -663,6 +663,9 @@ importers:
       vitest:
         specifier: ^4.0.8
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
 
   packages/vector-chroma:
     dependencies:
@@ -689,8 +692,8 @@ importers:
   packages/vector-lancedb:
     dependencies:
       '@lancedb/lancedb':
-        specifier: ^0.13.0
-        version: 0.13.0(apache-arrow@17.0.0)
+        specifier: ^0.30.0
+        version: 0.30.0(apache-arrow@17.0.0)
     devDependencies:
       '@anvia/core':
         specifier: workspace:*
@@ -711,8 +714,8 @@ importers:
   packages/vector-milvus:
     dependencies:
       '@zilliz/milvus2-sdk-node':
-        specifier: ^2.5.0
-        version: 2.6.17
+        specifier: ^3.0.3
+        version: 3.0.3
     devDependencies:
       '@anvia/core':
         specifier: workspace:*
@@ -733,8 +736,8 @@ importers:
   packages/vector-pgvector:
     dependencies:
       pg:
-        specifier: ^8.21.0
-        version: 8.21.0
+        specifier: ^8.22.0
+        version: 8.22.0
       pgvector:
         specifier: ^0.3.0
         version: 0.3.0
@@ -761,8 +764,8 @@ importers:
   packages/vector-pinecone:
     dependencies:
       '@pinecone-database/pinecone':
-        specifier: ^5.1.0
-        version: 5.1.2
+        specifier: ^8.0.0
+        version: 8.0.0
     devDependencies:
       '@anvia/core':
         specifier: workspace:*
@@ -805,8 +808,8 @@ importers:
   packages/vector-redis:
     dependencies:
       redis:
-        specifier: ^4.7.0
-        version: 4.7.1
+        specifier: ^6.0.0
+        version: 6.0.0(@opentelemetry/api@1.9.1)
     devDependencies:
       '@anvia/core':
         specifier: workspace:*
@@ -827,7 +830,7 @@ importers:
   packages/vector-weaviate:
     dependencies:
       weaviate-client:
-        specifier: ^3.5.0
+        specifier: ^3.13.1
         version: 3.13.1
     devDependencies:
       '@anvia/core':
@@ -855,8 +858,8 @@ packages:
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
-  '@anthropic-ai/sdk@0.104.1':
-    resolution: {integrity: sha512-gGACa/+IaiXzRRmF96aOhamoBgapKRBiFWbmmTFP8aMkpaEcuStF+Q61bjo4vPxBM7gqWJNZqsngslRdnLHv0Q==}
+  '@anthropic-ai/sdk@0.105.0':
+    resolution: {integrity: sha512-sDyu+aM9cE6uZE+HgRjjHRb+qqb87GHZOx+8bE0YlWetdL1YcVLxn8h9ltxGOflyChTe6PMEo50kMQV4cw0hfg==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -1850,8 +1853,8 @@ packages:
       tailwindcss:
         optional: true
 
-  '@google/genai@2.8.0':
-    resolution: {integrity: sha512-pc2ayxqO5+O7AvnHBqpNHIk7PAZkHZgL31tbyx0gJZBSS9qPYiQoqwK7oYOw/ePmG6QY4EMSu+304vD5QlhXAw==}
+  '@google/genai@2.9.0':
+    resolution: {integrity: sha512-3DRdSJ0LaKFig3FNGeRDn9BQxtjZm2qr0hNH2d771LKcG0HvUYddlN0LPdSp8XU7Ekb04i9q3+tt64uYqavUdw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.25.2
@@ -1879,8 +1882,8 @@ packages:
     peerDependencies:
       hono: ^4
 
-  '@hono/node-server@2.0.4':
-    resolution: {integrity: sha512-Ut3y0dMMPWy6bZ2kVfx25EOVbZlm15dhF4mOsezMlhpNHy+4MkU1qN9Y6lnruYi4wPmFzimGX2X7LF/FwHli4A==}
+  '@hono/node-server@2.0.5':
+    resolution: {integrity: sha512-yQFvDmyDo3y6rEOJZDUYPJ49DIKTPpIk4kGvm40xx4Ejne0Pu9a1+exxPN+C1UppWK/WGZX9F++/Xs231tE86g==}
     engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
@@ -2097,53 +2100,67 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
-  '@lancedb/lancedb-darwin-arm64@0.13.0':
-    resolution: {integrity: sha512-x+oRj7PDlxOONr27+NgLIk+Pm8VjnEO5VNoEkDv/j4sBimMp3CZNiD/OndxDlOpT1RykJJSMQ1SCYWtInNramQ==}
+  '@lancedb/lancedb-darwin-arm64@0.30.0':
+    resolution: {integrity: sha512-x6dmsjRIv0xumELYnFAEfyFDxqcO/n4rHYCJvC27RbRez0UmbByi6OMTgbSoSTatrQSPRCL7JJSa5pwNeawnIg==}
     engines: {node: '>= 18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@lancedb/lancedb-darwin-x64@0.13.0':
-    resolution: {integrity: sha512-xNwxx/rjvAO0qfKKrsMZyI93ftbz0oxVO34F6nSaPe9u53R+JJJOnYkVAt2Suv0B5lFqeiqgFtE0c5LsD/SUaw==}
-    engines: {node: '>= 18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@lancedb/lancedb-linux-arm64-gnu@0.13.0':
-    resolution: {integrity: sha512-s3wxoMYERvtk2XrXBNjf1BJVta1+c9mi2x1W0Jxm2iThALUU+MnzY7oAzF3l/JmYJCjxgEEHne0+ZRz0Nrwt4A==}
+  '@lancedb/lancedb-linux-arm64-gnu@0.30.0':
+    resolution: {integrity: sha512-CWUex7hRNiLkXFeTQlUGPyy5VktbXoUmQdZuiVCETZ6ggljEC7c7Qvzu2ge+jEZML+UE7tXL2lVC3klRFGczng==}
     engines: {node: '>= 18'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@lancedb/lancedb-linux-x64-gnu@0.13.0':
-    resolution: {integrity: sha512-AtJLPTmEU4LvZOhj6s7N/UgA9g01Qqm9rLkhosKHcDxKQcvqrVhsoOKJ7MRgfiiGxYUdnUHlehscPm5VdA0GMw==}
+  '@lancedb/lancedb-linux-arm64-musl@0.30.0':
+    resolution: {integrity: sha512-2MHmAS4tKePNVbwfgDrjCFj6BVuAgXlL2c9iWk7TfcwL+jcSxo52LFx03O0+ArpVCF2sI6aoDqZaQNre5zMniQ==}
+    engines: {node: '>= 18'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@lancedb/lancedb-linux-x64-gnu@0.30.0':
+    resolution: {integrity: sha512-0OpDNxsDE4OXD+PIFd7KdE42xhYIE+fZL+jCm1v3dTug4UEhumWBuSgbUIBP7t0yJZHwh62/QivVh/V1cPB2Bg==}
     engines: {node: '>= 18'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@lancedb/lancedb-win32-x64-msvc@0.13.0':
-    resolution: {integrity: sha512-5D04/JKidhq73nPK/BC/p+cnDazFxGfwy0XYSs3gyIwIGVVTfMggVs6Wn2Qu3OJ4ENYD7lQpQj/blNl+Ovqp8g==}
+  '@lancedb/lancedb-linux-x64-musl@0.30.0':
+    resolution: {integrity: sha512-4Bq7VngQt+lyxIcu79EN8nYJs8gvUnrIT6I/t2MSlpG/BXWHZG2A+PRii1Zq4GCUlRTTG+RlieCv8CBGSPm8bw==}
+    engines: {node: '>= 18'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@lancedb/lancedb-win32-arm64-msvc@0.30.0':
+    resolution: {integrity: sha512-N2DQg2XBWZirn5jS6kRJUxF679t3sKcIxBwP9zY4Idq5OVLAj0yfLueWIKhYxv8en7pBFYWdgw5j9dTS7XajyQ==}
+    engines: {node: '>= 18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@lancedb/lancedb-win32-x64-msvc@0.30.0':
+    resolution: {integrity: sha512-CDgN/ZmYqSlVX2nBJAF2PYEwqBBxotCVORjagmvrd0k5D7RBLlAQUEAR4gDMum2BpYsUkzdTYQpquLjRCVbwbQ==}
     engines: {node: '>= 18'}
     cpu: [x64]
     os: [win32]
 
-  '@lancedb/lancedb@0.13.0':
-    resolution: {integrity: sha512-QSzYvswjroH3aREKaqV6eXENo4zUAHLEPBrb2YCWNWZi/QhA8mbjJcB4hEnqQh55q4qgoqG6tuMsx4dd//mTiQ==}
+  '@lancedb/lancedb@0.30.0':
+    resolution: {integrity: sha512-d0FoEL6cthqgsulqAc7fck6kRXrSRGMTqlKYbhSGSazHU6vB2GEpD737Mu0HZd7fMyBUdhR9sD1W2C9uQZ5p0Q==}
     engines: {node: '>= 18'}
     cpu: [x64, arm64]
     os: [darwin, linux, win32]
     peerDependencies:
-      apache-arrow: '>=13.0.0 <=17.0.0'
+      apache-arrow: '>=15.0.0 <=18.1.0'
 
-  '@langfuse/core@5.4.1':
-    resolution: {integrity: sha512-TjaRTr9fGqaWuyYKFSezKxN4DWAaK/lq//hRMw8rQKFkZUs6vTgUODxqZTFTR6np5VnLVw+eZLlnHROPKbXqdg==}
+  '@langfuse/core@5.5.3':
+    resolution: {integrity: sha512-F2auGm6l4/QhQ6Y86+f6QqulXNetVsaI3u7ccyqADEtGcDWk1+faSczxuSMJ0X/EfrjVZ+98Luy/FEEah+HDRA==}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
 
-  '@langfuse/otel@5.4.1':
-    resolution: {integrity: sha512-w69aVC2fTmd7hyCTaX8zhhivHlsGVgZ551XOf6yMSOi3k8tlDML4dinnjJUP/6qTvdH54NYcmAIp5KZRbkouxg==}
+  '@langfuse/otel@5.5.3':
+    resolution: {integrity: sha512-j0nPAEFHKorEV8JtBRzZaSShUbjLYk7omtxXxy1bLvNb5QFGO1gF7HFm+fSqnoN70034EvTXYCNFDWpBrAH/vw==}
     engines: {node: '>=20'}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
@@ -2151,8 +2168,8 @@ packages:
       '@opentelemetry/exporter-trace-otlp-http': '>=0.202.0 <1.0.0'
       '@opentelemetry/sdk-trace-base': ^2.0.1
 
-  '@langfuse/tracing@5.4.1':
-    resolution: {integrity: sha512-nPyoPXXNMaJgaUZgIE0haWI/hrT7l4r/irp0o/FGaBYR2V07EFNvSKFcqOsX1pQvVvB6HyfNlYQm7AoQJj+fqQ==}
+  '@langfuse/tracing@5.5.3':
+    resolution: {integrity: sha512-t/WoFCOtXjdFSFx7A4+nesX0eB4c0gP7ca7j6kv38kIubPE+IniHOhNYPXdAdm5tc3EL+P+gpMCtibCBp8xYsQ==}
     engines: {node: '>=20'}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
@@ -2169,8 +2186,13 @@ packages:
   '@mermaid-js/parser@1.1.1':
     resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
 
-  '@mistralai/mistralai@2.2.5':
-    resolution: {integrity: sha512-ATbWzKkNzNAZ+gtw9MI/c/ULTMG80tKUiRNIbQFfg4OP0uEZZpTfXZeBCNfs5Dq0uqMQ/tQWc4o6RRJQtMrpDA==}
+  '@mistralai/mistralai@2.2.6':
+    resolution: {integrity: sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -2639,9 +2661,9 @@ packages:
       react: '>= 16.8'
       react-dom: '>= 16.8'
 
-  '@pinecone-database/pinecone@5.1.2':
-    resolution: {integrity: sha512-z7737KUA1hXwd508q1+o4bnRxj0NpMmzA2beyaFm7Y+EC2TYLT5ABuYsn/qhiwiEsYp8v1qS596eBhhvgNagig==}
-    engines: {node: '>=18.0.0'}
+  '@pinecone-database/pinecone@8.0.0':
+    resolution: {integrity: sha512-dItFqLdis2Pd5lC67aKn8HhvXajzlOz4+0RyK1CRcZMdSwG8YxUCBtH4yXPC8/6uLxfr2dvMWnRFuKgtPwwajQ==}
+    engines: {node: '>=20.0.0'}
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
@@ -2729,8 +2751,21 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-alert-dialog@1.1.16':
-    resolution: {integrity: sha512-vPaIgo0mxYlvcFaM9jB2Uot9TjGXMuAPEvrc6BOLeV+I5U8s1dkIoouYaa6lmSfc5SPMo5x5djOTOTvaigdGMQ==}
+  '@radix-ui/react-alert-dialog@1.1.17':
+    resolution: {integrity: sha512-563ygGeyWPrxyVCNp7OV4rE2aIXhFPknpFyo4wbDlcyMMPZ6ySh+zC5WTvY0ZFLgPTg/QB6tA8PyDQyJ2b4cPg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-arrow@1.1.10':
+    resolution: {integrity: sha512-j2VTDz1vgCsmuG0k5lBfOcM8n5JPFqZBcMryasFjHYMhwxYL5SRUV5lMSUpRdNtw3D/Sv8pzJtrlAgkssYSsQQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2755,19 +2790,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-arrow@1.1.9':
-    resolution: {integrity: sha512-yqHW5WQ/cTpU/un7dqqIKNy2iRU8BC0JB78PEzTfCCYvZu1U6W9KwObAniMk9nhSfyotKPQTYaUD/HB0f5muig==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-collapsible@1.1.12':
     resolution: {integrity: sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==}
     peerDependencies:
@@ -2781,8 +2803,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-collection@1.1.7':
-    resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
+  '@radix-ui/react-collection@1.1.10':
+    resolution: {integrity: sha512-IVVz4EvBcKjrzKgof714qDnz/SzQAkLA2Emh5edlHbgcE6fNd3Un6CJLlaYcnm8N4JmAtzQgse4dOKxcD2yc9g==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2794,8 +2816,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-collection@1.1.9':
-    resolution: {integrity: sha512-zuSVi7ziP7uQRqc+yGxsKJfNkdyHv3ZKDaHe0gzg4dRgws96TPKWIiz84tVHP4GEcEl8bC0mdt17NkcxaJHmaQ==}
+  '@radix-ui/react-collection@1.1.7':
+    resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2856,8 +2878,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-dialog@1.1.16':
-    resolution: {integrity: sha512-l9ok83YBclEZhbjgzt76Hw733e6cvRKPNgO6GJ/IETlufXG9p+fRu2wlvpImQvR6xdJ8h7J8J2DBvsPEiEsKMw==}
+  '@radix-ui/react-dialog@1.1.17':
+    resolution: {integrity: sha512-TDTYmpdq8dI2+Xgvgj9AJ8Ghqq+Eph/TRVEdaFQPDItIY+6QSkU7MJMeevw1568Yw/2Ijz8BTphPSP2XejKphw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2900,8 +2922,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-dismissable-layer@1.1.12':
-    resolution: {integrity: sha512-MhoruH6xEzsbvOmo4TNgMfmtvRGyDZw4MDSdf4ybMHfezjqwzv6hyd4lsMzBp8K9Sn6sGzCF62x1I7BYUECXOg==}
+  '@radix-ui/react-dismissable-layer@1.1.13':
+    resolution: {integrity: sha512-2v+zNAWWe0ySxgC0D0yeXMPQ23xZVgXZTerTz+JKlmdRj6gfTqmCcR29jb6d290DezXPGgruHWDX/vYUebtErg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2931,8 +2953,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-focus-scope@1.1.7':
-    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+  '@radix-ui/react-focus-scope@1.1.10':
+    resolution: {integrity: sha512-Fas/lXQqhVvqwAb64s5RFeHiHYElZ6SUQbZaNd6EkfhP/Al7wTIQ9WIR4QVX475tlu5yFCEdDcJH6/UwsZjMWw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2944,8 +2966,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-focus-scope@1.1.9':
-    resolution: {integrity: sha512-9Se8t+Zry+1rEOL7Y6l/4ANYU/TOtAtf8O2fKdwLltcaMcm6kOqYGbzO4tMFQ0bvzO920pRAoHpFZ4W85S3keQ==}
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3014,8 +3036,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-popper@1.3.0':
-    resolution: {integrity: sha512-9PB589e1aWZbrlFUHdz6WiPCL+xLZHQFX7oibqG/6Q0SwOkxDyQX9W/cyPa+sAPPKuC8cpLCpRczE5a/1DiwVQ==}
+  '@radix-ui/react-popper@1.3.1':
+    resolution: {integrity: sha512-bhnq/0DEPTi2lsOD3J5rTL65qUKHbKbhqHsmN9TMiclSXpipi651ooUKPPp6G5lF/WiHBdn1s0Wuqsn+myVAvw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3027,8 +3049,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-portal@1.1.11':
-    resolution: {integrity: sha512-UEytdjgEh2tJGgD/gZK4FUx6t1rNIlM3U0DENhSrG7I75FGm1DnaDuVUWF1pWAWUwGmn1sCJ1VGHn8LhN1aTOw==}
+  '@radix-ui/react-portal@1.1.12':
+    resolution: {integrity: sha512-m309havGzsjLHHaIX50G5PlvRs3xkgPCsGk/5PTvYm8D5q33yG0J7w/712PTOhid7NTaFETtnSXjngHQavvhVw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3092,8 +3114,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-primitive@2.1.5':
-    resolution: {integrity: sha512-zifXeB8Y88qCYx8PLZ5oQb32KwZub+s925mMoZsBBq9KUQqWKkREubTfs6ASjRPPBe7Jt9O8OHH89+95VG+grA==}
+  '@radix-ui/react-primitive@2.1.6':
+    resolution: {integrity: sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3131,8 +3153,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-scroll-area@1.2.11':
-    resolution: {integrity: sha512-DS39ziOgea75U/TrXKU2/oKp0be2jrDHnzFLvahg/0iNAT1Zq16e4Uw0WXwyXvsK+mG3BRyMb7A3NRZMDuEXtQ==}
+  '@radix-ui/react-scroll-area@1.2.12':
+    resolution: {integrity: sha512-xuafVzQiTCLsyEjakowTdG3OgTXsmO7IdCiO77otIa+z44xoLNs9Do5eg7POFumIOCjtG6djfm6RKUKpUa/csA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3144,8 +3166,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-select@2.3.0':
-    resolution: {integrity: sha512-mENc7WpJvJcW8hlMpzfFcHcEhTvYS5JMBmi9HVC1Q00uhBwML086MHYUV8QQdQv6lcu0Wg8dzd1RB8AFADcG/g==}
+  '@radix-ui/react-select@2.3.1':
+    resolution: {integrity: sha512-w6eDvY78LE9ZUiNnXCA1QVK8RYN7k9galFv09kjVydJqBAgHd7Y9A6h0UJ/6DCZNGZMZrB2ohcSW1Bo9d8+wWA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3157,8 +3179,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-separator@1.1.9':
-    resolution: {integrity: sha512-gvgW+JV/Mbjj6darztTetnmElpQEzZrXpJvfj+dOxNAxiyHEAyUvEjjl4zxblvmjmKmi3jfPoy7ZdxzCuUBJSA==}
+  '@radix-ui/react-separator@1.1.10':
+    resolution: {integrity: sha512-Y6K6jLQCVfCnTL2MEtGxDLffkhNfEfHsEg3Wa8JU+IWdn3EWbLXd3OuOfQRN7p/W/cUce1WyTk3QeuAoDBzN9g==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3188,8 +3210,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-slot@1.2.5':
-    resolution: {integrity: sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==}
+  '@radix-ui/react-slot@1.3.0':
+    resolution: {integrity: sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -3367,8 +3389,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-visually-hidden@1.2.5':
-    resolution: {integrity: sha512-tPcHNI3FajdDBFpl/Ez1m2WL0ufJqBKyHxMDBvKitopamK36WwBGOMicuMEZKkM5Wce41QxUyv6BsiqfrWBiGg==}
+  '@radix-ui/react-visually-hidden@1.2.6':
+    resolution: {integrity: sha512-jCE0WljWifTI4niIMCll06kGpsJTAPiZVU9H4WR1N6qW7At9ystHbN7dDB+we2xH535roFHj7qKS+RGj0FMDWQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3386,34 +3408,41 @@ packages:
   '@radix-ui/rect@1.1.2':
     resolution: {integrity: sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==}
 
-  '@redis/bloom@1.2.0':
-    resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
+  '@redis/bloom@6.0.0':
+    resolution: {integrity: sha512-P0n5NkV9IIdT6nYXOfMHG83sho8pE7Nay7yw27wOGVLv4DthgvzebpGz6m7VuMTizeJmw3LPw2Xek5wFUhGpVw==}
+    engines: {node: '>= 20.0.0'}
     peerDependencies:
-      '@redis/client': ^1.0.0
+      '@redis/client': ^6.0.0
 
-  '@redis/client@1.6.1':
-    resolution: {integrity: sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==}
-    engines: {node: '>=14'}
-
-  '@redis/graph@1.1.1':
-    resolution: {integrity: sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==}
+  '@redis/client@6.0.0':
+    resolution: {integrity: sha512-NS4iIT25r24sAjNQ2nSRdCW5jPJoV0rxkBee27oTeR+RXaOu89cjIsrww5rPBaYVGVdL1QCx9uz9141gZiSKdQ==}
+    engines: {node: '>= 20.0.0'}
     peerDependencies:
-      '@redis/client': ^1.0.0
+      '@node-rs/xxhash': ^1.1.0
+      '@opentelemetry/api': '>=1 <2'
+    peerDependenciesMeta:
+      '@node-rs/xxhash':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
 
-  '@redis/json@1.0.7':
-    resolution: {integrity: sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==}
+  '@redis/json@6.0.0':
+    resolution: {integrity: sha512-F+eqFfgPcy57Zs1KW7UtLnBtRk6lxAUIoe7dyZerpm6e+ssYXG/dWJrbrHFYs0b7tt6QBtYpVuukBuM9XqhUAg==}
+    engines: {node: '>= 20.0.0'}
     peerDependencies:
-      '@redis/client': ^1.0.0
+      '@redis/client': ^6.0.0
 
-  '@redis/search@1.2.0':
-    resolution: {integrity: sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==}
+  '@redis/search@6.0.0':
+    resolution: {integrity: sha512-VHuCJ2W0YWFixGZh/l//8JiyOsD4gN+NhjdRAGIoUe0UQ4mtq1NyY2ZJ973XT+vYhaU21XdK8r8oNrd5n7wbzQ==}
+    engines: {node: '>= 20.0.0'}
     peerDependencies:
-      '@redis/client': ^1.0.0
+      '@redis/client': ^6.0.0
 
-  '@redis/time-series@1.1.0':
-    resolution: {integrity: sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==}
+  '@redis/time-series@6.0.0':
+    resolution: {integrity: sha512-QWhkYsg+3lhBrBf+cbzybtV8LQcSrk7iXIgTaGU+pHNFTkql7TpVRE24ROS6M2ybVIV6O/zxTqfxgxxYiqyw0Q==}
+    engines: {node: '>= 20.0.0'}
     peerDependencies:
-      '@redis/client': ^1.0.0
+      '@redis/client': ^6.0.0
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
@@ -4286,8 +4315,8 @@ packages:
     engines: {node: '>= 18'}
     hasBin: true
 
-  '@zilliz/milvus2-sdk-node@2.6.17':
-    resolution: {integrity: sha512-Z+fCxhuHLV4kogU1T5SS9hDJqLH3KBEceU5snqDV/WDl6uxgNomqZY9md8TTRkHBISqNzDawEaZsi4MF6Y0oWA==}
+  '@zilliz/milvus2-sdk-node@3.0.3':
+    resolution: {integrity: sha512-7rC+MDmzfctc9wscIfqxkzTJCxWafSdkyFDESMIzEX1G2ndImRQzHfkrzjcPFqPBVgQHQScGnGa3W7edqcThjA==}
 
   abort-controller-x@0.5.0:
     resolution: {integrity: sha512-yTt9CI0x+nRfX6BFMenEGP8ooPvErGH6AbFz20C2IeOLIlDsrw/VHpgne3GsCEuTA410IiFiaLVFKmgM4bKEPQ==}
@@ -5640,8 +5669,8 @@ packages:
     resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
     engines: {node: '>=16.9.0'}
 
-  hono@4.12.25:
-    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
+  hono@4.12.26:
+    resolution: {integrity: sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -6465,8 +6494,8 @@ packages:
   onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
     resolution: {integrity: sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==}
 
-  openai@6.42.0:
-    resolution: {integrity: sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg==}
+  openai@6.44.0:
+    resolution: {integrity: sha512-09/gH+8jH0RgUwsgWHAaxsKGRT5zVZ95IaJUnqAWj6XejIBmnFRwq2WUIF37VtDEsmGrtPmvCs5+yBSeZGWvkA==}
     peerDependencies:
       ws: ^8.18.0
       zod: ^3.25 || ^4.0
@@ -6573,8 +6602,8 @@ packages:
   pg-cloudflare@1.4.0:
     resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
 
-  pg-connection-string@2.13.0:
-    resolution: {integrity: sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==}
+  pg-connection-string@2.14.0:
+    resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
 
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
@@ -6588,15 +6617,15 @@ packages:
   pg-protocol@1.13.0:
     resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
 
-  pg-protocol@1.14.0:
-    resolution: {integrity: sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==}
+  pg-protocol@1.15.0:
+    resolution: {integrity: sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==}
 
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
     engines: {node: '>=4'}
 
-  pg@8.21.0:
-    resolution: {integrity: sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==}
+  pg@8.22.0:
+    resolution: {integrity: sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
       pg-native: '>=3.0.1'
@@ -6891,8 +6920,9 @@ packages:
   redeyed@2.1.1:
     resolution: {integrity: sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==}
 
-  redis@4.7.1:
-    resolution: {integrity: sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==}
+  redis@6.0.0:
+    resolution: {integrity: sha512-n9Thfc39OXleEoPT2k5gwKsqY+HfCww3YS71ofcr9KKbkn89bpjU9dToIlD+JRdM3/GYQkwMtVgTxLyed+LptQ==}
+    engines: {node: '>= 20.0.0'}
 
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
@@ -7850,7 +7880,7 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.1.1
 
-  '@anthropic-ai/sdk@0.104.1(zod@4.4.3)':
+  '@anthropic-ai/sdk@0.105.0(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
       standardwebhooks: 1.0.0
@@ -8787,7 +8817,7 @@ snapshots:
       '@tailwindcss/oxide': 4.2.4
       tailwindcss: 4.2.4
 
-  '@google/genai@2.8.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
+  '@google/genai@2.9.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
@@ -8820,9 +8850,9 @@ snapshots:
     dependencies:
       hono: 4.12.23
 
-  '@hono/node-server@2.0.4(hono@4.12.25)':
+  '@hono/node-server@2.0.5(hono@4.12.26)':
     dependencies:
-      hono: 4.12.25
+      hono: 4.12.26
 
   '@huggingface/hub@2.11.0':
     dependencies:
@@ -8985,47 +9015,55 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
-  '@lancedb/lancedb-darwin-arm64@0.13.0':
+  '@lancedb/lancedb-darwin-arm64@0.30.0':
     optional: true
 
-  '@lancedb/lancedb-darwin-x64@0.13.0':
+  '@lancedb/lancedb-linux-arm64-gnu@0.30.0':
     optional: true
 
-  '@lancedb/lancedb-linux-arm64-gnu@0.13.0':
+  '@lancedb/lancedb-linux-arm64-musl@0.30.0':
     optional: true
 
-  '@lancedb/lancedb-linux-x64-gnu@0.13.0':
+  '@lancedb/lancedb-linux-x64-gnu@0.30.0':
     optional: true
 
-  '@lancedb/lancedb-win32-x64-msvc@0.13.0':
+  '@lancedb/lancedb-linux-x64-musl@0.30.0':
     optional: true
 
-  '@lancedb/lancedb@0.13.0(apache-arrow@17.0.0)':
+  '@lancedb/lancedb-win32-arm64-msvc@0.30.0':
+    optional: true
+
+  '@lancedb/lancedb-win32-x64-msvc@0.30.0':
+    optional: true
+
+  '@lancedb/lancedb@0.30.0(apache-arrow@17.0.0)':
     dependencies:
       apache-arrow: 17.0.0
       reflect-metadata: 0.2.2
     optionalDependencies:
-      '@lancedb/lancedb-darwin-arm64': 0.13.0
-      '@lancedb/lancedb-darwin-x64': 0.13.0
-      '@lancedb/lancedb-linux-arm64-gnu': 0.13.0
-      '@lancedb/lancedb-linux-x64-gnu': 0.13.0
-      '@lancedb/lancedb-win32-x64-msvc': 0.13.0
+      '@lancedb/lancedb-darwin-arm64': 0.30.0
+      '@lancedb/lancedb-linux-arm64-gnu': 0.30.0
+      '@lancedb/lancedb-linux-arm64-musl': 0.30.0
+      '@lancedb/lancedb-linux-x64-gnu': 0.30.0
+      '@lancedb/lancedb-linux-x64-musl': 0.30.0
+      '@lancedb/lancedb-win32-arm64-msvc': 0.30.0
+      '@lancedb/lancedb-win32-x64-msvc': 0.30.0
 
-  '@langfuse/core@5.4.1(@opentelemetry/api@1.9.1)':
+  '@langfuse/core@5.5.3(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@langfuse/otel@5.4.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))':
+  '@langfuse/otel@5.5.3(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))':
     dependencies:
-      '@langfuse/core': 5.4.1(@opentelemetry/api@1.9.1)
+      '@langfuse/core': 5.5.3(@opentelemetry/api@1.9.1)
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-http': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
 
-  '@langfuse/tracing@5.4.1(@opentelemetry/api@1.9.1)':
+  '@langfuse/tracing@5.5.3(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@langfuse/core': 5.4.1(@opentelemetry/api@1.9.1)
+      '@langfuse/core': 5.5.3(@opentelemetry/api@1.9.1)
       '@opentelemetry/api': 1.9.1
 
   '@manypkg/find-root@1.1.0':
@@ -9078,11 +9116,14 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
-  '@mistralai/mistralai@2.2.5':
+  '@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.1)':
     dependencies:
+      '@opentelemetry/semantic-conventions': 1.40.0
       ws: 8.21.0
       zod: 4.4.3
       zod-to-json-schema: 3.25.2(zod@4.4.3)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -9678,7 +9719,7 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@pinecone-database/pinecone@5.1.2': {}
+  '@pinecone-database/pinecone@8.0.0': {}
 
   '@pinojs/redact@0.4.0': {}
 
@@ -9707,7 +9748,7 @@ snapshots:
   '@protobufjs/fetch@1.1.0':
     dependencies:
       '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/inquire': 1.1.1
+      '@protobufjs/inquire': 1.1.2
 
   '@protobufjs/fetch@1.1.1':
     dependencies:
@@ -9758,14 +9799,22 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-alert-dialog@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-alert-dialog@1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.7)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.7)
-      '@radix-ui/react-dialog': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-slot': 1.2.5(@types/react@19.2.14)(react@19.2.7)
+      '@radix-ui/react-dialog': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-arrow@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
@@ -9777,15 +9826,6 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
-  '@radix-ui/react-arrow@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -9806,6 +9846,18 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-collection@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
@@ -9814,18 +9866,6 @@ snapshots:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
-  '@radix-ui/react-collection@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.7)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-slot': 1.2.5(@types/react@19.2.14)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -9876,19 +9916,19 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-dialog@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-dialog@1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.7)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.7)
-      '@radix-ui/react-dismissable-layer': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.14)(react@19.2.7)
-      '@radix-ui/react-focus-scope': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.7)
-      '@radix-ui/react-portal': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-slot': 1.2.5(@types/react@19.2.14)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.7)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.7)
       aria-hidden: 1.2.6
       react: 19.2.7
@@ -9923,11 +9963,11 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-dismissable-layer@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-dismissable-layer@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.7)
       '@radix-ui/react-use-escape-keydown': 1.1.2(@types/react@19.2.14)(react@19.2.7)
       react: 19.2.7
@@ -9948,6 +9988,17 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-focus-scope@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
@@ -9955,17 +10006,6 @@ snapshots:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
-  '@radix-ui/react-focus-scope@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -10047,13 +10087,13 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-popper@1.3.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-popper@1.3.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@floating-ui/react-dom': 2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-arrow': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-arrow': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.7)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.7)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.7)
       '@radix-ui/react-use-rect': 1.1.2(@types/react@19.2.14)(react@19.2.7)
@@ -10065,9 +10105,9 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-portal@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-portal@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -10113,9 +10153,9 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-primitive@2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-primitive@2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-slot': 1.2.5(@types/react@19.2.14)(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
@@ -10156,7 +10196,7 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-scroll-area@1.2.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-scroll-area@1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/number': 1.1.2
       '@radix-ui/primitive': 1.1.4
@@ -10164,7 +10204,7 @@ snapshots:
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.7)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.7)
       '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.7)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.7)
       react: 19.2.7
@@ -10173,28 +10213,28 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-select@2.3.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-select@2.3.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/number': 1.1.2
       '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collection': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.7)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.7)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.7)
-      '@radix-ui/react-dismissable-layer': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.14)(react@19.2.7)
-      '@radix-ui/react-focus-scope': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.7)
-      '@radix-ui/react-popper': 1.3.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-portal': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-popper': 1.3.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-slot': 1.2.5(@types/react@19.2.14)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.7)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.7)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.7)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.7)
       '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.14)(react@19.2.7)
-      '@radix-ui/react-visually-hidden': 1.2.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-visually-hidden': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       aria-hidden: 1.2.6
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -10203,9 +10243,9 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-separator@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-separator@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
@@ -10226,7 +10266,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-slot@1.2.5(@types/react@19.2.14)(react@19.2.7)':
+  '@radix-ui/react-slot@1.3.0(@types/react@19.2.14)(react@19.2.7)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.7)
       react: 19.2.7
@@ -10366,9 +10406,9 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-visually-hidden@1.2.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-visually-hidden@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
@@ -10379,31 +10419,27 @@ snapshots:
 
   '@radix-ui/rect@1.1.2': {}
 
-  '@redis/bloom@1.2.0(@redis/client@1.6.1)':
+  '@redis/bloom@6.0.0(@redis/client@6.0.0(@opentelemetry/api@1.9.1))':
     dependencies:
-      '@redis/client': 1.6.1
+      '@redis/client': 6.0.0(@opentelemetry/api@1.9.1)
 
-  '@redis/client@1.6.1':
+  '@redis/client@6.0.0(@opentelemetry/api@1.9.1)':
     dependencies:
       cluster-key-slot: 1.1.2
-      generic-pool: 3.9.0
-      yallist: 4.0.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
 
-  '@redis/graph@1.1.1(@redis/client@1.6.1)':
+  '@redis/json@6.0.0(@redis/client@6.0.0(@opentelemetry/api@1.9.1))':
     dependencies:
-      '@redis/client': 1.6.1
+      '@redis/client': 6.0.0(@opentelemetry/api@1.9.1)
 
-  '@redis/json@1.0.7(@redis/client@1.6.1)':
+  '@redis/search@6.0.0(@redis/client@6.0.0(@opentelemetry/api@1.9.1))':
     dependencies:
-      '@redis/client': 1.6.1
+      '@redis/client': 6.0.0(@opentelemetry/api@1.9.1)
 
-  '@redis/search@1.2.0(@redis/client@1.6.1)':
+  '@redis/time-series@6.0.0(@redis/client@6.0.0(@opentelemetry/api@1.9.1))':
     dependencies:
-      '@redis/client': 1.6.1
-
-  '@redis/time-series@1.1.0(@redis/client@1.6.1)':
-    dependencies:
-      '@redis/client': 1.6.1
+      '@redis/client': 6.0.0(@opentelemetry/api@1.9.1)
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
@@ -11297,7 +11333,7 @@ snapshots:
       readable-stream: 4.7.0
       utilium: 3.4.0
 
-  '@zilliz/milvus2-sdk-node@2.6.17':
+  '@zilliz/milvus2-sdk-node@3.0.3':
     dependencies:
       '@grpc/grpc-js': 1.14.3
       '@grpc/proto-loader': 0.8.0
@@ -12812,7 +12848,7 @@ snapshots:
 
   hono@4.12.23: {}
 
-  hono@4.12.25: {}
+  hono@4.12.26: {}
 
   html-escaper@2.0.2: {}
 
@@ -13858,7 +13894,7 @@ snapshots:
       platform: 1.3.6
       protobufjs: 7.5.6
 
-  openai@6.42.0(ws@8.21.0)(zod@4.4.3):
+  openai@6.44.0(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
       ws: 8.21.0
       zod: 4.4.3
@@ -13950,17 +13986,17 @@ snapshots:
   pg-cloudflare@1.4.0:
     optional: true
 
-  pg-connection-string@2.13.0: {}
+  pg-connection-string@2.14.0: {}
 
   pg-int8@1.0.1: {}
 
-  pg-pool@3.14.0(pg@8.21.0):
+  pg-pool@3.14.0(pg@8.22.0):
     dependencies:
-      pg: 8.21.0
+      pg: 8.22.0
 
   pg-protocol@1.13.0: {}
 
-  pg-protocol@1.14.0: {}
+  pg-protocol@1.15.0: {}
 
   pg-types@2.2.0:
     dependencies:
@@ -13970,11 +14006,11 @@ snapshots:
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
 
-  pg@8.21.0:
+  pg@8.22.0:
     dependencies:
-      pg-connection-string: 2.13.0
-      pg-pool: 3.14.0(pg@8.21.0)
-      pg-protocol: 1.14.0
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.22.0)
+      pg-protocol: 1.15.0
       pg-types: 2.2.0
       pgpass: 1.0.5
     optionalDependencies:
@@ -14318,14 +14354,16 @@ snapshots:
     dependencies:
       esprima: 4.0.1
 
-  redis@4.7.1:
+  redis@6.0.0(@opentelemetry/api@1.9.1):
     dependencies:
-      '@redis/bloom': 1.2.0(@redis/client@1.6.1)
-      '@redis/client': 1.6.1
-      '@redis/graph': 1.1.1(@redis/client@1.6.1)
-      '@redis/json': 1.0.7(@redis/client@1.6.1)
-      '@redis/search': 1.2.0(@redis/client@1.6.1)
-      '@redis/time-series': 1.1.0(@redis/client@1.6.1)
+      '@redis/bloom': 6.0.0(@redis/client@6.0.0(@opentelemetry/api@1.9.1))
+      '@redis/client': 6.0.0(@opentelemetry/api@1.9.1)
+      '@redis/json': 6.0.0(@redis/client@6.0.0(@opentelemetry/api@1.9.1))
+      '@redis/search': 6.0.0(@redis/client@6.0.0(@opentelemetry/api@1.9.1))
+      '@redis/time-series': 6.0.0(@redis/client@6.0.0(@opentelemetry/api@1.9.1))
+    transitivePeerDependencies:
+      - '@node-rs/xxhash'
+      - '@opentelemetry/api'
 
   reflect-metadata@0.2.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,6 @@ packages:
   - "packages/*"
   - "apps/*"
   - "examples/*"
-minimumReleaseAge: 10080
 overrides:
   '@anvia/core': "workspace:*"
 allowBuilds:


### PR DESCRIPTION
## Summary
- make pipeline construction schema-first and update pipeline docs/examples
- refresh upstream runtime dependency ranges and lockfile
- remove pnpm minimum release age guard to allow latest upstream dependency updates
- keep Redis vector schema constants stable with redis@6

## Verification
- bin/check-upstream-deps.sh
- pnpm --filter './packages/*' typecheck
- pnpm --filter './packages/*' test
- node apps/docs/scripts/check-reference-coverage.mjs
- pnpm docs:typecheck
- pnpm --filter @anvia/redis typecheck
- pnpm --filter @anvia/redis test
- pnpm --filter @anvia/redis build