### PR TITLE
Add changeset for Mistral OCR

### DIFF
--- a/.changeset/mistral-ocr-support.md
+++ b/.changeset/mistral-ocr-support.md
@@ -1,0 +1,5 @@
+---
+"@anvia/mistral": minor
+---
+
+Add a Mistral OCR model adapter with `client.ocrModel()`, support for document URLs, image URLs, file IDs, and byte uploads, plus normalized OCR response metadata.


### PR DESCRIPTION
## Summary
- add missing changeset for the Mistral OCR public API
- mark @anvia/mistral as a minor release because client.ocrModel() and OCR types were added

## Verification
- changeset file only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Mistral-powered OCR capabilities for document and image recognition.
  * Supports multiple input formats: URLs, file IDs, and direct uploads.
  * OCR results include normalized metadata for consistent formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->