### PR TITLE
Deploy docs after stable releases

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,9 +1,7 @@
 name: Deploy Docs
 
 on:
-  push:
-    branches:
-      - main
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,3 +102,10 @@ jobs:
         run: pnpm github-releases
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy-docs:
+    name: Deploy stable docs
+    if: github.event_name == 'workflow_dispatch'
+    needs: publish
+    uses: ./.github/workflows/docs-deploy.yml
+    secrets: inherit

--- a/CHANGESET_GUIDE.md
+++ b/CHANGESET_GUIDE.md
@@ -99,9 +99,11 @@ That command runs:
 pnpm --filter './packages/*' build && changeset publish
 ```
 
+After packages publish successfully, the release workflow deploys the production docs. Docs do not deploy automatically on every push to `main`.
+
 ## Publish Preview Packages
 
-Preview packages are early-access builds from `main`. They do not use Changesets, do not create GitHub Releases, and do not update the `latest` npm tag.
+Preview packages are early-access builds from `main`. They do not use Changesets, do not create GitHub Releases, do not deploy docs, and do not update the `latest` npm tag.
 
 Create changesets with the feature or fix PR that changes package behavior. Do not add a changeset only because you want a preview build. Preview publishing does not consume `.changeset/*.md` files; those changesets remain available for the stable `Version Packages` PR.
 


### PR DESCRIPTION
## Summary
- stop deploying production docs on every push to `main`
- make the docs deploy workflow reusable via `workflow_call`
- call docs deployment after the stable package publish job succeeds
- clarify in the changeset guide that preview releases do not deploy docs

## Validation
- `ruby -ryaml -e "ARGV.each { |file| YAML.load_file(file); puts \"parsed #{file}\" }" .github/workflows/release.yml .github/workflows/docs-deploy.yml`

## Notes
- `pnpm exec biome check CHANGESET_GUIDE.md .github/workflows/release.yml .github/workflows/docs-deploy.yml` was attempted, but Biome ignores Markdown and workflow YAML in this repo, so no files were processed.
