### PR TITLE
chore: update upstream dependencies

### DIFF
--- a/.changeset/fresh-schools-yell.md
+++ b/.changeset/fresh-schools-yell.md
@@ -1,0 +1,10 @@
+---
+"@anvia/anthropic": patch
+"@anvia/gemini": patch
+"@anvia/langfuse": patch
+"@anvia/mistral": patch
+"@anvia/openai": patch
+"@anvia/redis": patch
+---
+
+Update upstream runtime dependencies to their latest checked releases.

--- a/apps/docs/content/docs/changelog/anthropic.mdx
+++ b/apps/docs/content/docs/changelog/anthropic.mdx
@@ -9,6 +9,27 @@ Anthropic provider adapter for Anvia.
 
 Source: [`packages/provider-anthropic/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/provider-anthropic/CHANGELOG.md)
 
+## 0.3.10
+
+### Patch Changes
+
+- 2559d04: Refresh upstream runtime dependencies and make pipeline construction schema-first.
+- Updated dependencies [2559d04]
+  - @anvia/core@0.7.1
+
+## 0.3.9
+
+### Patch Changes
+
+- 94362c9: Move @anvia/core to peer dependencies for packages that expose or consume core types, preventing duplicate private-type incompatibilities in consumer apps.
+
+## 0.3.8
+
+### Patch Changes
+
+- Updated dependencies [ef5e727]
+  - @anvia/core@0.7.0
+
 ## 0.3.7
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/chroma.mdx
+++ b/apps/docs/content/docs/changelog/chroma.mdx
@@ -9,6 +9,19 @@ ChromaDB vector store adapter for Anvia.
 
 Source: [`packages/vector-chroma/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/vector-chroma/CHANGELOG.md)
 
+## 0.2.10
+
+### Patch Changes
+
+- 94362c9: Move @anvia/core to peer dependencies for packages that expose or consume core types, preventing duplicate private-type incompatibilities in consumer apps.
+
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [ef5e727]
+  - @anvia/core@0.7.0
+
 ## 0.2.8
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/core.mdx
+++ b/apps/docs/content/docs/changelog/core.mdx
@@ -9,6 +9,59 @@ Core runtime primitives for context-aware Anvia agents.
 
 Source: [`packages/core/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/core/CHANGELOG.md)
 
+## 0.8.0
+
+### Minor Changes
+
+- 3de3cce: Add an optional `update?` hook on `AgentGenerationObserver` so
+  observability adapters can record streaming deltas as they arrive.
+
+  The agent loop now awaits `observer.update?.({ turn, delta })` for
+  every delta produced by the underlying completion stream. The new
+  method is optional, so existing adapters keep working. A new
+  `AgentGenerationUpdateArgs` type is exported alongside.
+
+- 3de3cce: Add an optional `event?` hook on `AgentRunObserver` so
+  observability adapters can record ad-hoc checkpoints (e.g.
+  retrieval, validation) during a run.
+
+  The new method accepts an `AgentRunEventArgs` value with a `name`,
+  optional `attributes` map, optional `level`, and optional
+  `timestamp`. The hook is optional, so existing adapters keep
+  working without modification.
+
+- 3de3cce: Add an optional `promptRef?: { name; version? }` field on
+  `AgentRunStartArgs`. Observability adapters can use this to
+  record the prompt name and version on the trace root and on
+  each generation in the run.
+
+  The new field is optional, so existing call sites keep
+  compiling. The `AgentRunPromptRef` type is also exported
+  alongside.
+
+- 3de3cce: Extend the `EvalMetric` type with optional Langfuse-related
+  annotations: `dataType`, `scoreConfigId`, `configId`, and
+  `metadata`. All fields are optional, so existing metric definitions
+  keep compiling unchanged.
+
+  Add a `defineMetric()` identity helper that wraps a metric
+  definition for clearer intent at call sites. Re-export it from
+  `@anvia/core/evals`.
+
+## 0.7.1
+
+### Patch Changes
+
+- 2559d04: Refresh upstream runtime dependencies and make pipeline construction schema-first.
+
+## 0.7.0
+
+### Minor Changes
+
+- ef5e727: Add centralized tool approval handling with tool-level approval policies and `.approvals(...)` decision handlers.
+
+  Add React `useChat` human-input state for tool approvals and `ask_question` prompts, including helpers for approving, rejecting, and answering pending human input.
+
 ## 0.6.3
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/fastembed.mdx
+++ b/apps/docs/content/docs/changelog/fastembed.mdx
@@ -9,6 +9,25 @@ FastEmbed embedding model adapter for Anvia.
 
 Source: [`packages/embedding-fastembed/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/embedding-fastembed/CHANGELOG.md)
 
+## 0.2.11
+
+### Patch Changes
+
+- f8b8538: Refactor package entrypoints into barrel exports with focused internal modules.
+
+## 0.2.10
+
+### Patch Changes
+
+- 94362c9: Move @anvia/core to peer dependencies for packages that expose or consume core types, preventing duplicate private-type incompatibilities in consumer apps.
+
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [ef5e727]
+  - @anvia/core@0.7.0
+
 ## 0.2.8
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/gemini.mdx
+++ b/apps/docs/content/docs/changelog/gemini.mdx
@@ -9,6 +9,27 @@ Gemini provider adapter for Anvia.
 
 Source: [`packages/provider-gemini/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/provider-gemini/CHANGELOG.md)
 
+## 0.2.8
+
+### Patch Changes
+
+- 2559d04: Refresh upstream runtime dependencies and make pipeline construction schema-first.
+- Updated dependencies [2559d04]
+  - @anvia/core@0.7.1
+
+## 0.2.7
+
+### Patch Changes
+
+- 94362c9: Move @anvia/core to peer dependencies for packages that expose or consume core types, preventing duplicate private-type incompatibilities in consumer apps.
+
+## 0.2.6
+
+### Patch Changes
+
+- Updated dependencies [ef5e727]
+  - @anvia/core@0.7.0
+
 ## 0.2.5
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/index.mdx
+++ b/apps/docs/content/docs/changelog/index.mdx
@@ -11,69 +11,69 @@ Developers should keep writing release notes with `pnpm changeset`. The docs pag
 
 ## Core
 
-| Package | Current version | Release notes |
-| --- | --- | --- |
-| `@anvia/core` | `0.6.3` | [View changelog](/docs/changelog/core) |
+| Package | Current version | Released | Release notes |
+| --- | --- | --- | --- |
+| `@anvia/core` | `0.8.0` | 2026-06-24 | [View changelog](/docs/changelog/core) |
 
 ## Providers
 
-| Package | Current version | Release notes |
-| --- | --- | --- |
-| `@anvia/anthropic` | `0.3.7` | [View changelog](/docs/changelog/anthropic) |
-| `@anvia/gemini` | `0.2.5` | [View changelog](/docs/changelog/gemini) |
-| `@anvia/mistral` | `0.2.9` | [View changelog](/docs/changelog/mistral) |
-| `@anvia/openai` | `0.3.10` | [View changelog](/docs/changelog/openai) |
+| Package | Current version | Released | Release notes |
+| --- | --- | --- | --- |
+| `@anvia/anthropic` | `0.3.10` | 2026-06-20 | [View changelog](/docs/changelog/anthropic) |
+| `@anvia/gemini` | `0.2.8` | 2026-06-20 | [View changelog](/docs/changelog/gemini) |
+| `@anvia/mistral` | `0.3.0` | 2026-06-22 | [View changelog](/docs/changelog/mistral) |
+| `@anvia/openai` | `0.3.13` | 2026-06-20 | [View changelog](/docs/changelog/openai) |
 
 ## Embeddings
 
-| Package | Current version | Release notes |
-| --- | --- | --- |
-| `@anvia/fastembed` | `0.2.8` | [View changelog](/docs/changelog/fastembed) |
-| `@anvia/transformers` | `0.2.8` | [View changelog](/docs/changelog/transformers) |
+| Package | Current version | Released | Release notes |
+| --- | --- | --- | --- |
+| `@anvia/fastembed` | `0.2.11` | 2026-06-22 | [View changelog](/docs/changelog/fastembed) |
+| `@anvia/transformers` | `0.2.11` | 2026-06-22 | [View changelog](/docs/changelog/transformers) |
 
 ## Vector Stores
 
-| Package | Current version | Release notes |
-| --- | --- | --- |
-| `@anvia/chroma` | `0.2.8` | [View changelog](/docs/changelog/chroma) |
-| `@anvia/lancedb` | `0.2.0` | [View changelog](/docs/changelog/lancedb) |
-| `@anvia/milvus` | `0.3.3` | [View changelog](/docs/changelog/milvus) |
-| `@anvia/pgvector` | `0.2.8` | [View changelog](/docs/changelog/pgvector) |
-| `@anvia/pinecone` | `0.3.3` | [View changelog](/docs/changelog/pinecone) |
-| `@anvia/qdrant` | `0.2.8` | [View changelog](/docs/changelog/qdrant) |
-| `@anvia/redis` | `0.2.0` | [View changelog](/docs/changelog/redis) |
-| `@anvia/weaviate` | `0.2.0` | [View changelog](/docs/changelog/weaviate) |
+| Package | Current version | Released | Release notes |
+| --- | --- | --- | --- |
+| `@anvia/chroma` | `0.2.10` | 2026-06-20 | [View changelog](/docs/changelog/chroma) |
+| `@anvia/lancedb` | `0.2.3` | 2026-06-20 | [View changelog](/docs/changelog/lancedb) |
+| `@anvia/milvus` | `0.3.6` | 2026-06-20 | [View changelog](/docs/changelog/milvus) |
+| `@anvia/pgvector` | `0.2.11` | 2026-06-20 | [View changelog](/docs/changelog/pgvector) |
+| `@anvia/pinecone` | `0.3.6` | 2026-06-20 | [View changelog](/docs/changelog/pinecone) |
+| `@anvia/qdrant` | `0.2.10` | 2026-06-20 | [View changelog](/docs/changelog/qdrant) |
+| `@anvia/redis` | `0.2.3` | 2026-06-20 | [View changelog](/docs/changelog/redis) |
+| `@anvia/weaviate` | `0.2.3` | 2026-06-20 | [View changelog](/docs/changelog/weaviate) |
 
 ## Logger
 
-| Package | Current version | Release notes |
-| --- | --- | --- |
-| `@anvia/logger` | `0.3.8` | [View changelog](/docs/changelog/logger) |
+| Package | Current version | Released | Release notes |
+| --- | --- | --- | --- |
+| `@anvia/logger` | `0.3.10` | 2026-06-20 | [View changelog](/docs/changelog/logger) |
 
 ## Observability
 
-| Package | Current version | Release notes |
-| --- | --- | --- |
-| `@anvia/langfuse` | `0.2.4` | [View changelog](/docs/changelog/langfuse) |
-| `@anvia/otel` | `0.2.8` | [View changelog](/docs/changelog/otel) |
+| Package | Current version | Released | Release notes |
+| --- | --- | --- | --- |
+| `@anvia/langfuse` | `0.3.1` | 2026-06-25 | [View changelog](/docs/changelog/langfuse) |
+| `@anvia/otel` | `0.2.11` | 2026-06-22 | [View changelog](/docs/changelog/otel) |
 
 ## Tools
 
-| Package | Current version | Release notes |
-| --- | --- | --- |
-| `@anvia/sandbox` | `0.3.3` | [View changelog](/docs/changelog/sandbox) |
-| `@anvia/studio` | `0.6.1` | [View changelog](/docs/changelog/studio) |
+| Package | Current version | Released | Release notes |
+| --- | --- | --- | --- |
+| `@anvia/sandbox` | `0.3.5` | 2026-06-20 | [View changelog](/docs/changelog/sandbox) |
+| `@anvia/studio` | `0.7.4` | 2026-06-23 | [View changelog](/docs/changelog/studio) |
 
 ## React
 
-| Package | Current version | Release notes |
-| --- | --- | --- |
-| `@anvia/react` | `0.4.0` | [View changelog](/docs/changelog/react) |
+| Package | Current version | Released | Release notes |
+| --- | --- | --- | --- |
+| `@anvia/react` | `0.5.0` | 2026-06-19 | [View changelog](/docs/changelog/react) |
 
 ## Server
 
-| Package | Current version | Release notes |
-| --- | --- | --- |
-| `@anvia/server` | `0.3.1` | [View changelog](/docs/changelog/server) |
+| Package | Current version | Released | Release notes |
+| --- | --- | --- | --- |
+| `@anvia/server` | `0.3.1` | 2026-06-14 | [View changelog](/docs/changelog/server) |
 
 </div>

--- a/apps/docs/content/docs/changelog/lancedb.mdx
+++ b/apps/docs/content/docs/changelog/lancedb.mdx
@@ -9,6 +9,27 @@ LanceDB vector store adapter for Anvia.
 
 Source: [`packages/vector-lancedb/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/vector-lancedb/CHANGELOG.md)
 
+## 0.2.3
+
+### Patch Changes
+
+- 2559d04: Refresh upstream runtime dependencies and make pipeline construction schema-first.
+- Updated dependencies [2559d04]
+  - @anvia/core@0.7.1
+
+## 0.2.2
+
+### Patch Changes
+
+- 94362c9: Move @anvia/core to peer dependencies for packages that expose or consume core types, preventing duplicate private-type incompatibilities in consumer apps.
+
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies [ef5e727]
+  - @anvia/core@0.7.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/apps/docs/content/docs/changelog/langfuse.mdx
+++ b/apps/docs/content/docs/changelog/langfuse.mdx
@@ -9,6 +9,199 @@ Langfuse tracing adapter for Anvia.
 
 Source: [`packages/observability-langfuse/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/observability-langfuse/CHANGELOG.md)
 
+## 0.3.1
+
+### Patch Changes
+
+- 628afa4: Reuse resolved tracing configuration in Langfuse prompt and dataset clients, and standardize examples and docs on `LANGFUSE_TRACING_ENVIRONMENT`.
+
+## 0.3.0
+
+### Minor Changes
+
+- 3de3cce: Add env-var auto-init for tracing config and a `serviceName` option.
+
+  `langfuse.create()` now reads `LANGFUSE_PUBLIC_KEY`,
+  `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`,
+  `LANGFUSE_TRACING_ENVIRONMENT`, `LANGFUSE_RELEASE`, and
+  `LANGFUSE_SERVICE_NAME` from the environment when the matching option
+  is not provided. Explicit options still win over env vars.
+
+  The new `serviceName` option is recorded on the root observation's
+  metadata and set as the OpenTelemetry `service.name` resource
+  attribute on the underlying `NodeSDK`.
+
+- 3de3cce: Add Langfuse dataset and experiment-run support.
+
+  `createLangfuseDatasetClient(tracing, options)` exposes four
+  methods:
+
+  - `createDataset({ name, description?, metadata? })` PUTs to
+    `/api/public/datasets/:name`.
+  - `getDataset(name)` GETs `/api/public/datasets/:name` with
+    pagination driven by `meta.totalPages`.
+  - `upsertItems(name, items)` POSTs the items array to
+    `/api/public/datasets/:name/items`.
+  - `runExperiment({ datasetName, runName, items?, run })` POSTs
+    one batched payload to `/api/public/dataset-run-items` with
+    `{ runName, runDescription?, metadata?, datasetItemRuns }`.
+    When `items` is not provided the client fetches them from the
+    remote dataset first. Per-item failures are collected in
+    `errors`; the batch still posts with the successful subset.
+
+  `runEvalAsExperiment(evalOptions, experimentOptions)` runs an
+  `@anvia/core/evals` suite and posts a dataset run alongside the
+  metric scores, returning both `{ suite, datasetRun }`.
+
+  Auth uses the same `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY`
+  env vars and base URL as `langfuse.create()`. Per-request
+  timeout defaults to 30 seconds (configurable via
+  `options.timeoutMs`).
+
+- 3de3cce: Enrich the eval reporter with metadata, dataType propagation,
+  truncated input/expected summaries, and a configurable
+  `onMissingTrace` mode.
+
+  - Score body now includes `args.metric.metadata`, `dataType`,
+    `configId`/`scoreConfigId` from `args.metric`. Categorical and
+    boolean outcomes are sent with the correct `value` shape and
+    dataType.
+  - `case.input` and `case.expected` are JSON-serialized and added as
+    `caseInputSummary` / `caseExpectedSummary` in score metadata,
+    truncated to `truncateInputAt` bytes (default 2048) with a
+    `<truncated>` marker.
+  - `output.messages` is included by default; opt out with
+    `includeMessages: false`.
+  - New `onMissingTrace` option (`"ignore" | "warn" | "throw"`)
+    controls reporter behavior when no trace can be resolved. The
+    legacy `strict: true` flag is now an alias for `"throw"`.
+  - Trace resolution now falls back to `args.case.input.trace` if
+    `args.output.trace` is missing.
+  - The reporter does not mutate `args.metric.metadata`,
+    `args.case.metadata`, or `args.outcome.metadata`.
+
+- 3de3cce: Add PII redaction helpers. `createPiiRedactor` ships with default patterns for emails, credit cards (Luhn-validated), phones, IPv4 addresses, JWTs, and API keys, and supports `redactString`, `redactObject`, and `redactMessages`. Configure tracing with `redactInputs`, `redactOutputs`, and `redaction` to mask text before it leaves the process; `"deep"` recurses into nested values.
+- 3de3cce: Add a Langfuse prompt client and prompt-attribute binding on
+  traces and generations.
+
+  `createLangfusePromptClient(tracing, options)` exposes four
+  methods:
+
+  - `getPrompt(name, { version?, label?, cacheTtlMs?, refresh? })`
+    GETs `/api/public/v2/prompts/:name` and returns a parsed
+    `LangfusePrompt` (text or chat). Responses are cached in
+    memory for `cacheTtlMs` (default 60 s), keyed by
+    `name::version::label`.
+  - `getPromptText(name, options?)` projects the prompt string.
+  - `getPromptChat(name, options?)` projects the chat message
+    array.
+  - `refresh()` clears the cache.
+
+  The langfuse tracing instance now reads the prompt ref from
+  `args.promptRef` (typed) or `args.trace.metadata.promptName` /
+  `promptVersion` (string-keyed fallback) on `startRun`, and
+  attaches `langfuse.trace.metadata.promptName` /
+  `langfuse.trace.metadata.promptVersion` to the root and to each
+  generation in the run.
+
+  Auth uses the same `LANGFUSE_PUBLIC_KEY` /
+  `LANGFUSE_SECRET_KEY` env vars and base URL as
+  `langfuse.create()`. Per-request timeout defaults to 30
+  seconds, configurable via `options.timeoutMs`.
+
+- 3de3cce: Add an in-memory score queue with batched sends, exponential-backoff
+  retry, and a manual flush method.
+
+  - New `scoreBatchSize`, `scoreFlushIntervalMs` (default 250), and
+    `scoreMaxRetries` (default 3) options on `LangfuseTracingOptions`.
+    Setting `scoreBatchSize` enables the queue; the default is direct
+    send.
+  - New `flushScores()` and `scoreQueueDepth()` methods on
+    `LangfuseTracing`. `flush()` and `shutdown()` also drain the queue.
+  - Retries on 429 and 5xx with exponential backoff (200 ms base,
+    2x factor, ±25% jitter, capped at 5 s). Other 4xx throw
+    immediately.
+  - New `LangfuseScoreError` class. After all retries are exhausted,
+    the error's `scores` property contains the failed payloads.
+  - New `LangfuseScoreDataType` type export.
+
+- 3de3cce: Forward every streaming delta to Langfuse via
+  `generation.update({ output: { delta } })`, so dashboards reflect
+  partial output as the model produces it. Supported delta types:
+  `text_delta`, `reasoning_delta`, and `tool_call`.
+- 3de3cce: Add `LangfuseTraceHandle` and `getCurrentTrace()` to the langfuse
+  tracing instance so user code can record event observations and
+  attach attributes to the active trace without threading the run
+  observer through every function call.
+
+  `LangfuseTracing` now exposes `getCurrentTrace(): LangfuseTraceHandle | undefined`
+  and the returned handle has three fields:
+
+  - `traceId` and `observationId` for correlation
+  - `addAttributes(attributes)` to set metadata on the root
+    observation
+  - `addEvent(name, attributes?)` to create a Langfuse `event`
+    observation under the root
+
+  The handle is populated when `startRun` is called and cleared when
+  the run `end`s or `error`s. The handle is per-tracing-instance and
+  last-write-wins; concurrent runs on the same instance will race.
+
+  The langfuse adapter also implements the new `event?(...)` hook
+  that was added to `AgentRunObserver` in `@anvia/core`. Calling
+  `runObserver.event?.({ name, attributes })` creates a Langfuse
+  `event` observation under the active root and ends it immediately.
+
+- 3de3cce: Record extra data on Langfuse observations so the UI shows everything
+  the agent runtime emits.
+
+  - Generation observations now carry `providerRequest` and `modelInfo`
+    on start, and `firstDeltaMs` on end.
+  - Tool observations now carry `toolDefinition` and `toolMetadata` on
+    start, and `structuredResult` on end.
+  - `usageDetailsFromRecord` now consistently includes
+    `cachedInputTokens` and `cacheCreationInputTokens` to match the
+    main `usageDetails` helper.
+
+- 3de3cce: Add typed scores and per-score overrides to `tracing.score()`.
+
+  - New `dataType` field (`"NUMERIC" | "CATEGORICAL" | "BOOLEAN"`)
+    with boundary validation. `value` is now `number | string` to
+    support CATEGORICAL scores.
+  - New `configId` (canonical) and `scoreConfigId` (alias) fields for
+    Langfuse score configs.
+  - New `environment` per-score override.
+  - New `timestamp` accepting `Date` or ISO 8601 string.
+  - New `timeoutMs` option on `LangfuseTracingOptions` (default 30 s),
+    applied via `AbortSignal.timeout` to the score fetch.
+
+## 0.2.8
+
+### Patch Changes
+
+- f8b8538: Refactor package entrypoints into barrel exports with focused internal modules.
+
+## 0.2.7
+
+### Patch Changes
+
+- 2559d04: Refresh upstream runtime dependencies and make pipeline construction schema-first.
+- Updated dependencies [2559d04]
+  - @anvia/core@0.7.1
+
+## 0.2.6
+
+### Patch Changes
+
+- 94362c9: Move @anvia/core to peer dependencies for packages that expose or consume core types, preventing duplicate private-type incompatibilities in consumer apps.
+
+## 0.2.5
+
+### Patch Changes
+
+- Updated dependencies [ef5e727]
+  - @anvia/core@0.7.0
+
 ## 0.2.4
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/logger.mdx
+++ b/apps/docs/content/docs/changelog/logger.mdx
@@ -9,6 +9,19 @@ Structured logger adapters for Anvia.
 
 Source: [`packages/logger/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/logger/CHANGELOG.md)
 
+## 0.3.10
+
+### Patch Changes
+
+- 94362c9: Move @anvia/core to peer dependencies for packages that expose or consume core types, preventing duplicate private-type incompatibilities in consumer apps.
+
+## 0.3.9
+
+### Patch Changes
+
+- Updated dependencies [ef5e727]
+  - @anvia/core@0.7.0
+
 ## 0.3.8
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/milvus.mdx
+++ b/apps/docs/content/docs/changelog/milvus.mdx
@@ -9,6 +9,27 @@ Milvus vector store adapter for Anvia.
 
 Source: [`packages/vector-milvus/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/vector-milvus/CHANGELOG.md)
 
+## 0.3.6
+
+### Patch Changes
+
+- 2559d04: Refresh upstream runtime dependencies and make pipeline construction schema-first.
+- Updated dependencies [2559d04]
+  - @anvia/core@0.7.1
+
+## 0.3.5
+
+### Patch Changes
+
+- 94362c9: Move @anvia/core to peer dependencies for packages that expose or consume core types, preventing duplicate private-type incompatibilities in consumer apps.
+
+## 0.3.4
+
+### Patch Changes
+
+- Updated dependencies [ef5e727]
+  - @anvia/core@0.7.0
+
 ## 0.3.3
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/mistral.mdx
+++ b/apps/docs/content/docs/changelog/mistral.mdx
@@ -9,6 +9,33 @@ Mistral provider adapter for Anvia.
 
 Source: [`packages/provider-mistral/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/provider-mistral/CHANGELOG.md)
 
+## 0.3.0
+
+### Minor Changes
+
+- ce97135: Add a Mistral OCR model adapter with `client.ocrModel()`, support for document URLs, image URLs, file IDs, and byte uploads, plus normalized OCR response metadata.
+
+## 0.2.12
+
+### Patch Changes
+
+- 2559d04: Refresh upstream runtime dependencies and make pipeline construction schema-first.
+- Updated dependencies [2559d04]
+  - @anvia/core@0.7.1
+
+## 0.2.11
+
+### Patch Changes
+
+- 94362c9: Move @anvia/core to peer dependencies for packages that expose or consume core types, preventing duplicate private-type incompatibilities in consumer apps.
+
+## 0.2.10
+
+### Patch Changes
+
+- Updated dependencies [ef5e727]
+  - @anvia/core@0.7.0
+
 ## 0.2.9
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/openai.mdx
+++ b/apps/docs/content/docs/changelog/openai.mdx
@@ -9,6 +9,27 @@ OpenAI provider adapter for Anvia.
 
 Source: [`packages/provider-openai/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/provider-openai/CHANGELOG.md)
 
+## 0.3.13
+
+### Patch Changes
+
+- 2559d04: Refresh upstream runtime dependencies and make pipeline construction schema-first.
+- Updated dependencies [2559d04]
+  - @anvia/core@0.7.1
+
+## 0.3.12
+
+### Patch Changes
+
+- 94362c9: Move @anvia/core to peer dependencies for packages that expose or consume core types, preventing duplicate private-type incompatibilities in consumer apps.
+
+## 0.3.11
+
+### Patch Changes
+
+- Updated dependencies [ef5e727]
+  - @anvia/core@0.7.0
+
 ## 0.3.10
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/otel.mdx
+++ b/apps/docs/content/docs/changelog/otel.mdx
@@ -9,6 +9,25 @@ OpenTelemetry tracing adapter for Anvia.
 
 Source: [`packages/observability-otel/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/observability-otel/CHANGELOG.md)
 
+## 0.2.11
+
+### Patch Changes
+
+- f8b8538: Refactor package entrypoints into barrel exports with focused internal modules.
+
+## 0.2.10
+
+### Patch Changes
+
+- 94362c9: Move @anvia/core to peer dependencies for packages that expose or consume core types, preventing duplicate private-type incompatibilities in consumer apps.
+
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [ef5e727]
+  - @anvia/core@0.7.0
+
 ## 0.2.8
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/pgvector.mdx
+++ b/apps/docs/content/docs/changelog/pgvector.mdx
@@ -9,6 +9,27 @@ Postgres pgvector store adapter for Anvia.
 
 Source: [`packages/vector-pgvector/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/vector-pgvector/CHANGELOG.md)
 
+## 0.2.11
+
+### Patch Changes
+
+- 2559d04: Refresh upstream runtime dependencies and make pipeline construction schema-first.
+- Updated dependencies [2559d04]
+  - @anvia/core@0.7.1
+
+## 0.2.10
+
+### Patch Changes
+
+- 94362c9: Move @anvia/core to peer dependencies for packages that expose or consume core types, preventing duplicate private-type incompatibilities in consumer apps.
+
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [ef5e727]
+  - @anvia/core@0.7.0
+
 ## 0.2.8
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/pinecone.mdx
+++ b/apps/docs/content/docs/changelog/pinecone.mdx
@@ -9,6 +9,27 @@ Pinecone vector store adapter for Anvia.
 
 Source: [`packages/vector-pinecone/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/vector-pinecone/CHANGELOG.md)
 
+## 0.3.6
+
+### Patch Changes
+
+- 2559d04: Refresh upstream runtime dependencies and make pipeline construction schema-first.
+- Updated dependencies [2559d04]
+  - @anvia/core@0.7.1
+
+## 0.3.5
+
+### Patch Changes
+
+- 94362c9: Move @anvia/core to peer dependencies for packages that expose or consume core types, preventing duplicate private-type incompatibilities in consumer apps.
+
+## 0.3.4
+
+### Patch Changes
+
+- Updated dependencies [ef5e727]
+  - @anvia/core@0.7.0
+
 ## 0.3.3
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/qdrant.mdx
+++ b/apps/docs/content/docs/changelog/qdrant.mdx
@@ -9,6 +9,19 @@ Qdrant vector store adapter for Anvia.
 
 Source: [`packages/vector-qdrant/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/vector-qdrant/CHANGELOG.md)
 
+## 0.2.10
+
+### Patch Changes
+
+- 94362c9: Move @anvia/core to peer dependencies for packages that expose or consume core types, preventing duplicate private-type incompatibilities in consumer apps.
+
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [ef5e727]
+  - @anvia/core@0.7.0
+
 ## 0.2.8
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/react.mdx
+++ b/apps/docs/content/docs/changelog/react.mdx
@@ -9,6 +9,14 @@ React hooks and client transports for Anvia applications.
 
 Source: [`packages/react/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/react/CHANGELOG.md)
 
+## 0.5.0
+
+### Minor Changes
+
+- ef5e727: Add centralized tool approval handling with tool-level approval policies and `.approvals(...)` decision handlers.
+
+  Add React `useChat` human-input state for tool approvals and `ask_question` prompts, including helpers for approving, rejecting, and answering pending human input.
+
 ## 0.4.0
 
 ### Minor Changes

--- a/apps/docs/content/docs/changelog/redis.mdx
+++ b/apps/docs/content/docs/changelog/redis.mdx
@@ -9,6 +9,27 @@ Redis vector store adapter for Anvia.
 
 Source: [`packages/vector-redis/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/vector-redis/CHANGELOG.md)
 
+## 0.2.3
+
+### Patch Changes
+
+- 2559d04: Refresh upstream runtime dependencies and make pipeline construction schema-first.
+- Updated dependencies [2559d04]
+  - @anvia/core@0.7.1
+
+## 0.2.2
+
+### Patch Changes
+
+- 94362c9: Move @anvia/core to peer dependencies for packages that expose or consume core types, preventing duplicate private-type incompatibilities in consumer apps.
+
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies [ef5e727]
+  - @anvia/core@0.7.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/apps/docs/content/docs/changelog/sandbox.mdx
+++ b/apps/docs/content/docs/changelog/sandbox.mdx
@@ -9,6 +9,19 @@ Sandboxed workspace tools for Anvia agents.
 
 Source: [`packages/tool-sandbox/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/tool-sandbox/CHANGELOG.md)
 
+## 0.3.5
+
+### Patch Changes
+
+- 94362c9: Move @anvia/core to peer dependencies for packages that expose or consume core types, preventing duplicate private-type incompatibilities in consumer apps.
+
+## 0.3.4
+
+### Patch Changes
+
+- Updated dependencies [ef5e727]
+  - @anvia/core@0.7.0
+
 ## 0.3.3
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/studio.mdx
+++ b/apps/docs/content/docs/changelog/studio.mdx
@@ -9,6 +9,46 @@ Studio UI and HTTP runtime for Anvia agents.
 
 Source: [`packages/tool-studio/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/tool-studio/CHANGELOG.md)
 
+## 0.7.4
+
+### Patch Changes
+
+- f160948: Update Studio runtime and router dependencies.
+
+## 0.7.3
+
+### Patch Changes
+
+- ac55f41: Refactor Studio routing and modularize the UI/runtime internals while preserving existing Studio behavior.
+
+## 0.7.2
+
+### Patch Changes
+
+- 2559d04: Refresh upstream runtime dependencies and make pipeline construction schema-first.
+- Updated dependencies [2559d04]
+  - @anvia/core@0.7.1
+
+## 0.7.1
+
+### Patch Changes
+
+- 94362c9: Move @anvia/core to peer dependencies for packages that expose or consume core types, preventing duplicate private-type incompatibilities in consumer apps.
+
+## 0.7.0
+
+### Minor Changes
+
+- ef5e727: Add centralized tool approval handling with tool-level approval policies and `.approvals(...)` decision handlers.
+
+  Add React `useChat` human-input state for tool approvals and `ask_question` prompts, including helpers for approving, rejecting, and answering pending human input.
+
+### Patch Changes
+
+- Updated dependencies [ef5e727]
+  - @anvia/core@0.7.0
+  - @anvia/react@0.5.0
+
 ## 0.6.1
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/transformers.mdx
+++ b/apps/docs/content/docs/changelog/transformers.mdx
@@ -9,6 +9,25 @@ Transformers.js embedding model adapter for Anvia.
 
 Source: [`packages/embedding-transformers/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/embedding-transformers/CHANGELOG.md)
 
+## 0.2.11
+
+### Patch Changes
+
+- f8b8538: Refactor package entrypoints into barrel exports with focused internal modules.
+
+## 0.2.10
+
+### Patch Changes
+
+- 94362c9: Move @anvia/core to peer dependencies for packages that expose or consume core types, preventing duplicate private-type incompatibilities in consumer apps.
+
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [ef5e727]
+  - @anvia/core@0.7.0
+
 ## 0.2.8
 
 ### Patch Changes

--- a/apps/docs/content/docs/changelog/weaviate.mdx
+++ b/apps/docs/content/docs/changelog/weaviate.mdx
@@ -9,6 +9,27 @@ Weaviate vector store adapter for Anvia.
 
 Source: [`packages/vector-weaviate/CHANGELOG.md`](https://github.com/anvia-hq/anvia/blob/main/packages/vector-weaviate/CHANGELOG.md)
 
+## 0.2.3
+
+### Patch Changes
+
+- 2559d04: Refresh upstream runtime dependencies and make pipeline construction schema-first.
+- Updated dependencies [2559d04]
+  - @anvia/core@0.7.1
+
+## 0.2.2
+
+### Patch Changes
+
+- 94362c9: Move @anvia/core to peer dependencies for packages that expose or consume core types, preventing duplicate private-type incompatibilities in consumer apps.
+
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies [ef5e727]
+  - @anvia/core@0.7.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/apps/docs/scripts/generate-changelogs.mjs
+++ b/apps/docs/scripts/generate-changelogs.mjs
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -41,6 +42,7 @@ const packages = discoverPackages()
     const groupDiff = groupRank(a.group) - groupRank(b.group);
     return groupDiff === 0 ? a.pkg.name.localeCompare(b.pkg.name) : groupDiff;
   });
+const releaseDateCache = new Map();
 
 rmSync(outputDir, { recursive: true, force: true });
 mkdirSync(outputDir, { recursive: true });
@@ -135,13 +137,13 @@ function createIndex(items) {
 
     sections.push(`## ${groupTitles.get(group) ?? titleCase(group)}
 
-| Package | Current version | Release notes |
-| --- | --- | --- |
+| Package | Current version | Released | Release notes |
+| --- | --- | --- | --- |
 ${groupItems
-  .map(
-    (item) =>
-      `| \`${item.pkg.name}\` | \`${item.pkg.version}\` | [View changelog](/docs/changelog/${item.slug}) |`,
-  )
+  .map((item) => {
+    const releaseDate = getCurrentReleaseDate(item) ?? "Unknown";
+    return `| \`${item.pkg.name}\` | \`${item.pkg.version}\` | ${releaseDate} | [View changelog](/docs/changelog/${item.slug}) |`;
+  })
   .join("\n")}`);
   }
 
@@ -190,7 +192,58 @@ function normalizeChangelog(content, packageName) {
     return "No release notes have been recorded yet.\n";
   }
 
-  return `${trimmed.replace(new RegExp(`^# ${escapeRegExp(packageName)}\\s*\\n+`), "")}\n`;
+  const withoutTitle = trimmed.replace(new RegExp(`^# ${escapeRegExp(packageName)}\\s*\\n+`), "");
+
+  return `${withoutTitle}\n`;
+}
+
+function getReleaseDate(packageName, version, body) {
+  const tag = `${packageName}@${version}`;
+  if (releaseDateCache.has(tag)) return releaseDateCache.get(tag);
+
+  let releaseDate = getGitDate(tag);
+
+  if (releaseDate === undefined) {
+    const match = body.match(/\b[0-9a-f]{7,40}\b/i);
+    if (match !== null) releaseDate = getGitDate(match[0]);
+  }
+
+  releaseDateCache.set(tag, releaseDate);
+  return releaseDateCache.get(tag);
+}
+
+function getCurrentReleaseDate(item) {
+  if (!existsSync(item.changelogPath)) return undefined;
+
+  const content = readFileSync(item.changelogPath, "utf8");
+  const body = getReleaseSectionBody(content, item.pkg.name, item.pkg.version);
+  return getReleaseDate(item.pkg.name, item.pkg.version, body ?? "");
+}
+
+function getReleaseSectionBody(content, packageName, version) {
+  const trimmed = content.trim();
+  const withoutTitle = trimmed.replace(new RegExp(`^# ${escapeRegExp(packageName)}\\s*\\n+`), "");
+
+  for (const section of withoutTitle.split(/(?=^## )/m)) {
+    const match = section.match(/^## ([^\n]+)\n([\s\S]*)$/);
+    if (match !== null && match[1].trim() === version) return match[2];
+  }
+
+  return undefined;
+}
+
+function getGitDate(ref) {
+  try {
+    const date = execFileSync("git", ["log", "-1", "--format=%cs", ref], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+
+    return date === "" ? undefined : date;
+  } catch {
+    return undefined;
+  }
 }
 
 function missingChangelog(item) {

--- a/apps/docs/src/styles/app.css
+++ b/apps/docs/src/styles/app.css
@@ -174,17 +174,22 @@ body {
 
 .package-changelog-index table th:nth-child(1),
 .package-changelog-index table td:nth-child(1) {
-  width: 42%;
+  width: 36%;
 }
 
 .package-changelog-index table th:nth-child(2),
 .package-changelog-index table td:nth-child(2) {
-  width: 28%;
+  width: 20%;
 }
 
 .package-changelog-index table th:nth-child(3),
 .package-changelog-index table td:nth-child(3) {
-  width: 30%;
+  width: 18%;
+}
+
+.package-changelog-index table th:nth-child(4),
+.package-changelog-index table td:nth-child(4) {
+  width: 26%;
 }
 
 @media (max-width: 767px) {

--- a/packages/observability-langfuse/package.json
+++ b/packages/observability-langfuse/package.json
@@ -31,11 +31,11 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@langfuse/otel": "^5.5.3",
-    "@langfuse/tracing": "^5.5.3",
+    "@langfuse/otel": "^5.7.0",
+    "@langfuse/tracing": "^5.7.0",
     "@opentelemetry/resources": "^2.8.0",
     "@opentelemetry/sdk-node": "^0.219.0",
-    "@opentelemetry/semantic-conventions": "^1.40.0"
+    "@opentelemetry/semantic-conventions": "^1.41.1"
   },
   "devDependencies": {
     "@anvia/core": "workspace:*",

--- a/packages/provider-anthropic/package.json
+++ b/packages/provider-anthropic/package.json
@@ -33,7 +33,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.105.0"
+    "@anthropic-ai/sdk": "^0.106.0"
   },
   "devDependencies": {
     "@anvia/core": "workspace:*",

--- a/packages/provider-gemini/package.json
+++ b/packages/provider-gemini/package.json
@@ -33,7 +33,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@google/genai": "^2.9.0"
+    "@google/genai": "^2.10.0"
   },
   "devDependencies": {
     "@anvia/core": "workspace:*",

--- a/packages/provider-mistral/package.json
+++ b/packages/provider-mistral/package.json
@@ -33,7 +33,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mistralai/mistralai": "^2.2.6"
+    "@mistralai/mistralai": "^2.3.0"
   },
   "devDependencies": {
     "@anvia/core": "workspace:*",

--- a/packages/provider-openai/package.json
+++ b/packages/provider-openai/package.json
@@ -33,7 +33,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "openai": "^6.44.0"
+    "openai": "^6.45.0"
   },
   "devDependencies": {
     "@anvia/core": "workspace:*",

--- a/packages/vector-redis/package.json
+++ b/packages/vector-redis/package.json
@@ -31,7 +31,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "redis": "^6.0.0"
+    "redis": "^6.0.1"
   },
   "devDependencies": {
     "@anvia/core": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -385,11 +385,11 @@ importers:
   packages/observability-langfuse:
     dependencies:
       '@langfuse/otel':
-        specifier: ^5.5.3
-        version: 5.5.3(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
+        specifier: ^5.7.0
+        version: 5.7.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
       '@langfuse/tracing':
-        specifier: ^5.5.3
-        version: 5.5.3(@opentelemetry/api@1.9.1)
+        specifier: ^5.7.0
+        version: 5.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources':
         specifier: ^2.8.0
         version: 2.8.0(@opentelemetry/api@1.9.1)
@@ -397,8 +397,8 @@ importers:
         specifier: ^0.219.0
         version: 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions':
-        specifier: ^1.40.0
-        version: 1.40.0
+        specifier: ^1.41.1
+        version: 1.41.1
     devDependencies:
       '@anvia/core':
         specifier: workspace:*
@@ -441,8 +441,8 @@ importers:
   packages/provider-anthropic:
     dependencies:
       '@anthropic-ai/sdk':
-        specifier: ^0.105.0
-        version: 0.105.0(zod@4.4.3)
+        specifier: ^0.106.0
+        version: 0.106.0(zod@4.4.3)
     devDependencies:
       '@anvia/core':
         specifier: workspace:*
@@ -463,8 +463,8 @@ importers:
   packages/provider-gemini:
     dependencies:
       '@google/genai':
-        specifier: ^2.9.0
-        version: 2.9.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
+        specifier: ^2.10.0
+        version: 2.10.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
     devDependencies:
       '@anvia/core':
         specifier: workspace:*
@@ -485,8 +485,8 @@ importers:
   packages/provider-mistral:
     dependencies:
       '@mistralai/mistralai':
-        specifier: ^2.2.6
-        version: 2.2.6(@opentelemetry/api@1.9.1)
+        specifier: ^2.3.0
+        version: 2.3.0(@opentelemetry/api@1.9.1)
     devDependencies:
       '@anvia/core':
         specifier: workspace:*
@@ -507,8 +507,8 @@ importers:
   packages/provider-openai:
     dependencies:
       openai:
-        specifier: ^6.44.0
-        version: 6.44.0(ws@8.21.0)(zod@4.4.3)
+        specifier: ^6.45.0
+        version: 6.45.0(@aws-sdk/credential-provider-node@3.972.56)(@smithy/signature-v4@5.5.0)(ws@8.21.0)(zod@4.4.3)
     devDependencies:
       '@anvia/core':
         specifier: workspace:*
@@ -846,8 +846,8 @@ importers:
   packages/vector-redis:
     dependencies:
       redis:
-        specifier: ^6.0.0
-        version: 6.0.0(@opentelemetry/api@1.9.1)
+        specifier: ^6.0.1
+        version: 6.0.1(@opentelemetry/api@1.9.1)
     devDependencies:
       '@anvia/core':
         specifier: workspace:*
@@ -896,8 +896,8 @@ packages:
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
-  '@anthropic-ai/sdk@0.105.0':
-    resolution: {integrity: sha512-sDyu+aM9cE6uZE+HgRjjHRb+qqb87GHZOx+8bE0YlWetdL1YcVLxn8h9ltxGOflyChTe6PMEo50kMQV4cw0hfg==}
+  '@anthropic-ai/sdk@0.106.0':
+    resolution: {integrity: sha512-ufwVvYNDBj2dzOGupBCTaNzBLxqcTnGOzI4z8Wouxlt+mT3J3HuOmatgCy1VmwCHOUueqZ41ERhm0O99OUcbWA==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -1891,8 +1891,8 @@ packages:
       tailwindcss:
         optional: true
 
-  '@google/genai@2.9.0':
-    resolution: {integrity: sha512-3DRdSJ0LaKFig3FNGeRDn9BQxtjZm2qr0hNH2d771LKcG0HvUYddlN0LPdSp8XU7Ekb04i9q3+tt64uYqavUdw==}
+  '@google/genai@2.10.0':
+    resolution: {integrity: sha512-e4cFxj3tiuMtsgOT4G9c1hXyGJhg7/Buj7VVeBacRY3fRtkRZZ59Q3nuVp2xbq8BGQXLXCDB253qMhklMOeUDg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.25.2
@@ -2192,13 +2192,13 @@ packages:
     peerDependencies:
       apache-arrow: 18.1.0
 
-  '@langfuse/core@5.5.3':
-    resolution: {integrity: sha512-F2auGm6l4/QhQ6Y86+f6QqulXNetVsaI3u7ccyqADEtGcDWk1+faSczxuSMJ0X/EfrjVZ+98Luy/FEEah+HDRA==}
+  '@langfuse/core@5.7.0':
+    resolution: {integrity: sha512-kLFYagw3Js5QDesQbMLOzV4L4/0hYndSmAX6em6zDCmA4qMKfdRJMZ5F/fpl9LONFMTu7pU6WGLyUxM80hjYVQ==}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
 
-  '@langfuse/otel@5.5.3':
-    resolution: {integrity: sha512-j0nPAEFHKorEV8JtBRzZaSShUbjLYk7omtxXxy1bLvNb5QFGO1gF7HFm+fSqnoN70034EvTXYCNFDWpBrAH/vw==}
+  '@langfuse/otel@5.7.0':
+    resolution: {integrity: sha512-x5HANvvDV23btbTijz9eW2DzvX/sZ4orsahYXuwsCApOzEWSgEzd0ZrpHPSz4+epytps1RBe3M6e5gm2EgaAmA==}
     engines: {node: '>=20'}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
@@ -2206,8 +2206,8 @@ packages:
       '@opentelemetry/exporter-trace-otlp-http': '>=0.202.0 <1.0.0'
       '@opentelemetry/sdk-trace-base': ^2.0.1
 
-  '@langfuse/tracing@5.5.3':
-    resolution: {integrity: sha512-t/WoFCOtXjdFSFx7A4+nesX0eB4c0gP7ca7j6kv38kIubPE+IniHOhNYPXdAdm5tc3EL+P+gpMCtibCBp8xYsQ==}
+  '@langfuse/tracing@5.7.0':
+    resolution: {integrity: sha512-FCroWXE0510BUt2vHCEk64Wb+nywc3WVdx3+zaWyW1CI8mSa9i/yX+Oe2a956QRLPhVCeFgO27Y8Zlg7RaDWig==}
     engines: {node: '>=20'}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
@@ -2224,8 +2224,8 @@ packages:
   '@mermaid-js/parser@1.1.1':
     resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
 
-  '@mistralai/mistralai@2.2.6':
-    resolution: {integrity: sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==}
+  '@mistralai/mistralai@2.3.0':
+    resolution: {integrity: sha512-afV0/UAdu5d3hdY6G6lNkKXFM3vpC8PaOimw1LSe/fWnFYWnz5TIZI10DDMHepiN4Mx2sq1ekrulhgT3pTbtLg==}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
     peerDependenciesMeta:
@@ -2680,6 +2680,10 @@ packages:
 
   '@opentelemetry/semantic-conventions@1.40.0':
     resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
     engines: {node: '>=14'}
 
   '@orama/orama@3.1.18':
@@ -3446,14 +3450,14 @@ packages:
   '@radix-ui/rect@1.1.2':
     resolution: {integrity: sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==}
 
-  '@redis/bloom@6.0.0':
-    resolution: {integrity: sha512-P0n5NkV9IIdT6nYXOfMHG83sho8pE7Nay7yw27wOGVLv4DthgvzebpGz6m7VuMTizeJmw3LPw2Xek5wFUhGpVw==}
+  '@redis/bloom@6.0.1':
+    resolution: {integrity: sha512-6ys5hhea+47n7o97ZFI4GvdzTQk/arIsXZgH159l6IVtJ4rZaB+KVdAfwvIxlmGA7z+NNlO8UxjTeQrenqjZcQ==}
     engines: {node: '>= 20.0.0'}
     peerDependencies:
-      '@redis/client': ^6.0.0
+      '@redis/client': ^6.0.1
 
-  '@redis/client@6.0.0':
-    resolution: {integrity: sha512-NS4iIT25r24sAjNQ2nSRdCW5jPJoV0rxkBee27oTeR+RXaOu89cjIsrww5rPBaYVGVdL1QCx9uz9141gZiSKdQ==}
+  '@redis/client@6.0.1':
+    resolution: {integrity: sha512-SwYl64hKHE/NeO2VSSG1y/4zIm0cNepyOZtQrOpLiNRHmH2FdWBOecNzsLiXCQdFCF9MCyoPXwAbaG2iMO0A7Q==}
     engines: {node: '>= 20.0.0'}
     peerDependencies:
       '@node-rs/xxhash': ^1.1.0
@@ -3464,23 +3468,23 @@ packages:
       '@opentelemetry/api':
         optional: true
 
-  '@redis/json@6.0.0':
-    resolution: {integrity: sha512-F+eqFfgPcy57Zs1KW7UtLnBtRk6lxAUIoe7dyZerpm6e+ssYXG/dWJrbrHFYs0b7tt6QBtYpVuukBuM9XqhUAg==}
+  '@redis/json@6.0.1':
+    resolution: {integrity: sha512-KD1OztCYh7O9TkKMU9qZcFIKoudIGqmgXsOhQVq5A3REGrnl+wg0kporQFQCO+fcxe/nhvDgmBtXrm3diPGczA==}
     engines: {node: '>= 20.0.0'}
     peerDependencies:
-      '@redis/client': ^6.0.0
+      '@redis/client': ^6.0.1
 
-  '@redis/search@6.0.0':
-    resolution: {integrity: sha512-VHuCJ2W0YWFixGZh/l//8JiyOsD4gN+NhjdRAGIoUe0UQ4mtq1NyY2ZJ973XT+vYhaU21XdK8r8oNrd5n7wbzQ==}
+  '@redis/search@6.0.1':
+    resolution: {integrity: sha512-G09OujS3eOtQnP7kZC5eZTiazwgeimlo6Pf3vHnE1jO7rfqrtmMI0R1/ZXfzoW8p9vB4QiH538aEsWaHKd8l5w==}
     engines: {node: '>= 20.0.0'}
     peerDependencies:
-      '@redis/client': ^6.0.0
+      '@redis/client': ^6.0.1
 
-  '@redis/time-series@6.0.0':
-    resolution: {integrity: sha512-QWhkYsg+3lhBrBf+cbzybtV8LQcSrk7iXIgTaGU+pHNFTkql7TpVRE24ROS6M2ybVIV6O/zxTqfxgxxYiqyw0Q==}
+  '@redis/time-series@6.0.1':
+    resolution: {integrity: sha512-8aLGSDtCpnPTLD7lEiHHmuDCFppctLdT8geFIDf/7LWV9y8Vre6RB+aBZrgkeo3X1oPmTt1IbVAQVxsuJvkODw==}
     engines: {node: '>= 20.0.0'}
     peerDependencies:
-      '@redis/client': ^6.0.0
+      '@redis/client': ^6.0.1
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
@@ -6547,12 +6551,21 @@ packages:
   onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
     resolution: {integrity: sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==}
 
-  openai@6.44.0:
-    resolution: {integrity: sha512-09/gH+8jH0RgUwsgWHAaxsKGRT5zVZ95IaJUnqAWj6XejIBmnFRwq2WUIF37VtDEsmGrtPmvCs5+yBSeZGWvkA==}
+  openai@6.45.0:
+    resolution: {integrity: sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==}
     peerDependencies:
+      '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
+      '@smithy/hash-node': '>=4.3.0 <5'
+      '@smithy/signature-v4': '>=5.4.0 <6'
       ws: ^8.18.0
       zod: ^3.25 || ^4.0
     peerDependenciesMeta:
+      '@aws-sdk/credential-provider-node':
+        optional: true
+      '@smithy/hash-node':
+        optional: true
+      '@smithy/signature-v4':
+        optional: true
       ws:
         optional: true
       zod:
@@ -6973,8 +6986,8 @@ packages:
   redeyed@2.1.1:
     resolution: {integrity: sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==}
 
-  redis@6.0.0:
-    resolution: {integrity: sha512-n9Thfc39OXleEoPT2k5gwKsqY+HfCww3YS71ofcr9KKbkn89bpjU9dToIlD+JRdM3/GYQkwMtVgTxLyed+LptQ==}
+  redis@6.0.1:
+    resolution: {integrity: sha512-54FoTBdFw10Y602pShvk8CGJlSH55nY+CNAZaVk8YdxY3rENihdYm2lXrujrtupYTHyrVSZUxOdeStNQbNvnQg==}
     engines: {node: '>= 20.0.0'}
 
   reflect-metadata@0.2.2:
@@ -7940,7 +7953,7 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.1.1
 
-  '@anthropic-ai/sdk@0.105.0(zod@4.4.3)':
+  '@anthropic-ai/sdk@0.106.0(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
       standardwebhooks: 1.0.0
@@ -8877,7 +8890,7 @@ snapshots:
       '@tailwindcss/oxide': 4.2.4
       tailwindcss: 4.2.4
 
-  '@google/genai@2.9.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
+  '@google/genai@2.10.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
@@ -9109,21 +9122,21 @@ snapshots:
       '@lancedb/lancedb-win32-arm64-msvc': 0.30.0
       '@lancedb/lancedb-win32-x64-msvc': 0.30.0
 
-  '@langfuse/core@5.5.3(@opentelemetry/api@1.9.1)':
+  '@langfuse/core@5.7.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@langfuse/otel@5.5.3(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))':
+  '@langfuse/otel@5.7.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))':
     dependencies:
-      '@langfuse/core': 5.5.3(@opentelemetry/api@1.9.1)
+      '@langfuse/core': 5.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-http': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
 
-  '@langfuse/tracing@5.5.3(@opentelemetry/api@1.9.1)':
+  '@langfuse/tracing@5.7.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@langfuse/core': 5.5.3(@opentelemetry/api@1.9.1)
+      '@langfuse/core': 5.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/api': 1.9.1
 
   '@manypkg/find-root@1.1.0':
@@ -9176,7 +9189,7 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
-  '@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.1)':
+  '@mistralai/mistralai@2.3.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/semantic-conventions': 1.40.0
       ws: 8.21.0
@@ -9767,6 +9780,8 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/semantic-conventions@1.40.0': {}
+
+  '@opentelemetry/semantic-conventions@1.41.1': {}
 
   '@orama/orama@3.1.18': {}
 
@@ -10479,27 +10494,27 @@ snapshots:
 
   '@radix-ui/rect@1.1.2': {}
 
-  '@redis/bloom@6.0.0(@redis/client@6.0.0(@opentelemetry/api@1.9.1))':
+  '@redis/bloom@6.0.1(@redis/client@6.0.1(@opentelemetry/api@1.9.1))':
     dependencies:
-      '@redis/client': 6.0.0(@opentelemetry/api@1.9.1)
+      '@redis/client': 6.0.1(@opentelemetry/api@1.9.1)
 
-  '@redis/client@6.0.0(@opentelemetry/api@1.9.1)':
+  '@redis/client@6.0.1(@opentelemetry/api@1.9.1)':
     dependencies:
       cluster-key-slot: 1.1.2
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@redis/json@6.0.0(@redis/client@6.0.0(@opentelemetry/api@1.9.1))':
+  '@redis/json@6.0.1(@redis/client@6.0.1(@opentelemetry/api@1.9.1))':
     dependencies:
-      '@redis/client': 6.0.0(@opentelemetry/api@1.9.1)
+      '@redis/client': 6.0.1(@opentelemetry/api@1.9.1)
 
-  '@redis/search@6.0.0(@redis/client@6.0.0(@opentelemetry/api@1.9.1))':
+  '@redis/search@6.0.1(@redis/client@6.0.1(@opentelemetry/api@1.9.1))':
     dependencies:
-      '@redis/client': 6.0.0(@opentelemetry/api@1.9.1)
+      '@redis/client': 6.0.1(@opentelemetry/api@1.9.1)
 
-  '@redis/time-series@6.0.0(@redis/client@6.0.0(@opentelemetry/api@1.9.1))':
+  '@redis/time-series@6.0.1(@redis/client@6.0.1(@opentelemetry/api@1.9.1))':
     dependencies:
-      '@redis/client': 6.0.0(@opentelemetry/api@1.9.1)
+      '@redis/client': 6.0.1(@opentelemetry/api@1.9.1)
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
@@ -13979,8 +13994,10 @@ snapshots:
       platform: 1.3.6
       protobufjs: 7.5.6
 
-  openai@6.44.0(ws@8.21.0)(zod@4.4.3):
+  openai@6.45.0(@aws-sdk/credential-provider-node@3.972.56)(@smithy/signature-v4@5.5.0)(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
+      '@aws-sdk/credential-provider-node': 3.972.56
+      '@smithy/signature-v4': 5.5.0
       ws: 8.21.0
       zod: 4.4.3
 
@@ -14439,13 +14456,13 @@ snapshots:
     dependencies:
       esprima: 4.0.1
 
-  redis@6.0.0(@opentelemetry/api@1.9.1):
+  redis@6.0.1(@opentelemetry/api@1.9.1):
     dependencies:
-      '@redis/bloom': 6.0.0(@redis/client@6.0.0(@opentelemetry/api@1.9.1))
-      '@redis/client': 6.0.0(@opentelemetry/api@1.9.1)
-      '@redis/json': 6.0.0(@redis/client@6.0.0(@opentelemetry/api@1.9.1))
-      '@redis/search': 6.0.0(@redis/client@6.0.0(@opentelemetry/api@1.9.1))
-      '@redis/time-series': 6.0.0(@redis/client@6.0.0(@opentelemetry/api@1.9.1))
+      '@redis/bloom': 6.0.1(@redis/client@6.0.1(@opentelemetry/api@1.9.1))
+      '@redis/client': 6.0.1(@opentelemetry/api@1.9.1)
+      '@redis/json': 6.0.1(@redis/client@6.0.1(@opentelemetry/api@1.9.1))
+      '@redis/search': 6.0.1(@redis/client@6.0.1(@opentelemetry/api@1.9.1))
+      '@redis/time-series': 6.0.1(@redis/client@6.0.1(@opentelemetry/api@1.9.1))
     transitivePeerDependencies:
       - '@node-rs/xxhash'
       - '@opentelemetry/api'


### PR DESCRIPTION
## Summary
- update checked upstream runtime dependencies for Anthropic, Gemini, Langfuse, Mistral, OpenAI, and Redis wrappers
- add patch changeset entries for the affected packages
- add release dates to the package changelog index table while preserving the existing View changelog links

## Validation
- `bin/check-upstream-deps.sh`
- `pnpm --filter docs typecheck`
- `pnpm test`

Note: `docs/superpowers` is absent on the rebased branch/upstream base, so there is no removal diff in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded changelog pages with recent release entries across providers, vector stores, observability, and core packages.
  * Added release dates to the changelog index and updated the layout to show current versions more clearly.
* **New Features**
  * Documented new capabilities like Mistral OCR support, centralized tool approval handling, and improved tracing/metrics options.
* **Bug Fixes**
  * Noted dependency and packaging updates that help avoid compatibility issues and keep packages aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->