### PR TITLE
fix(changesets): enable out-of-range peer dep check and widen 0.x peer ranges

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  },
   "ignore": ["docs", "cookbook", "anvia-cli-agent"]
 }

--- a/packages/embedding-fastembed/package.json
+++ b/packages/embedding-fastembed/package.json
@@ -41,6 +41,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "^0.7.1"
+    "@anvia/core": ">=0.7.1 <1.0.0"
   }
 }

--- a/packages/embedding-transformers/package.json
+++ b/packages/embedding-transformers/package.json
@@ -41,6 +41,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "^0.7.1"
+    "@anvia/core": ">=0.7.1 <1.0.0"
   }
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -41,6 +41,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "^0.7.1"
+    "@anvia/core": ">=0.7.1 <1.0.0"
   }
 }

--- a/packages/observability-langfuse/package.json
+++ b/packages/observability-langfuse/package.json
@@ -45,6 +45,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "^0.7.1"
+    "@anvia/core": ">=0.7.1 <1.0.0"
   }
 }

--- a/packages/observability-otel/package.json
+++ b/packages/observability-otel/package.json
@@ -41,6 +41,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "^0.7.1"
+    "@anvia/core": ">=0.7.1 <1.0.0"
   }
 }

--- a/packages/provider-anthropic/package.json
+++ b/packages/provider-anthropic/package.json
@@ -43,6 +43,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "^0.7.1"
+    "@anvia/core": ">=0.7.1 <1.0.0"
   }
 }

--- a/packages/provider-gemini/package.json
+++ b/packages/provider-gemini/package.json
@@ -43,6 +43,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "^0.7.1"
+    "@anvia/core": ">=0.7.1 <1.0.0"
   }
 }

--- a/packages/provider-mistral/package.json
+++ b/packages/provider-mistral/package.json
@@ -43,6 +43,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "^0.7.1"
+    "@anvia/core": ">=0.7.1 <1.0.0"
   }
 }

--- a/packages/provider-openai/package.json
+++ b/packages/provider-openai/package.json
@@ -43,6 +43,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "^0.7.1"
+    "@anvia/core": ">=0.7.1 <1.0.0"
   }
 }

--- a/packages/tool-sandbox/package.json
+++ b/packages/tool-sandbox/package.json
@@ -42,6 +42,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "^0.7.1"
+    "@anvia/core": ">=0.7.1 <1.0.0"
   }
 }

--- a/packages/tool-studio/package.json
+++ b/packages/tool-studio/package.json
@@ -70,6 +70,6 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "@anvia/core": "^0.7.1"
+    "@anvia/core": ">=0.7.1 <1.0.0"
   }
 }

--- a/packages/vector-chroma/package.json
+++ b/packages/vector-chroma/package.json
@@ -41,6 +41,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "^0.7.1"
+    "@anvia/core": ">=0.7.1 <1.0.0"
   }
 }

--- a/packages/vector-lancedb/package.json
+++ b/packages/vector-lancedb/package.json
@@ -41,6 +41,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "^0.7.1"
+    "@anvia/core": ">=0.7.1 <1.0.0"
   }
 }

--- a/packages/vector-milvus/package.json
+++ b/packages/vector-milvus/package.json
@@ -41,6 +41,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "^0.7.1"
+    "@anvia/core": ">=0.7.1 <1.0.0"
   }
 }

--- a/packages/vector-pgvector/package.json
+++ b/packages/vector-pgvector/package.json
@@ -43,6 +43,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "^0.7.1"
+    "@anvia/core": ">=0.7.1 <1.0.0"
   }
 }

--- a/packages/vector-pinecone/package.json
+++ b/packages/vector-pinecone/package.json
@@ -41,6 +41,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "^0.7.1"
+    "@anvia/core": ">=0.7.1 <1.0.0"
   }
 }

--- a/packages/vector-qdrant/package.json
+++ b/packages/vector-qdrant/package.json
@@ -41,6 +41,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "^0.7.1"
+    "@anvia/core": ">=0.7.1 <1.0.0"
   }
 }

--- a/packages/vector-redis/package.json
+++ b/packages/vector-redis/package.json
@@ -41,6 +41,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "^0.7.1"
+    "@anvia/core": ">=0.7.1 <1.0.0"
   }
 }

--- a/packages/vector-weaviate/package.json
+++ b/packages/vector-weaviate/package.json
@@ -41,6 +41,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "^0.7.1"
+    "@anvia/core": ">=0.7.1 <1.0.0"
   }
 }


### PR DESCRIPTION
## Problem

PR #148 (the auto-generated release PR for the langfuse phased improvements) bumped 20 packages to 1.0.0. The root cause was a classic npm semver trap in changesets:

In npm semver, \`^0.7.1\` means \`>=0.7.1 <0.8.0\` (the minor is locked for 0.x packages). Every \`@anvia/*\` package declared \`"@anvia/core": "^0.7.1"\` in peer deps. When \`@anvia/core\` was bumped from 0.7.1 to 0.8.0, the new version left the peer range for every dependent. Changesets correctly interpreted this as a breaking change and major-bumped all 18 dependents, including \`@anvia/langfuse\` itself (which has \`@anvia/core\` as a peer dep).

## Fix

Two coordinated changes:

1. **Enable the experimental changesets flag** \`onlyUpdatePeerDependentsWhenOutOfRange: true\` in \`.changeset/config.json\`. With this flag, \`shouldBumpMajor\` only fires when the new version actually leaves the peer range.

2. **Widen the \`@anvia/core\` peer dep range** from \`^0.7.1\` to \`>=0.7.1 <1.0.0\` across the 19 dependent packages. The upper bound intentionally stays below 1.0.0 so a real major bump on \`@anvia/core\` will still propagate.

## Verified result

Re-ran \`pnpm changeset version\` locally with the fix applied:

| Package | Before | #148 (broken) | This fix |
| --- | --- | --- | --- |
| \`@anvia/core\` | 0.7.1 | 0.8.0 | 0.8.0 |
| \`@anvia/langfuse\` | 0.2.8 | 1.0.0 | 0.3.0 |
| 18 other dependents | 0.x.y | 1.0.0 | 0.x.y (unchanged) |
| \`peer-core-compat\` | 0.1.4 | 0.1.5 | 0.1.5 |

## Safety

- No code or public API changes.
- No accidental 1.0.0 mass-bump.
- Real majors on \`@anvia/core\` will still propagate as majors.
- Fully reversible.

Closes the issue exposed by #148 (which should be left closed, not merged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package compatibility requirements to accept a broader range of the core library while still excluding the next major version.
  * Adjusted release configuration to better control how related packages are updated during patch releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->