### PR TITLE
feat(langfuse): phased improvements to scoring, tracing, evals, prompts, datasets, and redaction

### DIFF
--- a/.changeset/core-agent-generation-update.md
+++ b/.changeset/core-agent-generation-update.md
@@ -1,0 +1,11 @@
+---
+"@anvia/core": minor
+---
+
+Add an optional `update?` hook on `AgentGenerationObserver` so
+observability adapters can record streaming deltas as they arrive.
+
+The agent loop now awaits `observer.update?.({ turn, delta })` for
+every delta produced by the underlying completion stream. The new
+method is optional, so existing adapters keep working. A new
+`AgentGenerationUpdateArgs` type is exported alongside.

--- a/.changeset/core-agent-run-event.md
+++ b/.changeset/core-agent-run-event.md
@@ -1,0 +1,12 @@
+---
+"@anvia/core": minor
+---
+
+Add an optional `event?` hook on `AgentRunObserver` so
+observability adapters can record ad-hoc checkpoints (e.g.
+retrieval, validation) during a run.
+
+The new method accepts an `AgentRunEventArgs` value with a `name`,
+optional `attributes` map, optional `level`, and optional
+`timestamp`. The hook is optional, so existing adapters keep
+working without modification.

--- a/.changeset/core-agent-run-prompt-ref.md
+++ b/.changeset/core-agent-run-prompt-ref.md
@@ -1,0 +1,12 @@
+---
+"@anvia/core": minor
+---
+
+Add an optional `promptRef?: { name; version? }` field on
+`AgentRunStartArgs`. Observability adapters can use this to
+record the prompt name and version on the trace root and on
+each generation in the run.
+
+The new field is optional, so existing call sites keep
+compiling. The `AgentRunPromptRef` type is also exported
+alongside.

--- a/.changeset/core-eval-metric-annotations.md
+++ b/.changeset/core-eval-metric-annotations.md
@@ -1,0 +1,12 @@
+---
+"@anvia/core": minor
+---
+
+Extend the `EvalMetric` type with optional Langfuse-related
+annotations: `dataType`, `scoreConfigId`, `configId`, and
+`metadata`. All fields are optional, so existing metric definitions
+keep compiling unchanged.
+
+Add a `defineMetric()` identity helper that wraps a metric
+definition for clearer intent at call sites. Re-export it from
+`@anvia/core/evals`.

--- a/.changeset/langfuse-config-foundations.md
+++ b/.changeset/langfuse-config-foundations.md
@@ -1,0 +1,15 @@
+---
+"@anvia/langfuse": minor
+---
+
+Add env-var auto-init for tracing config and a `serviceName` option.
+
+`langfuse.create()` now reads `LANGFUSE_PUBLIC_KEY`,
+`LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`,
+`LANGFUSE_TRACING_ENVIRONMENT`, `LANGFUSE_RELEASE`, and
+`LANGFUSE_SERVICE_NAME` from the environment when the matching option
+is not provided. Explicit options still win over env vars.
+
+The new `serviceName` option is recorded on the root observation's
+metadata and set as the OpenTelemetry `service.name` resource
+attribute on the underlying `NodeSDK`.

--- a/.changeset/langfuse-datasets.md
+++ b/.changeset/langfuse-datasets.md
@@ -1,0 +1,30 @@
+---
+"@anvia/langfuse": minor
+---
+
+Add Langfuse dataset and experiment-run support.
+
+`createLangfuseDatasetClient(tracing, options)` exposes four
+methods:
+
+- `createDataset({ name, description?, metadata? })` PUTs to
+  `/api/public/datasets/:name`.
+- `getDataset(name)` GETs `/api/public/datasets/:name` with
+  pagination driven by `meta.totalPages`.
+- `upsertItems(name, items)` POSTs the items array to
+  `/api/public/datasets/:name/items`.
+- `runExperiment({ datasetName, runName, items?, run })` POSTs
+  one batched payload to `/api/public/dataset-run-items` with
+  `{ runName, runDescription?, metadata?, datasetItemRuns }`.
+  When `items` is not provided the client fetches them from the
+  remote dataset first. Per-item failures are collected in
+  `errors`; the batch still posts with the successful subset.
+
+`runEvalAsExperiment(evalOptions, experimentOptions)` runs an
+`@anvia/core/evals` suite and posts a dataset run alongside the
+metric scores, returning both `{ suite, datasetRun }`.
+
+Auth uses the same `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY`
+env vars and base URL as `langfuse.create()`. Per-request
+timeout defaults to 30 seconds (configurable via
+`options.timeoutMs`).

--- a/.changeset/langfuse-eval-reporter-metadata.md
+++ b/.changeset/langfuse-eval-reporter-metadata.md
@@ -1,0 +1,25 @@
+---
+"@anvia/langfuse": minor
+---
+
+Enrich the eval reporter with metadata, dataType propagation,
+truncated input/expected summaries, and a configurable
+`onMissingTrace` mode.
+
+- Score body now includes `args.metric.metadata`, `dataType`,
+  `configId`/`scoreConfigId` from `args.metric`. Categorical and
+  boolean outcomes are sent with the correct `value` shape and
+  dataType.
+- `case.input` and `case.expected` are JSON-serialized and added as
+  `caseInputSummary` / `caseExpectedSummary` in score metadata,
+  truncated to `truncateInputAt` bytes (default 2048) with a
+  `<truncated>` marker.
+- `output.messages` is included by default; opt out with
+  `includeMessages: false`.
+- New `onMissingTrace` option (`"ignore" | "warn" | "throw"`)
+  controls reporter behavior when no trace can be resolved. The
+  legacy `strict: true` flag is now an alias for `"throw"`.
+- Trace resolution now falls back to `args.case.input.trace` if
+  `args.output.trace` is missing.
+- The reporter does not mutate `args.metric.metadata`,
+  `args.case.metadata`, or `args.outcome.metadata`.

--- a/.changeset/langfuse-pii-redaction.md
+++ b/.changeset/langfuse-pii-redaction.md
@@ -1,0 +1,5 @@
+---
+"@anvia/langfuse": minor
+---
+
+Add PII redaction helpers. `createPiiRedactor` ships with default patterns for emails, credit cards (Luhn-validated), phones, IPv4 addresses, JWTs, and API keys, and supports `redactString`, `redactObject`, and `redactMessages`. Configure tracing with `redactInputs`, `redactOutputs`, and `redaction` to mask text before it leaves the process; `"deep"` recurses into nested values.

--- a/.changeset/langfuse-prompt-management.md
+++ b/.changeset/langfuse-prompt-management.md
@@ -1,0 +1,31 @@
+---
+"@anvia/langfuse": minor
+---
+
+Add a Langfuse prompt client and prompt-attribute binding on
+traces and generations.
+
+`createLangfusePromptClient(tracing, options)` exposes four
+methods:
+
+- `getPrompt(name, { version?, label?, cacheTtlMs?, refresh? })`
+  GETs `/api/public/v2/prompts/:name` and returns a parsed
+  `LangfusePrompt` (text or chat). Responses are cached in
+  memory for `cacheTtlMs` (default 60 s), keyed by
+  `name::version::label`.
+- `getPromptText(name, options?)` projects the prompt string.
+- `getPromptChat(name, options?)` projects the chat message
+  array.
+- `refresh()` clears the cache.
+
+The langfuse tracing instance now reads the prompt ref from
+`args.promptRef` (typed) or `args.trace.metadata.promptName` /
+`promptVersion` (string-keyed fallback) on `startRun`, and
+attaches `langfuse.trace.metadata.promptName` /
+`langfuse.trace.metadata.promptVersion` to the root and to each
+generation in the run.
+
+Auth uses the same `LANGFUSE_PUBLIC_KEY` /
+`LANGFUSE_SECRET_KEY` env vars and base URL as
+`langfuse.create()`. Per-request timeout defaults to 30
+seconds, configurable via `options.timeoutMs`.

--- a/.changeset/langfuse-score-batching-and-retry.md
+++ b/.changeset/langfuse-score-batching-and-retry.md
@@ -1,0 +1,19 @@
+---
+"@anvia/langfuse": minor
+---
+
+Add an in-memory score queue with batched sends, exponential-backoff
+retry, and a manual flush method.
+
+- New `scoreBatchSize`, `scoreFlushIntervalMs` (default 250), and
+  `scoreMaxRetries` (default 3) options on `LangfuseTracingOptions`.
+  Setting `scoreBatchSize` enables the queue; the default is direct
+  send.
+- New `flushScores()` and `scoreQueueDepth()` methods on
+  `LangfuseTracing`. `flush()` and `shutdown()` also drain the queue.
+- Retries on 429 and 5xx with exponential backoff (200 ms base,
+  2x factor, ±25% jitter, capped at 5 s). Other 4xx throw
+  immediately.
+- New `LangfuseScoreError` class. After all retries are exhausted,
+  the error's `scores` property contains the failed payloads.
+- New `LangfuseScoreDataType` type export.

--- a/.changeset/langfuse-streaming-deltas.md
+++ b/.changeset/langfuse-streaming-deltas.md
@@ -1,0 +1,8 @@
+---
+"@anvia/langfuse": minor
+---
+
+Forward every streaming delta to Langfuse via
+`generation.update({ output: { delta } })`, so dashboards reflect
+partial output as the model produces it. Supported delta types:
+`text_delta`, `reasoning_delta`, and `tool_call`.

--- a/.changeset/langfuse-trace-handle.md
+++ b/.changeset/langfuse-trace-handle.md
@@ -1,0 +1,26 @@
+---
+"@anvia/langfuse": minor
+---
+
+Add `LangfuseTraceHandle` and `getCurrentTrace()` to the langfuse
+tracing instance so user code can record event observations and
+attach attributes to the active trace without threading the run
+observer through every function call.
+
+`LangfuseTracing` now exposes `getCurrentTrace(): LangfuseTraceHandle | undefined`
+and the returned handle has three fields:
+
+- `traceId` and `observationId` for correlation
+- `addAttributes(attributes)` to set metadata on the root
+  observation
+- `addEvent(name, attributes?)` to create a Langfuse `event`
+  observation under the root
+
+The handle is populated when `startRun` is called and cleared when
+the run `end`s or `error`s. The handle is per-tracing-instance and
+last-write-wins; concurrent runs on the same instance will race.
+
+The langfuse adapter also implements the new `event?(...)` hook
+that was added to `AgentRunObserver` in `@anvia/core`. Calling
+`runObserver.event?.({ name, attributes })` creates a Langfuse
+`event` observation under the active root and ends it immediately.

--- a/.changeset/langfuse-tracing-surface-enrichment.md
+++ b/.changeset/langfuse-tracing-surface-enrichment.md
@@ -1,0 +1,14 @@
+---
+"@anvia/langfuse": minor
+---
+
+Record extra data on Langfuse observations so the UI shows everything
+the agent runtime emits.
+
+- Generation observations now carry `providerRequest` and `modelInfo`
+  on start, and `firstDeltaMs` on end.
+- Tool observations now carry `toolDefinition` and `toolMetadata` on
+  start, and `structuredResult` on end.
+- `usageDetailsFromRecord` now consistently includes
+  `cachedInputTokens` and `cacheCreationInputTokens` to match the
+  main `usageDetails` helper.

--- a/.changeset/langfuse-typed-score-api.md
+++ b/.changeset/langfuse-typed-score-api.md
@@ -1,0 +1,15 @@
+---
+"@anvia/langfuse": minor
+---
+
+Add typed scores and per-score overrides to `tracing.score()`.
+
+- New `dataType` field (`"NUMERIC" | "CATEGORICAL" | "BOOLEAN"`)
+  with boundary validation. `value` is now `number | string` to
+  support CATEGORICAL scores.
+- New `configId` (canonical) and `scoreConfigId` (alias) fields for
+  Langfuse score configs.
+- New `environment` per-score override.
+- New `timestamp` accepting `Date` or ISO 8601 string.
+- New `timeoutMs` option on `LangfuseTracingOptions` (default 30 s),
+  applied via `AbortSignal.timeout` to the score fetch.

--- a/apps/docs/content/docs/reference/core/evals.mdx
+++ b/apps/docs/content/docs/reference/core/evals.mdx
@@ -36,6 +36,10 @@ Purpose: normalized metric result. Use `EvalOutcome.pass(...)`, `EvalOutcome.fai
 ```ts
 type EvalMetric<Input, Output, Score = unknown, Expected = unknown> = {
   name: string;
+  dataType?: "NUMERIC" | "CATEGORICAL" | "BOOLEAN";
+  configId?: string;
+  scoreConfigId?: string;
+  metadata?: Record<string, JsonValue | undefined>;
   evaluate(args: EvalMetricArgs<Input, Output, Expected>): EvalOutcome<Score> | Promise<EvalOutcome<Score>>;
 };
 
@@ -57,9 +61,13 @@ type EvalCaseResult<Input, Output, Expected = unknown> = {
   targetError?: unknown;
   metrics: EvalMetricResult[];
 };
+
+function defineMetric<Input, Output, Score, Expected>(
+  metric: EvalMetric<Input, Output, Score, Expected>,
+): EvalMetric<Input, Output, Score, Expected>;
 ```
 
-Purpose: evaluates one case output and records normalized metric results.
+Purpose: evaluates one case output and records normalized metric results. `defineMetric` is an identity helper that preserves type inference and signals intent when adding optional annotations.
 
 ## EvalReporter
 

--- a/apps/docs/content/docs/reference/core/observability.mdx
+++ b/apps/docs/content/docs/reference/core/observability.mdx
@@ -40,8 +40,14 @@ type AgentRunStartArgs = {
   instructions?: string;
   trace?: AgentTraceOptions;
   prompt: Message;
+  promptRef?: AgentRunPromptRef;
   history: Message[];
   maxTurns: number;
+};
+
+type AgentRunPromptRef = {
+  name: string;
+  version?: number;
 };
 
 type AgentRunEndArgs = {
@@ -51,6 +57,13 @@ type AgentRunEndArgs = {
 };
 
 type AgentRunErrorArgs = { error: unknown; usage: Usage; messages: Message[] };
+
+type AgentRunEventArgs = {
+  name: string;
+  attributes?: Record<string, JsonValue | undefined>;
+  level?: "DEFAULT" | "WARNING" | "ERROR";
+  timestamp?: Date | string;
+};
 
 interface AgentRunObserver {
   readonly trace?: AgentTraceInfo;
@@ -62,6 +75,7 @@ interface AgentRunObserver {
   ): AgentToolObserver | undefined | Promise<AgentToolObserver | undefined>;
   end(args: AgentRunEndArgs): void | Promise<void>;
   error?(args: AgentRunErrorArgs): void | Promise<void>;
+  event?(args: AgentRunEventArgs): void | Promise<void>;
 }
 ```
 
@@ -81,10 +95,15 @@ type AgentGenerationEndArgs<RawResponse = unknown> = {
   firstDeltaMs?: number;
 };
 type AgentGenerationErrorArgs = { turn: number; error: unknown };
+type AgentGenerationUpdateArgs = {
+  turn: number;
+  delta: AgentDeltaEvent;
+};
 
 interface AgentGenerationObserver {
   end(args: AgentGenerationEndArgs): void | Promise<void>;
   error?(args: AgentGenerationErrorArgs): void | Promise<void>;
+  update?(args: AgentGenerationUpdateArgs): void | Promise<void>;
 }
 
 type AgentToolStartArgs = {

--- a/apps/docs/content/docs/reference/integrations/langfuse.mdx
+++ b/apps/docs/content/docs/reference/integrations/langfuse.mdx
@@ -14,10 +14,18 @@ type LangfuseTracingOptions = {
   baseUrl?: string;
   environment?: string;
   release?: string;
+  serviceName?: string;
+  timeoutMs?: number;
+  scoreBatchSize?: number;
+  scoreFlushIntervalMs?: number;
+  scoreMaxRetries?: number;
+  redactInputs?: LangfuseRedactionMode;
+  redactOutputs?: LangfuseRedactionMode;
+  redaction?: LangfuseRedactionOptions;
 };
 ```
 
-Purpose: configure Langfuse tracing and scoring.
+Purpose: configure Langfuse tracing, scoring, batching, and redaction.
 
 Return behavior: consumed by `langfuse.create(...)`.
 
@@ -30,25 +38,52 @@ type LangfuseTracing = AgentObserver & {
   flush(): Promise<void>;
   shutdown(): Promise<void>;
   score(args: LangfuseScoreArgs): Promise<void>;
+  flushScores(): Promise<void>;
+  scoreQueueDepth(): number;
+  getCurrentTrace(): LangfuseTraceHandle | undefined;
 };
 ```
 
-Purpose: Agent observer with Langfuse lifecycle and scoring methods.
+Purpose: Agent observer with Langfuse lifecycle, scoring, and trace-handle methods.
 
 Return behavior: can be passed to `AgentBuilder.observe(...)`.
 
 Notable errors: `score(...)` throws without a trace id or credentials and rejects on Langfuse API failures.
 
+## LangfuseTraceHandle
+
+```ts
+type LangfuseTraceHandle = {
+  readonly traceId: string;
+  readonly observationId: string;
+  addAttributes(attributes: Record<string, JsonValue | undefined>): void;
+  addEvent(name: string, attributes?: Record<string, JsonValue | undefined>): void;
+};
+```
+
+Purpose: record ad-hoc checkpoints and attach metadata to the active trace without threading the run observer through every function call.
+
+Return behavior: `addEvent(...)` creates an event observation under the active root; `addAttributes(...)` updates the root observation's metadata.
+
+Notable errors: calls after the run ends reject because the root observation no longer accepts children.
+
 ## LangfuseScoreArgs
 
 ```ts
+type LangfuseScoreDataType = "NUMERIC" | "CATEGORICAL" | "BOOLEAN";
+
 type LangfuseScoreArgs = {
   traceId?: string;
   observationId?: string;
   name: string;
-  value: number;
+  value: number | string;
+  dataType?: LangfuseScoreDataType;
   comment?: string;
   metadata?: Record<string, JsonValue | undefined>;
+  configId?: string;
+  scoreConfigId?: string;
+  environment?: string;
+  timestamp?: Date | string;
 };
 ```
 
@@ -57,6 +92,17 @@ Purpose: submit Langfuse scores for a trace or observation.
 Return behavior: consumed by `LangfuseTracing.score(...)`.
 
 Notable errors: score submission requires a trace id and Langfuse credentials.
+
+## LangfuseScoreError
+
+```ts
+class LangfuseScoreError extends Error {
+  readonly scores: LangfuseScoreArgs[];
+  override readonly cause?: unknown;
+}
+```
+
+Purpose: raised when a queued score exhausts retries; carries the failed payloads on `scores`.
 
 ## langfuse
 
@@ -78,6 +124,9 @@ Notable errors: construction or later flush/shutdown can fail through OpenTeleme
 type LangfuseEvalReporterOptions = {
   publishInvalid?: boolean;
   strict?: boolean;
+  onMissingTrace?: "ignore" | "warn" | "throw";
+  truncateInputAt?: number;
+  includeMessages?: boolean;
 };
 
 function createLangfuseEvalReporter<Input = unknown, Output = unknown, Expected = unknown>(
@@ -90,4 +139,196 @@ Purpose: bridge core eval metric results to Langfuse scores.
 
 Return behavior: returns an `EvalReporter` for `runEvalSuite(...)`. Invalid outcomes are skipped unless `publishInvalid` is true.
 
-Notable errors: with `strict: true`, missing trace ids reject the reporter call; scoring errors reject through the supplied tracing object.
+Notable errors: with `strict: true` (or `onMissingTrace: "throw"`), missing trace ids reject the reporter call; scoring errors reject through the supplied tracing object.
+
+## Datasets and Experiments
+
+```ts
+type LangfuseDatasetClientOptions = {
+  baseUrl?: string;
+  publicKey?: string;
+  secretKey?: string;
+  pageSize?: number;
+  timeoutMs?: number;
+};
+
+type LangfuseDatasetItem<Input = unknown, Expected = unknown> = {
+  id: string;
+  input: Input;
+  expected?: Expected;
+  metadata?: Record<string, JsonValue | undefined>;
+};
+
+type LangfuseDataset<Input = unknown, Expected = unknown> = {
+  name: string;
+  description?: string;
+  metadata?: Record<string, JsonValue | undefined>;
+  items: LangfuseDatasetItem<Input, Expected>[];
+};
+
+type LangfuseRunItemResult<Output = unknown> = {
+  output: Output;
+  trace?: { traceId: string; observationId?: string };
+};
+
+type LangfuseRunItemError = {
+  itemId: string;
+  error: unknown;
+};
+
+type LangfuseRunExperimentOptions<Input = unknown, Output = unknown, Expected = unknown> = {
+  datasetName: string;
+  runName: string;
+  description?: string;
+  metadata?: Record<string, JsonValue | undefined>;
+  items?: LangfuseDatasetItem<Input, Expected>[];
+  run: (item: LangfuseDatasetItem<Input, Expected>) =>
+    | LangfuseRunItemResult<Output>
+    | Promise<LangfuseRunItemResult<Output>>;
+};
+
+type LangfuseRunExperimentResult = {
+  runName: string;
+  datasetName: string;
+  posted: number;
+  errors: LangfuseRunItemError[];
+};
+
+type LangfuseDatasetClient = {
+  createDataset(dataset: {
+    name: string;
+    description?: string;
+    metadata?: Record<string, JsonValue | undefined>;
+  }): Promise<LangfuseDataset<unknown, unknown>>;
+  getDataset<Input, Expected>(name: string): Promise<LangfuseDataset<Input, Expected>>;
+  upsertItems<Input, Expected>(
+    name: string,
+    items: LangfuseDatasetItem<Input, Expected>[],
+  ): Promise<void>;
+  runExperiment<Input, Output, Expected>(
+    options: LangfuseRunExperimentOptions<Input, Output, Expected>,
+  ): Promise<LangfuseRunExperimentResult>;
+};
+
+function createLangfuseDatasetClient(
+  tracing: Pick<LangfuseTracing, "score">,
+  options: LangfuseDatasetClientOptions,
+): LangfuseDatasetClient;
+```
+
+Purpose: manage Langfuse datasets and post batched dataset runs.
+
+Return behavior: `createDataset` / `getDataset` round-trip dataset metadata; `upsertItems` posts items to the dataset; `runExperiment` runs the supplied `run` per item and posts the successful results.
+
+Notable errors: non-2xx on the batched run POST throws, with item-level errors surfaced on the thrown error.
+
+## Eval Experiment Runner
+
+```ts
+type RunEvalAsExperimentOptions = {
+  tracing: Pick<LangfuseTracing, "score">;
+  datasetName: string;
+  runName: string;
+  description?: string;
+  metadata?: Record<string, JsonValue | undefined>;
+  reporters?: ReadonlyArray<EvalReporter<unknown, unknown, unknown>>;
+};
+
+type RunEvalAsExperimentResult = {
+  suite: EvalSuiteResult<unknown, unknown, unknown>;
+  datasetRun: LangfuseRunExperimentResult;
+};
+
+function runEvalAsExperiment(
+  evalOptions: RunEvalSuiteOptions<unknown, unknown, unknown>,
+  experimentOptions: RunEvalAsExperimentOptions,
+): Promise<RunEvalAsExperimentResult>;
+```
+
+Purpose: run an eval suite and post the results as a Langfuse dataset run alongside the metric scores.
+
+## Prompt Management
+
+```ts
+type LangfusePromptClientOptions = {
+  baseUrl?: string;
+  publicKey?: string;
+  secretKey?: string;
+  cacheTtlMs?: number;
+  timeoutMs?: number;
+};
+
+type LangfusePromptGetOptions = {
+  version?: number;
+  label?: string;
+  cacheTtlMs?: number;
+  refresh?: boolean;
+};
+
+type LangfuseChatMessage = {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string;
+};
+
+type LangfusePrompt = {
+  name: string;
+  version: number;
+  labels: string[];
+  prompt: string | LangfuseChatMessage[];
+  type: "text" | "chat";
+  tags?: string[];
+  resolvedAt: Date;
+};
+
+type LangfusePromptClient = {
+  getPrompt(name: string, options?: LangfusePromptGetOptions): Promise<LangfusePrompt>;
+  getPromptText(name: string, options?: LangfusePromptGetOptions): Promise<string>;
+  getPromptChat(name: string, options?: LangfusePromptGetOptions): Promise<LangfuseChatMessage[]>;
+  refresh(): void;
+};
+
+function createLangfusePromptClient(
+  tracing: Pick<LangfuseTracing, "score">,
+  options: LangfusePromptClientOptions,
+): LangfusePromptClient;
+```
+
+Purpose: fetch prompts from Langfuse's prompt store with an in-memory TTL cache.
+
+Return behavior: `getPromptText` / `getPromptChat` throw if the resolved prompt is the other shape.
+
+Notable errors: invalid prompts throw; per-request timeouts throw via `AbortSignal.timeout`.
+
+## PII Redaction
+
+```ts
+type LangfuseRedactionMode = boolean | "deep";
+
+type RedactorPattern = {
+  name: string;
+  regex: RegExp;
+};
+
+type LangfuseRedactionOptions = {
+  patterns?: RedactorPattern[];
+  replacement?: string;
+};
+
+type PiiRedactor = {
+  redactString(input: string): string;
+  redactObject<T>(input: T): T;
+  redactMessages(input: Message[]): Message[];
+  patternNames(): string[];
+};
+
+const DEFAULT_PATTERNS: RedactorPattern[];
+
+function createPiiRedactor(options?: LangfuseRedactionOptions): PiiRedactor;
+```
+
+Purpose: mask personally identifiable information before it leaves the process.
+
+Return behavior: `redactString` runs configured patterns in order; `redactObject` recurses into nested values; `redactMessages` redacts the text parts of message content arrays.
+
+Notable errors: redaction failures propagate so callers can choose to retry or fall back.
+

--- a/packages/core/src/agent/request.ts
+++ b/packages/core/src/agent/request.ts
@@ -348,6 +348,7 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
               throw event.error;
             }
             if (mapped !== undefined) {
+              await generationObservers.update?.({ turn: currentTurns, delta: mapped });
               yield await emit(addTurn(currentTurns, mapped));
             }
           }

--- a/packages/core/src/evals/index.ts
+++ b/packages/core/src/evals/index.ts
@@ -1,4 +1,5 @@
 export * from "./agent-target";
+export { defineMetric } from "./metric";
 export * from "./metrics";
 export * from "./outcome";
 export { runEvalSuite } from "./runner";

--- a/packages/core/src/evals/metric.ts
+++ b/packages/core/src/evals/metric.ts
@@ -1,0 +1,7 @@
+import type { EvalMetric } from "./types";
+
+export function defineMetric<Input, Output, Score, Expected>(
+  metric: EvalMetric<Input, Output, Score, Expected>,
+): EvalMetric<Input, Output, Score, Expected> {
+  return metric;
+}

--- a/packages/core/src/evals/types.ts
+++ b/packages/core/src/evals/types.ts
@@ -25,6 +25,10 @@ export type EvalMetricArgs<Input, Output, Expected = unknown> = {
 
 export type EvalMetric<Input, Output, Score = unknown, Expected = unknown> = {
   name: string;
+  dataType?: "NUMERIC" | "CATEGORICAL" | "BOOLEAN" | undefined;
+  scoreConfigId?: string | undefined;
+  configId?: string | undefined;
+  metadata?: EvalMetadata | undefined;
   evaluate(
     args: EvalMetricArgs<Input, Output, Expected>,
   ): EvalOutcome<Score> | Promise<EvalOutcome<Score>>;

--- a/packages/core/src/observability/group.ts
+++ b/packages/core/src/observability/group.ts
@@ -3,6 +3,7 @@ import type {
   AgentGenerationErrorArgs,
   AgentGenerationObserver,
   AgentGenerationStartArgs,
+  AgentGenerationUpdateArgs,
   AgentObserverRegistration,
   AgentRunEndArgs,
   AgentRunErrorArgs,
@@ -137,6 +138,19 @@ export class ActiveGenerationObservers {
       }
       try {
         await observer.error(args);
+      } catch (error) {
+        this.handleError(error);
+      }
+    }
+  }
+
+  async update(args: AgentGenerationUpdateArgs): Promise<void> {
+    for (const observer of this.generationObservers) {
+      if (observer.update === undefined) {
+        continue;
+      }
+      try {
+        await observer.update(args);
       } catch (error) {
         this.handleError(error);
       }

--- a/packages/core/src/observability/group.ts
+++ b/packages/core/src/observability/group.ts
@@ -7,6 +7,7 @@ import type {
   AgentObserverRegistration,
   AgentRunEndArgs,
   AgentRunErrorArgs,
+  AgentRunEventArgs,
   AgentRunObserver,
   AgentRunStartArgs,
   AgentToolEndArgs,
@@ -102,6 +103,19 @@ export class ActiveAgentRunObservers {
       }
       try {
         await runObserver.error(args);
+      } catch (error) {
+        this.handleError(error);
+      }
+    }
+  }
+
+  async event(args: AgentRunEventArgs): Promise<void> {
+    for (const runObserver of this.runObservers) {
+      if (runObserver.event === undefined) {
+        continue;
+      }
+      try {
+        await runObserver.event(args);
       } catch (error) {
         this.handleError(error);
       }

--- a/packages/core/src/observability/index.ts
+++ b/packages/core/src/observability/index.ts
@@ -3,6 +3,7 @@ export type {
   AgentGenerationErrorArgs,
   AgentGenerationObserver,
   AgentGenerationStartArgs,
+  AgentGenerationUpdateArgs,
   AgentObserver,
   AgentObserverRegistration,
   AgentRunEndArgs,

--- a/packages/core/src/observability/index.ts
+++ b/packages/core/src/observability/index.ts
@@ -10,6 +10,7 @@ export type {
   AgentRunErrorArgs,
   AgentRunEventArgs,
   AgentRunObserver,
+  AgentRunPromptRef,
   AgentRunStartArgs,
   AgentToolEndArgs,
   AgentToolErrorArgs,

--- a/packages/core/src/observability/index.ts
+++ b/packages/core/src/observability/index.ts
@@ -8,6 +8,7 @@ export type {
   AgentObserverRegistration,
   AgentRunEndArgs,
   AgentRunErrorArgs,
+  AgentRunEventArgs,
   AgentRunObserver,
   AgentRunStartArgs,
   AgentToolEndArgs,

--- a/packages/core/src/observability/types.ts
+++ b/packages/core/src/observability/types.ts
@@ -29,12 +29,18 @@ export type AgentTraceOptions = {
   failOnObserverError?: boolean | undefined;
 };
 
+export type AgentRunPromptRef = {
+  name: string;
+  version?: number | undefined;
+};
+
 export type AgentRunStartArgs = {
   agentName?: string | undefined;
   agentDescription?: string | undefined;
   instructions?: string | undefined;
   trace?: AgentTraceOptions | undefined;
   prompt: Message;
+  promptRef?: AgentRunPromptRef | undefined;
   history: Message[];
   maxTurns: number;
 };

--- a/packages/core/src/observability/types.ts
+++ b/packages/core/src/observability/types.ts
@@ -1,3 +1,4 @@
+import type { AgentDeltaEvent } from "../agent/stream-accumulator";
 import type {
   CompletionModelCapabilities,
   CompletionRequest,
@@ -71,6 +72,11 @@ export type AgentGenerationErrorArgs = {
   error: unknown;
 };
 
+export type AgentGenerationUpdateArgs = {
+  turn: number;
+  delta: AgentDeltaEvent;
+};
+
 export type AgentToolStartArgs = {
   turn: number;
   toolCall: ToolCall;
@@ -99,6 +105,7 @@ export type AgentToolStreamEventArgs = AgentToolStartArgs & {
 export interface AgentGenerationObserver {
   end(args: AgentGenerationEndArgs): void | Promise<void>;
   error?(args: AgentGenerationErrorArgs): void | Promise<void>;
+  update?(args: AgentGenerationUpdateArgs): void | Promise<void>;
 }
 
 export interface AgentToolObserver {

--- a/packages/core/src/observability/types.ts
+++ b/packages/core/src/observability/types.ts
@@ -4,6 +4,7 @@ import type {
   CompletionRequest,
   CompletionResponse,
   JsonObject,
+  JsonValue,
   Message,
   ToolCall,
   ToolDefinition,
@@ -77,6 +78,13 @@ export type AgentGenerationUpdateArgs = {
   delta: AgentDeltaEvent;
 };
 
+export type AgentRunEventArgs = {
+  name: string;
+  attributes?: Record<string, JsonValue | undefined> | undefined;
+  level?: "DEFAULT" | "WARNING" | "ERROR" | undefined;
+  timestamp?: Date | string | undefined;
+};
+
 export type AgentToolStartArgs = {
   turn: number;
   toolCall: ToolCall;
@@ -124,6 +132,7 @@ export interface AgentRunObserver {
   ): AgentToolObserver | undefined | Promise<AgentToolObserver | undefined>;
   end(args: AgentRunEndArgs): void | Promise<void>;
   error?(args: AgentRunErrorArgs): void | Promise<void>;
+  event?(args: AgentRunEventArgs): void | Promise<void>;
 }
 
 export interface AgentObserver {

--- a/packages/core/test/evals.test.ts
+++ b/packages/core/test/evals.test.ts
@@ -8,6 +8,7 @@ import {
   type CompletionRequest,
   type CompletionResponse,
   contains,
+  defineMetric,
   type Embedding,
   type EmbeddingModel,
   type EvalMetricArgs,
@@ -235,6 +236,32 @@ describe("evals", () => {
     });
 
     expect(result.invalid).toBe(1);
+  });
+});
+
+describe("defineMetric", () => {
+  it("returns the metric object unchanged and preserves annotations", async () => {
+    const metric = defineMetric({
+      name: "quality",
+      dataType: "CATEGORICAL" as const,
+      scoreConfigId: "sc-1",
+      metadata: { suite: "qa" },
+      evaluate: () => EvalOutcome.pass("good"),
+    });
+
+    expect(metric.name).toBe("quality");
+    expect(metric.dataType).toBe("CATEGORICAL");
+    expect(metric.scoreConfigId).toBe("sc-1");
+    expect(metric.metadata).toEqual({ suite: "qa" });
+    const args: EvalMetricArgs<string, string> = {
+      suiteName: "qa",
+      case: { id: "c", input: "x" },
+      output: "x",
+    };
+    await expect(Promise.resolve(metric.evaluate(args))).resolves.toEqual({
+      outcome: "pass",
+      score: "good",
+    });
   });
 });
 

--- a/packages/core/test/observability.test.ts
+++ b/packages/core/test/observability.test.ts
@@ -14,6 +14,7 @@ import {
   type AgentObserver,
   type AgentRunEndArgs,
   type AgentRunErrorArgs,
+  type AgentRunEventArgs,
   type AgentRunObserver,
   type AgentRunStartArgs,
   type AgentToolEndArgs,
@@ -642,6 +643,84 @@ describe("active agent observer groups", () => {
     await expect(tool.streamEvent(toolStreamEventArgs())).rejects.toThrow(error);
     await expect(tool.end(toolEndArgs())).rejects.toThrow(error);
     await expect(tool.error(toolErrorArgs())).rejects.toThrow(error);
+  });
+
+  it("fans out run event() to observers that implement it", async () => {
+    const seen: AgentRunEventArgs[] = [];
+    const active = await startAgentRunObservers(
+      [
+        {
+          observer: {
+            startRun: () =>
+              createRunObserver({
+                event(args) {
+                  seen.push(args);
+                },
+              }),
+          },
+        },
+        {
+          observer: {
+            startRun: () =>
+              createRunObserver({
+                event(args) {
+                  seen.push(args);
+                },
+              }),
+          },
+        },
+      ],
+      runStartArgs(),
+      false,
+    );
+
+    const args: AgentRunEventArgs = {
+      name: "retrieval.done",
+      attributes: { docCount: 4 },
+    };
+    await expect(active.event(args)).resolves.toBeUndefined();
+    expect(seen).toHaveLength(2);
+    expect(seen[0]).toEqual(args);
+    expect(seen[1]).toEqual(args);
+  });
+
+  it("skips run observers that omit event?", async () => {
+    const active = await startAgentRunObservers(
+      [
+        {
+          observer: {
+            startRun: () => createRunObserver({}),
+          },
+        },
+      ],
+      runStartArgs(),
+      false,
+    );
+
+    await expect(active.event({ name: "noop", attributes: { ok: true } })).resolves.toBeUndefined();
+  });
+
+  it("propagates event errors when failOnObserverError is set", async () => {
+    const error = new Error("event failed");
+    const active = await startAgentRunObservers(
+      [
+        {
+          observer: {
+            startRun: () =>
+              createRunObserver({
+                event() {
+                  throw error;
+                },
+              }),
+          },
+          failOnObserverError: true,
+        },
+      ],
+      runStartArgs(),
+      true,
+    );
+
+    await expect(active.event({ name: "validation.passed" })).rejects.toThrow(error);
   });
 });
 

--- a/packages/core/test/observability.test.ts
+++ b/packages/core/test/observability.test.ts
@@ -16,6 +16,7 @@ import {
   type AgentRunErrorArgs,
   type AgentRunEventArgs,
   type AgentRunObserver,
+  type AgentRunPromptRef,
   type AgentRunStartArgs,
   type AgentToolEndArgs,
   type AgentToolErrorArgs,
@@ -848,3 +849,17 @@ async function collect<T>(events: AsyncIterable<T>): Promise<T[]> {
   }
   return result;
 }
+
+describe("AgentRunPromptRef", () => {
+  it("is accepted on AgentRunStartArgs", () => {
+    const promptRef: AgentRunPromptRef = { name: "support.system", version: 3 };
+    const args: AgentRunStartArgs = {
+      prompt: { role: "user", content: [{ type: "text", text: "hi" }] },
+      history: [],
+      maxTurns: 1,
+      promptRef,
+    };
+    expect(args.promptRef?.name).toBe("support.system");
+    expect(args.promptRef?.version).toBe(3);
+  });
+});

--- a/packages/core/test/observability.test.ts
+++ b/packages/core/test/observability.test.ts
@@ -381,6 +381,73 @@ describe("agent observability", () => {
         .send(),
     ).rejects.toThrow("observer failed");
   });
+
+  it("calls update on streaming observers once per delta", async () => {
+    const updates: Array<{ turn: number; delta: { type: string; delta?: string } }> = [];
+    const observer: AgentObserver = {
+      startRun(): AgentRunObserver {
+        return {
+          startGeneration: () => ({
+            update: (args) => {
+              updates.push(args);
+            },
+            end: () => {},
+          }),
+          end: () => {},
+        };
+      },
+    };
+    const model = new StreamingQueueModel([
+      [
+        { type: "text_delta", delta: "he" },
+        { type: "text_delta", delta: "llo" },
+      ],
+    ]);
+    const agent = new AgentBuilder("test-agent", model).observe(observer).build();
+    await collect(agent.prompt("hi").stream());
+
+    expect(updates).toEqual([
+      { turn: 1, delta: { type: "text_delta", delta: "he" } },
+      { turn: 1, delta: { type: "text_delta", delta: "llo" } },
+    ]);
+  });
+
+  it("does not call update for non-streaming completions", async () => {
+    const updates: unknown[] = [];
+    const observer: AgentObserver = {
+      startRun(): AgentRunObserver {
+        return {
+          startGeneration: () => ({
+            update: (args) => {
+              updates.push(args);
+            },
+            end: () => {},
+          }),
+          end: () => {},
+        };
+      },
+    };
+    const model = new QueueModel([response([AssistantContent.text("ok")])]);
+    const agent = new AgentBuilder("test-agent", model).observe(observer).build();
+    await agent.prompt("hi").send();
+    expect(updates).toEqual([]);
+  });
+
+  it("honors observers that omit the optional update method", async () => {
+    const observer: AgentObserver = {
+      startRun(): AgentRunObserver {
+        return {
+          startGeneration: () => ({
+            end: () => {},
+          }),
+          end: () => {},
+        };
+      },
+    };
+    const model = new StreamingQueueModel([[{ type: "text_delta", delta: "hi" }]]);
+    const agent = new AgentBuilder("test-agent", model).observe(observer).build();
+    await expect(collect(agent.prompt("hi").stream())).resolves.toBeDefined();
+  });
 });
 
 describe("active agent observer groups", () => {

--- a/packages/observability-langfuse/README.md
+++ b/packages/observability-langfuse/README.md
@@ -80,6 +80,10 @@ shows everything the agent runtime emits:
   (with `provider`, `defaultModel`, and `capabilities`) on start, and
   `firstDeltaMs` on end. `usageDetails` always includes
   `cachedInputTokens` and `cacheCreationInputTokens`.
+- **Generation observations** receive a `generation.update({ output: { delta } })`
+  call for every streaming delta (`text_delta`, `reasoning_delta`,
+  `tool_call`), so the Langfuse UI reflects partial output as the
+  model produces it.
 - **Tool observations** carry `toolDefinition` and `toolMetadata` on
   start, and `structuredResult` on end.
 - **Root run observation** carries `serviceName` and the configured

--- a/packages/observability-langfuse/README.md
+++ b/packages/observability-langfuse/README.md
@@ -412,6 +412,57 @@ already attach metadata to `withTrace(...)`.
   array; throws if the prompt is a text prompt.
 - `refresh()`: clears the cache.
 
+## PII redaction
+
+Mask personally identifiable information in observations before it
+leaves the process. The default pattern set catches emails,
+credit cards (with Luhn validation), phone numbers, IPv4
+addresses, JWTs, and common API key shapes.
+
+```ts
+import { langfuse } from "@anvia/langfuse";
+
+const tracing = langfuse.create({
+  publicKey: "pk",
+  secretKey: "sk",
+  redactInputs: true,
+  redactOutputs: "deep",
+});
+```
+
+- `redactInputs` redacts text on root inputs, chat history, and tool
+  arguments.
+- `redactOutputs` redacts generation output text and tool results.
+- `"deep"` recurses into nested objects and arrays (in addition to
+  top-level strings).
+
+### Customizing
+
+```ts
+const tracing = langfuse.create({
+  publicKey: "pk",
+  secretKey: "sk",
+  redactOutputs: true,
+  redaction: {
+    replacement: "[HIDDEN]",
+    patterns: [
+      { name: "ssn", regex: /\b\d{3}-\d{2}-\d{4}\b/g },
+    ],
+  },
+});
+```
+
+`createPiiRedactor(options)` is also exported for ad-hoc use:
+
+```ts
+import { createPiiRedactor } from "@anvia/langfuse";
+
+const redactor = createPiiRedactor();
+const safe = redactor.redactString("email alice@example.com today");
+const safeMessages = redactor.redactMessages(messages);
+const safeObject = redactor.redactObject(spanInput);
+```
+
 ## Exports
 
 - `langfuse`
@@ -441,6 +492,12 @@ already attach metadata to `withTrace(...)`.
 - `LangfuseChatMessage`
 - `RunEvalAsExperimentOptions`
 - `RunEvalAsExperimentResult`
+- `createPiiRedactor`
+- `DEFAULT_PATTERNS`
+- `PiiRedactor`
+- `RedactorPattern`
+- `LangfuseRedactionOptions`
+- `LangfuseRedactionMode`
 
 ## Development
 

--- a/packages/observability-langfuse/README.md
+++ b/packages/observability-langfuse/README.md
@@ -49,6 +49,28 @@ await tracing.flush();
 
 Use `flush()` after short-lived jobs. Use `shutdown()` when the process is exiting.
 
+## Configuration
+
+`langfuse.create()` accepts the following options. Any option that is
+left undefined falls back to the matching environment variable, and
+explicit options always win.
+
+| Option        | Environment variable          | Notes                                                      |
+| ------------- | ----------------------------- | ---------------------------------------------------------- |
+| `publicKey`   | `LANGFUSE_PUBLIC_KEY`         | Required for score publishing.                             |
+| `secretKey`   | `LANGFUSE_SECRET_KEY`         | Required for score publishing.                             |
+| `baseUrl`     | `LANGFUSE_BASE_URL`           | Defaults to `https://cloud.langfuse.com`.                  |
+| `environment` | `LANGFUSE_TRACING_ENVIRONMENT`| Tag attached to every trace.                               |
+| `release`     | `LANGFUSE_RELEASE`            | Tag attached to every trace.                               |
+| `serviceName` | `LANGFUSE_SERVICE_NAME`       | Recorded on the root observation and as the OTel `service.name` resource attribute. |
+
+```ts
+const tracing = langfuse.create({
+  // All fields are optional and fall back to env vars.
+  serviceName: "support-agent",
+});
+```
+
 ## Eval Scores
 
 ```ts

--- a/packages/observability-langfuse/README.md
+++ b/packages/observability-langfuse/README.md
@@ -98,6 +98,25 @@ const reporter = createLangfuseEvalReporter(tracing);
 
 The reporter reads trace information from eval output when available, then publishes metric scores to Langfuse.
 
+### Typed scores and overrides
+
+`tracing.score()` accepts a `dataType` (`"NUMERIC" | "CATEGORICAL" | "BOOLEAN"`), a `configId` (or its `scoreConfigId` alias), a per-score `environment` override, and a `timestamp` (Date or ISO 8601 string). The adapter validates `value` against the dataType at the boundary.
+
+```ts
+await tracing.score({
+  traceId: trace.traceId,
+  name: "verdict",
+  value: "pass",        // string for CATEGORICAL
+  dataType: "CATEGORICAL",
+  configId: "cfg-1",
+  environment: "staging",
+  timestamp: new Date(),
+});
+```
+
+The score fetch has a default timeout of 30 s, overrideable via
+`langfuse.create({ timeoutMs: ... })`.
+
 ## Exports
 
 - `langfuse`

--- a/packages/observability-langfuse/README.md
+++ b/packages/observability-langfuse/README.md
@@ -102,6 +102,62 @@ const reporter = createLangfuseEvalReporter(tracing);
 
 The reporter reads trace information from eval output when available, then publishes metric scores to Langfuse.
 
+### Eval reporter options
+
+```ts
+const reporter = createLangfuseEvalReporter(tracing, {
+  publishInvalid: false, // publish invalid outcomes as zero scores
+  onMissingTrace: "ignore", // "ignore" | "warn" | "throw"
+  truncateInputAt: 2048, // max bytes for case input/expected summaries
+  includeMessages: true, // include output.messages in score metadata
+});
+```
+
+- `onMissingTrace` decides what happens when no trace can be
+  resolved for a case. `"ignore"` (default, also when `strict` is
+  not set) drops the score silently. `"warn"` logs a
+  `console.warn`. `"throw"` rejects with an error. The legacy
+  `strict: true` option continues to work as an alias for
+  `"throw"`.
+
+- `truncateInputAt` caps the byte size of `caseInputSummary` and
+  `caseExpectedSummary` metadata keys. Truncation appends
+  `<truncated>` to the cut value.
+
+- `includeMessages` controls whether `output.messages` (if present)
+  is included in score metadata.
+
+### Trace resolution
+
+The reporter resolves a trace ID for each case in three tiers:
+
+1. `output.trace` (most direct, set by an agent run).
+2. `case.input.trace` (useful when the case input bundles trace
+   info).
+3. `case.metadata.traceId` (and optional `observationId`).
+
+### Metric annotations
+
+`EvalMetric` (in `@anvia/core`) accepts optional `dataType`,
+`configId` / `scoreConfigId`, and `metadata` fields. The reporter
+forwards them to Langfuse, so categorical or boolean metrics are
+sent with the right shape:
+
+```ts
+import { defineMetric, EvalOutcome } from "@anvia/core";
+
+const judge = defineMetric({
+  name: "quality",
+  dataType: "CATEGORICAL",
+  configId: "quality-config",
+  metadata: { source: "judge-llm" },
+  evaluate: () => EvalOutcome.pass("good"),
+});
+```
+
+`defineMetric` is a small identity helper that signals intent and
+preserves type inference; plain object literals continue to work.
+
 ### Typed scores and overrides
 
 `tracing.score()` accepts a `dataType` (`"NUMERIC" | "CATEGORICAL" | "BOOLEAN"`), a `configId` (or its `scoreConfigId` alias), a per-score `environment` override, and a `timestamp` (Date or ISO 8601 string). The adapter validates `value` against the dataType at the boundary.

--- a/packages/observability-langfuse/README.md
+++ b/packages/observability-langfuse/README.md
@@ -117,13 +117,43 @@ await tracing.score({
 The score fetch has a default timeout of 30 s, overrideable via
 `langfuse.create({ timeoutMs: ... })`.
 
+### Batching and retry (high-volume evals)
+
+Enable the in-memory score queue by setting `scoreBatchSize` on
+`langfuse.create()`. When enabled, `tracing.score()` enqueues the
+score and returns immediately. The queue flushes when it reaches
+`scoreBatchSize`, on a debounce timer (`scoreFlushIntervalMs`,
+default 250 ms), and on `flushScores()`, `flush()`, or `shutdown()`.
+
+```ts
+const tracing = langfuse.create({
+  publicKey,
+  secretKey,
+  scoreBatchSize: 20,             // enable queue; flushes at 20 items
+  scoreFlushIntervalMs: 500,      // or after 500ms
+  scoreMaxRetries: 3,             // retry 429 / 5xx with backoff
+});
+
+await tracing.score({ traceId, name: "quality", value: 1 });
+await tracing.score({ traceId, name: "latency", value: 0.4 });
+await tracing.flushScores();       // drain the queue
+console.log(tracing.scoreQueueDepth()); // 0
+```
+
+`flush()` and `shutdown()` also drain the score queue. After all
+retries are exhausted, the queue throws a `LangfuseScoreError` whose
+`scores` property contains the failed payloads so you can inspect
+what was lost.
+
 ## Exports
 
 - `langfuse`
 - `createLangfuseEvalReporter`
+- `LangfuseScoreError`
 - `LangfuseTracing`
 - `LangfuseTracingOptions`
 - `LangfuseScoreArgs`
+- `LangfuseScoreDataType`
 - `LangfuseEvalReporterOptions`
 
 ## Development

--- a/packages/observability-langfuse/README.md
+++ b/packages/observability-langfuse/README.md
@@ -149,12 +149,74 @@ retries are exhausted, the queue throws a `LangfuseScoreError` whose
 `scores` property contains the failed payloads so you can inspect
 what was lost.
 
+## Event observations & trace handle
+
+After a run starts, you can record ad-hoc checkpoints and attach
+extra attributes to the active trace without threading the run
+observer through every function call. The tracing instance exposes
+the most recent trace through `getCurrentTrace()`:
+
+```ts
+import { langfuse } from "@anvia/langfuse";
+
+const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+
+await tracing.startRun({
+  agentName: "support",
+  prompt: { role: "user", content: [{ type: "text", text: "hi" }] },
+  history: [],
+  maxTurns: 3,
+});
+
+const trace = tracing.getCurrentTrace();
+
+trace?.addEvent("retrieval.done", { docCount: 4 });
+trace?.addEvent("validation.passed");
+trace?.addAttributes({ quality: "high" });
+```
+
+`addEvent` creates a Langfuse `event` observation under the active
+root and ends it immediately. `addAttributes` updates the root
+observation's metadata. Both calls bubble up to Langfuse via the
+existing OpenTelemetry span processor.
+
+If you have the run observer returned by `startRun`, you can also
+use its `event?(...)` hook (added in `@anvia/core`) to record
+checkpoints:
+
+```ts
+const run = await tracing.startRun({
+  agentName: "support",
+  prompt: { role: "user", content: [{ type: "text", text: "hi" }] },
+  history: [],
+  maxTurns: 3,
+});
+
+await run.event?.({
+  name: "retrieval.done",
+  attributes: { docCount: 4 },
+});
+```
+
+The trace handle is cleared when the run `end`s or `error`s. If you
+call `addEvent` or `addAttributes` after that, the underlying
+Langfuse SDK will reject the call because the root observation is
+no longer accepting children. We let the error propagate so it is
+visible.
+
+`getCurrentTrace()` is per-tracing-instance and last-write-wins:
+when multiple runs start on the same instance, the handle always
+points at the most recent run. For true concurrency, manage your
+own context (e.g. capture the run observer or build your own
+mapping keyed on user/session).
+
 ## Exports
 
 - `langfuse`
 - `createLangfuseEvalReporter`
 - `LangfuseScoreError`
 - `LangfuseTracing`
+- `LangfuseTraceHandle`
 - `LangfuseTracingOptions`
 - `LangfuseScoreArgs`
 - `LangfuseScoreDataType`

--- a/packages/observability-langfuse/README.md
+++ b/packages/observability-langfuse/README.md
@@ -266,10 +266,102 @@ points at the most recent run. For true concurrency, manage your
 own context (e.g. capture the run observer or build your own
 mapping keyed on user/session).
 
+## Datasets & Experiment runs
+
+Bridge `@anvia/core/evals` to Langfuse's dataset / experiment-run
+workflow. The dataset client surfaces the four endpoints you need
+to create a dataset, fetch its items, upsert items, and post a
+batched dataset-run-items payload.
+
+```ts
+import {
+  createLangfuseDatasetClient,
+  runEvalAsExperiment,
+  langfuse,
+} from "@anvia/langfuse";
+
+const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+const client = createLangfuseDatasetClient(tracing, {
+  publicKey: "pk",
+  secretKey: "sk",
+});
+
+await client.createDataset({ name: "support-smoke" });
+await client.upsertItems("support-smoke", [
+  { id: "c-1", input: { q: "hi" }, expected: "hello" },
+  { id: "c-2", input: { q: "bye" } },
+]);
+
+const dataset = await client.getDataset("support-smoke");
+console.log(dataset.items);
+
+await client.runExperiment({
+  datasetName: "support-smoke",
+  runName: "smoke-2026-06",
+  run: (item) => ({
+    output: `answer-for-${item.id}`,
+    trace: { traceId: `trace-${item.id}` },
+  }),
+});
+```
+
+For eval suites, `runEvalAsExperiment` runs the suite and posts a
+dataset run alongside the metric scores:
+
+```ts
+import { runEvalAsExperiment } from "@anvia/langfuse";
+
+const { suite, datasetRun } = await runEvalAsExperiment(
+  {
+    name: "smoke",
+    cases: [
+      { id: "c-1", input: "a", expected: "A" },
+      { id: "c-2", input: "b", expected: "B" },
+    ],
+    target: async (input) => input.toUpperCase(),
+    metrics: [/* ... */],
+    reporters: [/* existing reporters still score */],
+  },
+  {
+    tracing,
+    datasetName: "smoke-set",
+    runName: "smoke-run",
+  },
+);
+
+console.log(suite.passed, datasetRun.posted);
+```
+
+### Options
+
+- `createLangfuseDatasetClient(tracing, options)`:
+  - `publicKey`, `secretKey`, `baseUrl`: override the tracing
+    instance's resolved values. Falls back to env vars
+    (`LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`).
+  - `pageSize` (default `50`): dataset item pagination.
+  - `timeoutMs` (default `30_000`): per-request timeout via
+    `AbortSignal.timeout`.
+- `client.runExperiment({ ... })`:
+  - `items` (optional): supply items directly to skip the
+    `getDataset` round trip.
+  - `run`: invoked per item, returns `{ output, trace? }`.
+    Per-item failures are caught and surfaced in the result's
+    `errors` array; only successful items reach the batched POST.
+
+### Failure handling
+
+`runExperiment` continues on per-item errors. The `errors` array
+contains `{ itemId, error }` entries for failed items; the POST
+still goes out with the successful subset. Non-2xx on the
+batched POST throws (and the items that already errored are
+also included in the thrown error's context).
+
 ## Exports
 
 - `langfuse`
+- `createLangfuseDatasetClient`
 - `createLangfuseEvalReporter`
+- `runEvalAsExperiment`
 - `LangfuseScoreError`
 - `LangfuseTracing`
 - `LangfuseTraceHandle`
@@ -277,6 +369,16 @@ mapping keyed on user/session).
 - `LangfuseScoreArgs`
 - `LangfuseScoreDataType`
 - `LangfuseEvalReporterOptions`
+- `LangfuseDatasetClient`
+- `LangfuseDatasetClientOptions`
+- `LangfuseDataset`
+- `LangfuseDatasetItem`
+- `LangfuseRunExperimentOptions`
+- `LangfuseRunExperimentResult`
+- `LangfuseRunItemResult`
+- `LangfuseRunItemError`
+- `RunEvalAsExperimentOptions`
+- `RunEvalAsExperimentResult`
 
 ## Development
 

--- a/packages/observability-langfuse/README.md
+++ b/packages/observability-langfuse/README.md
@@ -71,6 +71,23 @@ const tracing = langfuse.create({
 });
 ```
 
+## Observation metadata
+
+The adapter records extra data on Langfuse observations so the UI
+shows everything the agent runtime emits:
+
+- **Generation observations** carry `providerRequest` and `modelInfo`
+  (with `provider`, `defaultModel`, and `capabilities`) on start, and
+  `firstDeltaMs` on end. `usageDetails` always includes
+  `cachedInputTokens` and `cacheCreationInputTokens`.
+- **Tool observations** carry `toolDefinition` and `toolMetadata` on
+  start, and `structuredResult` on end.
+- **Root run observation** carries `serviceName` and the configured
+  `metadata` from `AgentRunStartArgs`.
+
+User-supplied `trace.metadata` always wins over the built-in fields
+above (the spread order preserves it).
+
 ## Eval Scores
 
 ```ts

--- a/packages/observability-langfuse/README.md
+++ b/packages/observability-langfuse/README.md
@@ -356,11 +356,68 @@ still goes out with the successful subset. Non-2xx on the
 batched POST throws (and the items that already errored are
 also included in the thrown error's context).
 
+## Prompt management
+
+Pull prompts from Langfuse's prompt store and link generations to
+the prompt version. The tracing instance attaches the prompt name
+and version to the root trace and every generation in the run
+when a prompt ref is configured.
+
+```ts
+import { createLangfusePromptClient, langfuse } from "@anvia/langfuse";
+
+const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+const prompts = createLangfusePromptClient(tracing, {
+  publicKey: "pk",
+  secretKey: "sk",
+});
+
+const prompt = await prompts.getPrompt("support.system");
+console.log(prompt.prompt, prompt.version);
+
+await tracing.startRun({
+  agentName: "support",
+  prompt: { role: "user", content: [{ type: "text", text: "hi" }] },
+  history: [],
+  maxTurns: 3,
+  promptRef: { name: "support.system", version: prompt.version },
+});
+```
+
+`promptRef` is also accepted on `trace.metadata` (keys
+`promptName` and `promptVersion`) for back-compat with users who
+already attach metadata to `withTrace(...)`.
+
+### Prompt client options
+
+- `cacheTtlMs` (default `60_000`): in-memory TTL per
+  `${name}::${version}::${label}` key.
+- `timeoutMs` (default `30_000`): per-request timeout via
+  `AbortSignal.timeout`.
+- `publicKey`, `secretKey`, `baseUrl`: override the tracing
+  instance's resolved values, falling back to env vars.
+
+### Per-call options
+
+- `getPrompt(name, { version?, label?, cacheTtlMs?, refresh? })`:
+  - `version` and `label` filter the upstream request.
+  - `cacheTtlMs` overrides the client default for this call.
+  - `refresh: true` skips the cache and re-fetches.
+
+### Helpers
+
+- `getPromptText(name, options?)`: returns the prompt string;
+  throws if the prompt is a chat prompt.
+- `getPromptChat(name, options?)`: returns the chat message
+  array; throws if the prompt is a text prompt.
+- `refresh()`: clears the cache.
+
 ## Exports
 
 - `langfuse`
 - `createLangfuseDatasetClient`
 - `createLangfuseEvalReporter`
+- `createLangfusePromptClient`
 - `runEvalAsExperiment`
 - `LangfuseScoreError`
 - `LangfuseTracing`
@@ -377,6 +434,11 @@ also included in the thrown error's context).
 - `LangfuseRunExperimentResult`
 - `LangfuseRunItemResult`
 - `LangfuseRunItemError`
+- `LangfusePromptClient`
+- `LangfusePromptClientOptions`
+- `LangfusePromptGetOptions`
+- `LangfusePrompt`
+- `LangfuseChatMessage`
 - `RunEvalAsExperimentOptions`
 - `RunEvalAsExperimentResult`
 

--- a/packages/observability-langfuse/package.json
+++ b/packages/observability-langfuse/package.json
@@ -33,7 +33,9 @@
   "dependencies": {
     "@langfuse/otel": "^5.5.3",
     "@langfuse/tracing": "^5.5.3",
-    "@opentelemetry/sdk-node": "^0.219.0"
+    "@opentelemetry/resources": "^2.8.0",
+    "@opentelemetry/sdk-node": "^0.219.0",
+    "@opentelemetry/semantic-conventions": "^1.40.0"
   },
   "devDependencies": {
     "@anvia/core": "workspace:*",

--- a/packages/observability-langfuse/src/dataset-client.ts
+++ b/packages/observability-langfuse/src/dataset-client.ts
@@ -1,0 +1,225 @@
+import type { JsonValue } from "@anvia/core/completion";
+import { resolveOption } from "./helpers.js";
+import { LangfuseScoreError } from "./scoring.js";
+import type {
+  LangfuseDataset,
+  LangfuseDatasetClient,
+  LangfuseDatasetClientOptions,
+  LangfuseDatasetItem,
+  LangfuseRunExperimentOptions,
+  LangfuseRunExperimentResult,
+  LangfuseRunItemError,
+  LangfuseTracing,
+} from "./types.js";
+
+const DEFAULT_PAGE_SIZE = 50;
+const DEFAULT_TIMEOUT_MS = 30_000;
+const MAX_PAGINATION_PAGES = 100;
+
+export function createLangfuseDatasetClient(
+  _tracing: Pick<LangfuseTracing, "score">,
+  options: LangfuseDatasetClientOptions = {},
+): LangfuseDatasetClient {
+  const baseUrl =
+    resolveOption(options.baseUrl, process.env.LANGFUSE_BASE_URL) ?? "https://cloud.langfuse.com";
+  const publicKey = resolveOption(options.publicKey, process.env.LANGFUSE_PUBLIC_KEY);
+  const secretKey = resolveOption(options.secretKey, process.env.LANGFUSE_SECRET_KEY);
+  const pageSize = options.pageSize ?? DEFAULT_PAGE_SIZE;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const fetchImpl: typeof fetch = (...args) =>
+    fetch(args[0], { ...(args[1] ?? {}), signal: AbortSignal.timeout(timeoutMs) });
+
+  const authHeader = buildAuthHeader(publicKey, secretKey);
+
+  async function request<T>(input: string, init: RequestInit): Promise<T> {
+    const response = await fetchImpl(input, {
+      ...init,
+      headers: {
+        ...(init.headers ?? {}),
+        ...authHeader,
+        "Content-Type": "application/json",
+      },
+    });
+    if (!response.ok) {
+      const body = await readErrorBody(response);
+      throw new LangfuseScoreError(
+        `Langfuse request failed: ${response.status} ${response.statusText}: ${body}`,
+        [],
+      );
+    }
+    if (response.status === 204) {
+      return undefined as T;
+    }
+    return (await response.json()) as T;
+  }
+
+  return {
+    async createDataset(dataset) {
+      const url = `${baseUrl}/api/public/datasets/${encodeURIComponent(dataset.name)}`;
+      await request<unknown>(url, {
+        method: "PUT",
+        body: JSON.stringify({
+          name: dataset.name,
+          description: dataset.description,
+          metadata: dataset.metadata,
+        }),
+      });
+      return {
+        name: dataset.name,
+        ...(dataset.description === undefined ? {} : { description: dataset.description }),
+        ...(dataset.metadata === undefined ? {} : { metadata: dataset.metadata }),
+        items: [],
+      };
+    },
+
+    async getDataset<Input, Expected>(name: string): Promise<LangfuseDataset<Input, Expected>> {
+      const items: LangfuseDatasetItem<Input, Expected>[] = [];
+      let description: string | undefined;
+      let metadata: Record<string, JsonValue | undefined> | undefined;
+      for (let page = 1; page <= MAX_PAGINATION_PAGES; page += 1) {
+        const url = new URL(`${baseUrl}/api/public/datasets/${encodeURIComponent(name)}`);
+        url.searchParams.set("page", String(page));
+        url.searchParams.set("limit", String(pageSize));
+        const response = await request<{
+          name: string;
+          description?: string | undefined;
+          metadata?: Record<string, JsonValue | undefined> | undefined;
+          items: Array<{
+            id: string;
+            input: Input;
+            expected?: Expected | undefined;
+            metadata?: Record<string, JsonValue | undefined> | undefined;
+          }>;
+          meta?: { totalPages?: number | undefined };
+        }>(url.toString(), { method: "GET" });
+        if (description === undefined && response.description !== undefined) {
+          description = response.description;
+        }
+        if (metadata === undefined && response.metadata !== undefined) {
+          metadata = response.metadata;
+        }
+        for (const item of response.items) {
+          items.push({
+            id: item.id,
+            input: item.input,
+            ...(item.expected === undefined ? {} : { expected: item.expected }),
+            ...(item.metadata === undefined ? {} : { metadata: item.metadata }),
+          });
+        }
+        const totalPages = response.meta?.totalPages;
+        if (totalPages !== undefined && page >= totalPages) {
+          break;
+        }
+        if (totalPages === undefined && response.items.length < pageSize) {
+          break;
+        }
+      }
+      const dataset: LangfuseDataset<Input, Expected> = {
+        name,
+        items,
+      };
+      if (description !== undefined) dataset.description = description;
+      if (metadata !== undefined) dataset.metadata = metadata;
+      return dataset;
+    },
+
+    async upsertItems<Input, Expected>(
+      name: string,
+      items: LangfuseDatasetItem<Input, Expected>[],
+    ): Promise<void> {
+      const url = `${baseUrl}/api/public/datasets/${encodeURIComponent(name)}/items`;
+      await request<unknown>(url, {
+        method: "POST",
+        body: JSON.stringify({ items }),
+      });
+    },
+
+    async runExperiment<Input, Output, Expected>(
+      opts: LangfuseRunExperimentOptions<Input, Output, Expected>,
+    ): Promise<LangfuseRunExperimentResult> {
+      let items = opts.items;
+      if (items === undefined) {
+        const dataset = await this.getDataset<Input, Expected>(opts.datasetName);
+        items = dataset.items;
+      }
+      if (items === undefined || items.length === 0) {
+        return {
+          runName: opts.runName,
+          datasetName: opts.datasetName,
+          posted: 0,
+          errors: [],
+        };
+      }
+      const datasetItemRuns: Array<{
+        datasetItemId: string;
+        traceId?: string;
+        observationId?: string;
+        output: JsonValue;
+      }> = [];
+      const errors: LangfuseRunItemError[] = [];
+      for (const item of items) {
+        try {
+          const result = await opts.run(item);
+          datasetItemRuns.push({
+            datasetItemId: item.id,
+            ...(result.trace?.traceId === undefined ? {} : { traceId: result.trace.traceId }),
+            ...(result.trace?.observationId === undefined
+              ? {}
+              : { observationId: result.trace.observationId }),
+            output: toJsonValue(result.output),
+          });
+        } catch (error) {
+          errors.push({ itemId: item.id, error });
+        }
+      }
+      const url = `${baseUrl}/api/public/dataset-run-items`;
+      const body: Record<string, unknown> = {
+        runName: opts.runName,
+        datasetItemRuns,
+      };
+      if (opts.description !== undefined) body.runDescription = opts.description;
+      if (opts.metadata !== undefined) body.metadata = opts.metadata;
+      await request<unknown>(url, {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+      return {
+        runName: opts.runName,
+        datasetName: opts.datasetName,
+        posted: datasetItemRuns.length,
+        errors,
+      };
+    },
+  };
+}
+
+function buildAuthHeader(
+  publicKey: string | undefined,
+  secretKey: string | undefined,
+): Record<string, string> {
+  if (publicKey === undefined || secretKey === undefined) {
+    return {};
+  }
+  const encoded = Buffer.from(`${publicKey}:${secretKey}`).toString("base64");
+  return { Authorization: `Basic ${encoded}` };
+}
+
+async function readErrorBody(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch {
+    return "<unreadable>";
+  }
+}
+
+function toJsonValue(value: unknown): JsonValue {
+  if (value === null) return null;
+  if (typeof value === "string" || typeof value === "boolean") return value;
+  if (typeof value === "number") return value;
+  try {
+    return JSON.parse(JSON.stringify(value)) as JsonValue;
+  } catch {
+    return String(value);
+  }
+}

--- a/packages/observability-langfuse/src/eval-reporter.ts
+++ b/packages/observability-langfuse/src/eval-reporter.ts
@@ -1,11 +1,22 @@
+import type { JsonValue } from "@anvia/core/completion";
 import type { EvalOutcome, EvalReportArgs, EvalReporter } from "@anvia/core/evals";
 import type { AgentTraceInfo } from "@anvia/core/observability";
-import type { LangfuseEvalReporterOptions, LangfuseTracing } from "./types.js";
+import type {
+  LangfuseEvalReporterOptions,
+  LangfuseScoreDataType,
+  LangfuseTracing,
+} from "./types.js";
+
+const DEFAULT_TRUNCATE_BYTES = 2048;
 
 export function createLangfuseEvalReporter<Input = unknown, Output = unknown, Expected = unknown>(
   tracing: Pick<LangfuseTracing, "score">,
   options: LangfuseEvalReporterOptions = {},
 ): EvalReporter<Input, Output, Expected> {
+  const onMissingTrace = options.onMissingTrace ?? (options.strict === true ? "throw" : "ignore");
+  const truncateAt = options.truncateInputAt ?? DEFAULT_TRUNCATE_BYTES;
+  const includeMessages = options.includeMessages ?? true;
+
   return {
     async report(args) {
       if (args.outcome.outcome === "invalid" && options.publishInvalid !== true) {
@@ -14,47 +25,171 @@ export function createLangfuseEvalReporter<Input = unknown, Output = unknown, Ex
 
       const trace = traceFromEvalReport(args);
       if (trace?.traceId === undefined || trace.traceId.length === 0) {
-        if (options.strict === true) {
+        if (onMissingTrace === "throw") {
           throw new Error("Langfuse eval reporter requires traceId");
+        }
+        if (onMissingTrace === "warn") {
+          // eslint-disable-next-line no-console
+          console.warn(
+            "[anvia/langfuse] eval reporter dropped score because no traceId was found",
+            { caseId: args.case.id, metric: args.metric.name },
+          );
         }
         return;
       }
 
+      const scoreValue = buildScoreValue(args.outcome, args.metric.dataType);
+      const metadata = buildScoreMetadata({
+        args,
+        truncateAt,
+        includeMessages,
+      });
+      const comment = scoreComment(args.outcome);
+
       await tracing.score({
         traceId: trace.traceId,
-        name: args.metric.name,
-        value: scoreValue(args.outcome),
-        metadata: {
-          suiteName: args.suiteName,
-          caseId: args.case.id,
-          outcome: args.outcome.outcome,
-        },
         ...(trace.observationId === undefined ? {} : { observationId: trace.observationId }),
-        ...(scoreComment(args.outcome) === undefined
+        name: args.metric.name,
+        value: scoreValue,
+        ...(args.metric.dataType === undefined ? {} : { dataType: args.metric.dataType }),
+        ...(resolveConfigId(args.metric) === undefined
           ? {}
-          : { comment: scoreComment(args.outcome) as string }),
+          : { configId: resolveConfigId(args.metric) as string }),
+        ...(comment === undefined ? {} : { comment }),
+        ...(metadata === undefined ? {} : { metadata }),
       });
     },
   };
 }
 
-function scoreValue(outcome: EvalOutcome): number {
-  if (outcome.outcome === "invalid") {
-    return 0;
+function resolveConfigId(metric: {
+  scoreConfigId?: string | undefined;
+  configId?: string | undefined;
+}): string | undefined {
+  return metric.configId ?? metric.scoreConfigId;
+}
+
+function buildScoreMetadata<Input, Output, Score, Expected>({
+  args,
+  truncateAt,
+  includeMessages,
+}: {
+  args: EvalReportArgs<Input, Output, Score, Expected>;
+  truncateAt: number;
+  includeMessages: boolean;
+}): Record<string, JsonValue | undefined> | undefined {
+  const merged: Record<string, JsonValue | undefined> = {
+    suiteName: args.suiteName,
+    caseId: args.case.id,
+    outcome: args.outcome.outcome,
+  };
+  mergeMetadata(merged, args.outcome.metadata);
+  mergeMetadata(merged, args.metric.metadata);
+  const inputSummary = truncateValue(args.case.input, truncateAt);
+  if (inputSummary !== undefined) {
+    merged.caseInputSummary = inputSummary;
   }
-  if (typeof outcome.score === "number") {
-    return outcome.score;
+  if (args.case.expected !== undefined) {
+    const expectedSummary = truncateValue(args.case.expected, truncateAt);
+    if (expectedSummary !== undefined) {
+      merged.caseExpectedSummary = expectedSummary;
+    }
   }
-  if (typeof outcome.score === "boolean") {
-    return outcome.score ? 1 : 0;
+  if (includeMessages) {
+    const messages = readMessages(args.output);
+    if (messages !== undefined) {
+      merged.messages = messages;
+    }
+  }
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+function mergeMetadata(
+  target: Record<string, JsonValue | undefined>,
+  source: Record<string, JsonValue | undefined> | undefined,
+): void {
+  if (source === undefined) return;
+  for (const [key, value] of Object.entries(source)) {
+    target[key] = value;
+  }
+}
+
+function truncateValue(value: unknown, maxBytes: number): string | undefined {
+  if (value === undefined) return undefined;
+  let serialized: string;
+  try {
+    serialized = typeof value === "string" ? value : JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+  if (serialized === undefined) return undefined;
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode(serialized);
+  if (bytes.length <= maxBytes) {
+    return serialized;
+  }
+  // Truncate at byte boundary by slicing, then append the marker.
+  const truncatedBytes = bytes.subarray(0, maxBytes);
+  const decoder = new TextDecoder("utf-8", { fatal: false });
+  return `${decoder.decode(truncatedBytes)}<truncated>`;
+}
+
+function readMessages(output: unknown): JsonValue[] | undefined {
+  if (typeof output !== "object" || output === null) return undefined;
+  const messages = (output as { messages?: unknown }).messages;
+  if (!Array.isArray(messages)) return undefined;
+  const serialized: JsonValue[] = [];
+  for (const entry of messages) {
+    if (entry === null || typeof entry !== "object") return undefined;
+    try {
+      // Round-trip via JSON to make sure we never put non-JSON values
+      // into a JsonValue-typed slot.
+      serialized.push(JSON.parse(JSON.stringify(entry)) as JsonValue);
+    } catch {
+      return undefined;
+    }
+  }
+  return serialized;
+}
+
+function buildScoreValue(
+  outcome: EvalOutcome,
+  dataType: LangfuseScoreDataType | undefined,
+): number | string {
+  if (dataType === "CATEGORICAL") {
+    const score = (outcome as { score?: unknown }).score;
+    if (typeof score === "string") return score;
+    if (typeof score === "number") return String(score);
+    if (typeof score === "boolean") return score ? "true" : "false";
+    if (score === null || score === undefined) {
+      return outcome.outcome === "pass" ? "pass" : outcome.outcome === "fail" ? "fail" : "invalid";
+    }
+    try {
+      return JSON.stringify(score);
+    } catch {
+      return outcome.outcome === "pass" ? "pass" : outcome.outcome;
+    }
+  }
+  if (dataType === "BOOLEAN") {
+    const score = (outcome as { score?: unknown }).score;
+    if (typeof score === "boolean") return score ? 1 : 0;
+    if (typeof score === "number") return score === 0 ? 0 : 1;
+    return outcome.outcome === "pass" ? 1 : 0;
+  }
+  // Numeric (default)
+  if (typeof (outcome as { score?: unknown }).score === "number") {
+    return (outcome as { score: number }).score;
+  }
+  if (typeof (outcome as { score?: unknown }).score === "boolean") {
+    return (outcome as { score: boolean }).score ? 1 : 0;
   }
   if (
-    typeof outcome.score === "object" &&
-    outcome.score !== null &&
-    "score" in outcome.score &&
-    typeof (outcome.score as { score?: unknown }).score === "number"
+    typeof (outcome as { score?: unknown }).score === "object" &&
+    (outcome as { score?: unknown }).score !== null &&
+    "score" in ((outcome as { score?: unknown }).score as object) &&
+    typeof ((outcome as { score?: unknown }).score as { score?: unknown }).score === "number"
   ) {
-    return (outcome.score as { score: number }).score;
+    return (outcome as { score: { score: number } }).score.score;
   }
   return outcome.outcome === "pass" ? 1 : 0;
 }
@@ -69,6 +204,10 @@ function traceFromEvalReport<Input, Output, Expected>(
   const outputTrace = traceFromOutput(args.output);
   if (outputTrace !== undefined) {
     return outputTrace;
+  }
+  const inputTrace = traceFromInput(args.case.input);
+  if (inputTrace !== undefined) {
+    return inputTrace;
   }
   const traceId = args.case.metadata?.traceId;
   const observationId = args.case.metadata?.observationId;
@@ -85,7 +224,17 @@ function traceFromOutput(output: unknown): AgentTraceInfo | undefined {
   if (typeof output !== "object" || output === null || !("trace" in output)) {
     return undefined;
   }
-  const trace = (output as { trace?: unknown }).trace;
+  return readTrace((output as { trace?: unknown }).trace);
+}
+
+function traceFromInput(input: unknown): AgentTraceInfo | undefined {
+  if (typeof input !== "object" || input === null || !("trace" in input)) {
+    return undefined;
+  }
+  return readTrace((input as { trace?: unknown }).trace);
+}
+
+function readTrace(trace: unknown): AgentTraceInfo | undefined {
   if (typeof trace !== "object" || trace === null) {
     return undefined;
   }

--- a/packages/observability-langfuse/src/experiment-runner.ts
+++ b/packages/observability-langfuse/src/experiment-runner.ts
@@ -1,0 +1,106 @@
+import type { JsonValue } from "@anvia/core/completion";
+import type { EvalCaseResult, EvalSuiteResult, RunEvalSuiteOptions } from "@anvia/core/evals";
+import { runEvalSuite } from "@anvia/core/evals";
+import { createLangfuseDatasetClient } from "./dataset-client.js";
+import type {
+  LangfuseDatasetClient,
+  LangfuseDatasetItem,
+  LangfuseRunExperimentOptions,
+  LangfuseRunExperimentResult,
+  LangfuseTracing,
+} from "./types.js";
+
+export type RunEvalAsExperimentOptions<Input, Output, Expected = unknown> = Omit<
+  LangfuseRunExperimentOptions<Input, Output, Expected>,
+  "items" | "run"
+> & {
+  tracing: Pick<LangfuseTracing, "score">;
+  client?: LangfuseDatasetClient;
+  pageSize?: number | undefined;
+  timeoutMs?: number | undefined;
+};
+
+export type RunEvalAsExperimentResult<Input, Output, Expected = unknown> = {
+  suite: EvalSuiteResult<Input, Output, Expected>;
+  datasetRun: LangfuseRunExperimentResult;
+};
+
+export async function runEvalAsExperiment<Input, Output, Expected = unknown>(
+  evalOptions: RunEvalSuiteOptions<Input, Output, Expected>,
+  experimentOptions: RunEvalAsExperimentOptions<Input, Output, Expected>,
+): Promise<RunEvalAsExperimentResult<Input, Output, Expected>> {
+  const client =
+    experimentOptions.client ??
+    createLangfuseDatasetClient(experimentOptions.tracing, {
+      ...(experimentOptions.pageSize === undefined ? {} : { pageSize: experimentOptions.pageSize }),
+      ...(experimentOptions.timeoutMs === undefined
+        ? {}
+        : { timeoutMs: experimentOptions.timeoutMs }),
+    });
+
+  const suite = await runEvalSuite(evalOptions);
+
+  const items: LangfuseDatasetItem<Input, Expected>[] = evalOptions.cases.map((testCase) => {
+    const item: LangfuseDatasetItem<Input, Expected> = {
+      id: testCase.id,
+      input: testCase.input,
+    };
+    if (testCase.expected !== undefined) {
+      item.expected = testCase.expected;
+    }
+    if (testCase.metadata !== undefined) {
+      item.metadata = testCase.metadata as Record<string, JsonValue | undefined>;
+    }
+    return item;
+  });
+
+  const datasetItemMap = new Map<string, EvalCaseResult<Input, Output, Expected>>();
+  for (const result of suite.results) {
+    datasetItemMap.set(result.case.id, result);
+  }
+
+  const datasetRun = await client.runExperiment<Input, Output, Expected>({
+    datasetName: experimentOptions.datasetName,
+    runName: experimentOptions.runName,
+    ...(experimentOptions.description === undefined
+      ? {}
+      : { description: experimentOptions.description }),
+    ...(experimentOptions.metadata === undefined ? {} : { metadata: experimentOptions.metadata }),
+    items,
+    run: (item) => {
+      const result = datasetItemMap.get(item.id);
+      if (result === undefined) {
+        return {
+          output: undefined as Output,
+          trace: undefined,
+        };
+      }
+      const output = (result.output ?? undefined) as Output;
+      const trace = readTraceFromOutput(result.output);
+      return { output, trace };
+    },
+  });
+
+  return { suite, datasetRun };
+}
+
+function readTraceFromOutput(
+  output: unknown,
+): { traceId: string; observationId?: string | undefined } | undefined {
+  if (typeof output !== "object" || output === null || !("trace" in output)) {
+    return undefined;
+  }
+  const trace = (output as { trace?: unknown }).trace;
+  if (typeof trace !== "object" || trace === null) {
+    return undefined;
+  }
+  const traceId = (trace as { traceId?: unknown }).traceId;
+  if (typeof traceId !== "string") {
+    return undefined;
+  }
+  const observationId = (trace as { observationId?: unknown }).observationId;
+  if (typeof observationId === "string") {
+    return { traceId, observationId };
+  }
+  return { traceId };
+}

--- a/packages/observability-langfuse/src/helpers.ts
+++ b/packages/observability-langfuse/src/helpers.ts
@@ -36,6 +36,8 @@ export function usageDetailsFromRecord(usage: Record<string, unknown>): Record<s
     totalTokens:
       numberValue(usage.totalTokens) ??
       (numberValue(usage.inputTokens) ?? 0) + (numberValue(usage.outputTokens) ?? 0),
+    cachedInputTokens: numberValue(usage.cachedInputTokens) ?? 0,
+    cacheCreationInputTokens: numberValue(usage.cacheCreationInputTokens) ?? 0,
   };
 }
 

--- a/packages/observability-langfuse/src/helpers.ts
+++ b/packages/observability-langfuse/src/helpers.ts
@@ -76,6 +76,18 @@ export function emptyToUndefined(value: string | undefined): string | undefined 
   return value === undefined || value.length === 0 ? undefined : value;
 }
 
+/**
+ * Resolve an option value: prefer the explicit option, fall back to the
+ * env var, and treat empty strings as missing. Empty env vars are common
+ * when a process inherits a process manager that injects blank values.
+ */
+export function resolveOption(
+  option: string | undefined,
+  envVar: string | undefined,
+): string | undefined {
+  return emptyToUndefined(option) ?? emptyToUndefined(envVar);
+}
+
 export function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }

--- a/packages/observability-langfuse/src/index.ts
+++ b/packages/observability-langfuse/src/index.ts
@@ -5,14 +5,20 @@ export type {
   RunEvalAsExperimentResult,
 } from "./experiment-runner.js";
 export { runEvalAsExperiment } from "./experiment-runner.js";
+export { createLangfusePromptClient } from "./prompt-client.js";
 export { LangfuseScoreError } from "./scoring.js";
 export { langfuse } from "./tracing.js";
 export type {
+  LangfuseChatMessage,
   LangfuseDataset,
   LangfuseDatasetClient,
   LangfuseDatasetClientOptions,
   LangfuseDatasetItem,
   LangfuseEvalReporterOptions,
+  LangfusePrompt,
+  LangfusePromptClient,
+  LangfusePromptClientOptions,
+  LangfusePromptGetOptions,
   LangfuseRunExperimentOptions,
   LangfuseRunExperimentResult,
   LangfuseRunItemError,

--- a/packages/observability-langfuse/src/index.ts
+++ b/packages/observability-langfuse/src/index.ts
@@ -1,8 +1,10 @@
 export { createLangfuseEvalReporter } from "./eval-reporter.js";
+export { LangfuseScoreError } from "./scoring.js";
 export { langfuse } from "./tracing.js";
 export type {
   LangfuseEvalReporterOptions,
   LangfuseScoreArgs,
+  LangfuseScoreDataType,
   LangfuseTracing,
   LangfuseTracingOptions,
 } from "./types.js";

--- a/packages/observability-langfuse/src/index.ts
+++ b/packages/observability-langfuse/src/index.ts
@@ -5,6 +5,7 @@ export type {
   LangfuseEvalReporterOptions,
   LangfuseScoreArgs,
   LangfuseScoreDataType,
+  LangfuseTraceHandle,
   LangfuseTracing,
   LangfuseTracingOptions,
 } from "./types.js";

--- a/packages/observability-langfuse/src/index.ts
+++ b/packages/observability-langfuse/src/index.ts
@@ -6,6 +6,12 @@ export type {
 } from "./experiment-runner.js";
 export { runEvalAsExperiment } from "./experiment-runner.js";
 export { createLangfusePromptClient } from "./prompt-client.js";
+export type {
+  LangfuseRedactionOptions,
+  PiiRedactor,
+  RedactorPattern,
+} from "./redaction.js";
+export { createPiiRedactor, DEFAULT_PATTERNS } from "./redaction.js";
 export { LangfuseScoreError } from "./scoring.js";
 export { langfuse } from "./tracing.js";
 export type {
@@ -19,6 +25,7 @@ export type {
   LangfusePromptClient,
   LangfusePromptClientOptions,
   LangfusePromptGetOptions,
+  LangfuseRedactionMode,
   LangfuseRunExperimentOptions,
   LangfuseRunExperimentResult,
   LangfuseRunItemError,

--- a/packages/observability-langfuse/src/index.ts
+++ b/packages/observability-langfuse/src/index.ts
@@ -1,8 +1,22 @@
+export { createLangfuseDatasetClient } from "./dataset-client.js";
 export { createLangfuseEvalReporter } from "./eval-reporter.js";
+export type {
+  RunEvalAsExperimentOptions,
+  RunEvalAsExperimentResult,
+} from "./experiment-runner.js";
+export { runEvalAsExperiment } from "./experiment-runner.js";
 export { LangfuseScoreError } from "./scoring.js";
 export { langfuse } from "./tracing.js";
 export type {
+  LangfuseDataset,
+  LangfuseDatasetClient,
+  LangfuseDatasetClientOptions,
+  LangfuseDatasetItem,
   LangfuseEvalReporterOptions,
+  LangfuseRunExperimentOptions,
+  LangfuseRunExperimentResult,
+  LangfuseRunItemError,
+  LangfuseRunItemResult,
   LangfuseScoreArgs,
   LangfuseScoreDataType,
   LangfuseTraceHandle,

--- a/packages/observability-langfuse/src/prompt-client.ts
+++ b/packages/observability-langfuse/src/prompt-client.ts
@@ -1,0 +1,154 @@
+import { resolveOption } from "./helpers.js";
+import { LangfuseScoreError } from "./scoring.js";
+import type {
+  LangfuseChatMessage,
+  LangfusePrompt,
+  LangfusePromptClient,
+  LangfusePromptClientOptions,
+  LangfusePromptGetOptions,
+  LangfuseTracing,
+} from "./types.js";
+
+const DEFAULT_CACHE_TTL_MS = 60_000;
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export function createLangfusePromptClient(
+  _tracing: Pick<LangfuseTracing, "score">,
+  options: LangfusePromptClientOptions = {},
+): LangfusePromptClient {
+  const baseUrl =
+    resolveOption(options.baseUrl, process.env.LANGFUSE_BASE_URL) ?? "https://cloud.langfuse.com";
+  const publicKey = resolveOption(options.publicKey, process.env.LANGFUSE_PUBLIC_KEY);
+  const secretKey = resolveOption(options.secretKey, process.env.LANGFUSE_SECRET_KEY);
+  const defaultTtl = options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const cache = new Map<string, { prompt: LangfusePrompt; expiresAt: number }>();
+  const authHeader = buildAuthHeader(publicKey, secretKey);
+
+  async function request<T>(input: string): Promise<T> {
+    const response = await fetch(input, {
+      method: "GET",
+      headers: { ...authHeader },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!response.ok) {
+      const body = await readErrorBody(response);
+      throw new LangfuseScoreError(
+        `Langfuse request failed: ${response.status} ${response.statusText}: ${body}`,
+        [],
+      );
+    }
+    return (await response.json()) as T;
+  }
+
+  async function getPrompt(
+    name: string,
+    opts: LangfusePromptGetOptions = {},
+  ): Promise<LangfusePrompt> {
+    const key = `${name}::${opts.version ?? ""}::${opts.label ?? ""}`;
+    const ttl = opts.cacheTtlMs ?? defaultTtl;
+    if (opts.refresh !== true) {
+      const cached = cache.get(key);
+      if (cached !== undefined && cached.expiresAt > Date.now()) {
+        return cached.prompt;
+      }
+    }
+    const url = new URL(`${baseUrl}/api/public/v2/prompts/${encodeURIComponent(name)}`);
+    if (opts.version !== undefined) {
+      url.searchParams.set("version", String(opts.version));
+    }
+    if (opts.label !== undefined) {
+      url.searchParams.set("label", opts.label);
+    }
+    const raw = await request<{
+      name: string;
+      version: number;
+      labels?: string[];
+      prompt: unknown;
+      type: "text" | "chat";
+      tags?: string[];
+    }>(url.toString());
+    const prompt: LangfusePrompt = {
+      name: raw.name,
+      version: raw.version,
+      labels: raw.labels ?? [],
+      prompt: normalizePrompt(raw.prompt, raw.type),
+      type: raw.type,
+      ...(raw.tags === undefined ? {} : { tags: raw.tags }),
+      resolvedAt: new Date(),
+    };
+    cache.set(key, { prompt, expiresAt: Date.now() + ttl });
+    return prompt;
+  }
+
+  function getPromptText(name: string, opts?: LangfusePromptGetOptions): Promise<string> {
+    return getPrompt(name, opts).then((prompt) => {
+      if (typeof prompt.prompt !== "string") {
+        throw new Error(`Prompt ${name} is a chat prompt; expected text`);
+      }
+      return prompt.prompt;
+    });
+  }
+
+  function getPromptChat(
+    name: string,
+    opts?: LangfusePromptGetOptions,
+  ): Promise<LangfuseChatMessage[]> {
+    return getPrompt(name, opts).then((prompt) => {
+      if (typeof prompt.prompt === "string") {
+        throw new Error(`Prompt ${name} is a text prompt; expected chat`);
+      }
+      return prompt.prompt;
+    });
+  }
+
+  function refresh(): void {
+    cache.clear();
+  }
+
+  return { getPrompt, getPromptText, getPromptChat, refresh };
+}
+
+function normalizePrompt(raw: unknown, type: "text" | "chat"): string | LangfuseChatMessage[] {
+  if (type === "text") {
+    if (typeof raw === "string") return raw;
+    throw new Error("Expected text prompt to be a string");
+  }
+  if (!Array.isArray(raw)) {
+    throw new Error("Expected chat prompt to be an array of messages");
+  }
+  return raw.map((entry) => {
+    if (typeof entry !== "object" || entry === null) {
+      throw new Error("Expected chat message to be an object");
+    }
+    const role = (entry as { role?: unknown }).role;
+    const content = (entry as { content?: unknown }).content;
+    if (typeof content !== "string") {
+      throw new Error("Expected chat message content to be a string");
+    }
+    if (role !== "system" && role !== "user" && role !== "assistant" && role !== "tool") {
+      throw new Error(`Unexpected chat message role: ${String(role)}`);
+    }
+    return { role, content };
+  });
+}
+
+function buildAuthHeader(
+  publicKey: string | undefined,
+  secretKey: string | undefined,
+): Record<string, string> {
+  if (publicKey === undefined || secretKey === undefined) {
+    return {};
+  }
+  const encoded = Buffer.from(`${publicKey}:${secretKey}`).toString("base64");
+  return { Authorization: `Basic ${encoded}` };
+}
+
+async function readErrorBody(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch {
+    return "<unreadable>";
+  }
+}

--- a/packages/observability-langfuse/src/redaction.ts
+++ b/packages/observability-langfuse/src/redaction.ts
@@ -1,0 +1,178 @@
+import type { Message } from "@anvia/core/completion";
+
+export type RedactorPattern = {
+  name: string;
+  regex: RegExp;
+};
+
+export type LangfuseRedactionOptions = {
+  patterns?: RedactorPattern[];
+  replacement?: string;
+};
+
+export type PiiRedactor = {
+  redactString(input: string): string;
+  redactObject<T>(input: T): T;
+  redactMessages(input: Message[]): Message[];
+  patternNames(): string[];
+};
+
+const DEFAULT_REPLACEMENT = "[REDACTED]";
+const MAX_DEPTH = 16;
+
+export function createPiiRedactor(options: LangfuseRedactionOptions = {}): PiiRedactor {
+  const patterns = options.patterns ?? DEFAULT_PATTERNS;
+  const replacement = options.replacement ?? DEFAULT_REPLACEMENT;
+  const compiled = patterns.map((p) => ({
+    name: p.name,
+    regex: cloneRegex(p.regex, "g"),
+  }));
+  const patternNamesList = patterns.map((p) => p.name);
+
+  function redactString(input: string): string {
+    if (typeof input !== "string") return input;
+    let out = input;
+    for (const { name, regex } of compiled) {
+      out = applyPattern(out, name, regex, replacement);
+    }
+    return out;
+  }
+
+  function redactObject<T>(input: T): T {
+    return redactValue(input, 0, redactString) as T;
+  }
+
+  function redactMessages(input: Message[]): Message[] {
+    return input.map((message) => redactMessage(message, redactString));
+  }
+
+  function patternNames(): string[] {
+    return patternNamesList;
+  }
+
+  return { redactString, redactObject, redactMessages, patternNames };
+}
+
+export const DEFAULT_PATTERNS: RedactorPattern[] = [
+  { name: "email", regex: /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g },
+  { name: "creditCard", regex: /\b(?:\d[ -]?){13,19}\b/g },
+  { name: "ipv4", regex: /\b(?:\d{1,3}\.){3}\d{1,3}\b/g },
+  {
+    name: "phone",
+    regex:
+      /(?<!\d)(?:\+\d{1,3}[\s.-]?)?(?:\(\d{2,4}\)[\s.-]?)?\d{3,4}[\s.-]?\d{3,4}(?:[\s.-]?\d{3,4})?(?!\d)/g,
+  },
+  { name: "jwt", regex: /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g },
+  {
+    name: "apiKey",
+    regex: /\b(?:sk|pk|api|key|token)[-_][A-Za-z0-9]{16,}\b/gi,
+  },
+];
+
+function applyPattern(input: string, name: string, regex: RegExp, replacement: string): string {
+  if (name === "creditCard") {
+    return redactCreditCards(input, replacement);
+  }
+  return input.replace(regex, replacement);
+}
+
+function redactCreditCards(input: string, replacement: string): string {
+  let out = "";
+  let i = 0;
+  while (i < input.length) {
+    const ch = input.charAt(i);
+    if (/\d/.test(ch)) {
+      const { length, valid } = longestLuhnChunk(input.slice(i));
+      if (valid) {
+        out += replacement;
+        i += length;
+        continue;
+      }
+    }
+    out += ch;
+    i += 1;
+  }
+  return out;
+}
+
+function longestLuhnChunk(s: string): { length: number; valid: boolean } {
+  let length = 0;
+  let bestValid = 0;
+  while (length < s.length && length < 40) {
+    const ch = s.charAt(length);
+    if (!/\d/.test(ch) && ch !== "-") break;
+    length += 1;
+    const candidate = s.slice(0, length).replace(/\D/g, "");
+    if (candidate.length >= 13 && candidate.length <= 19) {
+      if (startsWithKnownPrefix(candidate) && passesLuhn(candidate)) {
+        bestValid = length;
+      }
+    }
+  }
+  return { length: bestValid, valid: bestValid > 0 };
+}
+
+function startsWithKnownPrefix(digits: string): boolean {
+  if (digits.startsWith("4")) return true;
+  const two = digits.slice(0, 2);
+  if (two === "51" || two === "52" || two === "53" || two === "54" || two === "55") return true;
+  const four = digits.slice(0, 4);
+  if (four === "2221" || four === "2720") return true;
+  const twoAgain = digits.slice(0, 2);
+  if (twoAgain === "34" || twoAgain === "37") return true;
+  if (four === "6011" || twoAgain === "65") return true;
+  return digits.startsWith("35");
+}
+
+export function passesLuhn(digits: string): boolean {
+  if (!/^\d+$/.test(digits)) return false;
+  let sum = 0;
+  let alt = false;
+  for (let i = digits.length - 1; i >= 0; i -= 1) {
+    const raw = digits.charCodeAt(i) - 48;
+    let value = raw;
+    if (alt) {
+      value *= 2;
+      if (value > 9) value -= 9;
+    }
+    sum += value;
+    alt = !alt;
+  }
+  return sum % 10 === 0;
+}
+
+function cloneRegex(source: RegExp, flags: string): RegExp {
+  return new RegExp(source.source, flags + source.flags.replace(/g/g, ""));
+}
+
+function redactValue(
+  value: unknown,
+  depth: number,
+  redactStringFn: (s: string) => string,
+): unknown {
+  if (depth > MAX_DEPTH) return value;
+  if (typeof value === "string") return redactStringFn(value);
+  if (Array.isArray(value))
+    return value.map((entry) => redactValue(entry, depth + 1, redactStringFn));
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      out[key] = redactValue(entry, depth + 1, redactStringFn);
+    }
+    return out;
+  }
+  return value;
+}
+
+function redactMessage(message: Message, redactStringFn: (s: string) => string): Message {
+  if (!Array.isArray(message.content)) return message;
+  const newContent = message.content.map((part) => {
+    if (part === null || typeof part !== "object") return part;
+    const rec = part as Record<string, unknown>;
+    if (rec.type === "text" && typeof rec.text === "string") {
+      return { ...part, text: redactStringFn(rec.text) };
+    }
+    return part;
+  });
+  return { ...message, content: newContent as never };
+}

--- a/packages/observability-langfuse/src/scoring.ts
+++ b/packages/observability-langfuse/src/scoring.ts
@@ -1,0 +1,193 @@
+import type { LangfuseScoreArgs } from "./types.js";
+
+export class LangfuseScoreError extends Error {
+  readonly scores: LangfuseScoreArgs[];
+  override readonly cause?: unknown;
+
+  constructor(message: string, scores: LangfuseScoreArgs[], cause?: unknown) {
+    super(message);
+    this.name = "LangfuseScoreError";
+    this.scores = scores;
+    if (cause !== undefined) {
+      this.cause = cause;
+    }
+  }
+}
+
+export type ScoreQueueOptions = {
+  baseUrl: string;
+  publicKey: string;
+  secretKey: string;
+  timeoutMs: number;
+  batchSize: number;
+  flushIntervalMs: number;
+  maxRetries: number;
+  fetchImpl?: typeof fetch;
+  sleep?: (ms: number) => Promise<void>;
+  setTimer?: (handler: () => void, ms: number) => unknown;
+  clearTimer?: (handle: unknown) => void;
+};
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+const defaultSetTimer = (handler: () => void, ms: number): unknown => setTimeout(handler, ms);
+const defaultClearTimer = (handle: unknown): void => {
+  clearTimeout(handle as ReturnType<typeof setTimeout>);
+};
+
+export function computeBackoff(attempt: number, jitter: number = Math.random()): number {
+  const base = 200;
+  const exponential = base * 2 ** attempt;
+  const capped = Math.min(exponential, 5_000);
+  const jitterAmount = capped * 0.25 * (jitter * 2 - 1);
+  return Math.max(0, Math.round(capped + jitterAmount));
+}
+
+export class ScoreQueue {
+  private readonly pending: LangfuseScoreArgs[] = [];
+  private timer: unknown = null;
+  private flushing: Promise<void> | null = null;
+  private readonly baseUrl: string;
+  private readonly publicKey: string;
+  private readonly secretKey: string;
+  private readonly timeoutMs: number;
+  private readonly batchSize: number;
+  private readonly flushIntervalMs: number;
+  private readonly maxRetries: number;
+  private readonly fetchImpl: typeof fetch;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private readonly setTimer: (handler: () => void, ms: number) => unknown;
+  private readonly clearTimer: (handle: unknown) => void;
+
+  constructor(options: ScoreQueueOptions) {
+    this.baseUrl = options.baseUrl;
+    this.publicKey = options.publicKey;
+    this.secretKey = options.secretKey;
+    this.timeoutMs = options.timeoutMs;
+    this.batchSize = options.batchSize;
+    this.flushIntervalMs = options.flushIntervalMs;
+    this.maxRetries = options.maxRetries;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.sleep = options.sleep ?? defaultSleep;
+    this.setTimer = options.setTimer ?? defaultSetTimer;
+    this.clearTimer = options.clearTimer ?? defaultClearTimer;
+  }
+
+  enqueue(score: LangfuseScoreArgs): void {
+    this.pending.push(score);
+    if (this.pending.length >= this.batchSize) {
+      void this.flush();
+      return;
+    }
+    this.scheduleTimer();
+  }
+
+  depth(): number {
+    return this.pending.length;
+  }
+
+  async flush(): Promise<void> {
+    if (this.flushing !== null) {
+      await this.flushing;
+      return;
+    }
+    if (this.pending.length === 0) {
+      this.clearScheduledTimer();
+      return;
+    }
+    const batch = this.pending.splice(0, this.pending.length);
+    this.clearScheduledTimer();
+    this.flushing = this.sendBatch(batch).finally(() => {
+      this.flushing = null;
+    });
+    await this.flushing;
+  }
+
+  async shutdown(): Promise<void> {
+    this.clearScheduledTimer();
+    await this.flush();
+  }
+
+  private scheduleTimer(): void {
+    if (this.timer !== null) {
+      return;
+    }
+    this.timer = this.setTimer(() => {
+      this.timer = null;
+      void this.flush();
+    }, this.flushIntervalMs);
+  }
+
+  private clearScheduledTimer(): void {
+    if (this.timer !== null) {
+      this.clearTimer(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private async sendBatch(scores: LangfuseScoreArgs[]): Promise<void> {
+    const body = scores.map((score) => buildScoreBody(score));
+    let lastError: unknown;
+    for (let attempt = 0; attempt < this.maxRetries; attempt += 1) {
+      try {
+        const response = await this.fetchImpl(`${this.baseUrl}/api/public/scores`, {
+          method: "POST",
+          headers: {
+            Authorization: `Basic ${Buffer.from(`${this.publicKey}:${this.secretKey}`).toString("base64")}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(body),
+          signal: AbortSignal.timeout(this.timeoutMs),
+        });
+        if (response.ok) {
+          return;
+        }
+        if (response.status === 429 || response.status >= 500) {
+          lastError = new Error(`Langfuse score batch failed with HTTP ${response.status}`);
+        } else {
+          const text = await response.text();
+          throw new LangfuseScoreError(
+            `Langfuse score batch failed with HTTP ${response.status}: ${text}`,
+            scores,
+          );
+        }
+      } catch (error) {
+        if (error instanceof LangfuseScoreError) {
+          throw error;
+        }
+        lastError = error;
+      }
+      if (attempt < this.maxRetries - 1) {
+        await this.sleep(computeBackoff(attempt));
+      }
+    }
+    throw new LangfuseScoreError(
+      `Langfuse score batch failed after ${this.maxRetries} attempts`,
+      scores,
+      lastError,
+    );
+  }
+}
+
+function buildScoreBody(score: LangfuseScoreArgs): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    traceId: score.traceId,
+    name: score.name,
+    value: score.value,
+  };
+  if (score.observationId !== undefined) body.observationId = score.observationId;
+  if (score.dataType !== undefined) body.dataType = score.dataType;
+  if (score.comment !== undefined) body.comment = score.comment;
+  if (score.metadata !== undefined) body.metadata = score.metadata;
+  const configId = score.configId ?? score.scoreConfigId;
+  if (configId !== undefined) body.configId = configId;
+  if (score.environment !== undefined) body.environment = score.environment;
+  if (score.timestamp !== undefined) {
+    body.timestamp =
+      score.timestamp instanceof Date ? score.timestamp.toISOString() : score.timestamp;
+  }
+  return body;
+}

--- a/packages/observability-langfuse/src/tracing.ts
+++ b/packages/observability-langfuse/src/tracing.ts
@@ -4,6 +4,7 @@ import type {
   AgentGenerationErrorArgs,
   AgentGenerationObserver,
   AgentGenerationStartArgs,
+  AgentGenerationUpdateArgs,
   AgentRunEndArgs,
   AgentRunErrorArgs,
   AgentRunObserver,
@@ -403,6 +404,12 @@ class LangfuseRunObserver implements AgentRunObserver {
 
 class LangfuseGenerationObserver implements AgentGenerationObserver {
   constructor(private readonly generation: LangfuseGeneration) {}
+
+  update(args: AgentGenerationUpdateArgs): void {
+    this.generation.update({
+      output: { delta: args.delta },
+    });
+  }
 
   end(args: AgentGenerationEndArgs): void {
     this.generation

--- a/packages/observability-langfuse/src/tracing.ts
+++ b/packages/observability-langfuse/src/tracing.ts
@@ -40,6 +40,8 @@ import {
 } from "./helpers.js";
 import type { LangfuseScoreArgs, LangfuseTracing, LangfuseTracingOptions } from "./types.js";
 
+type LangfuseScoreDataType = NonNullable<LangfuseScoreArgs["dataType"]>;
+
 export const langfuse = {
   create(options: LangfuseTracingOptions = {}): LangfuseTracing {
     return new LangfuseAgentObserver(options);
@@ -53,6 +55,7 @@ class LangfuseAgentObserver implements LangfuseTracing {
   private readonly secretKey: string | undefined;
   private readonly baseUrl: string;
   private readonly serviceName: string | undefined;
+  private readonly timeoutMs: number;
 
   constructor(options: LangfuseTracingOptions) {
     this.publicKey = resolveOption(options.publicKey, process.env.LANGFUSE_PUBLIC_KEY);
@@ -60,6 +63,7 @@ class LangfuseAgentObserver implements LangfuseTracing {
     this.baseUrl =
       resolveOption(options.baseUrl, process.env.LANGFUSE_BASE_URL) ?? "https://cloud.langfuse.com";
     this.serviceName = resolveOption(options.serviceName, process.env.LANGFUSE_SERVICE_NAME);
+    this.timeoutMs = options.timeoutMs ?? 30_000;
     const processorOptions: ConstructorParameters<typeof LangfuseSpanProcessor>[0] = {
       baseUrl: this.baseUrl,
     };
@@ -141,6 +145,7 @@ class LangfuseAgentObserver implements LangfuseTracing {
     if (this.publicKey === undefined || this.secretKey === undefined) {
       throw new Error("Langfuse score requires publicKey and secretKey");
     }
+    assertScoreValue(args.value, args.dataType);
 
     const body: Record<string, unknown> = {
       traceId: args.traceId,
@@ -148,8 +153,16 @@ class LangfuseAgentObserver implements LangfuseTracing {
       value: args.value,
     };
     if (args.observationId !== undefined) body.observationId = args.observationId;
+    if (args.dataType !== undefined) body.dataType = args.dataType;
     if (args.comment !== undefined) body.comment = args.comment;
     if (args.metadata !== undefined) body.metadata = args.metadata;
+    const configId = args.configId ?? args.scoreConfigId;
+    if (configId !== undefined) body.configId = configId;
+    if (args.environment !== undefined) body.environment = args.environment;
+    if (args.timestamp !== undefined) {
+      body.timestamp =
+        args.timestamp instanceof Date ? args.timestamp.toISOString() : args.timestamp;
+    }
 
     const response = await fetch(`${this.baseUrl}/api/public/scores`, {
       method: "POST",
@@ -158,12 +171,34 @@ class LangfuseAgentObserver implements LangfuseTracing {
         "Content-Type": "application/json",
       },
       body: JSON.stringify(body),
+      signal: AbortSignal.timeout(this.timeoutMs),
     });
     if (!response.ok) {
       throw new Error(
         `Langfuse score failed with HTTP ${response.status}: ${await response.text()}`,
       );
     }
+  }
+}
+
+function assertScoreValue(value: number | string, dataType: LangfuseScoreArgs["dataType"]): void {
+  if (dataType === "NUMERIC") {
+    if (typeof value !== "number") {
+      throw new TypeError(`Langfuse score dataType=NUMERIC requires a number value`);
+    }
+    return;
+  }
+  if (dataType === "CATEGORICAL") {
+    if (typeof value !== "string") {
+      throw new TypeError(`Langfuse score dataType=CATEGORICAL requires a string value`);
+    }
+    return;
+  }
+  if (dataType === "BOOLEAN") {
+    if (value !== 0 && value !== 1) {
+      throw new TypeError(`Langfuse score dataType=BOOLEAN requires value 0 or 1`);
+    }
+    return;
   }
 }
 

--- a/packages/observability-langfuse/src/tracing.ts
+++ b/packages/observability-langfuse/src/tracing.ts
@@ -40,8 +40,6 @@ import {
 } from "./helpers.js";
 import type { LangfuseScoreArgs, LangfuseTracing, LangfuseTracingOptions } from "./types.js";
 
-type LangfuseScoreDataType = NonNullable<LangfuseScoreArgs["dataType"]>;
-
 export const langfuse = {
   create(options: LangfuseTracingOptions = {}): LangfuseTracing {
     return new LangfuseAgentObserver(options);

--- a/packages/observability-langfuse/src/tracing.ts
+++ b/packages/observability-langfuse/src/tracing.ts
@@ -7,6 +7,7 @@ import type {
   AgentGenerationUpdateArgs,
   AgentRunEndArgs,
   AgentRunErrorArgs,
+  AgentRunEventArgs,
   AgentRunObserver,
   AgentRunStartArgs,
   AgentToolEndArgs,
@@ -40,7 +41,12 @@ import {
   usageDetailsFromRecord,
 } from "./helpers.js";
 import { ScoreQueue } from "./scoring.js";
-import type { LangfuseScoreArgs, LangfuseTracing, LangfuseTracingOptions } from "./types.js";
+import type {
+  LangfuseScoreArgs,
+  LangfuseTraceHandle,
+  LangfuseTracing,
+  LangfuseTracingOptions,
+} from "./types.js";
 
 export const langfuse = {
   create(options: LangfuseTracingOptions = {}): LangfuseTracing {
@@ -57,6 +63,7 @@ class LangfuseAgentObserver implements LangfuseTracing {
   private readonly serviceName: string | undefined;
   private readonly timeoutMs: number;
   private readonly queue: ScoreQueue | null;
+  private currentHandle: LangfuseTraceHandle | undefined;
 
   constructor(options: LangfuseTracingOptions) {
     this.publicKey = resolveOption(options.publicKey, process.env.LANGFUSE_PUBLIC_KEY);
@@ -138,10 +145,20 @@ class LangfuseAgentObserver implements LangfuseTracing {
     );
     applyTraceAttributes(root, args);
 
-    return new LangfuseRunObserver(root, {
+    const runObserver = new LangfuseRunObserver(root, {
       traceId: root.traceId,
       observationId: root.id,
     });
+    this.currentHandle = runObserver.getHandle();
+    runObserver.setCurrentHandle = (handle) => {
+      this.currentHandle = handle;
+    };
+    runObserver.clearCurrentHandle = () => {
+      if (this.currentHandle === runObserver.getHandle()) {
+        this.currentHandle = undefined;
+      }
+    };
+    return runObserver;
   }
 
   async flush(): Promise<void> {
@@ -160,6 +177,10 @@ class LangfuseAgentObserver implements LangfuseTracing {
 
   scoreQueueDepth(): number {
     return this.queue?.depth() ?? 0;
+  }
+
+  getCurrentTrace(): LangfuseTraceHandle | undefined {
+    return this.currentHandle;
   }
 
   async score(args: LangfuseScoreArgs): Promise<void> {
@@ -278,11 +299,18 @@ function serializeMetadataValue(value: unknown): string | undefined {
 
 class LangfuseRunObserver implements AgentRunObserver {
   private readonly turnSpans = new Map<number, LangfuseSpan>();
+  // Assigned by LangfuseAgentObserver.startRun so that the run can
+  // publish trace-handle updates back to the agent observer.
+  setCurrentHandle: ((handle: LangfuseTraceHandle) => void) | undefined;
+  clearCurrentHandle: (() => void) | undefined;
+  private handle: LangfuseTraceHandle;
 
   constructor(
     private readonly root: LangfuseAgent,
     readonly trace: AgentTraceInfo,
-  ) {}
+  ) {
+    this.handle = this.buildHandle();
+  }
 
   startGeneration(args: AgentGenerationStartArgs): AgentGenerationObserver {
     this.closeEarlierTurns(args.turn);
@@ -349,6 +377,7 @@ class LangfuseRunObserver implements AgentRunObserver {
         },
       })
       .end();
+    this.clearCurrentHandle?.();
   }
 
   error(args: AgentRunErrorArgs): void {
@@ -366,6 +395,32 @@ class LangfuseRunObserver implements AgentRunObserver {
         },
       })
       .end();
+    this.clearCurrentHandle?.();
+  }
+
+  event(args: AgentRunEventArgs): void {
+    const metadata: Record<string, unknown> = { ...(args.attributes ?? {}) };
+    this.root.startObservation(args.name, { metadata }, { asType: "event" }).end();
+  }
+
+  getHandle(): LangfuseTraceHandle {
+    return this.handle;
+  }
+
+  private buildHandle(): LangfuseTraceHandle {
+    return {
+      traceId: this.trace.traceId ?? "",
+      observationId: this.trace.observationId ?? "",
+      addAttributes: (attributes) => {
+        this.root.update({ metadata: attributes });
+        this.setCurrentHandle?.(this.handle);
+      },
+      addEvent: (name, attributes) => {
+        const metadata: Record<string, unknown> = { ...(attributes ?? {}) };
+        this.root.startObservation(name, { metadata }, { asType: "event" }).end();
+        this.setCurrentHandle?.(this.handle);
+      },
+    };
   }
 
   private turnSpan(turn: number): LangfuseSpan {

--- a/packages/observability-langfuse/src/tracing.ts
+++ b/packages/observability-langfuse/src/tracing.ts
@@ -9,6 +9,7 @@ import type {
   AgentRunErrorArgs,
   AgentRunEventArgs,
   AgentRunObserver,
+  AgentRunPromptRef,
   AgentRunStartArgs,
   AgentToolEndArgs,
   AgentToolErrorArgs,
@@ -145,10 +146,15 @@ class LangfuseAgentObserver implements LangfuseTracing {
     );
     applyTraceAttributes(root, args);
 
-    const runObserver = new LangfuseRunObserver(root, {
-      traceId: root.traceId,
-      observationId: root.id,
-    });
+    const promptRef = resolvePromptRef(args);
+    const runObserver = new LangfuseRunObserver(
+      root,
+      {
+        traceId: root.traceId,
+        observationId: root.id,
+      },
+      promptRef,
+    );
     this.currentHandle = runObserver.getHandle();
     runObserver.setCurrentHandle = (handle) => {
       this.currentHandle = handle;
@@ -281,6 +287,59 @@ function applyTraceAttributes(root: LangfuseAgent, args: AgentRunStartArgs): voi
     }
     root.otelSpan.setAttribute(`${LangfuseOtelSpanAttributes.TRACE_METADATA}.${key}`, serialized);
   }
+  const promptRef = resolvePromptRef(args);
+  if (promptRef !== undefined) {
+    root.otelSpan.setAttribute(
+      `${LangfuseOtelSpanAttributes.TRACE_METADATA}.promptName`,
+      promptRef.name,
+    );
+    if (promptRef.version !== undefined) {
+      root.otelSpan.setAttribute(
+        `${LangfuseOtelSpanAttributes.TRACE_METADATA}.promptVersion`,
+        String(promptRef.version),
+      );
+    }
+  }
+}
+
+function resolvePromptRef(args: AgentRunStartArgs): AgentRunPromptRef | undefined {
+  if (args.promptRef !== undefined) {
+    return args.promptRef;
+  }
+  const metadata = args.trace?.metadata;
+  if (metadata === undefined) {
+    return undefined;
+  }
+  const name = metadata.promptName;
+  if (typeof name !== "string" || name.length === 0) {
+    return undefined;
+  }
+  const rawVersion = metadata.promptVersion;
+  if (rawVersion === undefined || rawVersion === null) {
+    return { name };
+  }
+  const version =
+    typeof rawVersion === "number"
+      ? rawVersion
+      : typeof rawVersion === "string" && rawVersion.trim().length > 0
+        ? Number(rawVersion)
+        : undefined;
+  if (version === undefined || !Number.isFinite(version)) {
+    return { name };
+  }
+  return { name, version };
+}
+
+function promptMetadata(
+  ref: AgentRunPromptRef | undefined,
+): Record<string, string | number | undefined> {
+  if (ref === undefined) {
+    return {};
+  }
+  return {
+    promptName: ref.name,
+    ...(ref.version === undefined ? {} : { promptVersion: ref.version }),
+  };
 }
 
 function serializeMetadataValue(value: unknown): string | undefined {
@@ -304,12 +363,15 @@ class LangfuseRunObserver implements AgentRunObserver {
   setCurrentHandle: ((handle: LangfuseTraceHandle) => void) | undefined;
   clearCurrentHandle: (() => void) | undefined;
   private handle: LangfuseTraceHandle;
+  private readonly promptRef: AgentRunPromptRef | undefined;
 
   constructor(
     private readonly root: LangfuseAgent,
     readonly trace: AgentTraceInfo,
+    promptRef?: AgentRunPromptRef,
   ) {
     this.handle = this.buildHandle();
+    this.promptRef = promptRef;
   }
 
   startGeneration(args: AgentGenerationStartArgs): AgentGenerationObserver {
@@ -337,6 +399,7 @@ class LangfuseRunObserver implements AgentRunObserver {
                 },
               }
             : {}),
+          ...promptMetadata(this.promptRef),
         },
       },
       { asType: "generation" },

--- a/packages/observability-langfuse/src/tracing.ts
+++ b/packages/observability-langfuse/src/tracing.ts
@@ -41,8 +41,10 @@ import {
   usageDetails,
   usageDetailsFromRecord,
 } from "./helpers.js";
+import { createPiiRedactor, type PiiRedactor } from "./redaction.js";
 import { ScoreQueue } from "./scoring.js";
 import type {
+  LangfuseRedactionMode,
   LangfuseScoreArgs,
   LangfuseTraceHandle,
   LangfuseTracing,
@@ -65,6 +67,9 @@ class LangfuseAgentObserver implements LangfuseTracing {
   private readonly timeoutMs: number;
   private readonly queue: ScoreQueue | null;
   private currentHandle: LangfuseTraceHandle | undefined;
+  private readonly redactor: PiiRedactor | undefined;
+  private readonly redactInputs: LangfuseRedactionMode | undefined;
+  private readonly redactOutputs: LangfuseRedactionMode | undefined;
 
   constructor(options: LangfuseTracingOptions) {
     this.publicKey = resolveOption(options.publicKey, process.env.LANGFUSE_PUBLIC_KEY);
@@ -109,15 +114,22 @@ class LangfuseAgentObserver implements LangfuseTracing {
             maxRetries: options.scoreMaxRetries ?? 3,
           })
         : null;
+    this.redactInputs = options.redactInputs;
+    this.redactOutputs = options.redactOutputs;
+    this.redactor =
+      options.redactInputs !== undefined || options.redactOutputs !== undefined
+        ? createPiiRedactor(options.redaction)
+        : undefined;
   }
 
   async startRun(args: AgentRunStartArgs): Promise<AgentRunObserver> {
     const traceId = args.trace?.traceId;
+    const redactedInput = this.maybeRedactInput({
+      prompt: args.prompt,
+      history: args.history,
+    });
     const rootAttributes: Parameters<typeof startObservation>[1] = {
-      input: {
-        prompt: args.prompt,
-        history: args.history,
-      },
+      input: redactedInput,
       metadata: {
         ...(this.serviceName !== undefined ? { serviceName: this.serviceName } : {}),
         agentName: args.agentName,
@@ -154,6 +166,11 @@ class LangfuseAgentObserver implements LangfuseTracing {
         observationId: root.id,
       },
       promptRef,
+      {
+        redactor: this.redactor,
+        redactInputs: this.redactInputs,
+        redactOutputs: this.redactOutputs,
+      },
     );
     this.currentHandle = runObserver.getHandle();
     runObserver.setCurrentHandle = (handle) => {
@@ -187,6 +204,16 @@ class LangfuseAgentObserver implements LangfuseTracing {
 
   getCurrentTrace(): LangfuseTraceHandle | undefined {
     return this.currentHandle;
+  }
+
+  private maybeRedactInput<T>(value: T): T {
+    if (this.redactor === undefined || this.redactInputs === undefined) return value;
+    return applyRedaction(this.redactor, value, this.redactInputs);
+  }
+
+  private maybeRedactOutput<T>(value: T): T {
+    if (this.redactor === undefined || this.redactOutputs === undefined) return value;
+    return applyRedaction(this.redactor, value, this.redactOutputs);
   }
 
   async score(args: LangfuseScoreArgs): Promise<void> {
@@ -302,6 +329,22 @@ function applyTraceAttributes(root: LangfuseAgent, args: AgentRunStartArgs): voi
   }
 }
 
+function applyRedaction<T>(redactor: PiiRedactor, value: T, mode: LangfuseRedactionMode): T {
+  if (mode === "deep") {
+    return redactor.redactObject(value);
+  }
+  if (typeof value === "string") {
+    return redactor.redactString(value) as unknown as T;
+  }
+  if (Array.isArray(value)) {
+    return redactor.redactMessages(value as never) as unknown as T;
+  }
+  if (value !== null && typeof value === "object") {
+    return redactor.redactObject(value);
+  }
+  return value;
+}
+
 function resolvePromptRef(args: AgentRunStartArgs): AgentRunPromptRef | undefined {
   if (args.promptRef !== undefined) {
     return args.promptRef;
@@ -364,23 +407,45 @@ class LangfuseRunObserver implements AgentRunObserver {
   clearCurrentHandle: (() => void) | undefined;
   private handle: LangfuseTraceHandle;
   private readonly promptRef: AgentRunPromptRef | undefined;
+  private readonly redactor: PiiRedactor | undefined;
+  private readonly redactInputs: LangfuseRedactionMode | undefined;
+  private readonly redactOutputs: LangfuseRedactionMode | undefined;
 
   constructor(
     private readonly root: LangfuseAgent,
     readonly trace: AgentTraceInfo,
-    promptRef?: AgentRunPromptRef,
+    promptRef: AgentRunPromptRef | undefined,
+    redaction: {
+      redactor: PiiRedactor | undefined;
+      redactInputs: LangfuseRedactionMode | undefined;
+      redactOutputs: LangfuseRedactionMode | undefined;
+    },
   ) {
     this.handle = this.buildHandle();
     this.promptRef = promptRef;
+    this.redactor = redaction.redactor;
+    this.redactInputs = redaction.redactInputs;
+    this.redactOutputs = redaction.redactOutputs;
+  }
+
+  redactInputValue<T>(value: T): T {
+    if (this.redactor === undefined || this.redactInputs === undefined) return value;
+    return applyRedaction(this.redactor, value, this.redactInputs);
+  }
+
+  redactOutputValue<T>(value: T): T {
+    if (this.redactor === undefined || this.redactOutputs === undefined) return value;
+    return applyRedaction(this.redactor, value, this.redactOutputs);
   }
 
   startGeneration(args: AgentGenerationStartArgs): AgentGenerationObserver {
     this.closeEarlierTurns(args.turn);
     const turn = this.turnSpan(args.turn);
+    const redactedChatHistory = this.redactInputValue(args.request.chatHistory);
     const generation = turn.startObservation(
       `model.turn.${args.turn}`,
       {
-        input: args.request.chatHistory,
+        input: redactedChatHistory,
         model: args.request.model ?? "default",
         modelParameters: modelParameters(args.request),
         metadata: {
@@ -404,16 +469,17 @@ class LangfuseRunObserver implements AgentRunObserver {
       },
       { asType: "generation" },
     );
-    return new LangfuseGenerationObserver(generation);
+    return new LangfuseGenerationObserver(generation, this);
   }
 
   startTool(args: AgentToolStartArgs): AgentToolObserver {
     const turn = this.turnSpan(args.turn);
+    const redactedArgs = this.redactInputValue(args.args);
     const tool = turn.startObservation(
       `tool.${args.toolName}`,
       {
         input: {
-          args: args.args,
+          args: redactedArgs,
           toolCall: args.toolCall,
         },
         metadata: {
@@ -426,14 +492,15 @@ class LangfuseRunObserver implements AgentRunObserver {
       },
       { asType: "tool" },
     );
-    return new LangfuseToolObserver(tool);
+    return new LangfuseToolObserver(tool, this);
   }
 
   end(args: AgentRunEndArgs): void {
     this.closeAllTurns();
+    const redactedOutput = this.redactOutputValue(args.output);
     this.root
       .update({
-        output: args.output,
+        output: redactedOutput,
         metadata: {
           usage: args.usage,
           messages: args.messages,
@@ -521,7 +588,10 @@ class LangfuseRunObserver implements AgentRunObserver {
 }
 
 class LangfuseGenerationObserver implements AgentGenerationObserver {
-  constructor(private readonly generation: LangfuseGeneration) {}
+  constructor(
+    private readonly generation: LangfuseGeneration,
+    private readonly run: LangfuseRunObserver,
+  ) {}
 
   update(args: AgentGenerationUpdateArgs): void {
     this.generation.update({
@@ -530,12 +600,14 @@ class LangfuseGenerationObserver implements AgentGenerationObserver {
   }
 
   end(args: AgentGenerationEndArgs): void {
+    const redactedText = this.run.redactOutputValue(textFromAssistantContent(args.response.choice));
+    const redactedChoice = this.run.redactOutputValue(args.response.choice);
     this.generation
       .update({
         output: {
           messageId: args.response.messageId,
-          content: args.response.choice,
-          text: textFromAssistantContent(args.response.choice),
+          content: redactedChoice,
+          text: redactedText,
         },
         usageDetails: usageDetails(args.response.usage),
         metadata: {
@@ -569,7 +641,10 @@ class LangfuseToolObserver implements AgentToolObserver {
     ended: boolean;
   }> = [];
 
-  constructor(private readonly tool: LangfuseTool) {}
+  constructor(
+    private readonly tool: LangfuseTool,
+    private readonly run: LangfuseRunObserver,
+  ) {}
 
   streamEvent(args: AgentToolStreamEventArgs): void {
     const wrapper = args.event;
@@ -699,14 +774,16 @@ class LangfuseToolObserver implements AgentToolObserver {
 
   end(args: AgentToolEndArgs): void {
     this.endOpenChildren();
+    const redactedResult = this.run.redactOutputValue(args.result);
+    const redactedStructured = this.run.redactOutputValue(args.structuredResult);
     const attributes: Parameters<LangfuseTool["update"]>[0] = {
-      output: args.result,
+      output: redactedResult,
       metadata: {
         turn: args.turn,
         internalCallId: args.internalCallId,
         toolCallId: args.toolCallId,
         skipped: args.skipped,
-        ...(args.structuredResult !== undefined ? { structuredResult: args.structuredResult } : {}),
+        ...(redactedStructured !== undefined ? { structuredResult: redactedStructured } : {}),
       },
       level: args.skipped ? "WARNING" : "DEFAULT",
     };

--- a/packages/observability-langfuse/src/tracing.ts
+++ b/packages/observability-langfuse/src/tracing.ts
@@ -225,6 +225,18 @@ class LangfuseRunObserver implements AgentRunObserver {
           turn: args.turn,
           toolCount: args.request.tools.length,
           hasOutputSchema: args.request.outputSchema !== undefined,
+          ...(args.providerRequest !== undefined ? { providerRequest: args.providerRequest } : {}),
+          ...(args.modelInfo !== undefined
+            ? {
+                modelInfo: {
+                  provider: args.modelInfo.provider,
+                  defaultModel: args.modelInfo.defaultModel,
+                  ...(args.modelInfo.capabilities !== undefined
+                    ? { capabilities: args.modelInfo.capabilities }
+                    : {}),
+                },
+              }
+            : {}),
         },
       },
       { asType: "generation" },
@@ -245,6 +257,8 @@ class LangfuseRunObserver implements AgentRunObserver {
           turn: args.turn,
           internalCallId: args.internalCallId,
           toolCallId: args.toolCallId,
+          ...(args.toolDefinition !== undefined ? { toolDefinition: args.toolDefinition } : {}),
+          ...(args.toolMetadata !== undefined ? { toolMetadata: args.toolMetadata } : {}),
         },
       },
       { asType: "tool" },
@@ -330,6 +344,7 @@ class LangfuseGenerationObserver implements AgentGenerationObserver {
         usageDetails: usageDetails(args.response.usage),
         metadata: {
           turn: args.turn,
+          ...(args.firstDeltaMs !== undefined ? { firstDeltaMs: args.firstDeltaMs } : {}),
         },
       })
       .end();
@@ -495,6 +510,7 @@ class LangfuseToolObserver implements AgentToolObserver {
         internalCallId: args.internalCallId,
         toolCallId: args.toolCallId,
         skipped: args.skipped,
+        ...(args.structuredResult !== undefined ? { structuredResult: args.structuredResult } : {}),
       },
       level: args.skipped ? "WARNING" : "DEFAULT",
     };

--- a/packages/observability-langfuse/src/tracing.ts
+++ b/packages/observability-langfuse/src/tracing.ts
@@ -24,15 +24,17 @@ import {
   type LangfuseTool,
   startObservation,
 } from "@langfuse/tracing";
+import { resourceFromAttributes } from "@opentelemetry/resources";
 import { NodeSDK } from "@opentelemetry/sdk-node";
+import { SEMRESATTRS_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 import {
   agentLabel,
   childMetadata,
-  emptyToUndefined,
   errorMessage,
   generationKey,
   isRecord,
   modelParameters,
+  resolveOption,
   usageDetails,
   usageDetailsFromRecord,
 } from "./helpers.js";
@@ -50,24 +52,36 @@ class LangfuseAgentObserver implements LangfuseTracing {
   private readonly publicKey: string | undefined;
   private readonly secretKey: string | undefined;
   private readonly baseUrl: string;
+  private readonly serviceName: string | undefined;
 
   constructor(options: LangfuseTracingOptions) {
-    this.publicKey = emptyToUndefined(options.publicKey);
-    this.secretKey = emptyToUndefined(options.secretKey);
-    this.baseUrl = emptyToUndefined(options.baseUrl) ?? "https://cloud.langfuse.com";
+    this.publicKey = resolveOption(options.publicKey, process.env.LANGFUSE_PUBLIC_KEY);
+    this.secretKey = resolveOption(options.secretKey, process.env.LANGFUSE_SECRET_KEY);
+    this.baseUrl =
+      resolveOption(options.baseUrl, process.env.LANGFUSE_BASE_URL) ?? "https://cloud.langfuse.com";
+    this.serviceName = resolveOption(options.serviceName, process.env.LANGFUSE_SERVICE_NAME);
     const processorOptions: ConstructorParameters<typeof LangfuseSpanProcessor>[0] = {
       baseUrl: this.baseUrl,
     };
     if (this.publicKey !== undefined) processorOptions.publicKey = this.publicKey;
     if (this.secretKey !== undefined) processorOptions.secretKey = this.secretKey;
-    const environment = emptyToUndefined(options.environment);
+    const environment = resolveOption(
+      options.environment,
+      process.env.LANGFUSE_TRACING_ENVIRONMENT,
+    );
     if (environment !== undefined) processorOptions.environment = environment;
-    const release = emptyToUndefined(options.release);
+    const release = resolveOption(options.release, process.env.LANGFUSE_RELEASE);
     if (release !== undefined) processorOptions.release = release;
     this.processor = new LangfuseSpanProcessor(processorOptions);
-    this.sdk = new NodeSDK({
+    const sdkOptions: ConstructorParameters<typeof NodeSDK>[0] = {
       spanProcessors: [this.processor],
-    });
+    };
+    if (this.serviceName !== undefined) {
+      sdkOptions.resource = resourceFromAttributes({
+        [SEMRESATTRS_SERVICE_NAME]: this.serviceName,
+      });
+    }
+    this.sdk = new NodeSDK(sdkOptions);
     this.sdk.start();
   }
 
@@ -79,6 +93,7 @@ class LangfuseAgentObserver implements LangfuseTracing {
         history: args.history,
       },
       metadata: {
+        ...(this.serviceName !== undefined ? { serviceName: this.serviceName } : {}),
         agentName: args.agentName,
         agentDescription: args.agentDescription,
         maxTurns: args.maxTurns,

--- a/packages/observability-langfuse/src/tracing.ts
+++ b/packages/observability-langfuse/src/tracing.ts
@@ -38,6 +38,7 @@ import {
   usageDetails,
   usageDetailsFromRecord,
 } from "./helpers.js";
+import { ScoreQueue } from "./scoring.js";
 import type { LangfuseScoreArgs, LangfuseTracing, LangfuseTracingOptions } from "./types.js";
 
 export const langfuse = {
@@ -54,6 +55,7 @@ class LangfuseAgentObserver implements LangfuseTracing {
   private readonly baseUrl: string;
   private readonly serviceName: string | undefined;
   private readonly timeoutMs: number;
+  private readonly queue: ScoreQueue | null;
 
   constructor(options: LangfuseTracingOptions) {
     this.publicKey = resolveOption(options.publicKey, process.env.LANGFUSE_PUBLIC_KEY);
@@ -85,6 +87,19 @@ class LangfuseAgentObserver implements LangfuseTracing {
     }
     this.sdk = new NodeSDK(sdkOptions);
     this.sdk.start();
+    const batchSize = options.scoreBatchSize ?? 0;
+    this.queue =
+      batchSize > 0 && this.publicKey !== undefined && this.secretKey !== undefined
+        ? new ScoreQueue({
+            baseUrl: this.baseUrl,
+            publicKey: this.publicKey,
+            secretKey: this.secretKey,
+            timeoutMs: this.timeoutMs,
+            batchSize,
+            flushIntervalMs: options.scoreFlushIntervalMs ?? 250,
+            maxRetries: options.scoreMaxRetries ?? 3,
+          })
+        : null;
   }
 
   async startRun(args: AgentRunStartArgs): Promise<AgentRunObserver> {
@@ -129,11 +144,21 @@ class LangfuseAgentObserver implements LangfuseTracing {
   }
 
   async flush(): Promise<void> {
+    await this.queue?.flush();
     await this.processor.forceFlush();
   }
 
   async shutdown(): Promise<void> {
+    await this.queue?.shutdown();
     await this.sdk.shutdown();
+  }
+
+  async flushScores(): Promise<void> {
+    await this.queue?.flush();
+  }
+
+  scoreQueueDepth(): number {
+    return this.queue?.depth() ?? 0;
   }
 
   async score(args: LangfuseScoreArgs): Promise<void> {
@@ -145,23 +170,16 @@ class LangfuseAgentObserver implements LangfuseTracing {
     }
     assertScoreValue(args.value, args.dataType);
 
-    const body: Record<string, unknown> = {
-      traceId: args.traceId,
-      name: args.name,
-      value: args.value,
-    };
-    if (args.observationId !== undefined) body.observationId = args.observationId;
-    if (args.dataType !== undefined) body.dataType = args.dataType;
-    if (args.comment !== undefined) body.comment = args.comment;
-    if (args.metadata !== undefined) body.metadata = args.metadata;
-    const configId = args.configId ?? args.scoreConfigId;
-    if (configId !== undefined) body.configId = configId;
-    if (args.environment !== undefined) body.environment = args.environment;
-    if (args.timestamp !== undefined) {
-      body.timestamp =
-        args.timestamp instanceof Date ? args.timestamp.toISOString() : args.timestamp;
+    if (this.queue !== null) {
+      this.queue.enqueue(args);
+      return;
     }
 
+    await this.sendScore(args);
+  }
+
+  private async sendScore(args: LangfuseScoreArgs): Promise<void> {
+    const body = buildScoreBody(args);
     const response = await fetch(`${this.baseUrl}/api/public/scores`, {
       method: "POST",
       headers: {
@@ -198,6 +216,26 @@ function assertScoreValue(value: number | string, dataType: LangfuseScoreArgs["d
     }
     return;
   }
+}
+
+function buildScoreBody(score: LangfuseScoreArgs): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    traceId: score.traceId,
+    name: score.name,
+    value: score.value,
+  };
+  if (score.observationId !== undefined) body.observationId = score.observationId;
+  if (score.dataType !== undefined) body.dataType = score.dataType;
+  if (score.comment !== undefined) body.comment = score.comment;
+  if (score.metadata !== undefined) body.metadata = score.metadata;
+  const configId = score.configId ?? score.scoreConfigId;
+  if (configId !== undefined) body.configId = configId;
+  if (score.environment !== undefined) body.environment = score.environment;
+  if (score.timestamp !== undefined) {
+    body.timestamp =
+      score.timestamp instanceof Date ? score.timestamp.toISOString() : score.timestamp;
+  }
+  return body;
 }
 
 function applyTraceAttributes(root: LangfuseAgent, args: AgentRunStartArgs): void {

--- a/packages/observability-langfuse/src/types.ts
+++ b/packages/observability-langfuse/src/types.ts
@@ -119,3 +119,40 @@ export type LangfuseDatasetClient = {
     options: LangfuseRunExperimentOptions<Input, Output, Expected>,
   ): Promise<LangfuseRunExperimentResult>;
 };
+
+export type LangfusePromptClientOptions = {
+  baseUrl?: string | undefined;
+  publicKey?: string | undefined;
+  secretKey?: string | undefined;
+  cacheTtlMs?: number | undefined;
+  timeoutMs?: number | undefined;
+};
+
+export type LangfusePromptGetOptions = {
+  version?: number | undefined;
+  label?: string | undefined;
+  cacheTtlMs?: number | undefined;
+  refresh?: boolean | undefined;
+};
+
+export type LangfuseChatMessage = {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string;
+};
+
+export type LangfusePrompt = {
+  name: string;
+  version: number;
+  labels: string[];
+  prompt: string | LangfuseChatMessage[];
+  type: "text" | "chat";
+  tags?: string[];
+  resolvedAt: Date;
+};
+
+export type LangfusePromptClient = {
+  getPrompt(name: string, options?: LangfusePromptGetOptions): Promise<LangfusePrompt>;
+  getPromptText(name: string, options?: LangfusePromptGetOptions): Promise<string>;
+  getPromptChat(name: string, options?: LangfusePromptGetOptions): Promise<LangfuseChatMessage[]>;
+  refresh(): void;
+};

--- a/packages/observability-langfuse/src/types.ts
+++ b/packages/observability-langfuse/src/types.ts
@@ -1,6 +1,18 @@
 import type { JsonValue } from "@anvia/core/completion";
 import type { AgentObserver } from "@anvia/core/observability";
 
+export type LangfuseRedactionMode = boolean | "deep";
+
+export type LangfuseRedactionOptions = {
+  patterns?: RedactorPattern[];
+  replacement?: string;
+};
+
+export type RedactorPattern = {
+  name: string;
+  regex: RegExp;
+};
+
 export type LangfuseTracingOptions = {
   publicKey?: string | undefined;
   secretKey?: string | undefined;
@@ -12,6 +24,9 @@ export type LangfuseTracingOptions = {
   scoreBatchSize?: number | undefined;
   scoreFlushIntervalMs?: number | undefined;
   scoreMaxRetries?: number | undefined;
+  redactInputs?: LangfuseRedactionMode | undefined;
+  redactOutputs?: LangfuseRedactionMode | undefined;
+  redaction?: LangfuseRedactionOptions | undefined;
 };
 
 export type LangfuseScoreDataType = "NUMERIC" | "CATEGORICAL" | "BOOLEAN";

--- a/packages/observability-langfuse/src/types.ts
+++ b/packages/observability-langfuse/src/types.ts
@@ -8,15 +8,23 @@ export type LangfuseTracingOptions = {
   environment?: string | undefined;
   release?: string | undefined;
   serviceName?: string | undefined;
+  timeoutMs?: number | undefined;
 };
+
+export type LangfuseScoreDataType = "NUMERIC" | "CATEGORICAL" | "BOOLEAN";
 
 export type LangfuseScoreArgs = {
   traceId?: string | undefined;
   observationId?: string | undefined;
   name: string;
-  value: number;
+  value: number | string;
+  dataType?: LangfuseScoreDataType | undefined;
   comment?: string | undefined;
   metadata?: Record<string, JsonValue | undefined> | undefined;
+  configId?: string | undefined;
+  scoreConfigId?: string | undefined;
+  environment?: string | undefined;
+  timestamp?: Date | string | undefined;
 };
 
 export type LangfuseTracing = AgentObserver & {

--- a/packages/observability-langfuse/src/types.ts
+++ b/packages/observability-langfuse/src/types.ts
@@ -49,4 +49,7 @@ export type LangfuseTracing = AgentObserver & {
 export type LangfuseEvalReporterOptions = {
   publishInvalid?: boolean | undefined;
   strict?: boolean | undefined;
+  onMissingTrace?: "ignore" | "warn" | "throw" | undefined;
+  truncateInputAt?: number | undefined;
+  includeMessages?: boolean | undefined;
 };

--- a/packages/observability-langfuse/src/types.ts
+++ b/packages/observability-langfuse/src/types.ts
@@ -7,6 +7,7 @@ export type LangfuseTracingOptions = {
   baseUrl?: string | undefined;
   environment?: string | undefined;
   release?: string | undefined;
+  serviceName?: string | undefined;
 };
 
 export type LangfuseScoreArgs = {

--- a/packages/observability-langfuse/src/types.ts
+++ b/packages/observability-langfuse/src/types.ts
@@ -30,12 +30,20 @@ export type LangfuseScoreArgs = {
   timestamp?: Date | string | undefined;
 };
 
+export type LangfuseTraceHandle = {
+  readonly traceId: string;
+  readonly observationId: string;
+  addAttributes(attributes: Record<string, JsonValue | undefined>): void;
+  addEvent(name: string, attributes?: Record<string, JsonValue | undefined>): void;
+};
+
 export type LangfuseTracing = AgentObserver & {
   flush(): Promise<void>;
   shutdown(): Promise<void>;
   score(args: LangfuseScoreArgs): Promise<void>;
   flushScores(): Promise<void>;
   scoreQueueDepth(): number;
+  getCurrentTrace(): LangfuseTraceHandle | undefined;
 };
 
 export type LangfuseEvalReporterOptions = {

--- a/packages/observability-langfuse/src/types.ts
+++ b/packages/observability-langfuse/src/types.ts
@@ -9,6 +9,9 @@ export type LangfuseTracingOptions = {
   release?: string | undefined;
   serviceName?: string | undefined;
   timeoutMs?: number | undefined;
+  scoreBatchSize?: number | undefined;
+  scoreFlushIntervalMs?: number | undefined;
+  scoreMaxRetries?: number | undefined;
 };
 
 export type LangfuseScoreDataType = "NUMERIC" | "CATEGORICAL" | "BOOLEAN";
@@ -31,6 +34,8 @@ export type LangfuseTracing = AgentObserver & {
   flush(): Promise<void>;
   shutdown(): Promise<void>;
   score(args: LangfuseScoreArgs): Promise<void>;
+  flushScores(): Promise<void>;
+  scoreQueueDepth(): number;
 };
 
 export type LangfuseEvalReporterOptions = {

--- a/packages/observability-langfuse/src/types.ts
+++ b/packages/observability-langfuse/src/types.ts
@@ -53,3 +53,69 @@ export type LangfuseEvalReporterOptions = {
   truncateInputAt?: number | undefined;
   includeMessages?: boolean | undefined;
 };
+
+export type LangfuseDatasetClientOptions = {
+  baseUrl?: string | undefined;
+  publicKey?: string | undefined;
+  secretKey?: string | undefined;
+  pageSize?: number | undefined;
+  timeoutMs?: number | undefined;
+};
+
+export type LangfuseDatasetItem<Input = unknown, Expected = unknown> = {
+  id: string;
+  input: Input;
+  expected?: Expected | undefined;
+  metadata?: Record<string, JsonValue | undefined> | undefined;
+};
+
+export type LangfuseDataset<Input = unknown, Expected = unknown> = {
+  name: string;
+  description?: string | undefined;
+  metadata?: Record<string, JsonValue | undefined> | undefined;
+  items: LangfuseDatasetItem<Input, Expected>[];
+};
+
+export type LangfuseRunItemResult<Output = unknown> = {
+  output: Output;
+  trace?: { traceId: string; observationId?: string | undefined } | undefined;
+};
+
+export type LangfuseRunItemError = {
+  itemId: string;
+  error: unknown;
+};
+
+export type LangfuseRunExperimentOptions<Input = unknown, Output = unknown, Expected = unknown> = {
+  datasetName: string;
+  runName: string;
+  description?: string | undefined;
+  metadata?: Record<string, JsonValue | undefined> | undefined;
+  items?: LangfuseDatasetItem<Input, Expected>[] | undefined;
+  run: (
+    item: LangfuseDatasetItem<Input, Expected>,
+  ) => LangfuseRunItemResult<Output> | Promise<LangfuseRunItemResult<Output>>;
+};
+
+export type LangfuseRunExperimentResult = {
+  runName: string;
+  datasetName: string;
+  posted: number;
+  errors: LangfuseRunItemError[];
+};
+
+export type LangfuseDatasetClient = {
+  createDataset(dataset: {
+    name: string;
+    description?: string | undefined;
+    metadata?: Record<string, JsonValue | undefined> | undefined;
+  }): Promise<LangfuseDataset<unknown, unknown>>;
+  getDataset<Input, Expected>(name: string): Promise<LangfuseDataset<Input, Expected>>;
+  upsertItems<Input, Expected>(
+    name: string,
+    items: LangfuseDatasetItem<Input, Expected>[],
+  ): Promise<void>;
+  runExperiment<Input, Output, Expected>(
+    options: LangfuseRunExperimentOptions<Input, Output, Expected>,
+  ): Promise<LangfuseRunExperimentResult>;
+};

--- a/packages/observability-langfuse/test/langfuse.test.ts
+++ b/packages/observability-langfuse/test/langfuse.test.ts
@@ -1067,6 +1067,192 @@ describe("langfuse", () => {
     ).rejects.toThrow("Langfuse score requires publicKey and secretKey");
   });
 
+  it("forwards dataType through the score body", async () => {
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+
+    await tracing.score({
+      traceId: "trace-1",
+      name: "quality",
+      value: 0.7,
+      dataType: "NUMERIC",
+    });
+    expect(JSON.parse(String(vi.mocked(fetch).mock.calls[0]?.[1]?.body))).toMatchObject({
+      dataType: "NUMERIC",
+      value: 0.7,
+    });
+
+    vi.mocked(fetch).mockClear();
+    await tracing.score({
+      traceId: "trace-1",
+      name: "verdict",
+      value: "pass",
+      dataType: "CATEGORICAL",
+    });
+    expect(JSON.parse(String(vi.mocked(fetch).mock.calls[0]?.[1]?.body))).toMatchObject({
+      dataType: "CATEGORICAL",
+      value: "pass",
+    });
+  });
+
+  it("rejects CATEGORICAL with a non-string value", async () => {
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    await expect(
+      tracing.score({
+        traceId: "trace-1",
+        name: "verdict",
+        value: 1,
+        dataType: "CATEGORICAL",
+      }),
+    ).rejects.toThrow(/CATEGORICAL/);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("accepts BOOLEAN scores with 0 or 1 and rejects other numbers", async () => {
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+
+    await tracing.score({ traceId: "trace-1", name: "is-correct", value: 0, dataType: "BOOLEAN" });
+    expect(JSON.parse(String(vi.mocked(fetch).mock.calls[0]?.[1]?.body))).toMatchObject({
+      dataType: "BOOLEAN",
+      value: 0,
+    });
+
+    vi.mocked(fetch).mockClear();
+    await tracing.score({ traceId: "trace-1", name: "is-correct", value: 1, dataType: "BOOLEAN" });
+    expect(JSON.parse(String(vi.mocked(fetch).mock.calls[0]?.[1]?.body))).toMatchObject({
+      dataType: "BOOLEAN",
+      value: 1,
+    });
+
+    await expect(
+      tracing.score({ traceId: "trace-1", name: "is-correct", value: 2, dataType: "BOOLEAN" }),
+    ).rejects.toThrow(/BOOLEAN/);
+  });
+
+  it("rejects NUMERIC with a non-number value", async () => {
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    await expect(
+      tracing.score({
+        traceId: "trace-1",
+        name: "quality",
+        value: "0.5",
+        dataType: "NUMERIC",
+      }),
+    ).rejects.toThrow(/NUMERIC/);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("sends configId and accepts scoreConfigId as an alias", async () => {
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+
+    await tracing.score({ traceId: "trace-1", name: "quality", value: 1, configId: "cfg-1" });
+    expect(JSON.parse(String(vi.mocked(fetch).mock.calls[0]?.[1]?.body))).toMatchObject({
+      configId: "cfg-1",
+    });
+
+    vi.mocked(fetch).mockClear();
+    await tracing.score({ traceId: "trace-1", name: "quality", value: 1, scoreConfigId: "cfg-2" });
+    expect(JSON.parse(String(vi.mocked(fetch).mock.calls[0]?.[1]?.body))).toMatchObject({
+      configId: "cfg-2",
+    });
+  });
+
+  it("prefers configId over scoreConfigId when both are set", async () => {
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    await tracing.score({
+      traceId: "trace-1",
+      name: "quality",
+      value: 1,
+      configId: "canonical",
+      scoreConfigId: "alias",
+    });
+    const body = JSON.parse(String(vi.mocked(fetch).mock.calls[0]?.[1]?.body));
+    expect(body.configId).toBe("canonical");
+    expect(body).not.toHaveProperty("scoreConfigId");
+  });
+
+  it("forwards environment and timestamp overrides in the score body", async () => {
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    await tracing.score({
+      traceId: "trace-1",
+      name: "quality",
+      value: 1,
+      environment: "staging",
+      timestamp: "2026-06-24T00:00:00Z",
+    });
+    const body = JSON.parse(String(vi.mocked(fetch).mock.calls[0]?.[1]?.body));
+    expect(body).toMatchObject({
+      environment: "staging",
+      timestamp: "2026-06-24T00:00:00Z",
+    });
+  });
+
+  it("normalizes a Date timestamp to ISO 8601", async () => {
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    await tracing.score({
+      traceId: "trace-1",
+      name: "quality",
+      value: 1,
+      timestamp: new Date("2026-06-24T00:00:00Z"),
+    });
+    const body = JSON.parse(String(vi.mocked(fetch).mock.calls[0]?.[1]?.body));
+    expect(body.timestamp).toBe("2026-06-24T00:00:00.000Z");
+  });
+
+  it("applies a default 30s timeout and respects timeoutMs", async () => {
+    const fetchMock = vi.mocked(fetch);
+
+    const defaultTracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    await defaultTracing.score({ traceId: "trace-1", name: "quality", value: 1 });
+    const defaultSignal = (fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.signal as
+      | AbortSignal
+      | undefined;
+    expect(defaultSignal).toBeInstanceOf(AbortSignal);
+    expect(defaultSignal?.aborted).toBe(false);
+
+    vi.mocked(fetch).mockClear();
+    const slowTracing = langfuse.create({ publicKey: "pk", secretKey: "sk", timeoutMs: 50 });
+    fetchMock.mockImplementationOnce(
+      (_url, init) =>
+        new Promise((_, reject) => {
+          const signal = (init as RequestInit | undefined)?.signal as AbortSignal | undefined;
+          if (signal === undefined) {
+            reject(new Error("missing signal"));
+            return;
+          }
+          if (signal.aborted) {
+            reject(new DOMException("aborted", "AbortError"));
+            return;
+          }
+          signal.addEventListener("abort", () => {
+            reject(new DOMException("aborted", "AbortError"));
+          });
+        }),
+    );
+    await expect(
+      slowTracing.score({ traceId: "trace-1", name: "quality", value: 1 }),
+    ).rejects.toBeInstanceOf(DOMException);
+  });
+
+  it("does not read the response body on 2xx", async () => {
+    const textSpy = vi.fn(async () => "unused");
+    const response = new Response(null, { status: 204 });
+    Object.defineProperty(response, "text", { value: textSpy });
+    vi.mocked(fetch).mockReturnValueOnce(Promise.resolve(response));
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    await tracing.score({ traceId: "trace-1", name: "quality", value: 1 });
+    expect(textSpy).not.toHaveBeenCalled();
+  });
+
+  it("includes the error response text in the rejection message", async () => {
+    vi.mocked(fetch).mockReturnValueOnce(Promise.resolve(new Response("oops", { status: 500 })));
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    await expect(tracing.score({ traceId: "trace-1", name: "quality", value: 1 })).rejects.toThrow(
+      /oops/,
+    );
+  });
+
   it("reports eval outcomes as Langfuse scores", async () => {
     const score = vi.fn();
     const reporter = createReporter({ score });

--- a/packages/observability-langfuse/test/langfuse.test.ts
+++ b/packages/observability-langfuse/test/langfuse.test.ts
@@ -216,6 +216,333 @@ describe("langfuse", () => {
     );
   });
 
+  it("records providerRequest and modelInfo on the generation observation", async () => {
+    const root = fakeObservation("root", "trace-1", "obs-root");
+    const turn = fakeObservation("turn", "trace-1", "obs-turn");
+    const generation = fakeObservation("generation", "trace-1", "obs-generation");
+    root.startObservation.mockReturnValueOnce(turn);
+    turn.startObservation.mockReturnValueOnce(generation);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const run = (await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+
+    await run.startGeneration?.({
+      turn: 1,
+      request: {
+        model: "gpt-4o",
+        chatHistory: [userMessage("hi")],
+        documents: [],
+        tools: [],
+        additionalParams: {},
+      },
+      providerRequest: { model: "gpt-4o", messages: [{ role: "user", content: "hi" }] },
+      modelInfo: {
+        provider: "openai",
+        defaultModel: "gpt-4o",
+        capabilities: {
+          streaming: true,
+          tools: true,
+          toolChoice: true,
+          imageInput: false,
+          documentInput: false,
+          outputSchema: false,
+          reasoning: false,
+        },
+      },
+    });
+
+    expect(turn.startObservation).toHaveBeenCalledWith(
+      "model.turn.1",
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          providerRequest: { model: "gpt-4o", messages: [{ role: "user", content: "hi" }] },
+          modelInfo: {
+            provider: "openai",
+            defaultModel: "gpt-4o",
+            capabilities: {
+              streaming: true,
+              tools: true,
+              toolChoice: true,
+              imageInput: false,
+              documentInput: false,
+              outputSchema: false,
+              reasoning: false,
+            },
+          },
+        }),
+      }),
+      { asType: "generation" },
+    );
+  });
+
+  it("records modelInfo without capabilities when omitted", async () => {
+    const root = fakeObservation("root", "trace-1", "obs-root");
+    const turn = fakeObservation("turn", "trace-1", "obs-turn");
+    const generation = fakeObservation("generation", "trace-1", "obs-generation");
+    root.startObservation.mockReturnValueOnce(turn);
+    turn.startObservation.mockReturnValueOnce(generation);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const run = (await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+
+    await run.startGeneration?.({
+      turn: 1,
+      request: {
+        model: "gpt-4o",
+        chatHistory: [userMessage("hi")],
+        documents: [],
+        tools: [],
+        additionalParams: {},
+      },
+      modelInfo: { provider: "openai", defaultModel: "gpt-4o" },
+    });
+
+    const call = turn.startObservation.mock.calls[0]?.[1] as
+      | { metadata?: Record<string, unknown> }
+      | undefined;
+    expect(call?.metadata?.modelInfo).toEqual({
+      provider: "openai",
+      defaultModel: "gpt-4o",
+    });
+    expect(call?.metadata?.modelInfo).not.toHaveProperty("capabilities");
+  });
+
+  it("does not record providerRequest or modelInfo when absent", async () => {
+    const root = fakeObservation("root", "trace-1", "obs-root");
+    const turn = fakeObservation("turn", "trace-1", "obs-turn");
+    const generation = fakeObservation("generation", "trace-1", "obs-generation");
+    root.startObservation.mockReturnValueOnce(turn);
+    turn.startObservation.mockReturnValueOnce(generation);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const run = (await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+
+    await run.startGeneration?.(generationStartArgs());
+
+    const call = turn.startObservation.mock.calls[0]?.[1] as
+      | { metadata?: Record<string, unknown> }
+      | undefined;
+    expect(call?.metadata).not.toHaveProperty("providerRequest");
+    expect(call?.metadata).not.toHaveProperty("modelInfo");
+  });
+
+  it("records firstDeltaMs on generation end", async () => {
+    const root = fakeObservation("root", "trace-1", "obs-root");
+    const turn = fakeObservation("turn", "trace-1", "obs-turn");
+    const generation = fakeObservation("generation", "trace-1", "obs-generation");
+    root.startObservation.mockReturnValueOnce(turn);
+    turn.startObservation.mockReturnValueOnce(generation);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const run = (await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+
+    const generationObserver = await run.startGeneration?.(generationStartArgs());
+    await generationObserver?.end({
+      turn: 1,
+      response: {
+        messageId: "msg-1",
+        choice: [AssistantContent.text("Done")],
+        usage: usage(2, 3),
+        rawResponse: {},
+      },
+      firstDeltaMs: 12,
+    });
+    expect(generation.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({ firstDeltaMs: 12 }),
+      }),
+    );
+  });
+
+  it("omits firstDeltaMs from generation end when absent", async () => {
+    const root = fakeObservation("root", "trace-1", "obs-root");
+    const turn = fakeObservation("turn", "trace-1", "obs-turn");
+    const generation = fakeObservation("generation", "trace-1", "obs-generation");
+    root.startObservation.mockReturnValueOnce(turn);
+    turn.startObservation.mockReturnValueOnce(generation);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const run = (await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+
+    const generationObserver = await run.startGeneration?.(generationStartArgs());
+    await generationObserver?.end({
+      turn: 1,
+      response: {
+        messageId: "msg-1",
+        choice: [AssistantContent.text("Done")],
+        usage: usage(2, 3),
+        rawResponse: {},
+      },
+    });
+    const call = generation.update.mock.calls[0]?.[0] as
+      | { metadata?: Record<string, unknown> }
+      | undefined;
+    expect(call?.metadata).not.toHaveProperty("firstDeltaMs");
+  });
+
+  it("records toolDefinition and toolMetadata on tool start", async () => {
+    const root = fakeObservation("root", "trace-1", "obs-root");
+    const turn = fakeObservation("turn", "trace-1", "obs-turn");
+    const tool = fakeObservation("tool", "trace-1", "obs-tool");
+    root.startObservation.mockReturnValueOnce(turn);
+    turn.startObservation.mockReturnValueOnce(tool);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const run = (await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+
+    await run.startTool?.({
+      turn: 1,
+      toolName: "get_ticket",
+      args: '{"id":"TICKET-1"}',
+      toolCall: AssistantContent.toolCall("call-1", "get_ticket", { id: "TICKET-1" }),
+      internalCallId: "internal-1",
+      toolCallId: "call-1",
+      toolDefinition: {
+        name: "get_ticket",
+        description: "Fetch a support ticket",
+        parameters: { type: "object", properties: { id: { type: "string" } } },
+      },
+      toolMetadata: { source: "cookbook" },
+    });
+
+    expect(turn.startObservation).toHaveBeenCalledWith(
+      "tool.get_ticket",
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          toolDefinition: {
+            name: "get_ticket",
+            description: "Fetch a support ticket",
+            parameters: { type: "object", properties: { id: { type: "string" } } },
+          },
+          toolMetadata: { source: "cookbook" },
+        }),
+      }),
+      { asType: "tool" },
+    );
+  });
+
+  it("records structuredResult on tool end", async () => {
+    const root = fakeObservation("root", "trace-1", "obs-root");
+    const turn = fakeObservation("turn", "trace-1", "obs-turn");
+    const tool = fakeObservation("tool", "trace-1", "obs-tool");
+    root.startObservation.mockReturnValueOnce(turn);
+    turn.startObservation.mockReturnValueOnce(tool);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const run = (await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+
+    const toolObserver = (await run.startTool?.({
+      turn: 1,
+      toolName: "get_ticket",
+      args: '{"id":"TICKET-1"}',
+      toolCall: AssistantContent.toolCall("call-1", "get_ticket", { id: "TICKET-1" }),
+      internalCallId: "internal-1",
+      toolCallId: "call-1",
+    })) as AgentToolObserver | undefined;
+
+    await toolObserver?.end({
+      turn: 1,
+      toolName: "get_ticket",
+      args: '{"id":"TICKET-1"}',
+      toolCall: AssistantContent.toolCall("call-1", "get_ticket", { id: "TICKET-1" }),
+      result: '{"id":"TICKET-1"}',
+      structuredResult: [{ type: "text", text: "TICKET-1" }],
+      skipped: false,
+      internalCallId: "internal-1",
+      toolCallId: "call-1",
+    });
+    expect(tool.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          structuredResult: [{ type: "text", text: "TICKET-1" }],
+        }),
+      }),
+    );
+  });
+
+  it("omits structuredResult from tool end when absent", async () => {
+    const root = fakeObservation("root", "trace-1", "obs-root");
+    const turn = fakeObservation("turn", "trace-1", "obs-turn");
+    const tool = fakeObservation("tool", "trace-1", "obs-tool");
+    root.startObservation.mockReturnValueOnce(turn);
+    turn.startObservation.mockReturnValueOnce(tool);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const run = (await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+
+    const toolObserver = (await run.startTool?.({
+      turn: 1,
+      toolName: "get_ticket",
+      args: '{"id":"TICKET-1"}',
+      toolCall: AssistantContent.toolCall("call-1", "get_ticket", { id: "TICKET-1" }),
+      internalCallId: "internal-1",
+      toolCallId: "call-1",
+    })) as AgentToolObserver | undefined;
+
+    await toolObserver?.end({
+      turn: 1,
+      toolName: "get_ticket",
+      args: '{"id":"TICKET-1"}',
+      toolCall: AssistantContent.toolCall("call-1", "get_ticket", { id: "TICKET-1" }),
+      result: '{"id":"TICKET-1"}',
+      skipped: false,
+      internalCallId: "internal-1",
+      toolCallId: "call-1",
+    });
+    const call = tool.update.mock.calls[0]?.[0] as
+      | { metadata?: Record<string, unknown> }
+      | undefined;
+    expect(call?.metadata).not.toHaveProperty("structuredResult");
+  });
+
   it("maps runs, generations, tools, and trace attributes to Langfuse observations", async () => {
     const root = fakeObservation("root", "trace-1", "obs-root");
     const turn = fakeObservation("turn", "trace-1", "obs-turn");
@@ -900,6 +1227,54 @@ describe("langfuse", () => {
       expect.objectContaining({ traceId: "trace-fallback", value: 1 }),
     );
     expect(score).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("usageDetailsFromRecord", () => {
+  it("includes cache token fields when present", async () => {
+    const { usageDetailsFromRecord } = await import("../src/helpers");
+    expect(
+      usageDetailsFromRecord({
+        inputTokens: 1,
+        outputTokens: 2,
+        totalTokens: 3,
+        cachedInputTokens: 4,
+        cacheCreationInputTokens: 5,
+      }),
+    ).toEqual({
+      inputTokens: 1,
+      outputTokens: 2,
+      totalTokens: 3,
+      cachedInputTokens: 4,
+      cacheCreationInputTokens: 5,
+    });
+  });
+
+  it("defaults cache token fields to 0 when absent", async () => {
+    const { usageDetailsFromRecord } = await import("../src/helpers");
+    expect(
+      usageDetailsFromRecord({
+        inputTokens: 1,
+        outputTokens: 2,
+      }),
+    ).toEqual({
+      inputTokens: 1,
+      outputTokens: 2,
+      totalTokens: 3,
+      cachedInputTokens: 0,
+      cacheCreationInputTokens: 0,
+    });
+  });
+
+  it("defaults every field to 0 when given an empty record", async () => {
+    const { usageDetailsFromRecord } = await import("../src/helpers");
+    expect(usageDetailsFromRecord({})).toEqual({
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      cachedInputTokens: 0,
+      cacheCreationInputTokens: 0,
+    });
   });
 });
 

--- a/packages/observability-langfuse/test/langfuse.test.ts
+++ b/packages/observability-langfuse/test/langfuse.test.ts
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createLangfuseDatasetClient } from "../src/dataset-client";
 import { runEvalAsExperiment } from "../src/experiment-runner";
 import { createLangfuseEvalReporter as createReporter, langfuse } from "../src/index";
+import { createLangfusePromptClient } from "../src/prompt-client";
 import { ScoreQueue } from "../src/scoring";
 
 const mocks = vi.hoisted(() => ({
@@ -2861,4 +2862,325 @@ function createDatasetClient(
   options: Parameters<typeof createLangfuseDatasetClient>[1] = {},
 ): ReturnType<typeof createLangfuseDatasetClient> {
   return createLangfuseDatasetClient(tracing, options);
+}
+
+describe("LangfusePromptClient", () => {
+  function makePromptJson(body: Record<string, unknown>, status = 200): Response {
+    return new Response(JSON.stringify(body), { status });
+  }
+
+  function basicAuth(publicKey: string, secretKey: string): string {
+    const encoded = Buffer.from(`${publicKey}:${secretKey}`).toString("base64");
+    return `Basic ${encoded}`;
+  }
+
+  it("getPrompt GETs /api/public/v2/prompts/:name with auth", async () => {
+    vi.mocked(fetch).mockReturnValueOnce(
+      Promise.resolve(
+        makePromptJson({
+          name: "support.system",
+          version: 3,
+          labels: ["production"],
+          prompt: "You are a support agent.",
+          type: "text",
+          tags: ["qa"],
+        }),
+      ),
+    );
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const client = createPromptClient(tracing, { publicKey: "pk", secretKey: "sk" });
+    const prompt = await client.getPrompt("support.system");
+
+    expect(prompt.name).toBe("support.system");
+    expect(prompt.version).toBe(3);
+    expect(prompt.labels).toEqual(["production"]);
+    expect(prompt.prompt).toBe("You are a support agent.");
+    expect(prompt.type).toBe("text");
+    expect(prompt.tags).toEqual(["qa"]);
+
+    const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/api/public/v2/prompts/support.system");
+    const headers = new Headers(init.headers);
+    expect(headers.get("Authorization")).toBe(basicAuth("pk", "sk"));
+  });
+
+  it("getPrompt includes ?version and ?label when supplied", async () => {
+    vi.mocked(fetch).mockReturnValueOnce(
+      Promise.resolve(
+        makePromptJson({
+          name: "support.system",
+          version: 2,
+          prompt: "old",
+          type: "text",
+        }),
+      ),
+    );
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const client = createPromptClient(tracing, { publicKey: "pk", secretKey: "sk" });
+    await client.getPrompt("support.system", { version: 2, label: "staging" });
+
+    const [url] = vi.mocked(fetch).mock.calls[0] as [string];
+    expect(url).toContain("version=2");
+    expect(url).toContain("label=staging");
+  });
+
+  it("getPrompt returns the cached value within the TTL", async () => {
+    vi.mocked(fetch).mockReturnValue(
+      Promise.resolve(
+        makePromptJson({
+          name: "support.system",
+          version: 1,
+          prompt: "cached",
+          type: "text",
+        }),
+      ),
+    );
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const client = createPromptClient(tracing, { publicKey: "pk", secretKey: "sk" });
+    const a = await client.getPrompt("support.system");
+    const b = await client.getPrompt("support.system");
+    expect(a).toBe(b);
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
+  });
+
+  it("getPrompt refetches after the TTL elapses", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.mocked(fetch).mockImplementation(async () =>
+        makePromptJson({
+          name: "support.system",
+          version: 1,
+          prompt: "fresh",
+          type: "text",
+        }),
+      );
+
+      const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+      const client = createPromptClient(tracing, {
+        publicKey: "pk",
+        secretKey: "sk",
+        cacheTtlMs: 1000,
+      });
+      await client.getPrompt("support.system");
+      vi.advanceTimersByTime(2000);
+      await client.getPrompt("support.system");
+      expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("getPrompt({ refresh: true }) skips the cache", async () => {
+    vi.mocked(fetch).mockImplementation(async () =>
+      makePromptJson({
+        name: "support.system",
+        version: 1,
+        prompt: "fresh",
+        type: "text",
+      }),
+    );
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const client = createPromptClient(tracing, { publicKey: "pk", secretKey: "sk" });
+    await client.getPrompt("support.system");
+    await client.getPrompt("support.system", { refresh: true });
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2);
+  });
+
+  it("getPrompt throws on non-2xx with the response body", async () => {
+    vi.mocked(fetch).mockReturnValueOnce(
+      Promise.resolve(new Response("not found", { status: 404 })),
+    );
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const client = createPromptClient(tracing, { publicKey: "pk", secretKey: "sk" });
+    await expect(client.getPrompt("missing")).rejects.toThrow(/not found/);
+  });
+
+  it("getPromptText returns the string for type=text", async () => {
+    vi.mocked(fetch).mockReturnValueOnce(
+      Promise.resolve(
+        makePromptJson({
+          name: "support.system",
+          version: 1,
+          prompt: "You are a support agent.",
+          type: "text",
+        }),
+      ),
+    );
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const client = createPromptClient(tracing, { publicKey: "pk", secretKey: "sk" });
+    await expect(client.getPromptText("support.system")).resolves.toBe("You are a support agent.");
+  });
+
+  it("getPromptText throws when the prompt is type=chat", async () => {
+    vi.mocked(fetch).mockReturnValueOnce(
+      Promise.resolve(
+        makePromptJson({
+          name: "support.chat",
+          version: 1,
+          prompt: [{ role: "system", content: "hi" }],
+          type: "chat",
+        }),
+      ),
+    );
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const client = createPromptClient(tracing, { publicKey: "pk", secretKey: "sk" });
+    await expect(client.getPromptText("support.chat")).rejects.toThrow(/chat prompt/);
+  });
+
+  it("getPromptChat returns the array for type=chat", async () => {
+    vi.mocked(fetch).mockReturnValueOnce(
+      Promise.resolve(
+        makePromptJson({
+          name: "support.chat",
+          version: 1,
+          prompt: [
+            { role: "system", content: "You are a support agent." },
+            { role: "user", content: "Help!" },
+          ],
+          type: "chat",
+        }),
+      ),
+    );
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const client = createPromptClient(tracing, { publicKey: "pk", secretKey: "sk" });
+    await expect(client.getPromptChat("support.chat")).resolves.toEqual([
+      { role: "system", content: "You are a support agent." },
+      { role: "user", content: "Help!" },
+    ]);
+  });
+
+  it("refresh() clears the cache", async () => {
+    vi.mocked(fetch).mockImplementation(async () =>
+      makePromptJson({
+        name: "support.system",
+        version: 1,
+        prompt: "hi",
+        type: "text",
+      }),
+    );
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const client = createPromptClient(tracing, { publicKey: "pk", secretKey: "sk" });
+    await client.getPrompt("support.system");
+    client.refresh();
+    await client.getPrompt("support.system");
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("Langfuse prompt attribute binding", () => {
+  it("attaches prompt name and version to the root when args.promptRef is set", async () => {
+    const root = fakeObservation("root", "trace-prompt", "obs-root-prompt");
+    root.startObservation.mockReturnValue(root);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+      promptRef: { name: "support.system", version: 3 },
+    });
+
+    expect(root.otelSpan.setAttribute).toHaveBeenCalledWith(
+      "langfuse.trace.metadata.promptName",
+      "support.system",
+    );
+    expect(root.otelSpan.setAttribute).toHaveBeenCalledWith(
+      "langfuse.trace.metadata.promptVersion",
+      "3",
+    );
+  });
+
+  it("falls back to trace.metadata.promptName/promptVersion", async () => {
+    const root = fakeObservation("root", "trace-prompt-2", "obs-root-prompt-2");
+    root.startObservation.mockReturnValue(root);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+      trace: { metadata: { promptName: "support.system", promptVersion: 2 } },
+    });
+
+    expect(root.otelSpan.setAttribute).toHaveBeenCalledWith(
+      "langfuse.trace.metadata.promptName",
+      "support.system",
+    );
+    expect(root.otelSpan.setAttribute).toHaveBeenCalledWith(
+      "langfuse.trace.metadata.promptVersion",
+      "2",
+    );
+  });
+
+  it("does not attach prompt attributes when neither source is set", async () => {
+    const root = fakeObservation("root", "trace-prompt-3", "obs-root-prompt-3");
+    root.startObservation.mockReturnValue(root);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    });
+
+    const calls = (root.otelSpan.setAttribute as ReturnType<typeof vi.fn>).mock.calls;
+    const promptCalls = calls.filter(
+      ([key]) => typeof key === "string" && key.startsWith("langfuse.trace.metadata.prompt"),
+    );
+    expect(promptCalls).toEqual([]);
+  });
+
+  it("attaches prompt attributes to each generation in the run", async () => {
+    const root = fakeObservation("root", "trace-prompt-4", "obs-root-prompt-4");
+    const turn = fakeObservation("turn", "trace-prompt-4", "obs-turn-prompt-4");
+    const generation = fakeObservation("generation", "trace-prompt-4", "obs-gen-prompt-4");
+    root.startObservation.mockReturnValueOnce(turn);
+    turn.startObservation.mockReturnValueOnce(generation);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const run = await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+      promptRef: { name: "support.system", version: 5 },
+    });
+    const runObserver = run as AgentRunObserver;
+
+    await runObserver.startGeneration?.(generationStartArgs());
+
+    expect(turn.startObservation).toHaveBeenCalledWith(
+      "model.turn.1",
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          promptName: "support.system",
+          promptVersion: 5,
+        }),
+      }),
+      { asType: "generation" },
+    );
+  });
+});
+
+function createPromptClient(
+  tracing: ReturnType<typeof langfuse.create>,
+  options: Parameters<typeof createLangfusePromptClient>[1] = {},
+): ReturnType<typeof createLangfusePromptClient> {
+  return createLangfusePromptClient(tracing, options);
 }

--- a/packages/observability-langfuse/test/langfuse.test.ts
+++ b/packages/observability-langfuse/test/langfuse.test.ts
@@ -1,11 +1,13 @@
 import { AssistantContent, type Message, type Usage } from "@anvia/core/completion";
-import { EvalOutcome, runEvalSuite } from "@anvia/core/evals";
+import { EvalOutcome, exactMatch, runEvalSuite } from "@anvia/core/evals";
 import type {
   AgentGenerationStartArgs,
   AgentRunObserver,
   AgentToolObserver,
 } from "@anvia/core/observability";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createLangfuseDatasetClient } from "../src/dataset-client";
+import { runEvalAsExperiment } from "../src/experiment-runner";
 import { createLangfuseEvalReporter as createReporter, langfuse } from "../src/index";
 import { ScoreQueue } from "../src/scoring";
 
@@ -2453,4 +2455,410 @@ function metric(name: string) {
     name,
     evaluate: () => EvalOutcome.pass(true),
   };
+}
+
+describe("LangfuseDatasetClient", () => {
+  function readJsonBody(body: unknown): unknown {
+    if (typeof body !== "string") return body;
+    try {
+      return JSON.parse(body);
+    } catch {
+      return body;
+    }
+  }
+
+  function makeFetchResponse(body: unknown, status = 200): Response {
+    return new Response(typeof body === "string" ? body : JSON.stringify(body), {
+      status,
+    });
+  }
+
+  function basicAuthHeader(publicKey: string, secretKey: string): string {
+    const encoded = Buffer.from(`${publicKey}:${secretKey}`).toString("base64");
+    return `Basic ${encoded}`;
+  }
+
+  it("createDataset PUTs to /api/public/datasets/:name with auth", async () => {
+    vi.mocked(fetch).mockReturnValueOnce(Promise.resolve(makeFetchResponse({ id: 1 })));
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const client = createDatasetClient(tracing, {
+      publicKey: "pk",
+      secretKey: "sk",
+    });
+    const dataset = await client.createDataset({
+      name: "support-set",
+      description: "smoke",
+      metadata: { owner: "team" },
+    });
+
+    expect(dataset.name).toBe("support-set");
+    expect(dataset.description).toBe("smoke");
+    expect(dataset.metadata).toEqual({ owner: "team" });
+    expect(vi.mocked(fetch)).toHaveBeenCalledOnce();
+    const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/api/public/datasets/support-set");
+    expect(init.method).toBe("PUT");
+    const headers = new Headers(init.headers);
+    expect(headers.get("Authorization")).toBe(basicAuthHeader("pk", "sk"));
+    expect(readJsonBody(init.body)).toEqual({
+      name: "support-set",
+      description: "smoke",
+      metadata: { owner: "team" },
+    });
+  });
+
+  it("getDataset GETs the dataset and returns items", async () => {
+    vi.mocked(fetch).mockReturnValueOnce(
+      Promise.resolve(
+        makeFetchResponse({
+          name: "support-set",
+          description: "smoke",
+          metadata: { owner: "team" },
+          items: [
+            { id: "i-1", input: { q: "hi" }, expected: "hello" },
+            { id: "i-2", input: { q: "bye" } },
+          ],
+          meta: { totalPages: 1 },
+        }),
+      ),
+    );
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const client = createDatasetClient(tracing, {
+      publicKey: "pk",
+      secretKey: "sk",
+    });
+    const dataset = await client.getDataset<{ q: string }, string>("support-set");
+
+    expect(dataset.name).toBe("support-set");
+    expect(dataset.description).toBe("smoke");
+    expect(dataset.metadata).toEqual({ owner: "team" });
+    expect(dataset.items).toHaveLength(2);
+    expect(dataset.items[0]?.id).toBe("i-1");
+    expect(dataset.items[0]?.input).toEqual({ q: "hi" });
+    expect(dataset.items[0]?.expected).toBe("hello");
+    const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/api/public/datasets/support-set?page=1&limit=50");
+    expect(init.method).toBe("GET");
+  });
+
+  it("getDataset paginates until exhausted", async () => {
+    vi.mocked(fetch)
+      .mockReturnValueOnce(
+        Promise.resolve(
+          makeFetchResponse({
+            name: "support-set",
+            items: [{ id: "i-1", input: "a" }],
+            meta: { totalPages: 2 },
+          }),
+        ),
+      )
+      .mockReturnValueOnce(
+        Promise.resolve(
+          makeFetchResponse({
+            name: "support-set",
+            items: [{ id: "i-2", input: "b" }],
+            meta: { totalPages: 2 },
+          }),
+        ),
+      );
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const client = createDatasetClient(tracing, {
+      publicKey: "pk",
+      secretKey: "sk",
+      pageSize: 1,
+    });
+    const dataset = await client.getDataset<string, string>("support-set");
+
+    expect(dataset.items).toHaveLength(2);
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2);
+    const secondCall = vi.mocked(fetch).mock.calls[1] as [string, RequestInit];
+    expect(secondCall[0]).toContain("page=2");
+  });
+
+  it("upsertItems POSTs the items array", async () => {
+    vi.mocked(fetch).mockReturnValueOnce(Promise.resolve(new Response(null, { status: 204 })));
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const client = createDatasetClient(tracing, {
+      publicKey: "pk",
+      secretKey: "sk",
+    });
+    await client.upsertItems("support-set", [
+      { id: "i-1", input: { q: "hi" }, expected: "hello" },
+      { id: "i-2", input: { q: "bye" } },
+    ]);
+
+    const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/api/public/datasets/support-set/items");
+    expect(init.method).toBe("POST");
+    expect(readJsonBody(init.body)).toEqual({
+      items: [
+        { id: "i-1", input: { q: "hi" }, expected: "hello" },
+        { id: "i-2", input: { q: "bye" } },
+      ],
+    });
+  });
+
+  it("upsertItems throws on non-2xx with the response body", async () => {
+    vi.mocked(fetch).mockReturnValueOnce(Promise.resolve(makeFetchResponse("bad request", 400)));
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const client = createDatasetClient(tracing, {
+      publicKey: "pk",
+      secretKey: "sk",
+    });
+
+    await expect(client.upsertItems("support-set", [{ id: "i-1", input: "x" }])).rejects.toThrow(
+      /bad request/,
+    );
+  });
+
+  it("runExperiment accepts local items and POSTs one batched run", async () => {
+    vi.mocked(fetch).mockReturnValueOnce(Promise.resolve(new Response(null, { status: 204 })));
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const client = createDatasetClient(tracing, {
+      publicKey: "pk",
+      secretKey: "sk",
+    });
+    const result = await client.runExperiment({
+      datasetName: "support-set",
+      runName: "run-1",
+      items: [
+        { id: "i-1", input: { q: "hi" }, expected: "hello" },
+        { id: "i-2", input: { q: "bye" } },
+      ],
+      run: (item) => ({
+        output: `out-${item.id}`,
+        trace: { traceId: `trace-${item.id}`, observationId: `obs-${item.id}` },
+      }),
+    });
+
+    expect(result).toEqual({
+      runName: "run-1",
+      datasetName: "support-set",
+      posted: 2,
+      errors: [],
+    });
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
+    const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/api/public/dataset-run-items");
+    expect(init.method).toBe("POST");
+    expect(readJsonBody(init.body)).toEqual({
+      runName: "run-1",
+      datasetItemRuns: [
+        {
+          datasetItemId: "i-1",
+          traceId: "trace-i-1",
+          observationId: "obs-i-1",
+          output: "out-i-1",
+        },
+        {
+          datasetItemId: "i-2",
+          traceId: "trace-i-2",
+          observationId: "obs-i-2",
+          output: "out-i-2",
+        },
+      ],
+    });
+  });
+
+  it("runExperiment pulls items from a remote dataset when items are not provided", async () => {
+    vi.mocked(fetch)
+      .mockReturnValueOnce(
+        Promise.resolve(
+          makeFetchResponse({
+            name: "remote-set",
+            items: [
+              { id: "i-1", input: "a" },
+              { id: "i-2", input: "b" },
+            ],
+            meta: { totalPages: 1 },
+          }),
+        ),
+      )
+      .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 204 })));
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const client = createDatasetClient(tracing, {
+      publicKey: "pk",
+      secretKey: "sk",
+    });
+    const result = await client.runExperiment({
+      datasetName: "remote-set",
+      runName: "run-2",
+      run: (item) => ({ output: `out-${item.id}`, trace: undefined }),
+    });
+
+    expect(result.posted).toBe(2);
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2);
+    const [getUrl] = vi.mocked(fetch).mock.calls[0] as [string];
+    expect(getUrl).toContain("/api/public/datasets/remote-set?");
+    const [postUrl] = vi.mocked(fetch).mock.calls[1] as [string];
+    expect(postUrl).toContain("/api/public/dataset-run-items");
+  });
+
+  it("runExperiment continues on per-item errors", async () => {
+    vi.mocked(fetch).mockReturnValueOnce(Promise.resolve(new Response(null, { status: 204 })));
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const client = createDatasetClient(tracing, {
+      publicKey: "pk",
+      secretKey: "sk",
+    });
+    const result = await client.runExperiment({
+      datasetName: "support-set",
+      runName: "run-3",
+      items: [
+        { id: "i-1", input: "a" },
+        { id: "i-2", input: "b" },
+        { id: "i-3", input: "c" },
+      ],
+      run: (item) => {
+        if (item.id === "i-2") throw new Error("kaboom");
+        return { output: `out-${item.id}`, trace: undefined };
+      },
+    });
+
+    expect(result.posted).toBe(2);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]?.itemId).toBe("i-2");
+    expect((result.errors[0]?.error as Error).message).toBe("kaboom");
+    const [, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    const body = readJsonBody(init.body) as { datasetItemRuns: unknown[] };
+    expect(body.datasetItemRuns).toHaveLength(2);
+  });
+
+  it("runExperiment throws on non-2xx POST", async () => {
+    vi.mocked(fetch).mockReturnValueOnce(Promise.resolve(makeFetchResponse("server error", 500)));
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const client = createDatasetClient(tracing, {
+      publicKey: "pk",
+      secretKey: "sk",
+    });
+
+    await expect(
+      client.runExperiment({
+        datasetName: "support-set",
+        runName: "run-4",
+        items: [{ id: "i-1", input: "a" }],
+        run: (item) => ({ output: `out-${item.id}`, trace: undefined }),
+      }),
+    ).rejects.toThrow(/server error/);
+  });
+
+  it("runExperiment returns empty posted count when dataset has no items", async () => {
+    vi.mocked(fetch).mockReturnValueOnce(
+      Promise.resolve(makeFetchResponse({ name: "empty-set", items: [], meta: { totalPages: 1 } })),
+    );
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const client = createDatasetClient(tracing, {
+      publicKey: "pk",
+      secretKey: "sk",
+    });
+    const result = await client.runExperiment({
+      datasetName: "empty-set",
+      runName: "run-5",
+      run: (item) => ({ output: `out-${item.id}`, trace: undefined }),
+    });
+
+    expect(result).toEqual({
+      runName: "run-5",
+      datasetName: "empty-set",
+      posted: 0,
+      errors: [],
+    });
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("runEvalAsExperiment", () => {
+  it("runs the eval suite and posts a dataset run with per-case outputs and traces", async () => {
+    vi.mocked(fetch).mockReturnValueOnce(Promise.resolve(new Response(null, { status: 204 })));
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const client = createDatasetClient(tracing, {
+      publicKey: "pk",
+      secretKey: "sk",
+    });
+    const { suite, datasetRun } = await runEvalAsExperiment(
+      {
+        name: "smoke",
+        cases: [
+          { id: "c-1", input: "a", expected: "A" },
+          { id: "c-2", input: "b", expected: "B" },
+        ],
+        target: async (input) =>
+          ({ output: input.toUpperCase(), trace: { traceId: `trace-${input}` } }) as never,
+        metrics: [exactMatch()],
+        reporters: [],
+      },
+      {
+        tracing,
+        client,
+        datasetName: "smoke-set",
+        runName: "smoke-run",
+      },
+    );
+
+    expect(suite.passed).toBe(2);
+    expect(datasetRun.posted).toBe(2);
+    expect(datasetRun.errors).toEqual([]);
+    const [, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as {
+      runName: string;
+      datasetItemRuns: Array<{
+        datasetItemId: string;
+        traceId?: string;
+        output: unknown;
+      }>;
+    };
+    expect(body.runName).toBe("smoke-run");
+    expect(body.datasetItemRuns).toHaveLength(2);
+    expect(body.datasetItemRuns[0]?.datasetItemId).toBe("c-1");
+    expect(body.datasetItemRuns[0]?.traceId).toBe("trace-a");
+    expect(body.datasetItemRuns[1]?.datasetItemId).toBe("c-2");
+    expect(body.datasetItemRuns[1]?.traceId).toBe("trace-b");
+  });
+
+  it("wires the metric reporter and the dataset run separately", async () => {
+    vi.mocked(fetch).mockReturnValueOnce(Promise.resolve(new Response(null, { status: 204 })));
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const reporter = createReporter(tracing);
+    const client = createDatasetClient(tracing, {
+      publicKey: "pk",
+      secretKey: "sk",
+    });
+    const { suite } = await runEvalAsExperiment(
+      {
+        name: "smoke",
+        cases: [{ id: "c-1", input: "a", expected: "a" }],
+        target: async (input) => input,
+        metrics: [exactMatch()],
+        reporters: [reporter],
+      },
+      {
+        tracing,
+        client,
+        datasetName: "smoke-set",
+        runName: "smoke-run",
+      },
+    );
+
+    expect(suite.passed).toBe(1);
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
+  });
+});
+
+function createDatasetClient(
+  tracing: ReturnType<typeof langfuse.create>,
+  options: Parameters<typeof createLangfuseDatasetClient>[1] = {},
+): ReturnType<typeof createLangfuseDatasetClient> {
+  return createLangfuseDatasetClient(tracing, options);
 }

--- a/packages/observability-langfuse/test/langfuse.test.ts
+++ b/packages/observability-langfuse/test/langfuse.test.ts
@@ -7,6 +7,7 @@ import type {
 } from "@anvia/core/observability";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createLangfuseEvalReporter as createReporter, langfuse } from "../src/index";
+import { ScoreQueue } from "../src/scoring";
 
 const mocks = vi.hoisted(() => ({
   forceFlush: vi.fn(),
@@ -1413,6 +1414,284 @@ describe("langfuse", () => {
       expect.objectContaining({ traceId: "trace-fallback", value: 1 }),
     );
     expect(score).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("ScoreQueue", () => {
+  type QueueHandle = {
+    queue: ScoreQueue;
+    fetchMock: ReturnType<typeof vi.fn>;
+    sleepMock: ReturnType<typeof vi.fn>;
+  };
+
+  function makeQueue(
+    overrides: Partial<{
+      fetchImpl: typeof fetch;
+      sleep: (ms: number) => Promise<void>;
+      setTimer: (handler: () => void, ms: number) => unknown;
+      clearTimer: (handle: unknown) => void;
+      flushIntervalMs: number;
+      batchSize: number;
+      maxRetries: number;
+    }> = {},
+  ): QueueHandle {
+    const fetchMock = (overrides.fetchImpl ??
+      vi.fn(async () => new Response(null, { status: 204 }))) as
+      | typeof fetch
+      | ReturnType<typeof vi.fn>;
+    const sleepMock = (overrides.sleep ?? vi.fn(async () => {})) as
+      | ((ms: number) => Promise<void>)
+      | ReturnType<typeof vi.fn>;
+    const queue = new ScoreQueue({
+      baseUrl: "https://langfuse.test",
+      publicKey: "pk",
+      secretKey: "sk",
+      timeoutMs: 5_000,
+      batchSize: overrides.batchSize ?? 3,
+      flushIntervalMs: overrides.flushIntervalMs ?? 100,
+      maxRetries: overrides.maxRetries ?? 3,
+      fetchImpl: fetchMock as typeof fetch,
+      sleep: sleepMock as (ms: number) => Promise<void>,
+      ...(overrides.setTimer ? { setTimer: overrides.setTimer } : {}),
+      ...(overrides.clearTimer ? { clearTimer: overrides.clearTimer } : {}),
+    });
+    return {
+      queue,
+      fetchMock: fetchMock as ReturnType<typeof vi.fn>,
+      sleepMock: sleepMock as ReturnType<typeof vi.fn>,
+    };
+  }
+
+  function scoreArgs(overrides: Partial<{ traceId: string; name: string; value: number }> = {}) {
+    return {
+      traceId: "trace-1",
+      name: "quality",
+      value: 1,
+      ...overrides,
+    };
+  }
+
+  it("enqueue keeps depth accurate", () => {
+    const { queue } = makeQueue();
+    expect(queue.depth()).toBe(0);
+    queue.enqueue(scoreArgs());
+    queue.enqueue(scoreArgs({ name: "latency" }));
+    expect(queue.depth()).toBe(2);
+  });
+
+  it("flush posts a JSON array with all pending scores", async () => {
+    const { queue, fetchMock } = makeQueue();
+    queue.enqueue(scoreArgs());
+    queue.enqueue(scoreArgs({ name: "latency", value: 0.5 }));
+
+    await queue.flush();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    expect(Array.isArray(body)).toBe(true);
+    expect(body).toHaveLength(2);
+    expect(body[0]).toMatchObject({ traceId: "trace-1", name: "quality", value: 1 });
+    expect(body[1]).toMatchObject({ name: "latency", value: 0.5 });
+    expect(queue.depth()).toBe(0);
+  });
+
+  it("flush returns when the response is 2xx and clears the queue", async () => {
+    const { queue, fetchMock } = makeQueue();
+    queue.enqueue(scoreArgs());
+    await expect(queue.flush()).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(queue.depth()).toBe(0);
+  });
+
+  it("retries on 429 with exponential backoff", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 429 }))
+      .mockResolvedValueOnce(new Response(null, { status: 429 }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+    const sleepMock = vi.fn(async () => {});
+    const { queue } = makeQueue({
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      sleep: sleepMock,
+    });
+
+    queue.enqueue(scoreArgs());
+    await queue.flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(sleepMock).toHaveBeenCalledTimes(2);
+    const sleepCalls = sleepMock.mock.calls as unknown as Array<[number]>;
+    const first = sleepCalls[0]?.[0] ?? 0;
+    const second = sleepCalls[1]?.[0] ?? 0;
+    expect(first).toBeGreaterThan(0);
+    expect(second).toBeGreaterThanOrEqual(first);
+  });
+
+  it("retries on 500 with exponential backoff", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+    const sleepMock = vi.fn(async () => {});
+    const { queue } = makeQueue({
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      sleep: sleepMock,
+    });
+
+    queue.enqueue(scoreArgs());
+    await queue.flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(sleepMock).toHaveBeenCalledOnce();
+  });
+
+  it("does not retry on 400 and throws LangfuseScoreError with scores", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("bad", { status: 400 }));
+    const { queue } = makeQueue({ fetchImpl: fetchMock as unknown as typeof fetch });
+    const scores = [scoreArgs(), scoreArgs({ name: "latency" })];
+
+    for (const s of scores) queue.enqueue(s);
+
+    await expect(queue.flush()).rejects.toMatchObject({
+      name: "LangfuseScoreError",
+      message: expect.stringMatching(/HTTP 400/),
+      scores: expect.arrayContaining([
+        expect.objectContaining({ name: "quality" }),
+        expect.objectContaining({ name: "latency" }),
+      ]),
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("gives up after maxRetries and throws LangfuseScoreError", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 500 }));
+    const sleepMock = vi.fn(async () => {});
+    const { queue } = makeQueue({
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      sleep: sleepMock,
+      maxRetries: 3,
+    });
+
+    queue.enqueue(scoreArgs());
+    await expect(queue.flush()).rejects.toMatchObject({
+      name: "LangfuseScoreError",
+      message: expect.stringMatching(/after 3 attempts/),
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(sleepMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("size threshold triggers an immediate flush without waiting for the timer", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
+    const { queue } = makeQueue({ fetchImpl: fetchMock as unknown as typeof fetch, batchSize: 2 });
+
+    queue.enqueue(scoreArgs());
+    queue.enqueue(scoreArgs({ name: "latency" }));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(queue.depth()).toBe(0);
+  });
+
+  it("shutdown flushes pending scores and clears the timer", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
+    const { queue } = makeQueue({ fetchImpl: fetchMock as unknown as typeof fetch });
+
+    queue.enqueue(scoreArgs());
+    await queue.shutdown();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(queue.depth()).toBe(0);
+  });
+});
+
+describe("score queue integration", () => {
+  it("score() direct-sends when scoreBatchSize is not set", async () => {
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    expect(tracing.scoreQueueDepth()).toBe(0);
+
+    await tracing.score({ traceId: "t", name: "n", value: 1 });
+    expect(vi.mocked(fetch)).toHaveBeenCalledOnce();
+    expect(tracing.scoreQueueDepth()).toBe(0);
+  });
+
+  it("score() enqueues when scoreBatchSize is set and exposes depth", async () => {
+    const tracing = langfuse.create({
+      publicKey: "pk",
+      secretKey: "sk",
+      scoreBatchSize: 10,
+    });
+    expect(tracing.scoreQueueDepth()).toBe(0);
+
+    await tracing.score({ traceId: "t", name: "n", value: 1 });
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+    expect(tracing.scoreQueueDepth()).toBe(1);
+  });
+
+  it("flushScores() drains the queue and posts one batched request", async () => {
+    const tracing = langfuse.create({
+      publicKey: "pk",
+      secretKey: "sk",
+      scoreBatchSize: 10,
+    });
+    await tracing.score({ traceId: "t1", name: "quality", value: 1 });
+    await tracing.score({ traceId: "t2", name: "latency", value: 0.4 });
+    expect(tracing.scoreQueueDepth()).toBe(2);
+
+    await tracing.flushScores();
+    expect(vi.mocked(fetch)).toHaveBeenCalledOnce();
+    const body = JSON.parse(String(vi.mocked(fetch).mock.calls[0]?.[1]?.body));
+    expect(body).toHaveLength(2);
+    expect(tracing.scoreQueueDepth()).toBe(0);
+  });
+
+  it("flush() also drains the score queue in addition to processor.forceFlush()", async () => {
+    const tracing = langfuse.create({
+      publicKey: "pk",
+      secretKey: "sk",
+      scoreBatchSize: 10,
+    });
+    await tracing.score({ traceId: "t1", name: "quality", value: 1 });
+    expect(tracing.scoreQueueDepth()).toBe(1);
+
+    await tracing.flush();
+    expect(vi.mocked(fetch)).toHaveBeenCalledOnce();
+    expect(tracing.scoreQueueDepth()).toBe(0);
+    expect(mocks.forceFlush).toHaveBeenCalledOnce();
+  });
+
+  it("shutdown() drains the score queue and stops the SDK", async () => {
+    const tracing = langfuse.create({
+      publicKey: "pk",
+      secretKey: "sk",
+      scoreBatchSize: 10,
+    });
+    await tracing.score({ traceId: "t1", name: "quality", value: 1 });
+
+    await tracing.shutdown();
+    expect(vi.mocked(fetch)).toHaveBeenCalledOnce();
+    expect(tracing.scoreQueueDepth()).toBe(0);
+    expect(mocks.shutdown).toHaveBeenCalledOnce();
+  });
+
+  it("LangfuseScoreError carries the failed scores when a batch fails non-retryably", async () => {
+    vi.mocked(fetch).mockReturnValueOnce(Promise.resolve(new Response("bad", { status: 400 })));
+
+    const tracing = langfuse.create({
+      publicKey: "pk",
+      secretKey: "sk",
+      scoreBatchSize: 10,
+    });
+    await tracing.score({ traceId: "t1", name: "quality", value: 1 });
+    await tracing.score({ traceId: "t2", name: "latency", value: 0.4 });
+
+    await expect(tracing.flushScores()).rejects.toMatchObject({
+      name: "LangfuseScoreError",
+      scores: expect.arrayContaining([
+        expect.objectContaining({ traceId: "t1" }),
+        expect.objectContaining({ traceId: "t2" }),
+      ]),
+    });
   });
 });
 

--- a/packages/observability-langfuse/test/langfuse.test.ts
+++ b/packages/observability-langfuse/test/langfuse.test.ts
@@ -15,6 +15,10 @@ const mocks = vi.hoisted(() => ({
   processorConstructor: vi.fn(),
   sdkConstructor: vi.fn(),
   startObservation: vi.fn(),
+  resourceFromAttributes: vi.fn((attributes: Record<string, unknown>) => ({
+    __resource: true,
+    attributes,
+  })),
 }));
 
 vi.mock("@langfuse/otel", () => ({
@@ -36,6 +40,15 @@ vi.mock("@opentelemetry/sdk-node", () => ({
       mocks.sdkConstructor(options);
     }
   },
+}));
+
+vi.mock("@opentelemetry/resources", () => ({
+  resourceFromAttributes: (attributes: Record<string, unknown>) =>
+    mocks.resourceFromAttributes(attributes),
+}));
+
+vi.mock("@opentelemetry/semantic-conventions", () => ({
+  SEMRESATTRS_SERVICE_NAME: "service.name",
 }));
 
 vi.mock("@langfuse/tracing", () => ({
@@ -87,6 +100,120 @@ describe("langfuse", () => {
 
     expect(mocks.forceFlush).toHaveBeenCalledOnce();
     expect(mocks.shutdown).toHaveBeenCalledOnce();
+  });
+
+  it("resolves options from environment variables when not provided explicitly", () => {
+    vi.stubEnv("LANGFUSE_PUBLIC_KEY", "env-public");
+    vi.stubEnv("LANGFUSE_SECRET_KEY", "env-secret");
+    vi.stubEnv("LANGFUSE_BASE_URL", "https://env.langfuse.test");
+    vi.stubEnv("LANGFUSE_TRACING_ENVIRONMENT", "staging");
+    vi.stubEnv("LANGFUSE_RELEASE", "env-release");
+
+    langfuse.create();
+
+    expect(mocks.processorConstructor).toHaveBeenCalledWith({
+      baseUrl: "https://env.langfuse.test",
+      publicKey: "env-public",
+      secretKey: "env-secret",
+      environment: "staging",
+      release: "env-release",
+    });
+  });
+
+  it("prefers explicit options over environment variables", () => {
+    vi.stubEnv("LANGFUSE_PUBLIC_KEY", "env-public");
+    vi.stubEnv("LANGFUSE_SECRET_KEY", "env-secret");
+    vi.stubEnv("LANGFUSE_TRACING_ENVIRONMENT", "staging");
+    vi.stubEnv("LANGFUSE_RELEASE", "env-release");
+
+    langfuse.create({
+      publicKey: "option-public",
+      secretKey: "option-secret",
+      environment: "prod",
+      release: "option-release",
+    });
+
+    expect(mocks.processorConstructor).toHaveBeenCalledWith({
+      baseUrl: "https://cloud.langfuse.com",
+      publicKey: "option-public",
+      secretKey: "option-secret",
+      environment: "prod",
+      release: "option-release",
+    });
+  });
+
+  it("treats empty string env values as missing", () => {
+    vi.stubEnv("LANGFUSE_PUBLIC_KEY", "");
+    vi.stubEnv("LANGFUSE_SECRET_KEY", "");
+
+    langfuse.create();
+
+    const call = mocks.processorConstructor.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(call).toBeDefined();
+    expect(call).not.toHaveProperty("publicKey");
+    expect(call).not.toHaveProperty("secretKey");
+  });
+
+  it("surfaces serviceName as a NodeSDK resource attribute when set via option", () => {
+    langfuse.create({ serviceName: "support-agent" });
+
+    expect(mocks.resourceFromAttributes).toHaveBeenCalledWith({
+      "service.name": "support-agent",
+    });
+    expect(mocks.sdkConstructor).toHaveBeenCalledWith({
+      spanProcessors: [expect.any(Object)],
+      resource: expect.objectContaining({
+        __resource: true,
+        attributes: { "service.name": "support-agent" },
+      }),
+    });
+  });
+
+  it("surfaces serviceName as a NodeSDK resource attribute when set via env", () => {
+    vi.stubEnv("LANGFUSE_SERVICE_NAME", "env-service");
+
+    langfuse.create();
+
+    expect(mocks.resourceFromAttributes).toHaveBeenCalledWith({
+      "service.name": "env-service",
+    });
+    expect(mocks.sdkConstructor).toHaveBeenCalledWith({
+      spanProcessors: [expect.any(Object)],
+      resource: expect.objectContaining({
+        __resource: true,
+        attributes: { "service.name": "env-service" },
+      }),
+    });
+  });
+
+  it("does not construct a NodeSDK resource when serviceName is absent", () => {
+    langfuse.create({ publicKey: "pk", secretKey: "sk" });
+
+    const call = mocks.sdkConstructor.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(call).toBeDefined();
+    expect(call).not.toHaveProperty("resource");
+    expect(mocks.resourceFromAttributes).not.toHaveBeenCalled();
+  });
+
+  it("includes serviceName in the root observation metadata", async () => {
+    const root = fakeObservation("root", "trace-1", "obs-root");
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({ serviceName: "support-agent" });
+    await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    });
+
+    expect(mocks.startObservation).toHaveBeenCalledWith(
+      "support",
+      expect.objectContaining({
+        metadata: expect.objectContaining({ serviceName: "support-agent" }),
+      }),
+      { asType: "agent" },
+    );
   });
 
   it("maps runs, generations, tools, and trace attributes to Langfuse observations", async () => {

--- a/packages/observability-langfuse/test/langfuse.test.ts
+++ b/packages/observability-langfuse/test/langfuse.test.ts
@@ -1417,6 +1417,119 @@ describe("langfuse", () => {
   });
 });
 
+describe("LangfuseGenerationObserver.update", () => {
+  it("forwards text deltas to generation.update with output.delta", async () => {
+    const root = fakeObservation("root", "trace-1", "obs-root");
+    const turn = fakeObservation("turn", "trace-1", "obs-turn");
+    const generation = fakeObservation("generation", "trace-1", "obs-generation");
+    root.startObservation.mockReturnValueOnce(turn);
+    turn.startObservation.mockReturnValueOnce(generation);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const run = (await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+
+    const generationObserver = await run.startGeneration?.(generationStartArgs());
+    generationObserver?.update?.({ turn: 1, delta: { type: "text_delta", delta: "hi" } });
+    expect(generation.update).toHaveBeenCalledWith({
+      output: { delta: { type: "text_delta", delta: "hi" } },
+    });
+  });
+
+  it("forwards reasoning deltas with id and signature", async () => {
+    const root = fakeObservation("root", "trace-1", "obs-root");
+    const turn = fakeObservation("turn", "trace-1", "obs-turn");
+    const generation = fakeObservation("generation", "trace-1", "obs-generation");
+    root.startObservation.mockReturnValueOnce(turn);
+    turn.startObservation.mockReturnValueOnce(generation);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const run = (await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+
+    const generationObserver = await run.startGeneration?.(generationStartArgs());
+    generationObserver?.update?.({
+      turn: 1,
+      delta: { type: "reasoning_delta", delta: "thinking...", id: "r1", signature: "sig" },
+    });
+    expect(generation.update).toHaveBeenCalledWith({
+      output: {
+        delta: { type: "reasoning_delta", delta: "thinking...", id: "r1", signature: "sig" },
+      },
+    });
+  });
+
+  it("forwards tool_call deltas with the toolCall payload", async () => {
+    const root = fakeObservation("root", "trace-1", "obs-root");
+    const turn = fakeObservation("turn", "trace-1", "obs-turn");
+    const generation = fakeObservation("generation", "trace-1", "obs-generation");
+    root.startObservation.mockReturnValueOnce(turn);
+    turn.startObservation.mockReturnValueOnce(generation);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const run = (await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+
+    const generationObserver = await run.startGeneration?.(generationStartArgs());
+    const toolCall = AssistantContent.toolCall("call-1", "search", { q: "x" });
+    generationObserver?.update?.({ turn: 1, delta: { type: "tool_call", toolCall } });
+    expect(generation.update).toHaveBeenCalledWith({
+      output: { delta: { type: "tool_call", toolCall } },
+    });
+  });
+
+  it("preserves the final end output after streaming deltas", async () => {
+    const root = fakeObservation("root", "trace-1", "obs-root");
+    const turn = fakeObservation("turn", "trace-1", "obs-turn");
+    const generation = fakeObservation("generation", "trace-1", "obs-generation");
+    root.startObservation.mockReturnValueOnce(turn);
+    turn.startObservation.mockReturnValueOnce(generation);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const run = (await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+
+    const generationObserver = await run.startGeneration?.(generationStartArgs());
+    generationObserver?.update?.({ turn: 1, delta: { type: "text_delta", delta: "he" } });
+    generationObserver?.update?.({ turn: 1, delta: { type: "text_delta", delta: "llo" } });
+    generationObserver?.end({
+      turn: 1,
+      response: {
+        messageId: "msg-1",
+        choice: [AssistantContent.text("hello")],
+        usage: usage(2, 3),
+        rawResponse: {},
+      },
+    });
+    expect(generation.update).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        output: expect.objectContaining({ text: "hello" }),
+      }),
+    );
+    expect(generation.end).toHaveBeenCalledOnce();
+  });
+});
+
 describe("ScoreQueue", () => {
   type QueueHandle = {
     queue: ScoreQueue;

--- a/packages/observability-langfuse/test/langfuse.test.ts
+++ b/packages/observability-langfuse/test/langfuse.test.ts
@@ -1276,6 +1276,7 @@ describe("langfuse", () => {
         suiteName: "suite",
         caseId: "case-1",
         outcome: "pass",
+        caseInputSummary: "input",
       },
     });
   });
@@ -1414,6 +1415,352 @@ describe("langfuse", () => {
       expect.objectContaining({ traceId: "trace-fallback", value: 1 }),
     );
     expect(score).toHaveBeenCalledTimes(3);
+  });
+
+  it("forwards metric.metadata, dataType, and configId to the score body", async () => {
+    const score = vi.fn();
+    const reporter = createReporter({ score });
+
+    await reporter.report({
+      suiteName: "suite",
+      case: { id: "case-1", input: "input" },
+      output: { trace: { traceId: "trace-1" } },
+      metric: {
+        name: "quality",
+        dataType: "CATEGORICAL",
+        configId: "sc-1",
+        scoreConfigId: "sc-1-alt",
+        metadata: { suite: "qa", tags: ["smoke"] },
+        evaluate: () => EvalOutcome.pass("good"),
+      },
+      outcome: EvalOutcome.pass("good"),
+    });
+
+    expect(score).toHaveBeenCalledWith(
+      expect.objectContaining({
+        traceId: "trace-1",
+        name: "quality",
+        value: "good",
+        dataType: "CATEGORICAL",
+        configId: "sc-1",
+        metadata: expect.objectContaining({
+          suite: "qa",
+          tags: ["smoke"],
+          caseInputSummary: "input",
+        }),
+      }),
+    );
+  });
+
+  it("prefers metric.configId over scoreConfigId when both are set", async () => {
+    const score = vi.fn();
+    const reporter = createReporter({ score });
+
+    await reporter.report({
+      suiteName: "suite",
+      case: { id: "case-1", input: "input" },
+      output: { trace: { traceId: "trace-1" } },
+      metric: {
+        name: "quality",
+        configId: "config-wins",
+        scoreConfigId: "config-loses",
+        evaluate: () => EvalOutcome.pass(true),
+      },
+      outcome: EvalOutcome.pass(true),
+    });
+
+    expect(score).toHaveBeenCalledWith(expect.objectContaining({ configId: "config-wins" }));
+  });
+
+  it("sends categorical outcome scores as strings with dataType", async () => {
+    const score = vi.fn();
+    const reporter = createReporter({ score });
+
+    await reporter.report({
+      suiteName: "suite",
+      case: { id: "case-1", input: "input" },
+      output: { trace: { traceId: "trace-1" } },
+      metric: { name: "quality", dataType: "CATEGORICAL", evaluate: () => EvalOutcome.pass("ok") },
+      outcome: EvalOutcome.pass("ok"),
+    });
+    await reporter.report({
+      suiteName: "suite",
+      case: { id: "case-2", input: "input" },
+      output: { trace: { traceId: "trace-2" } },
+      metric: { name: "quality", dataType: "CATEGORICAL", evaluate: () => EvalOutcome.fail(true) },
+      outcome: EvalOutcome.fail(true),
+    });
+    await reporter.report({
+      suiteName: "suite",
+      case: { id: "case-3", input: "input" },
+      output: { trace: { traceId: "trace-3" } },
+      metric: {
+        name: "quality",
+        dataType: "CATEGORICAL",
+        evaluate: () => EvalOutcome.pass(undefined),
+      },
+      outcome: EvalOutcome.pass(undefined),
+    });
+
+    expect(score).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ value: "ok", dataType: "CATEGORICAL" }),
+    );
+    expect(score).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ value: "true", dataType: "CATEGORICAL" }),
+    );
+    expect(score).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ value: "pass", dataType: "CATEGORICAL" }),
+    );
+  });
+
+  it("sends boolean outcomes as 0/1 when dataType is BOOLEAN", async () => {
+    const score = vi.fn();
+    const reporter = createReporter({ score });
+
+    await reporter.report({
+      suiteName: "suite",
+      case: { id: "case-1", input: "input" },
+      output: { trace: { traceId: "trace-1" } },
+      metric: { name: "boolean", dataType: "BOOLEAN", evaluate: () => EvalOutcome.pass(true) },
+      outcome: EvalOutcome.pass(true),
+    });
+    await reporter.report({
+      suiteName: "suite",
+      case: { id: "case-2", input: "input" },
+      output: { trace: { traceId: "trace-2" } },
+      metric: { name: "boolean", dataType: "BOOLEAN", evaluate: () => EvalOutcome.pass(undefined) },
+      outcome: EvalOutcome.pass(undefined),
+    });
+
+    expect(score).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ value: 1, dataType: "BOOLEAN" }),
+    );
+    expect(score).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ value: 1, dataType: "BOOLEAN" }),
+    );
+  });
+
+  it("includes truncated case input and expected summaries", async () => {
+    const score = vi.fn();
+    const reporter = createReporter({ score }, { truncateInputAt: 32 });
+
+    const bigInput = "a".repeat(200);
+    const bigExpected = { note: "b".repeat(200) };
+
+    await reporter.report({
+      suiteName: "suite",
+      case: { id: "case-1", input: bigInput, expected: bigExpected },
+      output: { trace: { traceId: "trace-1" } },
+      metric: metric("quality"),
+      outcome: EvalOutcome.pass(true),
+    });
+
+    const call = score.mock.calls[0]?.[0] as { metadata?: Record<string, unknown> };
+    expect(call.metadata?.caseInputSummary).toMatch(/^a+<truncated>$/);
+    expect(call.metadata?.caseExpectedSummary).toMatch(/<truncated>$/);
+  });
+
+  it("includes output.messages when includeMessages is not set", async () => {
+    const score = vi.fn();
+    const reporter = createReporter({ score });
+
+    await reporter.report({
+      suiteName: "suite",
+      case: { id: "case-1", input: "input" },
+      output: {
+        trace: { traceId: "trace-1" },
+        messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      },
+      metric: metric("quality"),
+      outcome: EvalOutcome.pass(true),
+    });
+
+    expect(score).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+        }),
+      }),
+    );
+  });
+
+  it("omits output.messages when includeMessages is false", async () => {
+    const score = vi.fn();
+    const reporter = createReporter({ score }, { includeMessages: false });
+
+    await reporter.report({
+      suiteName: "suite",
+      case: { id: "case-1", input: "input" },
+      output: {
+        trace: { traceId: "trace-1" },
+        messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      },
+      metric: metric("quality"),
+      outcome: EvalOutcome.pass(true),
+    });
+
+    const call = score.mock.calls[0]?.[0] as { metadata?: Record<string, unknown> };
+    expect(call.metadata).not.toHaveProperty("messages");
+  });
+
+  it("falls back to args.case.input.trace when output.trace is missing", async () => {
+    const score = vi.fn();
+    const reporter = createReporter({ score });
+
+    await reporter.report({
+      suiteName: "suite",
+      case: {
+        id: "case-1",
+        input: { trace: { traceId: "trace-from-input", observationId: "obs-from-input" } },
+      },
+      output: { output: "answer" },
+      metric: metric("quality"),
+      outcome: EvalOutcome.pass(true),
+    });
+
+    expect(score).toHaveBeenCalledWith(
+      expect.objectContaining({
+        traceId: "trace-from-input",
+        observationId: "obs-from-input",
+      }),
+    );
+  });
+
+  it("ignores malformed args.case.input.trace without throwing", async () => {
+    const score = vi.fn();
+    const reporter = createReporter({ score });
+
+    await reporter.report({
+      suiteName: "suite",
+      case: {
+        id: "case-1",
+        input: { trace: "not-an-object" },
+      },
+      output: { output: "answer" },
+      metric: metric("quality"),
+      outcome: EvalOutcome.pass(true),
+    });
+
+    expect(score).not.toHaveBeenCalled();
+  });
+
+  it("onMissingTrace 'throw' raises when no trace can be found", async () => {
+    const score = vi.fn();
+    const reporter = createReporter({ score }, { onMissingTrace: "throw" });
+
+    await expect(
+      reporter.report({
+        suiteName: "suite",
+        case: { id: "case-1", input: "input" },
+        output: "answer",
+        metric: metric("quality"),
+        outcome: EvalOutcome.pass(true),
+      }),
+    ).rejects.toThrow(/traceId/);
+  });
+
+  it("onMissingTrace 'warn' logs a console warning but does not throw", async () => {
+    const score = vi.fn();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const reporter = createReporter({ score }, { onMissingTrace: "warn" });
+
+    await expect(
+      reporter.report({
+        suiteName: "suite",
+        case: { id: "case-1", input: "input" },
+        output: "answer",
+        metric: metric("quality"),
+        outcome: EvalOutcome.pass(true),
+      }),
+    ).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledOnce();
+    expect(score).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("onMissingTrace 'ignore' returns silently when no trace can be found", async () => {
+    const score = vi.fn();
+    const reporter = createReporter({ score }, { onMissingTrace: "ignore" });
+
+    await expect(
+      reporter.report({
+        suiteName: "suite",
+        case: { id: "case-1", input: "input" },
+        output: "answer",
+        metric: metric("quality"),
+        outcome: EvalOutcome.pass(true),
+      }),
+    ).resolves.toBeUndefined();
+    expect(score).not.toHaveBeenCalled();
+  });
+
+  it("strict: true continues to work as an alias for onMissingTrace 'throw'", async () => {
+    const score = vi.fn();
+    const reporter = createReporter({ score }, { strict: true });
+
+    await expect(
+      reporter.report({
+        suiteName: "suite",
+        case: { id: "case-1", input: "input" },
+        output: "answer",
+        metric: metric("quality"),
+        outcome: EvalOutcome.pass(true),
+      }),
+    ).rejects.toThrow(/traceId/);
+  });
+
+  it("forwards args.outcome.metadata into the score metadata", async () => {
+    const score = vi.fn();
+    const reporter = createReporter({ score });
+
+    await reporter.report({
+      suiteName: "suite",
+      case: { id: "case-1", input: "input" },
+      output: { trace: { traceId: "trace-1" } },
+      metric: metric("quality"),
+      outcome: EvalOutcome.pass(true, {
+        metadata: { judge: "llm-judge-1", rationale: "looks good" },
+      }),
+    });
+
+    expect(score).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          judge: "llm-judge-1",
+          rationale: "looks good",
+        }),
+      }),
+    );
+  });
+
+  it("does not mutate metric.metadata or case.metadata", async () => {
+    const score = vi.fn();
+    const reporter = createReporter({ score });
+
+    const metricMeta = { suite: "qa" };
+    const caseMeta = { traceId: "trace-1" };
+    const metric = {
+      name: "quality",
+      metadata: metricMeta,
+      evaluate: () => EvalOutcome.pass(true, { metadata: { reason: "looks good" } }),
+    };
+    const testCase = { id: "case-1", input: "input", metadata: caseMeta };
+
+    await reporter.report({
+      suiteName: "suite",
+      case: testCase,
+      output: "answer",
+      metric,
+      outcome: EvalOutcome.pass(true, { metadata: { reason: "looks good" } }),
+    });
+
+    expect(metricMeta).toEqual({ suite: "qa" });
+    expect(caseMeta).toEqual({ traceId: "trace-1" });
   });
 });
 

--- a/packages/observability-langfuse/test/langfuse.test.ts
+++ b/packages/observability-langfuse/test/langfuse.test.ts
@@ -3184,3 +3184,363 @@ function createPromptClient(
 ): ReturnType<typeof createLangfusePromptClient> {
   return createLangfusePromptClient(tracing, options);
 }
+
+describe("PII redaction", () => {
+  it("redacts a single email address", async () => {
+    const { createPiiRedactor } = await import("../src/redaction");
+    const r = createPiiRedactor();
+    expect(r.redactString("contact alice@example.com for details")).toBe(
+      "contact [REDACTED] for details",
+    );
+  });
+
+  it("redacts phone numbers in common shapes", async () => {
+    const { createPiiRedactor } = await import("../src/redaction");
+    const r = createPiiRedactor();
+    expect(r.redactString("Call (415) 555-1212 or +1 415-555-1313 today")).toBe(
+      "Call [REDACTED] or [REDACTED] today",
+    );
+  });
+
+  it("redacts IPv4 addresses", async () => {
+    const { createPiiRedactor } = await import("../src/redaction");
+    const r = createPiiRedactor();
+    expect(r.redactString("server 192.168.1.42 was down")).toBe("server [REDACTED] was down");
+  });
+
+  it("redacts JWT-shaped strings", async () => {
+    const { createPiiRedactor } = await import("../src/redaction");
+    const r = createPiiRedactor();
+    const header = "eyJ".padEnd(36, "A");
+    const middle = "B".repeat(20);
+    const tail = "C".repeat(20);
+    const jwt = `${header}.${middle}.${tail}`;
+    expect(r.redactString(`token=${jwt}`)).toBe("token=[REDACTED]");
+  });
+
+  it("redacts common API-key shapes", async () => {
+    const { createPiiRedactor } = await import("../src/redaction");
+    const r = createPiiRedactor();
+    expect(r.redactString("use sk-abcdefghijklmnopqrstuv to authenticate")).toBe(
+      "use [REDACTED] to authenticate",
+    );
+  });
+
+  it("redacts credit-card-shaped sequences that pass Luhn", async () => {
+    const { createPiiRedactor, passesLuhn } = await import("../src/redaction");
+    expect(passesLuhn("4111111111111111")).toBe(true);
+    const r = createPiiRedactor();
+    expect(r.redactString("card 4111-1111-1111-1111 today")).toBe("card [REDACTED] today");
+  });
+
+  it("does not redact credit-card-shaped sequences that fail Luhn", async () => {
+    const { createPiiRedactor, passesLuhn } = await import("../src/redaction");
+    expect(passesLuhn("4111111111111112")).toBe(false);
+    const r = createPiiRedactor();
+    expect(r.redactString("not a card: 4111111111111112")).toBe("not a card: 4111111111111112");
+  });
+
+  it("redacts multiple patterns in a single string", async () => {
+    const { createPiiRedactor } = await import("../src/redaction");
+    const r = createPiiRedactor();
+    expect(r.redactString("from alice@example.com to 10.0.0.1 at 415-555-1212")).toBe(
+      "from [REDACTED] to [REDACTED] at [REDACTED]",
+    );
+  });
+
+  it("uses the configured replacement", async () => {
+    const { createPiiRedactor } = await import("../src/redaction");
+    const r = createPiiRedactor({ replacement: "<HIDDEN>" });
+    expect(r.redactString("alice@example.com")).toBe("<HIDDEN>");
+  });
+
+  it("redactMessages redacts text inside message content", async () => {
+    const { createPiiRedactor } = await import("../src/redaction");
+    const r = createPiiRedactor();
+    const out = r.redactMessages([
+      { role: "user", content: [{ type: "text", text: "hi alice@example.com" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "use 10.0.0.1" },
+          { type: "tool_call", id: "c", function: { name: "x", arguments: {} } },
+        ],
+      },
+    ]);
+    expect(out[0]?.content[0]).toMatchObject({ text: "hi [REDACTED]" });
+    expect(out[1]?.content[0]).toMatchObject({ text: "use [REDACTED]" });
+    expect(out[1]?.content[1]).toEqual({
+      type: "tool_call",
+      id: "c",
+      function: { name: "x", arguments: {} },
+    });
+  });
+
+  it("redactObject recurses into nested objects and arrays", async () => {
+    const { createPiiRedactor } = await import("../src/redaction");
+    const r = createPiiRedactor();
+    const out = r.redactObject({
+      contact: "alice@example.com",
+      list: ["server 10.0.0.1", { nested: "call 415-555-1212" }],
+    });
+    expect(out).toEqual({
+      contact: "[REDACTED]",
+      list: ["server [REDACTED]", { nested: "call [REDACTED]" }],
+    });
+  });
+
+  it("redactObject returns primitives unchanged", async () => {
+    const { createPiiRedactor } = await import("../src/redaction");
+    const r = createPiiRedactor();
+    expect(r.redactObject(42)).toBe(42);
+    expect(r.redactObject(null)).toBe(null);
+    expect(r.redactObject(true)).toBe(true);
+  });
+
+  it("patternNames returns the configured pattern names", async () => {
+    const { createPiiRedactor } = await import("../src/redaction");
+    const r = createPiiRedactor();
+    expect(r.patternNames()).toEqual(["email", "creditCard", "ipv4", "phone", "jwt", "apiKey"]);
+  });
+
+  it("custom patterns replace the default set", async () => {
+    const { createPiiRedactor } = await import("../src/redaction");
+    const r = createPiiRedactor({
+      patterns: [{ name: "ssn", regex: /\b\d{3}-\d{2}-\d{4}\b/g }],
+    });
+    expect(r.patternNames()).toEqual(["ssn"]);
+    expect(r.redactString("ssn 123-45-6789 not alice@example.com")).toBe(
+      "ssn [REDACTED] not alice@example.com",
+    );
+  });
+});
+
+describe("Langfuse redaction integration", () => {
+  it("is off by default: an email in args.prompt flows through unchanged", async () => {
+    const root = fakeObservation("root", "trace-redact-1", "obs-root-redact-1");
+    root.startObservation.mockReturnValue(root);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("email alice@example.com please"),
+      history: [],
+      maxTurns: 1,
+    });
+
+    const inputArg = mocks.startObservation.mock.calls[0]?.[1] as {
+      input: { prompt: { content: Array<{ text?: string }> } };
+    };
+    const text = inputArg.input.prompt.content[0]?.text;
+    expect(text).toBe("email alice@example.com please");
+  });
+
+  it("with redactInputs: true the email is replaced with [REDACTED]", async () => {
+    const root = fakeObservation("root", "trace-redact-2", "obs-root-redact-2");
+    root.startObservation.mockReturnValue(root);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({
+      publicKey: "pk",
+      secretKey: "sk",
+      redactInputs: true,
+    });
+    await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("email alice@example.com please"),
+      history: [userMessage("also bob@example.com")],
+      maxTurns: 1,
+    });
+
+    const inputArg = mocks.startObservation.mock.calls[0]?.[1] as {
+      input: {
+        prompt: { content: Array<{ text?: string }> };
+        history: Array<{ content: Array<{ text?: string }> }>;
+      };
+    };
+    expect(inputArg.input.prompt.content[0]?.text).toBe("email [REDACTED] please");
+    expect(inputArg.input.history[0]?.content[0]?.text).toBe("also [REDACTED]");
+  });
+
+  it("with redactInputs: 'deep' the chat history text is also redacted", async () => {
+    const root = fakeObservation("root", "trace-redact-3", "obs-root-redact-3");
+    const turn = fakeObservation("turn", "trace-redact-3", "obs-turn-redact-3");
+    const generation = fakeObservation("generation", "trace-redact-3", "obs-gen-redact-3");
+    root.startObservation.mockReturnValueOnce(turn);
+    turn.startObservation.mockReturnValueOnce(generation);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({
+      publicKey: "pk",
+      secretKey: "sk",
+      redactInputs: "deep",
+    });
+    const run = await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    });
+    if (!run?.startGeneration) throw new Error("missing startGeneration");
+    await run.startGeneration({
+      ...generationStartArgs(),
+      request: {
+        ...generationStartArgs().request,
+        chatHistory: [userMessage("hello alice@example.com")],
+      },
+    });
+
+    const call = turn.startObservation.mock.calls[0];
+    const input = (call?.[1] as { input: Array<{ content: Array<{ text?: string }> }> }).input;
+    expect(input[0]?.content[0]?.text).toBe("hello [REDACTED]");
+  });
+
+  it("with redactOutputs: true the generation output text is redacted", async () => {
+    const root = fakeObservation("root", "trace-redact-4", "obs-root-redact-4");
+    const turn = fakeObservation("turn", "trace-redact-4", "obs-turn-redact-4");
+    const generation = fakeObservation("generation", "trace-redact-4", "obs-gen-redact-4");
+    root.startObservation.mockReturnValueOnce(turn);
+    turn.startObservation.mockReturnValueOnce(generation);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({
+      publicKey: "pk",
+      secretKey: "sk",
+      redactOutputs: true,
+    });
+    const run = (await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+
+    const generationObserver = await run.startGeneration?.(generationStartArgs());
+    await generationObserver?.end({
+      turn: 1,
+      response: {
+        messageId: "msg-1",
+        choice: [AssistantContent.text("reply to alice@example.com")],
+        usage: usage(1, 2),
+        rawResponse: {},
+      },
+    });
+
+    const updateCall = generation.update.mock.calls.at(-1)?.[0] as {
+      output: { text: string };
+    };
+    expect(updateCall.output.text).toBe("reply to [REDACTED]");
+  });
+
+  it("with redactOutputs: 'deep' the choice array is deeply redacted", async () => {
+    const root = fakeObservation("root", "trace-redact-5", "obs-root-redact-5");
+    const turn = fakeObservation("turn", "trace-redact-5", "obs-turn-redact-5");
+    const generation = fakeObservation("generation", "trace-redact-5", "obs-gen-redact-5");
+    root.startObservation.mockReturnValueOnce(turn);
+    turn.startObservation.mockReturnValueOnce(generation);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({
+      publicKey: "pk",
+      secretKey: "sk",
+      redactOutputs: "deep",
+    });
+    const run = (await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+
+    const generationObserver = await run.startGeneration?.(generationStartArgs());
+    await generationObserver?.end({
+      turn: 1,
+      response: {
+        messageId: "msg-1",
+        choice: [AssistantContent.text("server 10.0.0.1")],
+        usage: usage(1, 2),
+        rawResponse: {},
+      },
+    });
+
+    const updateCall = generation.update.mock.calls.at(-1)?.[0] as {
+      output: { content: Array<{ text?: string }> };
+    };
+    const text = updateCall.output.content[0]?.text;
+    expect(text).toBe("server [REDACTED]");
+  });
+
+  it("redacts tool args and result when the corresponding mode is on", async () => {
+    const root = fakeObservation("root", "trace-redact-6", "obs-root-redact-6");
+    const turn = fakeObservation("turn", "trace-redact-6", "obs-turn-redact-6");
+    const tool = fakeObservation("tool", "trace-redact-6", "obs-tool-redact-6");
+    root.startObservation.mockReturnValueOnce(turn);
+    turn.startObservation.mockReturnValueOnce(tool);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({
+      publicKey: "pk",
+      secretKey: "sk",
+      redactInputs: true,
+      redactOutputs: true,
+    });
+    const run = (await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+
+    const toolObserver = (await run.startTool?.({
+      turn: 1,
+      toolName: "lookup",
+      args: '{"email":"alice@example.com"}',
+      toolCall: AssistantContent.toolCall("c-1", "lookup", { email: "alice@example.com" }),
+      internalCallId: "i-1",
+      toolCallId: "c-1",
+    })) as AgentToolObserver;
+
+    const startCall = turn.startObservation.mock.calls[0];
+    const startInput = (startCall?.[1] as { input: { args: string } }).input;
+    expect(startInput.args).toBe('{"email":"[REDACTED]"}');
+
+    await toolObserver?.end({
+      turn: 1,
+      toolName: "lookup",
+      args: '{"email":"alice@example.com"}',
+      toolCall: AssistantContent.toolCall("c-1", "lookup", { email: "alice@example.com" }),
+      internalCallId: "i-1",
+      toolCallId: "c-1",
+      result: "wrote to alice@example.com",
+      skipped: false,
+    });
+
+    const endCall = tool.update.mock.calls.at(-1)?.[0] as { output: string };
+    expect(endCall.output).toBe("wrote to [REDACTED]");
+  });
+
+  it("redaction.replacement propagates to the redactor", async () => {
+    const root = fakeObservation("root", "trace-redact-7", "obs-root-redact-7");
+    root.startObservation.mockReturnValue(root);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({
+      publicKey: "pk",
+      secretKey: "sk",
+      redactInputs: true,
+      redaction: { replacement: "<HIDDEN>" },
+    });
+    await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("alice@example.com"),
+      history: [],
+      maxTurns: 1,
+    });
+
+    const inputArg = mocks.startObservation.mock.calls[0]?.[1] as {
+      input: { prompt: { content: Array<{ text?: string }> } };
+    };
+    expect(inputArg.input.prompt.content[0]?.text).toBe("<HIDDEN>");
+  });
+});

--- a/packages/observability-langfuse/test/langfuse.test.ts
+++ b/packages/observability-langfuse/test/langfuse.test.ts
@@ -1856,6 +1856,208 @@ describe("usageDetailsFromRecord", () => {
   });
 });
 
+describe("LangfuseTraceHandle", () => {
+  it("getCurrentTrace() returns undefined before any run", () => {
+    const tracing = langfuse.create({ publicKey: "public", secretKey: "secret" });
+    expect(tracing.getCurrentTrace()).toBeUndefined();
+  });
+
+  it("getCurrentTrace() returns a handle during a run and clears it after end", async () => {
+    const root = fakeObservation("root", "trace-7", "obs-root-7");
+    root.startObservation.mockReturnValue(root);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({ publicKey: "public", secretKey: "secret" });
+    const runObserver = (await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+
+    const handle = tracing.getCurrentTrace();
+    expect(handle).toBeDefined();
+    expect(handle?.traceId).toBe("trace-7");
+    expect(handle?.observationId).toBe("obs-root-7");
+    expect(handle?.traceId).toBe(runObserver.trace?.traceId);
+    expect(handle?.observationId).toBe(runObserver.trace?.observationId);
+
+    await runObserver.end({
+      output: "Done",
+      usage: usage(1, 2),
+      messages: [],
+    });
+    expect(tracing.getCurrentTrace()).toBeUndefined();
+  });
+
+  it("getCurrentTrace() returns undefined after a run errors", async () => {
+    const root = fakeObservation("root", "trace-8", "obs-root-8");
+    root.startObservation.mockReturnValue(root);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({ publicKey: "public", secretKey: "secret" });
+    const runObserver = (await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+
+    expect(tracing.getCurrentTrace()).toBeDefined();
+
+    await runObserver.error?.({
+      error: new Error("boom"),
+      usage: usage(0, 0),
+      messages: [],
+    });
+    expect(tracing.getCurrentTrace()).toBeUndefined();
+  });
+
+  it("addAttributes updates the root observation metadata", async () => {
+    const root = fakeObservation("root", "trace-9", "obs-root-9");
+    root.startObservation.mockReturnValue(root);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({ publicKey: "public", secretKey: "secret" });
+    await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    });
+
+    tracing.getCurrentTrace()?.addAttributes({ quality: "high", score: 0.9 });
+    expect(root.update).toHaveBeenCalledWith({ metadata: { quality: "high", score: 0.9 } });
+  });
+
+  it("addEvent creates an event observation under the root and ends it", async () => {
+    const root = fakeObservation("root", "trace-10", "obs-root-10");
+    const event = fakeObservation("event", "trace-10", "obs-event-1");
+    root.startObservation.mockReturnValueOnce(event);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({ publicKey: "public", secretKey: "secret" });
+    await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    });
+
+    tracing.getCurrentTrace()?.addEvent("retrieval.done", { docCount: 4 });
+    expect(root.startObservation).toHaveBeenCalledWith(
+      "retrieval.done",
+      { metadata: { docCount: 4 } },
+      { asType: "event" },
+    );
+    expect(event.end).toHaveBeenCalledOnce();
+  });
+
+  it("event? on the run observer creates an event observation", async () => {
+    const root = fakeObservation("root", "trace-11", "obs-root-11");
+    const event = fakeObservation("event", "trace-11", "obs-event-2");
+    root.startObservation.mockReturnValueOnce(event);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({ publicKey: "public", secretKey: "secret" });
+    const runObserver = (await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+
+    await runObserver.event?.({
+      name: "validation.passed",
+      attributes: { checks: 3 },
+    });
+
+    expect(root.startObservation).toHaveBeenCalledWith(
+      "validation.passed",
+      { metadata: { checks: 3 } },
+      { asType: "event" },
+    );
+    expect(event.end).toHaveBeenCalledOnce();
+  });
+
+  it("multiple addEvent calls within one run all create observations", async () => {
+    const root = fakeObservation("root", "trace-12", "obs-root-12");
+    const eventA = fakeObservation("eventA", "trace-12", "obs-event-A");
+    const eventB = fakeObservation("eventB", "trace-12", "obs-event-B");
+    root.startObservation.mockReturnValueOnce(eventA).mockReturnValueOnce(eventB);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({ publicKey: "public", secretKey: "secret" });
+    await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    });
+
+    const handle = tracing.getCurrentTrace();
+    handle?.addEvent("retrieval.done");
+    handle?.addEvent("validation.passed");
+
+    expect(root.startObservation).toHaveBeenCalledTimes(2);
+    expect(root.startObservation).toHaveBeenNthCalledWith(
+      1,
+      "retrieval.done",
+      { metadata: {} },
+      { asType: "event" },
+    );
+    expect(root.startObservation).toHaveBeenNthCalledWith(
+      2,
+      "validation.passed",
+      { metadata: {} },
+      { asType: "event" },
+    );
+    expect(eventA.end).toHaveBeenCalledOnce();
+    expect(eventB.end).toHaveBeenCalledOnce();
+  });
+
+  it("sequential runs replace the handle (last-write-wins)", async () => {
+    const rootA = fakeObservation("rootA", "trace-A", "obs-root-A");
+    const rootB = fakeObservation("rootB", "trace-B", "obs-root-B");
+    rootA.startObservation.mockReturnValue(rootA);
+    rootB.startObservation.mockReturnValue(rootB);
+    mocks.startObservation.mockReturnValueOnce(rootA).mockReturnValueOnce(rootB);
+
+    const tracing = langfuse.create({ publicKey: "public", secretKey: "secret" });
+    const runA = (await tracing.startRun({
+      agentName: "agent-a",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+    const handleA = tracing.getCurrentTrace();
+    expect(handleA?.traceId).toBe("trace-A");
+
+    await runA.end({
+      output: "Done A",
+      usage: usage(1, 1),
+      messages: [],
+    });
+
+    const runB = (await tracing.startRun({
+      agentName: "agent-b",
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+    const handleB = tracing.getCurrentTrace();
+    expect(handleB?.traceId).toBe("trace-B");
+    expect(handleB).not.toBe(handleA);
+
+    await runB.end({
+      output: "Done B",
+      usage: usage(1, 1),
+      messages: [],
+    });
+    expect(tracing.getCurrentTrace()).toBeUndefined();
+  });
+});
+
 function fakeObservation(name: string, traceId: string, id: string) {
   const observation = {
     name,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,9 +362,15 @@ importers:
       '@langfuse/tracing':
         specifier: ^5.5.3
         version: 5.5.3(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources':
+        specifier: ^2.8.0
+        version: 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-node':
         specifier: ^0.219.0
         version: 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions':
+        specifier: ^1.40.0
+        version: 1.40.0
     devDependencies:
       '@anvia/core':
         specifier: workspace:*


### PR DESCRIPTION
Brings `@anvia/langfuse` and `@anvia/core` from a thin trace+score adapter to a full-featured Langfuse integration across ten incremental phases.

## Phases

1. Env-var config + serviceName (resolve from `LANGFUSE_*` env vars; tag root observation).
2. Richer observation metadata (providerRequest, modelInfo, firstDeltaMs, usageDetails, structuredResult).
3. Typed score API (dataType, configId/scoreConfigId, environment override, timestamp, validation).
4. Score queue with batching and retry (`scoreBatchSize`, debounced flush, 429/5xx backoff, `LangfuseScoreError`).
5. Streaming delta forwarder (`AgentGenerationUpdateArgs` + `update?` hook on `AgentGenerationObserver`).
6. Run events and trace handle (`AgentRunEventArgs` + `event?`; `LangfuseTraceHandle.addAttributes/addEvent`; `getCurrentTrace()`).
7. Eval reporter metadata and dataType (`EvalMetric` extensions + `defineMetric`; 3-tier trace resolution; categorical/boolean routing; `onMissingTrace`, `truncateInputAt`, `includeMessages`).
8. Dataset client and experiment-run helper (`createLangfuseDatasetClient`, `runEvalAsExperiment` with paging and Basic auth).
9. Prompt management (`createLangfusePromptClient` with TTL cache; `promptRef?` on `AgentRunStartArgs`; trace.metadata fallback; prompt attributes on root + each generation).
10. PII redaction (`createPiiRedactor` with default patterns; `redactInputs`/`redactOutputs`; "deep" mode; `redaction` options).

## Reference coverage

`apps/docs/scripts/check-reference-coverage.mjs` reports `TOTAL_MISSING_ENTRYPOINTS=0 TOTAL_MISSING_EXPORTS=0` (41 entrypoints / 685 exports). Doc updates ship alongside the implementation in this branch.

## Tests

- `@anvia/langfuse`: 131 tests pass.
- `@anvia/core`: 245 tests pass.
- Typecheck and build clean across the workspace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for richer Langfuse tracing, including run events, generation updates, prompt references, and active trace access.
  * Introduced prompt management, dataset/experiment workflows, and PII redaction options.
  * Added configurable score batching, retries, and typed score metadata support.

* **Bug Fixes**
  * Improved handling of missing traces and streaming output so partial generation data is recorded more reliably.
  * Added automatic environment-based configuration and service naming for easier setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->