### PR TITLE
fix: update changeset ignored docs package

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,5 +10,5 @@
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   },
-  "ignore": ["docs", "cookbook", "anvia-cli-agent"]
+  "ignore": ["www", "cookbook", "anvia-cli-agent"]
 }


### PR DESCRIPTION
## Summary
- replace stale Changesets ignore entry `docs` with the actual docs workspace package `www`
- keeps `cookbook` and `anvia-cli-agent` ignored as before

## Validation
- `pnpm exec changeset status --since HEAD`

This fixes the release workflow failure where `changeset version` rejects the missing ignored package `docs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation settings to ignore a different content area and keep other ignored areas unchanged.
  * No direct user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->