### PR TITLE
docs: update website agent docs and llms export

### DIFF
--- a/apps/www/src/components/Header.astro
+++ b/apps/www/src/components/Header.astro
@@ -1,6 +1,8 @@
 ---
 import Button from "./ui/Button.astro";
 
+const githubUrl = "https://github.com/anvia-hq/anvia";
+
 const menuGroups = [
   {
     label: "Docs",
@@ -87,6 +89,17 @@ const menuGroups = [
     </nav>
 
     <div class="hidden items-center gap-2.5 sm:flex">
+      <a
+        href={githubUrl}
+        target="_blank"
+        rel="noreferrer"
+        aria-label="Anvia on GitHub"
+        class="inline-flex h-9 w-9 items-center justify-center text-zinc-400 transition hover:text-zinc-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#2BF563]"
+      >
+        <svg aria-hidden="true" viewBox="0 0 24 24" class="h-5 w-5 fill-current">
+          <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56v-2.02c-3.2.7-3.88-1.38-3.88-1.38-.52-1.33-1.28-1.68-1.28-1.68-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.68 0-1.25.45-2.28 1.18-3.08-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.16 1.18A10.9 10.9 0 0 1 12 6.17c.98 0 1.94.13 2.86.39 2.19-1.49 3.16-1.18 3.16-1.18.62 1.58.23 2.75.11 3.04.74.8 1.18 1.83 1.18 3.08 0 4.41-2.69 5.38-5.25 5.67.41.36.78 1.07.78 2.15v3.03c0 .31.21.67.8.56A11.51 11.51 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z" />
+        </svg>
+      </a>
       <Button variant="outline" size="xs" href="/docs">Read docs</Button>
     </div>
 
@@ -127,6 +140,17 @@ const menuGroups = [
           }
         </div>
         <div class="mt-3 grid gap-2">
+          <a
+            href={githubUrl}
+            target="_blank"
+            rel="noreferrer"
+            aria-label="Anvia on GitHub"
+            class="mx-auto inline-flex h-10 w-10 items-center justify-center text-zinc-300 transition hover:text-zinc-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#2BF563]"
+          >
+            <svg aria-hidden="true" viewBox="0 0 24 24" class="h-5 w-5 fill-current">
+              <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56v-2.02c-3.2.7-3.88-1.38-3.88-1.38-.52-1.33-1.28-1.68-1.28-1.68-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.68 0-1.25.45-2.28 1.18-3.08-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.16 1.18A10.9 10.9 0 0 1 12 6.17c.98 0 1.94.13 2.86.39 2.19-1.49 3.16-1.18 3.16-1.18.62 1.58.23 2.75.11 3.04.74.8 1.18 1.83 1.18 3.08 0 4.41-2.69 5.38-5.25 5.67.41.36.78 1.07.78 2.15v3.03c0 .31.21.67.8.56A11.51 11.51 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z" />
+            </svg>
+          </a>
           <Button variant="outline" size="md" href="/docs">Read docs</Button>
         </div>
       </div>

--- a/apps/www/src/components/docs/DocsShell.astro
+++ b/apps/www/src/components/docs/DocsShell.astro
@@ -59,6 +59,7 @@ const sidebarGroups =
   }));
 const tableOfContents = headings.filter((heading) => heading.depth === 2 || heading.depth === 3);
 const hasTableOfContents = tableOfContents.length > 0;
+const githubUrl = "https://github.com/anvia-hq/anvia";
 const sidebarScrollKey =
   sidebarScrollKeyOverride ??
   `anvia:docs-sidebar-scroll:${currentId === "packages" ? "packages" : activeSection}`;
@@ -89,6 +90,17 @@ const sidebarScrollKey =
         <DocsSearch />
 
         <nav class="flex items-center gap-4 font-medium text-sm text-zinc-300" aria-label="Docs utility">
+          <a
+            href={githubUrl}
+            target="_blank"
+            rel="noreferrer"
+            aria-label="Anvia on GitHub"
+            class="inline-flex h-9 w-9 items-center justify-center text-zinc-400 transition hover:text-zinc-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#2BF563]"
+          >
+            <svg aria-hidden="true" viewBox="0 0 24 24" class="h-5 w-5 fill-current">
+              <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56v-2.02c-3.2.7-3.88-1.38-3.88-1.38-.52-1.33-1.28-1.68-1.28-1.68-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.68 0-1.25.45-2.28 1.18-3.08-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.16 1.18A10.9 10.9 0 0 1 12 6.17c.98 0 1.94.13 2.86.39 2.19-1.49 3.16-1.18 3.16-1.18.62 1.58.23 2.75.11 3.04.74.8 1.18 1.83 1.18 3.08 0 4.41-2.69 5.38-5.25 5.67.41.36.78 1.07.78 2.15v3.03c0 .31.21.67.8.56A11.51 11.51 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z" />
+            </svg>
+          </a>
           <a href="/" class="transition hover:text-zinc-100">Website -&gt;</a>
         </nav>
       </div>

--- a/apps/www/src/content/docs/advanced/agent-architecture.md
+++ b/apps/www/src/content/docs/advanced/agent-architecture.md
@@ -51,7 +51,7 @@ import { publicDocsTool } from "./support-tools";
 export const supportAgent = new AgentBuilder("support", model)
   .name("Support Agent")
   .instructions("Answer support questions clearly. Ask before guessing.")
-  .tool(publicDocsTool)
+  .tools([publicDocsTool])
   .defaultMaxTurns(3)
   .build();
 ```

--- a/apps/www/src/content/docs/advanced/agent-builder.md
+++ b/apps/www/src/content/docs/advanced/agent-builder.md
@@ -44,7 +44,7 @@ Use builder defaults for behavior that is safe across requests:
 
 - `.instructions(...)` for durable operating rules
 - `.context(text, id)` for small static documents
-- `.tool(...)` or `.tools(...)` for stable tool definitions
+- `.tools([...])` for stable tool definitions
 - `.mcp(...)` for tools loaded from MCP servers
 - `.skills(...)` for skill instructions and skill tools
 - `.dynamicContext(...)` for retrieval-selected context

--- a/apps/www/src/content/docs/advanced/dynamic-tool-catalogs.md
+++ b/apps/www/src/content/docs/advanced/dynamic-tool-catalogs.md
@@ -106,7 +106,7 @@ An agent can use both:
 
 ```ts
 const agent = new AgentBuilder("support", model)
-  .tool(createEscalationTool(scope))
+  .tools([createEscalationTool(scope)])
   .dynamicTools(toolIndex, {
     topK: 5,
     threshold: 0.7,

--- a/apps/www/src/content/docs/advanced/multi-agent-systems.md
+++ b/apps/www/src/content/docs/advanced/multi-agent-systems.md
@@ -28,14 +28,14 @@ Expose it as a tool on the coordinator:
 ```ts
 const supportAgent = new AgentBuilder("support", model)
   .instructions("Answer support questions. Ask policy_review before high-risk answers.")
-  .tool(
+  .tools([
     policyAgent.asTool({
       name: "policy_review",
       description: "Review a draft support answer for policy risk.",
       maxTurns: 2,
     }),
-  )
-  .tools(supportTools)
+    ...supportTools,
+  ])
   .build();
 ```
 
@@ -116,8 +116,10 @@ const coordinator = new AgentBuilder("incident-coordinator", model)
       "Synthesize the final answer yourself after tools return.",
     ].join("\n"),
   )
-  .tool(logAgent.asTool({ name: "log_analysis", maxTurns: 3 }))
-  .tool(policyAgent.asTool({ name: "policy_review", maxTurns: 2 }))
+  .tools([
+    logAgent.asTool({ name: "log_analysis", maxTurns: 3 }),
+    policyAgent.asTool({ name: "policy_review", maxTurns: 2 }),
+  ])
   .build();
 ```
 

--- a/apps/www/src/content/docs/advanced/rag-context.md
+++ b/apps/www/src/content/docs/advanced/rag-context.md
@@ -112,7 +112,7 @@ const searchRunbooks = runbookIndex.asTool({
 
 const agent = new AgentBuilder("incident-assistant", model)
   .instructions("Search runbooks before answering incident response questions.")
-  .tool(searchRunbooks)
+  .tools([searchRunbooks])
   .defaultMaxTurns(3)
   .build();
 ```

--- a/apps/www/src/content/docs/advanced/think-tool.md
+++ b/apps/www/src/content/docs/advanced/think-tool.md
@@ -24,8 +24,7 @@ const agent = new AgentBuilder("incident-review", model)
       "Do not expose private tool results in the final answer.",
     ].join("\n"),
   )
-  .tool(createThinkTool())
-  .tools(incidentTools)
+  .tools([createThinkTool(), ...incidentTools])
   .build();
 ```
 
@@ -69,7 +68,7 @@ const agent = new AgentBuilder("support", model)
   .instructions(
     "Use think when a request requires comparing tool results or planning multiple steps.",
   )
-  .tool(createThinkTool())
+  .tools([createThinkTool()])
   .build();
 ```
 

--- a/apps/www/src/content/docs/basics/add-tools.md
+++ b/apps/www/src/content/docs/basics/add-tools.md
@@ -47,7 +47,7 @@ const lookupOrder = createTool({
 
 const agent = new AgentBuilder("support", model)
   .instructions("Use tools when order data is needed.")
-  .tool(lookupOrder)
+  .tools([lookupOrder])
   .defaultMaxTurns(3)
   .build();
 ```

--- a/apps/www/src/content/docs/examples/retrieval-agent.md
+++ b/apps/www/src/content/docs/examples/retrieval-agent.md
@@ -122,8 +122,7 @@ const SUPPORT_DOC_SEARCH_INSTRUCTIONS = "Search support docs before answering po
 
 const agent = new AgentBuilder("checkout-support", model)
   .instructions(SUPPORT_DOC_SEARCH_INSTRUCTIONS)
-  .tool(searchSupportDocs)
-  .tools(createSupportTools(scope))
+  .tools([searchSupportDocs, ...createSupportTools(scope)])
   .defaultMaxTurns(4)
   .build();
 ```

--- a/apps/www/src/content/docs/packages/core/examples.md
+++ b/apps/www/src/content/docs/packages/core/examples.md
@@ -35,7 +35,7 @@ export function createSupportAgent(input: { model: CompletionModel; orders: Orde
 
   return new AgentBuilder("support", input.model)
     .instructions("Help customers with order questions.")
-    .tool(lookupOrder)
+    .tools([lookupOrder])
     .defaultMaxTurns(4)
     .build();
 }

--- a/apps/www/src/lib/llms.ts
+++ b/apps/www/src/lib/llms.ts
@@ -15,17 +15,28 @@ export async function buildLlmsIndex(options: LlmsOptions = {}) {
     "",
     "> TypeScript runtime for building provider-agnostic AI agents, tools, retrieval, pipelines, and observability inside application code.",
     "",
-    "Use these Basics docs links when you need Anvia documentation optimized for coding agents and LLM context windows.",
+    "Basics documentation optimized for coding agents and LLM context windows.",
   ];
 
-  if (docs.length > 0) {
-    lines.push("", `## ${sectionLabel("basics")}`, "");
-  }
-
   for (const entry of docs) {
+    const body = normalizeMarkdown(entry.body ?? "", baseUrl).trim();
+
     lines.push(
-      `- [${docLabel(entry)}](${absoluteUrl(docHref(entry), baseUrl)}): ${entry.data.description}`,
+      "",
+      "---",
+      "",
+      `# ${docLabel(entry)}`,
+      "",
+      `URL: ${absoluteUrl(docHref(entry), baseUrl)}`,
+      `Section: ${sectionLabel(entry.data.section)}`,
+      `Group: ${entry.data.sidebar.group}`,
+      `Description: ${entry.data.description}`,
+      "",
     );
+
+    if (body.length > 0) {
+      lines.push(body, "");
+    }
   }
 
   return `${lines.join("\n")}\n`;


### PR DESCRIPTION
## Summary
- Update AgentBuilder docs examples to use .tools([...]) instead of .tool(...)
- Add icon-only GitHub links to the website and docs headers
- Expand /llms.txt to include full Basics docs content instead of only links

## Verification
- pnpm --filter www build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub links in the site header and docs navigation, including desktop and mobile views, so visitors can open the project’s GitHub page more easily.

* **Documentation**
  * Updated several guides and examples to reflect the newer multi-tool registration style.
  * Improved the generated basics-docs index output with a richer, more structured format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->