### PR TITLE
Add preview package release channel

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -1,0 +1,51 @@
+name: Publish Preview Packages
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: package-preview-release
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish preview packages to npm
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Require main branch
+        run: |
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "Preview package publishing must run from the main branch."
+            exit 1
+          fi
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.0.4
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Publish preview packages
+        run: pnpm preview:release
+        env:
+          NPM_CONFIG_PROVENANCE: true
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGESET_GUIDE.md
+++ b/CHANGESET_GUIDE.md
@@ -99,6 +99,29 @@ That command runs:
 pnpm --filter './packages/*' build && changeset publish
 ```
 
+## Publish Preview Packages
+
+Preview packages are early-access builds from `main`. They do not use Changesets, do not create GitHub Releases, and do not update the `latest` npm tag.
+
+To publish a preview:
+
+1. Open GitHub Actions.
+2. Select the `Publish Preview Packages` workflow.
+3. Click `Run workflow`.
+4. Run it from the `main` branch.
+
+The workflow publishes every public package with a generated prerelease version:
+
+```txt
+0.7.2-preview.20260620T153000.abc1234
+```
+
+Users can install preview packages explicitly:
+
+```sh
+pnpm add @anvia/core@preview
+```
+
 ## Manual Version Check
 
 To preview what Changesets sees locally:

--- a/CHANGESET_GUIDE.md
+++ b/CHANGESET_GUIDE.md
@@ -103,6 +103,8 @@ pnpm --filter './packages/*' build && changeset publish
 
 Preview packages are early-access builds from `main`. They do not use Changesets, do not create GitHub Releases, and do not update the `latest` npm tag.
 
+Create changesets with the feature or fix PR that changes package behavior. Do not add a changeset only because you want a preview build. Preview publishing does not consume `.changeset/*.md` files; those changesets remain available for the stable `Version Packages` PR.
+
 To publish a preview:
 
 1. Open GitHub Actions.

--- a/package.json
+++ b/package.json
@@ -162,6 +162,8 @@
     "github-releases": "node scripts/create-github-releases.mjs",
     "version-packages": "changeset version",
     "release": "pnpm --filter @anvia/core build && pnpm --filter './packages/*' --filter '!@anvia/core' build && node scripts/publish-packages.mjs",
+    "preview:version": "node scripts/prepare-preview-release.mjs",
+    "preview:release": "pnpm preview:version && pnpm --filter @anvia/core build && pnpm --filter './packages/*' --filter '!@anvia/core' build && NPM_TAG=preview SKIP_GIT_TAGS=true node scripts/publish-packages.mjs",
     "check": "biome check .",
     "check:staged": "biome check --staged --vcs-enabled=true --vcs-client-kind=git --vcs-use-ignore-file=true --no-errors-on-unmatched",
     "check:fix": "biome check --write .",

--- a/scripts/prepare-preview-release.mjs
+++ b/scripts/prepare-preview-release.mjs
@@ -1,0 +1,145 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const packagesRoot = path.join(root, "packages");
+const dryRun = process.argv.includes("--dry-run");
+const buildId = process.env.PREVIEW_BUILD_ID ?? createBuildId();
+const dependencyFields = [
+  "dependencies",
+  "devDependencies",
+  "optionalDependencies",
+  "peerDependencies",
+];
+
+const packages = findPackageDirs(packagesRoot)
+  .map((dir) => ({ dir, packageJson: readPackageJson(dir) }))
+  .filter((pkg) => pkg.packageJson.private !== true)
+  .filter((pkg) => typeof pkg.packageJson.name === "string")
+  .filter((pkg) => typeof pkg.packageJson.version === "string")
+  .sort((a, b) => a.packageJson.name.localeCompare(b.packageJson.name));
+
+const previewVersions = new Map(
+  packages.map((pkg) => [
+    pkg.packageJson.name,
+    `${nextPatchVersion(pkg.packageJson.version)}-preview.${buildId}`,
+  ]),
+);
+
+for (const pkg of packages) {
+  const nextVersion = previewVersions.get(pkg.packageJson.name);
+  const updated = structuredClone(pkg.packageJson);
+  updated.version = nextVersion;
+
+  for (const field of dependencyFields) {
+    rewriteInternalDependencies(updated[field], previewVersions);
+  }
+
+  const relativePath = path.relative(root, path.join(pkg.dir, "package.json"));
+  console.info(`${pkg.packageJson.name}: ${pkg.packageJson.version} -> ${nextVersion}`);
+
+  if (!dryRun) {
+    writeFileSync(path.join(pkg.dir, "package.json"), `${JSON.stringify(updated, null, 2)}\n`);
+  } else {
+    for (const field of dependencyFields) {
+      for (const [name, version] of rewrittenDependencies(
+        pkg.packageJson[field],
+        previewVersions,
+      )) {
+        console.info(`  ${relativePath} ${field}.${name} -> ${version}`);
+      }
+    }
+  }
+}
+
+if (dryRun) {
+  console.info("Dry run complete. No package files were changed.");
+}
+
+function findPackageDirs(dir) {
+  const entries = readdirSync(dir).sort();
+  const dirs = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry);
+    if (!statSync(entryPath).isDirectory()) {
+      continue;
+    }
+
+    if (existsSync(path.join(entryPath, "package.json"))) {
+      dirs.push(entryPath);
+      continue;
+    }
+
+    dirs.push(...findPackageDirs(entryPath));
+  }
+
+  return dirs;
+}
+
+function readPackageJson(dir) {
+  return JSON.parse(readFileSync(path.join(dir, "package.json"), "utf8"));
+}
+
+function rewriteInternalDependencies(dependencies, versions) {
+  if (dependencies === undefined) {
+    return;
+  }
+
+  for (const name of Object.keys(dependencies)) {
+    const version = versions.get(name);
+    if (version !== undefined) {
+      dependencies[name] = version;
+    }
+  }
+}
+
+function* rewrittenDependencies(dependencies, versions) {
+  if (dependencies === undefined) {
+    return;
+  }
+
+  for (const name of Object.keys(dependencies)) {
+    const version = versions.get(name);
+    if (version !== undefined) {
+      yield [name, version];
+    }
+  }
+}
+
+function nextPatchVersion(version) {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-.+)?$/);
+  if (match === null) {
+    throw new Error(`Unsupported semver version: ${version}`);
+  }
+
+  const [, major, minor, patch] = match;
+  return `${major}.${minor}.${Number(patch) + 1}`;
+}
+
+function createBuildId() {
+  const timestamp = new Date()
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\.\d{3}Z$/, "");
+  const shortSha = getShortSha();
+  return shortSha === undefined ? timestamp : `${timestamp}.${shortSha}`;
+}
+
+function getShortSha() {
+  const envSha = process.env.GITHUB_SHA;
+  if (envSha !== undefined && envSha.length >= 7) {
+    return envSha.slice(0, 7);
+  }
+
+  const result = spawnSync("git", ["rev-parse", "--short=7", "HEAD"], {
+    cwd: root,
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    return undefined;
+  }
+
+  return result.stdout.trim();
+}

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -6,6 +6,9 @@ import path from "node:path";
 const root = process.cwd();
 const packagesRoot = path.join(root, "packages");
 const registry = process.env.npm_config_registry ?? process.env.NPM_CONFIG_REGISTRY;
+const npmTag = readOption("--tag", process.env.NPM_TAG ?? "latest");
+const skipGitTags =
+  process.env.SKIP_GIT_TAGS === "true" || process.argv.includes("--skip-git-tags");
 
 const packageDirs = findPackageDirs(packagesRoot);
 const packages = packageDirs
@@ -42,7 +45,7 @@ for (const pkg of sortedPackages) {
     "--access",
     publishConfig?.access ?? "public",
     "--tag",
-    "latest",
+    npmTag,
   ];
   const result = spawnSync("npm", args, {
     cwd: root,
@@ -64,7 +67,11 @@ if (published.length > 0) {
   for (const pkg of published) {
     console.info(`${pkg.name}@${pkg.version}`);
   }
-  createGitTags(published);
+  if (skipGitTags) {
+    console.info("Skipping git tag creation.");
+  } else {
+    createGitTags(published);
+  }
 }
 
 if (failed.length > 0) {
@@ -98,6 +105,20 @@ function findPackageDirs(dir) {
 
 function readPackageJson(dir) {
   return JSON.parse(readFileSync(path.join(dir, "package.json"), "utf8"));
+}
+
+function readOption(name, fallback) {
+  const index = process.argv.indexOf(name);
+  if (index === -1) {
+    return fallback;
+  }
+
+  const value = process.argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+
+  return value;
 }
 
 async function isVersionPublished(name, version) {


### PR DESCRIPTION
## Summary
- add a manual `Publish Preview Packages` workflow for npm `preview` releases from `main`
- add preview version preparation that publishes every public package as `<nextPatch>-preview.<timestamp>.<sha>` and rewrites internal `@anvia/*` references
- make package publishing configurable with `NPM_TAG` / `--tag` and `SKIP_GIT_TAGS` / `--skip-git-tags`
- document the preview release flow

## Validation
- `node scripts/prepare-preview-release.mjs --dry-run`
- `node --check scripts/prepare-preview-release.mjs && node --check scripts/publish-packages.mjs`
- `pnpm exec biome check package.json scripts/publish-packages.mjs scripts/prepare-preview-release.mjs .github/workflows/preview-release.yml CHANGESET_GUIDE.md`

## Notes
- `pnpm check` still fails on existing unrelated lint/format issues in `packages/core` and `packages/tool-studio`; those files are not touched by this PR.
