### PR TITLE
Update docs site and README presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
   <img src="apps/www/public/assets/logo.png" alt="Anvia logo" width="180" />
 </p>
 
-<h1 align="center">Anvia</h1>
-
 <p align="center">
   <strong>Build provider-agnostic AI agents and workflows in TypeScript.</strong>
 </p>
@@ -70,14 +68,6 @@ Anvia includes `@anvia/studio`, a local browser UI for inspecting and running ag
 ```ts
 new Studio([agent]).start({ port: 4021 });
 ```
-
-<p align="center">
-  <img src="apps/www/public/assets/illustrations/agent-gateway-card.png" alt="Anvia agent gateway preview" width="960" />
-</p>
-
-<p align="center">
-  <em>Preview of the Anvia website and agent gateway.</em>
-</p>
 
 ## What You Can Build
 


### PR DESCRIPTION
## Summary
- update the www site and deployment setup
- fill package docs content and improve docs code snippet styling
- remove legacy docs app CI
- clean up the README header and remove the Studio website preview

## Testing
- biome check ran from the README commit hook with no staged files to check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Redesigned the README header with a centered logo block, short product description, and existing badges for a cleaner introduction.
  * Removed the “agent gateway” preview illustration section to improve the flow into the “What You Can Build” content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->