### PR TITLE
Notify Discord on package releases

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -49,3 +49,8 @@ jobs:
         env:
           NPM_CONFIG_PROVENANCE: true
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Notify Discord
+        run: node scripts/notify-discord-release.mjs preview
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_PREVIEW_RELEASE_WEBHOOK_URL }}

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -51,6 +51,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Notify Discord
+        continue-on-error: true
         run: node scripts/notify-discord-release.mjs preview
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_PREVIEW_RELEASE_WEBHOOK_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Notify Discord
+        run: node scripts/notify-discord-release.mjs stable
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_STABLE_RELEASE_WEBHOOK_URL }}
+
   deploy-docs:
     name: Deploy stable docs
     if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Notify Discord
+        continue-on-error: true
         run: node scripts/notify-discord-release.mjs stable
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_STABLE_RELEASE_WEBHOOK_URL }}

--- a/scripts/notify-discord-release.mjs
+++ b/scripts/notify-discord-release.mjs
@@ -1,0 +1,142 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const packagesRoot = path.join(root, "packages");
+const webhookUrl = process.env.DISCORD_WEBHOOK_URL;
+const releaseChannel = process.argv[2];
+
+if (releaseChannel !== "stable" && releaseChannel !== "preview") {
+  throw new Error("Usage: node scripts/notify-discord-release.mjs <stable|preview>");
+}
+
+if (webhookUrl === undefined || webhookUrl.length === 0) {
+  console.warn("DISCORD_WEBHOOK_URL is not set. Skipping Discord release notification.");
+  process.exit(0);
+}
+
+const packages = findPackageDirs(packagesRoot)
+  .map((dir) => readPackageJson(dir))
+  .filter((pkg) => pkg.private !== true)
+  .filter((pkg) => typeof pkg.name === "string")
+  .filter((pkg) => typeof pkg.version === "string")
+  .sort((a, b) => a.name.localeCompare(b.name));
+
+const title =
+  releaseChannel === "stable" ? "Stable packages published" : "Preview packages published";
+const npmTag = releaseChannel === "stable" ? "latest" : "preview";
+const color = releaseChannel === "stable" ? 0x22c55e : 0xf59e0b;
+const repository = process.env.GITHUB_REPOSITORY;
+const serverUrl = process.env.GITHUB_SERVER_URL ?? "https://github.com";
+const runUrl =
+  repository !== undefined && process.env.GITHUB_RUN_ID !== undefined
+    ? `${serverUrl}/${repository}/actions/runs/${process.env.GITHUB_RUN_ID}`
+    : undefined;
+const commitUrl =
+  repository !== undefined && process.env.GITHUB_SHA !== undefined
+    ? `${serverUrl}/${repository}/commit/${process.env.GITHUB_SHA}`
+    : undefined;
+const shortSha = process.env.GITHUB_SHA?.slice(0, 7);
+
+const fields = [
+  {
+    name: "npm tag",
+    value: `\`${npmTag}\``,
+    inline: true,
+  },
+  {
+    name: "branch",
+    value: `\`${process.env.GITHUB_REF_NAME ?? "unknown"}\``,
+    inline: true,
+  },
+  {
+    name: "commit",
+    value:
+      commitUrl !== undefined && shortSha !== undefined
+        ? `[\`${shortSha}\`](${commitUrl})`
+        : `\`${shortSha ?? "unknown"}\``,
+    inline: true,
+  },
+  {
+    name: `packages (${packages.length})`,
+    value: packageList(packages),
+    inline: false,
+  },
+];
+
+if (runUrl !== undefined) {
+  fields.push({
+    name: "workflow run",
+    value: `[Open run](${runUrl})`,
+    inline: false,
+  });
+}
+
+const response = await fetch(webhookUrl, {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    embeds: [
+      {
+        title,
+        description:
+          releaseChannel === "stable"
+            ? "Stable packages were published successfully."
+            : "Preview packages were published successfully.",
+        color,
+        fields,
+        timestamp: new Date().toISOString(),
+      },
+    ],
+  }),
+});
+
+if (!response.ok) {
+  throw new Error(`Discord notification failed: ${response.status} ${await response.text()}`);
+}
+
+console.info(`Sent Discord notification for ${releaseChannel} release.`);
+
+function findPackageDirs(dir) {
+  const entries = readdirSync(dir).sort();
+  const dirs = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry);
+    if (!statSync(entryPath).isDirectory()) {
+      continue;
+    }
+
+    if (existsSync(path.join(entryPath, "package.json"))) {
+      dirs.push(entryPath);
+      continue;
+    }
+
+    dirs.push(...findPackageDirs(entryPath));
+  }
+
+  return dirs;
+}
+
+function readPackageJson(dir) {
+  return JSON.parse(readFileSync(path.join(dir, "package.json"), "utf8"));
+}
+
+function packageList(releases) {
+  const lines = releases.map((pkg) => `\`${pkg.name}@${pkg.version}\``);
+  const maxLength = 1000;
+  let output = "";
+
+  for (const line of lines) {
+    const next = output.length === 0 ? line : `${output}\n${line}`;
+    if (next.length > maxLength) {
+      const remaining = lines.length - output.split("\n").length;
+      return `${output}\nand ${remaining} more`;
+    }
+    output = next;
+  }
+
+  return output.length > 0 ? output : "No public packages found.";
+}

--- a/scripts/notify-discord-release.mjs
+++ b/scripts/notify-discord-release.mjs
@@ -77,6 +77,7 @@ const response = await fetch(webhookUrl, {
   headers: {
     "Content-Type": "application/json",
   },
+  signal: AbortSignal.timeout(10_000),
   body: JSON.stringify({
     embeds: [
       {


### PR DESCRIPTION
## Summary
- add a dependency-free Discord release notifier script
- notify stable releases with DISCORD_STABLE_RELEASE_WEBHOOK_URL
- notify preview releases with DISCORD_PREVIEW_RELEASE_WEBHOOK_URL

## Validation
- node --check scripts/notify-discord-release.mjs
- pnpm exec biome check scripts/notify-discord-release.mjs .github/workflows/release.yml .github/workflows/preview-release.yml
- parsed release workflow YAML files with Ruby YAML loader

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated Discord notifications after publishing both stable and preview packages.
  * Notifications include release context and a summarized list of published package versions.
  * Notification failures no longer interrupt the release workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->