### PR TITLE
Add Mistral OCR model

### DIFF
--- a/apps/docs/content/docs/guides/sdk-fundamentals/attachments.mdx
+++ b/apps/docs/content/docs/guides/sdk-fundamentals/attachments.mdx
@@ -90,7 +90,7 @@ For large document collections, preprocess text into embeddings and use [RAG Con
 | OpenAI | Use provider models that support the attachment type you send |
 | Anthropic | Attachment support depends on the selected model and provider SDK mapping |
 | Gemini | Supports image and document attachments; selected model limits still apply |
-| Mistral | Current Anvia Mistral support intentionally rejects image and document file attachments |
+| Mistral | Current Anvia Mistral chat support intentionally rejects image and document file attachments; use `client.ocrModel()` for Mistral OCR |
 | Compatible providers | Treat support as endpoint-specific, even when the API shape is compatible |
 
 Unsupported attachments usually fail as provider validation errors. Handle them at the same application boundary where you handle model configuration or request failures.

--- a/apps/docs/content/docs/models/providers/mistral.mdx
+++ b/apps/docs/content/docs/models/providers/mistral.mdx
@@ -1,9 +1,9 @@
 ---
 title: Mistral
-description: Use Mistral completion and embedding models with Anvia.
+description: Use Mistral completion, embedding, and OCR models with Anvia.
 ---
 
-Use `@anvia/mistral` when you want Mistral chat completion and embedding models through Anvia's normalized runtime.
+Use `@anvia/mistral` when you want Mistral chat completion, embedding, and OCR models through Anvia.
 
 ## Completion Model
 
@@ -38,6 +38,22 @@ const embedded = await embedDocuments(embeddings, documents, {
 
 Use embedding models for document preprocessing and retrieval.
 
+## OCR Model
+
+```ts
+const ocr = client.ocrModel();
+
+const result = await ocr.ocr({
+  source: {
+    type: "document_url",
+    url: "https://example.com/report.pdf",
+    documentName: "report.pdf",
+  },
+});
+```
+
+Use OCR models to extract markdown and page metadata from documents or images supported by Mistral OCR.
+
 ## Custom Client Options
 
 Use the constructor when credentials or a custom Mistral server URL come from your own configuration system.
@@ -57,6 +73,7 @@ You can also pass an existing Mistral SDK client when your app already owns prov
 | --- | --- |
 | Completion | `client.completionModel("mistral-large-latest")` |
 | Embeddings | `client.embeddingModel("mistral-embed")` |
+| OCR | `client.ocrModel("mistral-ocr-latest")` |
 | Custom server URL | `new MistralClient({ serverURL, apiKey })` |
 
-Mistral v1 support covers text completions, tools, tool choice, structured output, streaming, and embeddings. Image and document file attachments are intentionally rejected until Anvia adds full multimodal mapping for Mistral.
+Mistral v1 support covers text completions, tools, tool choice, structured output, streaming, embeddings, and OCR. Chat image and document file attachments are intentionally rejected until Anvia adds full multimodal mapping for Mistral.

--- a/apps/docs/content/docs/packages/mistral.mdx
+++ b/apps/docs/content/docs/packages/mistral.mdx
@@ -1,9 +1,9 @@
 ---
 title: "@anvia/mistral"
-description: Mistral completion and embedding models.
+description: Mistral completion, embedding, and OCR models.
 ---
 
-`@anvia/mistral` adapts the Mistral SDK into Anvia's provider-neutral interfaces. It supports completions (streaming and non-streaming) and embeddings.
+`@anvia/mistral` adapts the Mistral SDK into Anvia provider interfaces. It supports completions (streaming and non-streaming), embeddings, and Mistral OCR.
 
 ## Install
 
@@ -93,6 +93,24 @@ const embeddings = await embeddingModel.embedTexts(["hello", "world"]);
 | Option | Default | Purpose |
 | --- | -- | --- |
 | `maxBatchSize` | `512` | Texts per API call |
+
+## OCR Model
+
+```ts
+const ocr = client.ocrModel();
+
+const result = await ocr.ocr({
+  source: {
+    type: "document_url",
+    url: "https://example.com/invoice.pdf",
+    documentName: "invoice.pdf",
+  },
+});
+
+console.log(result.markdown);
+```
+
+OCR supports Mistral document URLs, image URLs, existing file IDs, and byte uploads through the Mistral files API.
 
 ## Tool Use
 

--- a/apps/docs/content/docs/reference/providers/mistral.mdx
+++ b/apps/docs/content/docs/reference/providers/mistral.mdx
@@ -81,16 +81,31 @@ type MistralOcrSource =
   | { type: "document_url"; url: string; documentName?: string }
   | { type: "image_url"; url: string }
   | { type: "file_id"; fileId: string }
-  | { type: "bytes"; data: Uint8Array | ArrayBuffer; filename: string };
+  | {
+      type: "bytes";
+      data: Uint8Array | ArrayBuffer;
+      filename: string;
+      expiry?: number | null;
+      visibility?: "workspace" | "user";
+    };
 
 type MistralOcrPage = {
   index: number;
   markdown: string;
   images: unknown[];
+  tables?: unknown[];
+  hyperlinks?: string[];
+  header?: string | null;
+  footer?: string | null;
+  dimensions?: unknown;
+  confidenceScores?: unknown;
 };
 
 type MistralOcrUploadedFile = {
   id: string;
+  filename?: string;
+  sizeBytes?: number;
+  purpose?: string;
   rawResponse: unknown;
 };
 

--- a/apps/docs/content/docs/reference/providers/mistral.mdx
+++ b/apps/docs/content/docs/reference/providers/mistral.mdx
@@ -20,10 +20,11 @@ class MistralClient {
   listModels(): Promise<ModelList>;
   completionModel(model?: string): MistralCompletionModel;
   embeddingModel(model?: string, options?: MistralEmbeddingModelOptions): MistralEmbeddingModel;
+  ocrModel(model?: string): MistralOcrModel;
 }
 ```
 
-Purpose: factory for Mistral completion, embedding, and model listing.
+Purpose: factory for Mistral completion, embedding, OCR, and model listing.
 
 Return behavior: creates or uses a Mistral SDK client, then returns normalized Anvia model adapters. `listModels()` fetches Mistral's model list and returns a normalized `ModelList`.
 
@@ -67,6 +68,44 @@ Return behavior: returns one `Embedding` per input text.
 
 Notable errors: rejects on Mistral SDK errors or mismatched embedding counts.
 
+## MistralOcrModel
+
+```ts
+const MISTRAL_OCR_LATEST = "mistral-ocr-latest";
+
+type MistralOcrRequest = {
+  source: MistralOcrSource;
+};
+
+type MistralOcrSource =
+  | { type: "document_url"; url: string; documentName?: string }
+  | { type: "image_url"; url: string }
+  | { type: "file_id"; fileId: string }
+  | { type: "bytes"; data: Uint8Array | ArrayBuffer; filename: string };
+
+type MistralOcrPage = {
+  index: number;
+  markdown: string;
+  images: unknown[];
+};
+
+type MistralOcrUploadedFile = {
+  id: string;
+  rawResponse: unknown;
+};
+
+class MistralOcrModel {
+  constructor(client: Mistral, defaultModel?: string);
+  ocr(request: MistralOcrRequest): Promise<MistralOcrResponse>;
+}
+```
+
+Purpose: adapter for Mistral OCR document processing.
+
+Return behavior: returns combined markdown/text, normalized page entries, upload metadata for byte sources, and the raw Mistral OCR response.
+
+Notable errors: rejects empty byte sources before upload; rejects or yields Mistral SDK/provider errors for upload and OCR failures.
+
 ## mistral Namespace
 
 ```ts
@@ -74,6 +113,8 @@ namespace mistral {
   MistralClient;
   MistralCompletionModel;
   MistralEmbeddingModel;
+  MistralOcrModel;
+  MISTRAL_OCR_LATEST;
   toMistralChatParams;
   fromMistralChatResponse;
   fromMistralChatStreamChunk;

--- a/packages/provider-mistral/README.md
+++ b/packages/provider-mistral/README.md
@@ -40,6 +40,21 @@ const embeddings = client.embeddingModel("mistral-embed");
 const vectors = await embeddings.embedTexts(["Refunds take five business days."]);
 ```
 
+## OCR
+
+```ts
+const ocr = client.ocrModel();
+const result = await ocr.ocr({
+  source: {
+    type: "document_url",
+    url: "https://example.com/invoice.pdf",
+    documentName: "invoice.pdf",
+  },
+});
+
+console.log(result.markdown);
+```
+
 ## Model Listing
 
 ```ts
@@ -48,15 +63,19 @@ const models = await client.listModels();
 
 ## Capabilities
 
-The v1 adapter supports text completions, streaming, tools, tool choice, structured output, Mistral embeddings, and model listing. Image inputs, document file inputs, transcription, audio generation, and image generation are not implemented yet.
+The v1 adapter supports text completions, streaming, tools, tool choice, structured output, Mistral embeddings, OCR, and model listing. Chat image inputs, chat document file inputs, transcription, audio generation, and image generation are not implemented yet.
 
 ## Exports
 
 - `MistralClient`
 - `MistralCompletionModel`
 - `MistralEmbeddingModel`
+- `MistralOcrModel`
 - `MistralClientOptions`
 - `MistralEmbeddingModelOptions`
+- `MistralOcrRequest`
+- `MistralOcrResponse`
+- `MISTRAL_OCR_LATEST`
 - `mistralMessageHelpers`
 - `mistral`
 

--- a/packages/provider-mistral/README.md
+++ b/packages/provider-mistral/README.md
@@ -75,6 +75,9 @@ The v1 adapter supports text completions, streaming, tools, tool choice, structu
 - `MistralEmbeddingModelOptions`
 - `MistralOcrRequest`
 - `MistralOcrResponse`
+- `MistralOcrSource`
+- `MistralOcrPage`
+- `MistralOcrUploadedFile`
 - `MISTRAL_OCR_LATEST`
 - `mistralMessageHelpers`
 - `mistral`

--- a/packages/provider-mistral/src/index.ts
+++ b/packages/provider-mistral/src/index.ts
@@ -2,11 +2,18 @@ export * as mistral from "./mistral/index";
 export {
   fromMistralChatResponse,
   fromMistralChatStreamChunk,
+  MISTRAL_OCR_LATEST,
   MistralClient,
   type MistralClientOptions,
   MistralCompletionModel,
   MistralEmbeddingModel,
   type MistralEmbeddingModelOptions,
+  MistralOcrModel,
+  type MistralOcrPage,
+  type MistralOcrRequest,
+  type MistralOcrResponse,
+  type MistralOcrSource,
+  type MistralOcrUploadedFile,
   mistralMessageHelpers,
   toMistralChatParams,
 } from "./mistral/index";

--- a/packages/provider-mistral/src/mistral/client.ts
+++ b/packages/provider-mistral/src/mistral/client.ts
@@ -6,6 +6,7 @@ import {
 import { Mistral } from "@mistralai/mistralai";
 import { MistralCompletionModel } from "./completion";
 import { MistralEmbeddingModel, type MistralEmbeddingModelOptions } from "./embedding";
+import { MISTRAL_OCR_LATEST, MistralOcrModel } from "./ocr";
 
 export type MistralClientOptions = {
   apiKey?: string | undefined;
@@ -34,6 +35,10 @@ export class MistralClient implements ModelListingClient {
     options: MistralEmbeddingModelOptions = {},
   ): MistralEmbeddingModel {
     return new MistralEmbeddingModel(this.client, model, options);
+  }
+
+  ocrModel(model = MISTRAL_OCR_LATEST): MistralOcrModel {
+    return new MistralOcrModel(this.client, model);
   }
 
   async listModels(): Promise<ModelList> {

--- a/packages/provider-mistral/src/mistral/index.ts
+++ b/packages/provider-mistral/src/mistral/index.ts
@@ -7,3 +7,12 @@ export {
   toMistralChatParams,
 } from "./completion";
 export { MistralEmbeddingModel, type MistralEmbeddingModelOptions } from "./embedding";
+export {
+  MISTRAL_OCR_LATEST,
+  MistralOcrModel,
+  type MistralOcrPage,
+  type MistralOcrRequest,
+  type MistralOcrResponse,
+  type MistralOcrSource,
+  type MistralOcrUploadedFile,
+} from "./ocr";

--- a/packages/provider-mistral/src/mistral/ocr.ts
+++ b/packages/provider-mistral/src/mistral/ocr.ts
@@ -157,7 +157,10 @@ export class MistralOcrModel {
     };
 
     if (request.additionalParams !== undefined && isPlainObject(request.additionalParams)) {
-      Object.assign(params, request.additionalParams);
+      const additionalParams = { ...request.additionalParams };
+      delete additionalParams.model;
+      delete additionalParams.document;
+      Object.assign(params, additionalParams);
     }
 
     if (request.pages !== undefined) params.pages = request.pages;

--- a/packages/provider-mistral/src/mistral/ocr.ts
+++ b/packages/provider-mistral/src/mistral/ocr.ts
@@ -1,0 +1,250 @@
+import type { JsonValue } from "@anvia/core/completion";
+import type { Mistral } from "@mistralai/mistralai";
+import { isPlainObject } from "../utils";
+
+export const MISTRAL_OCR_LATEST = "mistral-ocr-latest";
+
+export type MistralOcrSource =
+  | {
+      type: "document_url";
+      url: string;
+      documentName?: string | undefined;
+    }
+  | {
+      type: "image_url";
+      url: string;
+    }
+  | {
+      type: "file_id";
+      fileId: string;
+    }
+  | {
+      type: "bytes";
+      data: Uint8Array | ArrayBuffer;
+      filename: string;
+      expiry?: number | null | undefined;
+      visibility?: "workspace" | "user" | undefined;
+    };
+
+export type MistralOcrRequest = {
+  source: MistralOcrSource;
+  pages?: string | number[] | null | undefined;
+  includeImageBase64?: boolean | null | undefined;
+  imageLimit?: number | null | undefined;
+  imageMinSize?: number | null | undefined;
+  bboxAnnotationFormat?: JsonValue | null | undefined;
+  documentAnnotationFormat?: JsonValue | null | undefined;
+  documentAnnotationPrompt?: string | null | undefined;
+  tableFormat?: "markdown" | "html" | null | undefined;
+  extractHeader?: boolean | undefined;
+  extractFooter?: boolean | undefined;
+  confidenceScoresGranularity?: "word" | "page" | null | undefined;
+  additionalParams?: JsonValue | undefined;
+};
+
+export type MistralOcrUploadedFile = {
+  id: string;
+  filename?: string | undefined;
+  sizeBytes?: number | undefined;
+  purpose?: string | undefined;
+  rawResponse: unknown;
+};
+
+export type MistralOcrPage = {
+  index: number;
+  markdown: string;
+  images: unknown[];
+  tables?: unknown[] | undefined;
+  hyperlinks?: string[] | undefined;
+  header?: string | null | undefined;
+  footer?: string | null | undefined;
+  dimensions?: unknown;
+  confidenceScores?: unknown;
+};
+
+export type MistralOcrResponse<RawResponse = unknown> = {
+  text: string;
+  markdown: string;
+  pages: MistralOcrPage[];
+  model?: string | undefined;
+  usageInfo?: unknown;
+  documentAnnotation?: string | null | undefined;
+  uploadedFile?: MistralOcrUploadedFile | undefined;
+  rawResponse: RawResponse;
+};
+
+export class MistralOcrModel {
+  readonly provider = "mistral";
+
+  constructor(
+    private readonly client: Mistral,
+    readonly defaultModel = MISTRAL_OCR_LATEST,
+  ) {}
+
+  async ocr(request: MistralOcrRequest): Promise<MistralOcrResponse<unknown>> {
+    const { document, uploadedFile } = await this.documentFromSource(request.source);
+    const params = this.toOcrParams(request, document);
+    const response = await this.client.ocr.process(params as never);
+
+    return normalizeOcrResponse(response, uploadedFile);
+  }
+
+  private async documentFromSource(
+    source: MistralOcrSource,
+  ): Promise<{ document: Record<string, unknown>; uploadedFile?: MistralOcrUploadedFile }> {
+    if (source.type === "document_url") {
+      return {
+        document: {
+          type: "document_url",
+          documentUrl: source.url,
+          ...(source.documentName !== undefined ? { documentName: source.documentName } : {}),
+        },
+      };
+    }
+
+    if (source.type === "image_url") {
+      return {
+        document: {
+          type: "image_url",
+          imageUrl: source.url,
+        },
+      };
+    }
+
+    if (source.type === "file_id") {
+      return {
+        document: {
+          type: "file",
+          fileId: source.fileId,
+        },
+      };
+    }
+
+    const data = toUint8Array(source.data);
+    if (data.byteLength === 0) {
+      throw new Error("Mistral OCR byte source cannot be empty.");
+    }
+    if (source.filename.length === 0) {
+      throw new Error("Mistral OCR byte source filename cannot be empty.");
+    }
+
+    const uploadParams: Record<string, unknown> = {
+      file: {
+        content: data,
+        fileName: source.filename,
+      },
+      purpose: "ocr",
+    };
+    if (source.expiry !== undefined) uploadParams.expiry = source.expiry;
+    if (source.visibility !== undefined) uploadParams.visibility = source.visibility;
+
+    const uploadResponse = await this.client.files.upload(uploadParams as never);
+    const uploadedFile = uploadedFileFromResponse(uploadResponse);
+
+    return {
+      document: {
+        type: "file",
+        fileId: uploadedFile.id,
+      },
+      uploadedFile,
+    };
+  }
+
+  private toOcrParams(request: MistralOcrRequest, document: Record<string, unknown>) {
+    const params: Record<string, unknown> = {
+      model: this.defaultModel,
+      document,
+    };
+
+    if (request.additionalParams !== undefined && isPlainObject(request.additionalParams)) {
+      Object.assign(params, request.additionalParams);
+    }
+
+    if (request.pages !== undefined) params.pages = request.pages;
+    if (request.includeImageBase64 !== undefined) {
+      params.includeImageBase64 = request.includeImageBase64;
+    }
+    if (request.imageLimit !== undefined) params.imageLimit = request.imageLimit;
+    if (request.imageMinSize !== undefined) params.imageMinSize = request.imageMinSize;
+    if (request.bboxAnnotationFormat !== undefined) {
+      params.bboxAnnotationFormat = request.bboxAnnotationFormat;
+    }
+    if (request.documentAnnotationFormat !== undefined) {
+      params.documentAnnotationFormat = request.documentAnnotationFormat;
+    }
+    if (request.documentAnnotationPrompt !== undefined) {
+      params.documentAnnotationPrompt = request.documentAnnotationPrompt;
+    }
+    if (request.tableFormat !== undefined) params.tableFormat = request.tableFormat;
+    if (request.extractHeader !== undefined) params.extractHeader = request.extractHeader;
+    if (request.extractFooter !== undefined) params.extractFooter = request.extractFooter;
+    if (request.confidenceScoresGranularity !== undefined) {
+      params.confidenceScoresGranularity = request.confidenceScoresGranularity;
+    }
+
+    return params;
+  }
+}
+
+function normalizeOcrResponse(
+  response: unknown,
+  uploadedFile: MistralOcrUploadedFile | undefined,
+): MistralOcrResponse<unknown> {
+  const raw = isPlainObject(response) ? response : {};
+  const pages = Array.isArray(raw.pages) ? raw.pages.map(normalizeOcrPage) : [];
+  const markdown = pages.map((page) => page.markdown).join("\n\n");
+
+  return {
+    text: markdown,
+    markdown,
+    pages,
+    ...(typeof raw.model === "string" ? { model: raw.model } : {}),
+    ...(raw.usageInfo !== undefined ? { usageInfo: raw.usageInfo } : {}),
+    ...(typeof raw.documentAnnotation === "string" || raw.documentAnnotation === null
+      ? { documentAnnotation: raw.documentAnnotation }
+      : {}),
+    ...(uploadedFile !== undefined ? { uploadedFile } : {}),
+    rawResponse: response,
+  };
+}
+
+function normalizeOcrPage(page: unknown): MistralOcrPage {
+  const raw = isPlainObject(page) ? page : {};
+  return {
+    index: typeof raw.index === "number" ? raw.index : 0,
+    markdown: typeof raw.markdown === "string" ? raw.markdown : "",
+    images: Array.isArray(raw.images) ? raw.images : [],
+    ...(Array.isArray(raw.tables) ? { tables: raw.tables } : {}),
+    ...(isStringArray(raw.hyperlinks) ? { hyperlinks: raw.hyperlinks } : {}),
+    ...(typeof raw.header === "string" || raw.header === null ? { header: raw.header } : {}),
+    ...(typeof raw.footer === "string" || raw.footer === null ? { footer: raw.footer } : {}),
+    ...(raw.dimensions !== undefined ? { dimensions: raw.dimensions } : {}),
+    ...(raw.confidenceScores !== undefined ? { confidenceScores: raw.confidenceScores } : {}),
+  };
+}
+
+function uploadedFileFromResponse(response: unknown): MistralOcrUploadedFile {
+  if (!isPlainObject(response) || typeof response.id !== "string") {
+    throw new Error("Mistral OCR upload response contained no file id.");
+  }
+
+  return {
+    id: response.id,
+    ...(typeof response.filename === "string" ? { filename: response.filename } : {}),
+    ...(typeof response.sizeBytes === "number" ? { sizeBytes: response.sizeBytes } : {}),
+    ...(typeof response.purpose === "string" ? { purpose: response.purpose } : {}),
+    rawResponse: response,
+  };
+}
+
+function toUint8Array(data: Uint8Array | ArrayBuffer): Uint8Array {
+  if (data instanceof Uint8Array) {
+    return new Uint8Array(data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength));
+  }
+
+  return new Uint8Array(data);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}

--- a/packages/provider-mistral/test/client.test.ts
+++ b/packages/provider-mistral/test/client.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { MistralClient, MistralCompletionModel, MistralEmbeddingModel } from "../src/index";
+import {
+  MistralClient,
+  MistralCompletionModel,
+  MistralEmbeddingModel,
+  MistralOcrModel,
+} from "../src/index";
 
 describe("MistralClient", () => {
   it("validates explicit Mistral credentials", () => {
@@ -8,11 +13,12 @@ describe("MistralClient", () => {
     );
   });
 
-  it("creates completion and embedding models with an injected SDK client", () => {
+  it("creates completion, embedding, and OCR models with an injected SDK client", () => {
     const client = new MistralClient({ client: fakeSdk() as never });
 
     expect(client.completionModel()).toBeInstanceOf(MistralCompletionModel);
     expect(client.embeddingModel()).toBeInstanceOf(MistralEmbeddingModel);
+    expect(client.ocrModel()).toBeInstanceOf(MistralOcrModel);
   });
 
   it("lists models from the Mistral SDK", async () => {
@@ -60,6 +66,12 @@ function fakeSdk() {
     },
     embeddings: {
       create: async () => ({ data: [] }),
+    },
+    files: {
+      upload: async () => ({ id: "file-test" }),
+    },
+    ocr: {
+      process: async () => ({}),
     },
   };
 }

--- a/packages/provider-mistral/test/ocr.test.ts
+++ b/packages/provider-mistral/test/ocr.test.ts
@@ -72,6 +72,40 @@ describe("Mistral OCR models", () => {
     expect(response.rawResponse).toEqual(ocrResponse());
   });
 
+  it("does not allow additional params to override OCR model or document", async () => {
+    const calls: unknown[] = [];
+    const client = new MistralClient({
+      client: {
+        ocr: {
+          process: async (params: unknown) => {
+            calls.push(params);
+            return { pages: [] };
+          },
+        },
+      } as never,
+    });
+
+    await client.ocrModel("custom-ocr").ocr({
+      source: { type: "file_id", fileId: "file-123" },
+      additionalParams: {
+        model: "unsafe-model",
+        document: { type: "document_url", documentUrl: "https://example.com/unsafe.pdf" },
+        includeImageBase64: true,
+      },
+    });
+
+    expect(calls).toEqual([
+      {
+        model: "custom-ocr",
+        document: {
+          type: "file",
+          fileId: "file-123",
+        },
+        includeImageBase64: true,
+      },
+    ]);
+  });
+
   it("maps image URL and file id OCR requests", async () => {
     const calls: unknown[] = [];
     const client = new MistralClient({

--- a/packages/provider-mistral/test/ocr.test.ts
+++ b/packages/provider-mistral/test/ocr.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from "vitest";
+import { MISTRAL_OCR_LATEST, MistralClient } from "../src/index";
+
+describe("Mistral OCR models", () => {
+  it("maps document URL OCR requests", async () => {
+    const calls: unknown[] = [];
+    const client = new MistralClient({
+      client: {
+        ocr: {
+          process: async (params: unknown) => {
+            calls.push(params);
+            return ocrResponse();
+          },
+        },
+      } as never,
+    });
+
+    const response = await client.ocrModel().ocr({
+      source: {
+        type: "document_url",
+        url: "https://example.com/invoice.pdf",
+        documentName: "invoice.pdf",
+      },
+      pages: "0-2",
+      includeImageBase64: true,
+      tableFormat: "markdown",
+      extractHeader: true,
+      confidenceScoresGranularity: "page",
+      additionalParams: { imageLimit: 4, ignored: "kept" },
+    });
+
+    expect(calls).toEqual([
+      {
+        model: MISTRAL_OCR_LATEST,
+        document: {
+          type: "document_url",
+          documentUrl: "https://example.com/invoice.pdf",
+          documentName: "invoice.pdf",
+        },
+        imageLimit: 4,
+        ignored: "kept",
+        pages: "0-2",
+        includeImageBase64: true,
+        tableFormat: "markdown",
+        extractHeader: true,
+        confidenceScoresGranularity: "page",
+      },
+    ]);
+    expect(response.markdown).toBe("# Page 1\n\n# Page 2");
+    expect(response.text).toBe("# Page 1\n\n# Page 2");
+    expect(response.pages).toEqual([
+      {
+        index: 0,
+        markdown: "# Page 1",
+        images: [],
+        dimensions: { width: 100, height: 200 },
+      },
+      {
+        index: 1,
+        markdown: "# Page 2",
+        images: [{ id: "image-1" }],
+        tables: [{ rows: 2 }],
+        hyperlinks: ["https://example.com"],
+        header: "Header",
+        footer: "Footer",
+        dimensions: null,
+        confidenceScores: { page: 0.98 },
+      },
+    ]);
+    expect(response.model).toBe("mistral-ocr-latest");
+    expect(response.usageInfo).toEqual({ pagesProcessed: 2, docSizeBytes: 1234 });
+    expect(response.rawResponse).toEqual(ocrResponse());
+  });
+
+  it("maps image URL and file id OCR requests", async () => {
+    const calls: unknown[] = [];
+    const client = new MistralClient({
+      client: {
+        ocr: {
+          process: async (params: unknown) => {
+            calls.push(params);
+            return { pages: [] };
+          },
+        },
+      } as never,
+    });
+
+    await client.ocrModel("custom-ocr").ocr({
+      source: { type: "image_url", url: "https://example.com/page.png" },
+    });
+    await client.ocrModel("custom-ocr").ocr({
+      source: { type: "file_id", fileId: "file-123" },
+    });
+
+    expect(calls).toEqual([
+      {
+        model: "custom-ocr",
+        document: {
+          type: "image_url",
+          imageUrl: "https://example.com/page.png",
+        },
+      },
+      {
+        model: "custom-ocr",
+        document: {
+          type: "file",
+          fileId: "file-123",
+        },
+      },
+    ]);
+  });
+
+  it("uploads byte sources before running OCR and keeps upload metadata", async () => {
+    const uploads: unknown[] = [];
+    const ocrCalls: unknown[] = [];
+    const client = new MistralClient({
+      client: {
+        files: {
+          upload: async (params: unknown) => {
+            uploads.push(params);
+            return {
+              id: "uploaded-file",
+              filename: "scan.pdf",
+              sizeBytes: 3,
+              purpose: "ocr",
+            };
+          },
+        },
+        ocr: {
+          process: async (params: unknown) => {
+            ocrCalls.push(params);
+            return ocrResponse();
+          },
+        },
+      } as never,
+    });
+
+    const response = await client.ocrModel().ocr({
+      source: {
+        type: "bytes",
+        data: new Uint8Array([1, 2, 3]),
+        filename: "scan.pdf",
+        expiry: 3600,
+        visibility: "user",
+      },
+    });
+
+    expect(uploads).toEqual([
+      {
+        file: {
+          content: new Uint8Array([1, 2, 3]),
+          fileName: "scan.pdf",
+        },
+        purpose: "ocr",
+        expiry: 3600,
+        visibility: "user",
+      },
+    ]);
+    expect(ocrCalls).toEqual([
+      {
+        model: MISTRAL_OCR_LATEST,
+        document: {
+          type: "file",
+          fileId: "uploaded-file",
+        },
+      },
+    ]);
+    expect(response.uploadedFile).toEqual({
+      id: "uploaded-file",
+      filename: "scan.pdf",
+      sizeBytes: 3,
+      purpose: "ocr",
+      rawResponse: {
+        id: "uploaded-file",
+        filename: "scan.pdf",
+        sizeBytes: 3,
+        purpose: "ocr",
+      },
+    });
+  });
+
+  it("rejects empty byte sources before uploading", async () => {
+    const client = new MistralClient({
+      client: {
+        files: {
+          upload: async () => {
+            throw new Error("The provider should not be called for empty input.");
+          },
+        },
+        ocr: {
+          process: async () => {
+            throw new Error("The provider should not be called for empty input.");
+          },
+        },
+      } as never,
+    });
+
+    await expect(
+      client.ocrModel().ocr({
+        source: { type: "bytes", data: new Uint8Array(), filename: "empty.pdf" },
+      }),
+    ).rejects.toThrow("Mistral OCR byte source cannot be empty.");
+  });
+});
+
+function ocrResponse() {
+  return {
+    model: "mistral-ocr-latest",
+    pages: [
+      {
+        index: 0,
+        markdown: "# Page 1",
+        images: [],
+        dimensions: { width: 100, height: 200 },
+      },
+      {
+        index: 1,
+        markdown: "# Page 2",
+        images: [{ id: "image-1" }],
+        tables: [{ rows: 2 }],
+        hyperlinks: ["https://example.com"],
+        header: "Header",
+        footer: "Footer",
+        dimensions: null,
+        confidenceScores: { page: 0.98 },
+      },
+    ],
+    usageInfo: { pagesProcessed: 2, docSizeBytes: 1234 },
+  };
+}


### PR DESCRIPTION
## Summary
- add provider-specific Mistral OCR wrapper via client.ocrModel()
- support document URLs, image URLs, file IDs, and byte upload sources
- export OCR types/constants and update Mistral docs/reference coverage

## Verification
- pnpm --filter @anvia/mistral test
- pnpm --filter @anvia/mistral typecheck
- pnpm --filter @anvia/mistral build
- pnpm --filter docs reference-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OCR support for the Mistral provider, including a new `ocrModel()` entry point for extracting text from documents and images.
  * Supports document URLs, image URLs, file IDs, and byte uploads, returning structured markdown and per-page results with metadata.
* **Documentation**
  * Updated provider and package docs to describe OCR usage and capabilities, and clarified that chat image/document attachments are still rejected until multimodal mapping is available.
* **Tests**
  * Added coverage for OCR requests, source mapping, byte-upload flow, and error handling for empty byte sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->