### PR TITLE
Show changeset notes in Discord release notifications

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -49,9 +49,11 @@ jobs:
         env:
           NPM_CONFIG_PROVENANCE: true
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          PUBLISHED_PACKAGES_FILE: .published-packages.json
 
       - name: Notify Discord
         continue-on-error: true
         run: node scripts/notify-discord-release.mjs preview
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_PREVIEW_RELEASE_WEBHOOK_URL }}
+          PUBLISHED_PACKAGES_FILE: .published-packages.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,7 @@ jobs:
         env:
           NPM_CONFIG_PROVENANCE: true
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          PUBLISHED_PACKAGES_FILE: .published-packages.json
 
       - name: Push release tags
         run: git push --follow-tags
@@ -108,6 +109,7 @@ jobs:
         run: node scripts/notify-discord-release.mjs stable
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_STABLE_RELEASE_WEBHOOK_URL }}
+          PUBLISHED_PACKAGES_FILE: .published-packages.json
 
   deploy-docs:
     name: Deploy stable docs

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ coverage
 .turbo
 .wrangler
 .DS_Store
+.published-packages.json
 LAUNCH.md
 *.tsbuildinfo
 .env

--- a/scripts/notify-discord-release.mjs
+++ b/scripts/notify-discord-release.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 const root = process.cwd();
 const packagesRoot = path.join(root, "packages");
 const webhookUrl = process.env.DISCORD_WEBHOOK_URL;
+const publishedPackagesFile = process.env.PUBLISHED_PACKAGES_FILE;
 const releaseChannel = process.argv[2];
 
 if (releaseChannel !== "stable" && releaseChannel !== "preview") {
@@ -16,11 +17,30 @@ if (webhookUrl === undefined || webhookUrl.length === 0) {
 }
 
 const packages = findPackageDirs(packagesRoot)
-  .map((dir) => readPackageJson(dir))
-  .filter((pkg) => pkg.private !== true)
-  .filter((pkg) => typeof pkg.name === "string")
-  .filter((pkg) => typeof pkg.version === "string")
-  .sort((a, b) => a.name.localeCompare(b.name));
+  .map((dir) => ({ dir, packageJson: readPackageJson(dir) }))
+  .filter((pkg) => pkg.packageJson.private !== true)
+  .filter((pkg) => typeof pkg.packageJson.name === "string")
+  .filter((pkg) => typeof pkg.packageJson.version === "string")
+  .sort((a, b) => a.packageJson.name.localeCompare(b.packageJson.name));
+const publishedPackages = readPublishedPackages();
+const releasedPackages =
+  publishedPackages === undefined
+    ? packages
+    : packages.filter((pkg) => publishedPackages.has(pkg.packageJson.name));
+if (publishedPackages !== undefined && releasedPackages.length === 0) {
+  console.warn("No published packages were recorded. Skipping Discord release notification.");
+  process.exit(0);
+}
+
+const releaseNotes =
+  releaseChannel === "preview"
+    ? previewReleaseNotes(releasedPackages)
+    : stableReleaseNotes(releasedPackages);
+const changedPackageCount = new Set(releaseNotes.flatMap((note) => note.packages)).size;
+const packageSummary =
+  changedPackageCount > 0
+    ? `${changedPackageCount} changed package${changedPackageCount === 1 ? "" : "s"}`
+    : `${releasedPackages.length} published package${releasedPackages.length === 1 ? "" : "s"}`;
 
 const title =
   releaseChannel === "stable" ? "Stable packages published" : "Preview packages published";
@@ -58,8 +78,8 @@ const fields = [
     inline: true,
   },
   {
-    name: `packages (${packages.length})`,
-    value: packageList(packages),
+    name: "changes",
+    value: releaseNoteList(releaseNotes),
     inline: false,
   },
 ];
@@ -84,8 +104,8 @@ const response = await fetch(webhookUrl, {
         title,
         description:
           releaseChannel === "stable"
-            ? "Stable packages were published successfully."
-            : "Preview packages were published successfully.",
+            ? `Stable packages were published successfully: ${packageSummary}.`
+            : `Preview packages were published successfully: ${packageSummary}.`,
         color,
         fields,
         timestamp: new Date().toISOString(),
@@ -99,6 +119,225 @@ if (!response.ok) {
 }
 
 console.info(`Sent Discord notification for ${releaseChannel} release.`);
+
+function previewReleaseNotes(releases) {
+  const changesetNotes = changesetReleaseNotes();
+  if (changesetNotes.length > 0) {
+    return changesetNotes;
+  }
+
+  return latestChangelogNotes(releases);
+}
+
+function changesetReleaseNotes() {
+  const changesetRoot = path.join(root, ".changeset");
+  if (!existsSync(changesetRoot)) {
+    return [];
+  }
+
+  return readdirSync(changesetRoot)
+    .filter((entry) => entry.endsWith(".md") && entry !== "README.md")
+    .sort()
+    .map((entry) => parseChangeset(path.join(changesetRoot, entry)))
+    .filter((note) => note !== undefined);
+}
+
+function parseChangeset(filePath) {
+  const content = readFileSync(filePath, "utf8").trim();
+  const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  if (match === null) {
+    return undefined;
+  }
+
+  const [, frontmatter, body] = match;
+  const releases = [...frontmatter.matchAll(/^["']?([^"':]+(?:\/[^"':]+)?)["']?:\s*(\w+)/gm)].map(
+    ([, name, bump]) => ({ name, bump }),
+  );
+  const summary = normalizeMarkdown(body);
+
+  if (releases.length === 0 || summary.length === 0) {
+    return undefined;
+  }
+
+  const bumps = new Set(releases.map((release) => release.bump));
+  return {
+    packages: releases.map((release) => release.name),
+    summary: bumps.size === 1 ? `${[...bumps][0]}: ${summary}` : summary,
+  };
+}
+
+function stableReleaseNotes(releases) {
+  const notes = [];
+
+  for (const pkg of releases) {
+    const changelogPath = path.join(pkg.dir, "CHANGELOG.md");
+    if (!existsSync(changelogPath)) {
+      continue;
+    }
+
+    const entry = extractChangelogEntry(
+      readFileSync(changelogPath, "utf8"),
+      pkg.packageJson.version,
+    );
+    const changes = entry === undefined ? [] : changelogChanges(entry);
+    for (const change of changes) {
+      notes.push({
+        packages: [pkg.packageJson.name],
+        summary: change,
+      });
+    }
+  }
+
+  return dedupeReleaseNotes(notes);
+}
+
+function latestChangelogNotes(releases) {
+  const notes = [];
+
+  for (const pkg of releases) {
+    const changelogPath = path.join(pkg.dir, "CHANGELOG.md");
+    if (!existsSync(changelogPath)) {
+      continue;
+    }
+
+    const entry = extractLatestChangelogEntry(readFileSync(changelogPath, "utf8"));
+    const changes = entry === undefined ? [] : changelogChanges(entry);
+    for (const change of changes) {
+      notes.push({
+        packages: [pkg.packageJson.name],
+        summary: change,
+      });
+    }
+  }
+
+  return dedupeReleaseNotes(notes);
+}
+
+function extractLatestChangelogEntry(changelog) {
+  const lines = changelog.split(/\r?\n/);
+  const start = lines.findIndex((line) => /^##\s+/.test(line));
+  if (start === -1) {
+    return undefined;
+  }
+
+  const end = lines.findIndex((line, index) => index > start && /^##\s+/.test(line));
+  return lines
+    .slice(start, end === -1 ? lines.length : end)
+    .join("\n")
+    .trim();
+}
+
+function extractChangelogEntry(changelog, version) {
+  const lines = changelog.split(/\r?\n/);
+  const headingPattern = new RegExp(`^##\\s+\\[?${escapeRegExp(version)}\\]?\\b`);
+  const start = lines.findIndex((line) => headingPattern.test(line));
+  if (start === -1) {
+    return undefined;
+  }
+
+  const end = lines.findIndex((line, index) => index > start && /^##\s+/.test(line));
+  return lines
+    .slice(start, end === -1 ? lines.length : end)
+    .join("\n")
+    .trim();
+}
+
+function changelogChanges(entry) {
+  const changes = [];
+  let current;
+
+  for (const line of entry.split(/\r?\n/)) {
+    if (line.startsWith("- Updated dependencies")) {
+      current = undefined;
+      continue;
+    }
+
+    const bullet = line.match(/^-\s+(?:(?:[0-9a-f]{7,40}):\s*)?(.+)$/);
+    if (bullet !== null) {
+      if (current !== undefined) {
+        changes.push(current.trim());
+      }
+      current = bullet[1];
+      continue;
+    }
+
+    if (current !== undefined && /^\s{2,}\S/.test(line)) {
+      current = `${current} ${line.trim()}`;
+    }
+  }
+
+  if (current !== undefined) {
+    changes.push(current.trim());
+  }
+
+  return changes
+    .map((change) => normalizeMarkdown(change))
+    .filter((change) => change.length > 0 && !change.startsWith("- @anvia/"));
+}
+
+function dedupeReleaseNotes(notes) {
+  const seen = new Set();
+  const deduped = [];
+
+  for (const note of notes) {
+    const key = note.summary;
+    if (seen.has(key)) {
+      const existing = deduped.find((item) => item.summary === note.summary);
+      existing?.packages.push(...note.packages);
+      continue;
+    }
+
+    seen.add(key);
+    deduped.push({
+      packages: [...note.packages],
+      summary: note.summary,
+    });
+  }
+
+  return deduped;
+}
+
+function normalizeMarkdown(value) {
+  return value.replace(/\s+/g, " ").replace(/`/g, "").trim();
+}
+
+function releaseNoteList(notes) {
+  if (notes.length === 0) {
+    return "No changeset notes were found for this release.";
+  }
+
+  const maxLength = 1000;
+  let output = "";
+
+  for (const note of notes) {
+    const packageLabel = compactPackageLabel(note.packages);
+    const line = `- ${packageLabel}: ${note.summary}`;
+    const next = output.length === 0 ? line : `${output}\n${line}`;
+    if (next.length > maxLength) {
+      const remaining = notes.length - output.split("\n").length;
+      return `${output}\nand ${remaining} more change${remaining === 1 ? "" : "s"}`;
+    }
+    output = next;
+  }
+
+  return output;
+}
+
+function compactPackageLabel(packageNames) {
+  const unique = [...new Set(packageNames)].sort();
+  if (unique.length === 1) {
+    return `\`${unique[0]}\``;
+  }
+
+  if (unique.length <= 3) {
+    return unique.map((name) => `\`${name}\``).join(", ");
+  }
+
+  return `${unique
+    .slice(0, 2)
+    .map((name) => `\`${name}\``)
+    .join(", ")} and ${unique.length - 2} more`;
+}
 
 function findPackageDirs(dir) {
   const entries = readdirSync(dir).sort();
@@ -125,19 +364,26 @@ function readPackageJson(dir) {
   return JSON.parse(readFileSync(path.join(dir, "package.json"), "utf8"));
 }
 
-function packageList(releases) {
-  const lines = releases.map((pkg) => `\`${pkg.name}@${pkg.version}\``);
-  const maxLength = 1000;
-  let output = "";
-
-  for (const line of lines) {
-    const next = output.length === 0 ? line : `${output}\n${line}`;
-    if (next.length > maxLength) {
-      const remaining = lines.length - output.split("\n").length;
-      return `${output}\nand ${remaining} more`;
-    }
-    output = next;
+function readPublishedPackages() {
+  if (publishedPackagesFile === undefined || publishedPackagesFile.length === 0) {
+    return undefined;
   }
 
-  return output.length > 0 ? output : "No public packages found.";
+  const filePath = path.resolve(root, publishedPackagesFile);
+  if (!existsSync(filePath)) {
+    return undefined;
+  }
+
+  const releases = JSON.parse(readFileSync(filePath, "utf8"));
+  if (!Array.isArray(releases)) {
+    return undefined;
+  }
+
+  return new Set(
+    releases.filter((release) => typeof release?.name === "string").map((release) => release.name),
+  );
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/scripts/notify-discord-release.mjs
+++ b/scripts/notify-discord-release.mjs
@@ -303,7 +303,7 @@ function normalizeMarkdown(value) {
 
 function releaseNoteList(notes) {
   if (notes.length === 0) {
-    return "No changeset notes were found for this release.";
+    return "No release notes were found for this release.";
   }
 
   const maxLength = 1000;
@@ -314,6 +314,9 @@ function releaseNoteList(notes) {
     const line = `- ${packageLabel}: ${note.summary}`;
     const next = output.length === 0 ? line : `${output}\n${line}`;
     if (next.length > maxLength) {
+      if (output.length === 0) {
+        return `${line.slice(0, maxLength - 3)}...`;
+      }
       const remaining = notes.length - output.split("\n").length;
       return `${output}\nand ${remaining} more change${remaining === 1 ? "" : "s"}`;
     }
@@ -374,7 +377,12 @@ function readPublishedPackages() {
     return undefined;
   }
 
-  const releases = JSON.parse(readFileSync(filePath, "utf8"));
+  let releases;
+  try {
+    releases = JSON.parse(readFileSync(filePath, "utf8"));
+  } catch {
+    return undefined;
+  }
   if (!Array.isArray(releases)) {
     return undefined;
   }

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -1,11 +1,21 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
 const root = process.cwd();
 const packagesRoot = path.join(root, "packages");
 const registry = process.env.npm_config_registry ?? process.env.NPM_CONFIG_REGISTRY;
+const publishedPackagesFile = process.env.PUBLISHED_PACKAGES_FILE;
 const npmTag = readOption("--tag", process.env.NPM_TAG ?? "latest");
 const skipGitTags =
   process.env.SKIP_GIT_TAGS === "true" || process.argv.includes("--skip-git-tags");
@@ -82,6 +92,8 @@ if (failed.length > 0) {
   process.exit(1);
 }
 
+writePublishedPackages(published);
+
 if (published.length === 0) {
   console.warn("No unpublished projects to publish");
 }
@@ -105,6 +117,16 @@ function findPackageDirs(dir) {
 
 function readPackageJson(dir) {
   return JSON.parse(readFileSync(path.join(dir, "package.json"), "utf8"));
+}
+
+function writePublishedPackages(releases) {
+  if (publishedPackagesFile === undefined || publishedPackagesFile.length === 0) {
+    return;
+  }
+
+  const filePath = path.resolve(root, publishedPackagesFile);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(releases, null, 2)}\n`);
 }
 
 function readOption(name, fallback) {


### PR DESCRIPTION
## Summary
- replace noisy package/version dumps with concise release change notes
- read the exact package list published by the release script before building the Discord message
- use pending changesets for preview notes and package changelogs for stable notes
- skip Discord notification when no packages were published

## Validation
- node --check scripts/notify-discord-release.mjs && node --check scripts/publish-packages.mjs
- pnpm exec biome check scripts/notify-discord-release.mjs scripts/publish-packages.mjs .github/workflows/release.yml .github/workflows/preview-release.yml .gitignore
- parsed release workflow YAML files with Ruby YAML loader
- captured local webhook payloads for stable and preview notifications
- verified empty published package list skips webhook notification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Discord release notifications with release-note generation and more informative change summaries.
  * Added optional published-package tracking so notifications only cover packages actually published.

* **Chores**
  * Updated release and preview CI workflows to pass the published-package tracking file to publishing and notification steps.
  * Updated publish automation to write the published-package results file when enabled.
  * Ignored the generated published-packages file in version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->