### PR TITLE
test(core): improve coverage

### DIFF
--- a/packages/core/test/async-queue.test.ts
+++ b/packages/core/test/async-queue.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { createAsyncQueue } from "../src/internal/async-queue";
+
+describe("createAsyncQueue", () => {
+  it("yields values enqueued before reads and then completes when closed", async () => {
+    const queue = createAsyncQueue<number>();
+    queue.enqueue(1);
+    queue.enqueue(2);
+    queue.close();
+
+    await expect(collect(queue)).resolves.toEqual([1, 2]);
+  });
+
+  it("resolves pending reads when values arrive", async () => {
+    const queue = createAsyncQueue<string>();
+    const iterator = queue[Symbol.asyncIterator]();
+    const next = iterator.next();
+
+    queue.enqueue("ready");
+
+    await expect(next).resolves.toEqual({ value: "ready", done: false });
+  });
+
+  it("resolves pending reads as done when closed", async () => {
+    const queue = createAsyncQueue<string>();
+    const iterator = queue[Symbol.asyncIterator]();
+    const next = iterator.next();
+
+    queue.close();
+
+    await expect(next).resolves.toEqual({ value: undefined, done: true });
+    await expect(iterator.next()).resolves.toEqual({ value: undefined, done: true });
+  });
+
+  it("rejects pending and future reads when thrown", async () => {
+    const queue = createAsyncQueue<string>();
+    const iterator = queue[Symbol.asyncIterator]();
+    const error = new Error("queue failed");
+    const next = iterator.next();
+
+    queue.throw(error);
+
+    await expect(next).rejects.toThrow(error);
+    await expect(iterator.next()).rejects.toThrow(error);
+  });
+
+  it("ignores values enqueued after close", async () => {
+    const queue = createAsyncQueue<number>();
+
+    queue.close();
+    queue.enqueue(1);
+
+    await expect(collect(queue)).resolves.toEqual([]);
+  });
+
+  it("drains buffered values before surfacing a queued error", async () => {
+    const queue = createAsyncQueue<number>();
+    const iterator = queue[Symbol.asyncIterator]();
+    const error = new Error("late failure");
+
+    queue.enqueue(1);
+    queue.throw(error);
+
+    await expect(iterator.next()).resolves.toEqual({ value: 1, done: false });
+    await expect(iterator.next()).rejects.toThrow(error);
+  });
+});
+
+async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const values: T[] = [];
+  for await (const value of iterable) {
+    values.push(value);
+  }
+  return values;
+}

--- a/packages/core/test/embeddings-vector-store.test.ts
+++ b/packages/core/test/embeddings-vector-store.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
+import { matchesVectorFilter } from "../src/vector-store/filter";
 import {
   AgentBuilder,
   AssistantContent,
@@ -340,6 +341,66 @@ describe("in-memory vector store", () => {
     await expect(store.index(queryModel).search({ query: "base", topK: 1 })).rejects.toThrow(
       "Vector dimension mismatch",
     );
+  });
+});
+
+describe("vector metadata filters", () => {
+  const metadata = {
+    active: true,
+    category: "ops",
+    rank: 3,
+  };
+
+  it("matches absent filters and rejects absent metadata when a filter is present", () => {
+    expect(matchesVectorFilter(undefined, undefined)).toBe(true);
+    expect(matchesVectorFilter(metadata, undefined)).toBe(true);
+    expect(matchesVectorFilter(undefined, vectorFilter.eq("category", "ops"))).toBe(false);
+  });
+
+  it("evaluates equality and ordered comparisons for supported metadata values", () => {
+    expect(matchesVectorFilter(metadata, vectorFilter.eq("category", "ops"))).toBe(true);
+    expect(matchesVectorFilter(metadata, vectorFilter.eq("category", "support"))).toBe(false);
+    expect(matchesVectorFilter(metadata, vectorFilter.gt("rank", 2))).toBe(true);
+    expect(matchesVectorFilter(metadata, vectorFilter.gt("rank", 3))).toBe(false);
+    expect(matchesVectorFilter(metadata, vectorFilter.lt("rank", 4))).toBe(true);
+    expect(matchesVectorFilter(metadata, vectorFilter.lt("rank", 3))).toBe(false);
+    expect(matchesVectorFilter(metadata, vectorFilter.gt("category", "alpha"))).toBe(true);
+    expect(matchesVectorFilter(metadata, vectorFilter.lt("category", "zulu"))).toBe(true);
+    expect(matchesVectorFilter(metadata, vectorFilter.gt("active", false))).toBe(true);
+    expect(matchesVectorFilter(metadata, vectorFilter.lt("active", true))).toBe(false);
+  });
+
+  it("does not match ordered comparisons for missing or mixed-type values", () => {
+    expect(matchesVectorFilter(metadata, vectorFilter.gt("missing", 1))).toBe(false);
+    expect(matchesVectorFilter(metadata, vectorFilter.lt("rank", "4"))).toBe(false);
+    expect(matchesVectorFilter(metadata, vectorFilter.gt("active", 0))).toBe(false);
+  });
+
+  it("combines filters with boolean operators", () => {
+    expect(
+      matchesVectorFilter(
+        metadata,
+        vectorFilter.and(vectorFilter.eq("category", "ops"), vectorFilter.gt("rank", 2)),
+      ),
+    ).toBe(true);
+    expect(
+      matchesVectorFilter(
+        metadata,
+        vectorFilter.and(vectorFilter.eq("category", "ops"), vectorFilter.lt("rank", 2)),
+      ),
+    ).toBe(false);
+    expect(
+      matchesVectorFilter(
+        metadata,
+        vectorFilter.or(vectorFilter.eq("category", "support"), vectorFilter.eq("rank", 3)),
+      ),
+    ).toBe(true);
+    expect(
+      matchesVectorFilter(
+        metadata,
+        vectorFilter.or(vectorFilter.eq("category", "support"), vectorFilter.eq("rank", 4)),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/packages/core/test/mcp-connections.test.ts
+++ b/packages/core/test/mcp-connections.test.ts
@@ -12,8 +12,19 @@ const sdk = vi.hoisted(() => {
     options: unknown;
   };
 
+  type HttpTransportRecord = {
+    url: URL;
+    options: unknown;
+  };
+
+  type StdioTransportRecord = {
+    server: unknown;
+  };
+
   const clients: ClientRecord[] = [];
   const sseTransports: SseTransportRecord[] = [];
+  const httpTransports: HttpTransportRecord[] = [];
+  const stdioTransports: StdioTransportRecord[] = [];
 
   class Client {
     readonly metadata: unknown;
@@ -40,7 +51,36 @@ const sdk = vi.hoisted(() => {
     }
   }
 
-  return { Client, SSEClientTransport, clients, sseTransports };
+  class StreamableHTTPClientTransport {
+    readonly url: URL;
+    readonly options: unknown;
+
+    constructor(url: URL, options: unknown) {
+      this.url = url;
+      this.options = options;
+      httpTransports.push(this);
+    }
+  }
+
+  class StdioClientTransport {
+    readonly server: unknown;
+
+    constructor(server: unknown) {
+      this.server = server;
+      stdioTransports.push(this);
+    }
+  }
+
+  return {
+    Client,
+    SSEClientTransport,
+    StdioClientTransport,
+    StreamableHTTPClientTransport,
+    clients,
+    httpTransports,
+    sseTransports,
+    stdioTransports,
+  };
 });
 
 vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
@@ -51,10 +91,76 @@ vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({
   SSEClientTransport: sdk.SSEClientTransport,
 }));
 
+vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+  StdioClientTransport: sdk.StdioClientTransport,
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+  StreamableHTTPClientTransport: sdk.StreamableHTTPClientTransport,
+}));
+
 describe("MCP connection factories", () => {
   beforeEach(() => {
     sdk.clients.length = 0;
+    sdk.httpTransports.length = 0;
     sdk.sseTransports.length = 0;
+    sdk.stdioTransports.length = 0;
+  });
+
+  it("creates stdio connections with the SDK stdio transport", async () => {
+    const connection = mcp.stdio({
+      name: "local-server",
+      command: "node",
+      args: ["server.js"],
+      env: { API_KEY: "test-key" },
+    });
+
+    expect(connection.name).toBe("local-server");
+
+    const client = await connection.connect();
+
+    expect(sdk.clients).toHaveLength(1);
+    expect(client).toBe(sdk.clients[0]);
+    expect(sdk.clients[0]?.metadata).toEqual({
+      name: "@anvia/core",
+      version: "0.1.0",
+    });
+    expect(sdk.stdioTransports).toHaveLength(1);
+    expect(sdk.stdioTransports[0]).toBeInstanceOf(sdk.StdioClientTransport);
+    expect(sdk.stdioTransports[0]?.server).toEqual({
+      command: "node",
+      args: ["server.js"],
+      env: { API_KEY: "test-key" },
+    });
+    expect(sdk.clients[0]?.connectCalls).toEqual([sdk.stdioTransports[0]]);
+  });
+
+  it("creates streamable HTTP connections with the SDK HTTP transport", async () => {
+    const transportOptions = {
+      requestInit: {
+        headers: {
+          authorization: "Bearer test",
+        },
+      },
+    };
+
+    const connection = mcp.http({
+      name: "http-server",
+      url: "http://localhost:3000/mcp",
+      transport: transportOptions,
+    });
+
+    expect(connection.name).toBe("http-server");
+
+    const client = await connection.connect();
+
+    expect(sdk.clients).toHaveLength(1);
+    expect(client).toBe(sdk.clients[0]);
+    expect(sdk.httpTransports).toHaveLength(1);
+    expect(sdk.httpTransports[0]).toBeInstanceOf(sdk.StreamableHTTPClientTransport);
+    expect(sdk.httpTransports[0]?.url.href).toBe("http://localhost:3000/mcp");
+    expect(sdk.httpTransports[0]?.options).toBe(transportOptions);
+    expect(sdk.clients[0]?.connectCalls).toEqual([sdk.httpTransports[0]]);
   });
 
   it("creates legacy SSE connections with the SDK SSE transport", async () => {

--- a/packages/core/test/mcp.test.ts
+++ b/packages/core/test/mcp.test.ts
@@ -157,6 +157,65 @@ describe("MCP tools", () => {
     expect(client.callToolCalls).toEqual([{ name: "add", arguments: { x: 2, y: 5 } }]);
   });
 
+  it("omits null MCP arguments and rejects non-object arguments", async () => {
+    const client = fakeMcpClient({
+      tools: [
+        {
+          name: "ping",
+          inputSchema: { type: "object", properties: {}, required: [] },
+        },
+      ],
+      result: { content: [{ type: "text", text: "pong" }] },
+    });
+    const server = await connectMcp(fakeConnection("ping", client));
+
+    await expect(server.tools[0]?.call(null)).resolves.toBe("pong");
+    expect(client.callToolCalls).toEqual([{ name: "ping" }]);
+    await expect(server.tools[0]?.call("bad")).rejects.toThrow(
+      "MCP tool arguments must be a JSON object",
+    );
+  });
+
+  it("maps direct MCP toolResult payloads", async () => {
+    const stringClient = fakeMcpClient({
+      tools: [
+        {
+          name: "string_result",
+          inputSchema: { type: "object", properties: {}, required: [] },
+        },
+      ],
+      result: { toolResult: "done", content: [] },
+    });
+    const objectClient = fakeMcpClient({
+      tools: [
+        {
+          name: "object_result",
+          inputSchema: { type: "object", properties: {}, required: [] },
+        },
+      ],
+      result: { toolResult: { ok: true }, content: [] },
+    });
+    const undefinedClient = fakeMcpClient({
+      tools: [
+        {
+          name: "undefined_result",
+          inputSchema: { type: "object", properties: {}, required: [] },
+        },
+      ],
+      result: { toolResult: undefined, content: [] },
+    });
+
+    await expect(
+      (await connectMcp(fakeConnection("string", stringClient))).tools[0]?.call({}),
+    ).resolves.toBe("done");
+    await expect(
+      (await connectMcp(fakeConnection("object", objectClient))).tools[0]?.call({}),
+    ).resolves.toBe('{"ok":true}');
+    await expect(
+      (await connectMcp(fakeConnection("undefined", undefinedClient))).tools[0]?.call({}),
+    ).resolves.toBe("undefined");
+  });
+
   it("maps image and resource MCP tool results", async () => {
     const client = fakeMcpClient({
       tools: [
@@ -206,6 +265,23 @@ describe("MCP tools", () => {
     const errorServer = await connectMcp(fakeConnection("errors", errorClient));
 
     await expect(errorServer.tools[0]?.call({})).rejects.toThrow("denied");
+
+    const fallbackErrorClient = fakeMcpClient({
+      tools: [
+        {
+          name: "fallback_fail",
+          inputSchema: { type: "object", properties: {}, required: [] },
+        },
+      ],
+      result: { isError: true, content: [{ type: "image", mimeType: "image/png", data: "abc" }] },
+    });
+    const fallbackErrorServer = await connectMcp(
+      fakeConnection("fallback-errors", fallbackErrorClient),
+    );
+
+    await expect(fallbackErrorServer.tools[0]?.call({})).rejects.toThrow(
+      "MCP tool returned an error",
+    );
 
     const unsupportedClient = fakeMcpClient({
       tools: [

--- a/packages/core/test/observability.test.ts
+++ b/packages/core/test/observability.test.ts
@@ -1,15 +1,25 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
+import {
+  ActiveGenerationObservers,
+  ActiveToolObservers,
+  startAgentRunObservers,
+} from "../src/observability/group";
 import * as anvia from "./helpers/imports";
 import {
   AgentBuilder,
   type AgentGenerationEndArgs,
+  type AgentGenerationErrorArgs,
+  type AgentGenerationStartArgs,
   type AgentObserver,
   type AgentRunEndArgs,
   type AgentRunErrorArgs,
   type AgentRunObserver,
   type AgentRunStartArgs,
   type AgentToolEndArgs,
+  type AgentToolErrorArgs,
+  type AgentToolStartArgs,
+  type AgentToolStreamEventArgs,
   AssistantContent,
   type CompletionModel,
   type CompletionRequest,
@@ -20,6 +30,7 @@ import {
   type JsonObject,
   type StreamingCompletionModel,
   skipTool,
+  type ToolCall,
   Usage,
 } from "./helpers/imports";
 
@@ -372,11 +383,309 @@ describe("agent observability", () => {
   });
 });
 
+describe("active agent observer groups", () => {
+  it("skips undefined run observers and selects the first available trace", async () => {
+    const runObserver = createRunObserver({
+      trace: { traceId: "trace_1", observationId: "obs_1" },
+    });
+
+    const active = await startAgentRunObservers(
+      [{ observer: { startRun: () => undefined } }, { observer: { startRun: () => runObserver } }],
+      runStartArgs(),
+      false,
+    );
+
+    expect(active.trace).toEqual({ traceId: "trace_1", observationId: "obs_1" });
+  });
+
+  it("swallows run observer start failures unless global or registration strict mode is enabled", async () => {
+    const error = new Error("start failed");
+    const registration = {
+      observer: {
+        startRun() {
+          throw error;
+        },
+      },
+    };
+
+    await expect(
+      startAgentRunObservers([registration], runStartArgs(), false),
+    ).resolves.toMatchObject({
+      trace: undefined,
+    });
+    await expect(startAgentRunObservers([registration], runStartArgs(), true)).rejects.toThrow(
+      error,
+    );
+    await expect(
+      startAgentRunObservers(
+        [{ ...registration, failOnObserverError: true }],
+        runStartArgs(),
+        false,
+      ),
+    ).rejects.toThrow(error);
+  });
+
+  it("swallows nested observer failures in non-strict mode", async () => {
+    const error = new Error("nested failed");
+    const active = await startAgentRunObservers(
+      [
+        {
+          observer: {
+            startRun: () =>
+              createRunObserver({
+                startGeneration: () => {
+                  throw error;
+                },
+                startTool: () => {
+                  throw error;
+                },
+                end: () => {
+                  throw error;
+                },
+                error: () => {
+                  throw error;
+                },
+              }),
+          },
+        },
+      ],
+      runStartArgs(),
+      false,
+    );
+
+    await expect(active.startGeneration(generationStartArgs())).resolves.toBeInstanceOf(
+      ActiveGenerationObservers,
+    );
+    await expect(active.startTool(toolStartArgs())).resolves.toBeInstanceOf(ActiveToolObservers);
+    await expect(active.end(runEndArgs())).resolves.toBeUndefined();
+    await expect(active.error(runErrorArgs())).resolves.toBeUndefined();
+  });
+
+  it("throws nested observer failures in strict mode", async () => {
+    const error = new Error("strict failed");
+    const active = await startAgentRunObservers(
+      [
+        {
+          observer: {
+            startRun: () =>
+              createRunObserver({
+                startGeneration: () => {
+                  throw error;
+                },
+              }),
+          },
+        },
+      ],
+      runStartArgs(),
+      true,
+    );
+
+    await expect(active.startGeneration(generationStartArgs())).rejects.toThrow(error);
+  });
+
+  it("handles missing optional generation and tool observer methods", async () => {
+    const active = await startAgentRunObservers(
+      [
+        {
+          observer: {
+            startRun: () =>
+              createRunObserver({
+                startGeneration: () => undefined,
+                startTool: () => undefined,
+              }),
+          },
+        },
+      ],
+      runStartArgs(),
+      false,
+    );
+
+    const generationObservers = await active.startGeneration(generationStartArgs());
+    const toolObservers = await active.startTool(toolStartArgs());
+
+    await expect(generationObservers.error(generationErrorArgs())).resolves.toBeUndefined();
+    await expect(toolObservers.streamEvent(toolStreamEventArgs())).resolves.toBeUndefined();
+    await expect(toolObservers.error(toolErrorArgs())).resolves.toBeUndefined();
+  });
+
+  it("skips absent optional callbacks on active observers", async () => {
+    const active = await startAgentRunObservers(
+      [
+        {
+          observer: {
+            startRun: () =>
+              createRunObserver({
+                startGeneration: () => ({
+                  end() {},
+                }),
+                startTool: () => ({
+                  end() {},
+                }),
+              }),
+          },
+        },
+      ],
+      runStartArgs(),
+      false,
+    );
+
+    const generationObservers = await active.startGeneration(generationStartArgs());
+    const toolObservers = await active.startTool(toolStartArgs());
+
+    await expect(active.error(runErrorArgs())).resolves.toBeUndefined();
+    await expect(generationObservers.error(generationErrorArgs())).resolves.toBeUndefined();
+    await expect(toolObservers.streamEvent(toolStreamEventArgs())).resolves.toBeUndefined();
+    await expect(toolObservers.error(toolErrorArgs())).resolves.toBeUndefined();
+  });
+
+  it("applies strict handling inside generation and tool observer groups", async () => {
+    const error = new Error("group failed");
+    const generation = new ActiveGenerationObservers(
+      [
+        {
+          end() {
+            throw error;
+          },
+          error() {
+            throw error;
+          },
+        },
+      ],
+      true,
+    );
+    const tool = new ActiveToolObservers(
+      [
+        {
+          streamEvent() {
+            throw error;
+          },
+          end() {
+            throw error;
+          },
+          error() {
+            throw error;
+          },
+        },
+      ],
+      true,
+    );
+
+    await expect(generation.end(generationEndArgs())).rejects.toThrow(error);
+    await expect(generation.error(generationErrorArgs())).rejects.toThrow(error);
+    await expect(tool.streamEvent(toolStreamEventArgs())).rejects.toThrow(error);
+    await expect(tool.end(toolEndArgs())).rejects.toThrow(error);
+    await expect(tool.error(toolErrorArgs())).rejects.toThrow(error);
+  });
+});
+
 function response(choice: CompletionResponse["choice"]): CompletionResponse {
   return {
     choice,
     usage: Usage.empty(),
     rawResponse: {},
+  };
+}
+
+function createRunObserver(overrides: Partial<AgentRunObserver> = {}): AgentRunObserver {
+  return {
+    end() {},
+    ...overrides,
+  };
+}
+
+function runStartArgs(): AgentRunStartArgs {
+  return {
+    prompt: { role: "user", content: [{ type: "text", text: "hello" }] },
+    history: [],
+    maxTurns: 3,
+  };
+}
+
+function runEndArgs(): AgentRunEndArgs {
+  return {
+    output: "ok",
+    usage: Usage.empty(),
+    messages: [],
+  };
+}
+
+function runErrorArgs(): AgentRunErrorArgs {
+  return {
+    error: new Error("run failed"),
+    usage: Usage.empty(),
+    messages: [],
+  };
+}
+
+function generationStartArgs(): AgentGenerationStartArgs {
+  return {
+    turn: 0,
+    request: {
+      chatHistory: [],
+      documents: [],
+      tools: [],
+    },
+  };
+}
+
+function generationEndArgs(): AgentGenerationEndArgs {
+  return {
+    turn: 0,
+    response: response([AssistantContent.text("ok")]),
+  };
+}
+
+function generationErrorArgs(): AgentGenerationErrorArgs {
+  return {
+    turn: 0,
+    error: new Error("generation failed"),
+  };
+}
+
+function toolStartArgs(): AgentToolStartArgs {
+  return {
+    turn: 0,
+    toolCall: toolCall(),
+    toolName: "add",
+    args: '{"x":1,"y":2}',
+    internalCallId: "internal_1",
+    toolCallId: "call_1",
+  };
+}
+
+function toolEndArgs(): AgentToolEndArgs {
+  return {
+    ...toolStartArgs(),
+    result: "3",
+    skipped: false,
+  };
+}
+
+function toolErrorArgs(): AgentToolErrorArgs {
+  return {
+    ...toolStartArgs(),
+    error: new Error("tool failed"),
+  };
+}
+
+function toolStreamEventArgs(): AgentToolStreamEventArgs {
+  return {
+    ...toolStartArgs(),
+    event: {
+      agentId: "agent_1",
+      event: { chunk: '{"x":1' },
+    },
+  };
+}
+
+function toolCall(): ToolCall {
+  return {
+    type: "tool_call",
+    id: "call_1",
+    function: {
+      name: "add",
+      arguments: { x: 1, y: 2 },
+    },
   };
 }
 

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -3,5 +3,13 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
+    coverage: {
+      thresholds: {
+        statements: 90,
+        branches: 80,
+        functions: 90,
+        lines: 90,
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary
- add focused tests for core vector filters, async queue, MCP factories/results, and observer groups
- add core coverage thresholds to prevent regressions
- raise @anvia/core coverage above the initial 90/80/90/90 gate

## Verification
- pnpm --filter @anvia/core test
- pnpm --filter @anvia/core typecheck
- pnpm exec biome check packages/core/test/async-queue.test.ts packages/core/test/embeddings-vector-store.test.ts packages/core/test/mcp-connections.test.ts packages/core/test/mcp.test.ts packages/core/test/observability.test.ts packages/core/vitest.config.ts
- pnpm --filter @anvia/core exec vitest run --coverage

## Coverage
- Statements: 91.61%
- Branches: 80.40%
- Functions: 95.23%
- Lines: 91.52%

No changeset: test/config-only change.