### PR TITLE
Improve completion stream UI DX

### DIFF
--- a/.changeset/fresh-completion-stream-dx.md
+++ b/.changeset/fresh-completion-stream-dx.md
@@ -1,0 +1,6 @@
+---
+"@anvia/core": minor
+"@anvia/react": minor
+---
+
+Improve completion stream DX by allowing `createCompletionStream()` and `createCompletion()` to accept UI messages directly, and by letting React hooks consume raw completion or agent stream events without a separate UI stream adapter.

--- a/apps/www/src/content/docs/basics/react-client.md
+++ b/apps/www/src/content/docs/basics/react-client.md
@@ -23,24 +23,32 @@ Install `@anvia/react` and expose a server route that returns Anvia runtime even
 
 ```tsx
 import { useChat } from "@anvia/react";
+import { useState } from "react";
 
 export function Chat() {
   const chat = useChat({ endpoint: "/api/chat" });
+  const [input, setInput] = useState("");
 
   return (
     <form
       onSubmit={(event) => {
         event.preventDefault();
-        void chat.send();
+        void chat.sendMessage(input);
+        setInput("");
       }}
     >
       <div>
         {chat.messages.map((message) => (
-          <p key={message.id}>{message.content}</p>
+          <p key={message.id}>
+            {message.parts
+              .filter((part) => part.type === "text")
+              .map((part) => part.text)
+              .join("")}
+          </p>
         ))}
       </div>
 
-      <input value={chat.input} onChange={(event) => chat.setInput(event.target.value)} />
+      <input value={input} onChange={(event) => setInput(event.target.value)} />
       <button disabled={chat.status === "streaming"}>Send</button>
     </form>
   );
@@ -52,14 +60,14 @@ export function Chat() {
 `useChat` creates a fetch-backed transport when you pass `endpoint`. It sends the default chat request body:
 
 ```ts
-type DefaultChatRequest = {
-  message: string;
-  history: ChatMessage[];
+type UIStreamRequest = {
+  messages: UIMessage[];
   stream: true;
+  metadata?: JsonValue;
 };
 ```
 
-It reads JSONL by default and updates message state from runtime events.
+It reads JSONL by default and updates message state from raw completion streams, raw agent streams, or UI stream events.
 
 Use `createRequest` or a custom transport when your server expects a different request shape or event mapping.
 

--- a/apps/www/src/content/docs/packages/core/reference/completion.md
+++ b/apps/www/src/content/docs/packages/core/reference/completion.md
@@ -281,11 +281,11 @@ Notable errors: throws `CompletionCapabilityError` for unsupported tools, tool c
 ## Direct Completion Helpers
 
 ```ts
-type CreateCompletionInput = string | Message | Message[];
+type CreateCompletionInput = string | Message | Message[] | UIMessage | UIMessage[];
 
 type CreateCompletionBaseOptions = {
   input?: CreateCompletionInput;
-  messages?: Message[];
+  messages?: Message[] | UIMessage[];
   instructions?: string;
   documents?: Document[];
   tools?: ToolDefinition[];
@@ -337,13 +337,15 @@ Return behavior: `createCompletion(...)` always returns a promise for the final 
 
 `createParsedCompletion(...)` converts `schema` to `outputSchema`, calls the model once, parses the assistant text as JSON, validates it with the same schema, and returns `data` plus the normal completion result fields.
 
-`messages` supplies an existing transcript. `input` accepts a string, one message, or multiple messages and is appended after `messages`. At least one of `input` or `messages` is required.
+`messages` supplies an existing transcript. It can be core `Message[]` or React-facing `UIMessage[]`. `input` accepts a string, one message, or multiple messages and is appended after `messages`. At least one of `input` or `messages` is required.
+
+`UIMessage[]` is normalized internally, so endpoints used by `@anvia/react` can pass `body.messages` directly to `createCompletion(...)`, `createCompletionStream(...)`, or `createParsedCompletion(...)`.
 
 `params` maps to `CompletionRequest.additionalParams` for provider-specific options.
 
 Notable errors: `createCompletion(...)` rejects if input is empty or the request uses unsupported model features. `createCompletionStream(...)` throws before returning the stream when validation fails or when the model does not support streaming. `createParsedCompletion(...)` also rejects when the response text is not valid JSON or does not match `schema`.
 
-Direct completion streams are raw model streams. They can include text deltas, reasoning deltas, tool call deltas, tool calls, message ids, final responses, and errors. They do not execute tools and do not emit agent stream events such as `turn_start`, `tool_result`, `agent_tool_event`, or agent `final` output.
+Direct completion streams are raw model streams. They can include text deltas, reasoning deltas, tool call deltas, tool calls, message ids, final responses, and errors. They do not execute tools and do not emit agent stream events such as `turn_start`, `tool_result`, `agent_tool_event`, or agent `final` output. `@anvia/react` hooks consume these raw completion streams by default.
 
 ## CompletionRequestBuilder
 

--- a/apps/www/src/content/docs/packages/core/reference/ui.md
+++ b/apps/www/src/content/docs/packages/core/reference/ui.md
@@ -53,7 +53,12 @@ type UIStreamEvent =
   | { type: "message_start"; message: UIMessage }
   | { type: "text_delta"; messageId: string; partId: string; delta: string }
   | { type: "reasoning_delta"; messageId: string; partId: string; delta: string }
-  | { type: "tool_update"; messageId: string; partId: string; part: UIMessagePart }
+  | {
+      type: "tool_update";
+      messageId: string;
+      partId: string;
+      part: Extract<UIMessagePart, { type: "tool" }>;
+    }
   | { type: "message_end"; messageId: string; usage?: Usage; metadata?: JsonValue }
   | { type: "error"; error: UIError };
 

--- a/apps/www/src/content/docs/packages/core/reference/ui.md
+++ b/apps/www/src/content/docs/packages/core/reference/ui.md
@@ -75,7 +75,7 @@ type CreateAgentUIStreamOptions = {
 };
 ```
 
-Purpose: shared UI protocol for single-turn completions and multi-turn agent runs. The request always carries `messages`, and the response always emits `UIStreamEvent` records that build assistant `UIMessage` state on the client.
+Purpose: shared UI message shape for React-facing completion and chat state. The request always carries `messages`. React hooks can consume raw completion streams, raw agent streams, or `UIStreamEvent` records.
 
 ## uiMessagesToCoreMessages
 
@@ -106,9 +106,11 @@ function createCompletionUIStream<Model extends StreamingCompletionModel>(
 ): AsyncIterable<UIStreamEvent>;
 ```
 
-Purpose: run `createCompletionStream(...)` from UI messages and adapt the completion stream into UI stream events.
+Purpose: advanced adapter that runs `createCompletionStream(...)` from UI messages and adapts the completion stream into UI stream events.
 
 Return behavior: yields an assistant `message_start`, text or reasoning deltas, tool updates, `message_end`, and error events.
+
+For normal React completion routes, prefer calling `createCompletionStream(model, { messages: body.messages })` directly.
 
 ## createAgentUIStream
 
@@ -119,7 +121,7 @@ function createAgentUIStream(
 ): AsyncIterable<UIStreamEvent>;
 ```
 
-Purpose: run an agent from UI messages and adapt the agent stream into the same UI stream protocol used by completions.
+Purpose: advanced adapter that runs an agent from UI messages and adapts the agent stream into the UI stream protocol.
 
 Return behavior: yields assistant message events that can be consumed by `useChat` or `useCompletion` from `@anvia/react`.
 

--- a/apps/www/src/content/docs/packages/react/reference.md
+++ b/apps/www/src/content/docs/packages/react/reference.md
@@ -281,7 +281,7 @@ function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(options?: {
 
 Purpose: React chat state machine that sends `UIStreamRequest` by default and accumulates response events into `UIMessage[]`.
 
-Passing `endpoint` creates a default JSONL fetch transport. Passing `transport` makes the hook independent of HTTP. `sendMessage(...)` appends a user message, sends the full UI message history, and applies `UIStreamEvent` records as the assistant response arrives.
+Passing `endpoint` creates a default JSONL fetch transport. Passing `transport` makes the hook independent of HTTP. `sendMessage(...)` appends a user message and sends the full UI message history. The hook applies raw `CompletionStreamEvent`, raw `AgentStreamEvent`, or `UIStreamEvent` records as the assistant response arrives.
 
 ## useCompletion
 
@@ -322,7 +322,7 @@ function useCompletion<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
 
 Purpose: React hook for single-prompt text completion streaming that also exposes the underlying assistant `messages`.
 
-By default, `complete(prompt)` creates one user `UIMessage`, sends `{ messages, stream: true }`, and consumes standard `UIStreamEvent` records. `completion` is a convenience string derived from assistant text parts.
+By default, `complete(prompt)` creates one user `UIMessage`, sends `{ messages, stream: true }`, and consumes raw `CompletionStreamEvent`, raw `AgentStreamEvent`, or `UIStreamEvent` records. `completion` is a convenience string derived from assistant text parts.
 
 ## createDirectTransport
 

--- a/apps/www/src/content/docs/packages/react/reference.md
+++ b/apps/www/src/content/docs/packages/react/reference.md
@@ -60,7 +60,12 @@ type UIStreamEvent =
   | { type: "message_start"; message: UIMessage }
   | { type: "text_delta"; messageId: string; partId: string; delta: string }
   | { type: "reasoning_delta"; messageId: string; partId: string; delta: string }
-  | { type: "tool_update"; messageId: string; partId: string; part: UIMessagePart }
+  | {
+      type: "tool_update";
+      messageId: string;
+      partId: string;
+      part: Extract<UIMessagePart, { type: "tool" }>;
+    }
   | { type: "message_end"; messageId: string; usage?: unknown; metadata?: unknown }
   | { type: "error"; error: UIError };
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -96,13 +96,17 @@ for await (const event of createCompletionStream(model, {
 }
 ```
 
-Use `createCompletionUIStream` when a React UI sends standardized `UIMessage[]`:
+React hooks send standardized `UIMessage[]` in their request body. Pass those messages directly to
+`createCompletionStream`; the helper normalizes them before calling the provider:
 
 ```ts
-import { createCompletionUIStream } from "@anvia/core/ui";
+import { createCompletionStream } from "@anvia/core";
+import type { UIStreamRequest } from "@anvia/core/ui";
 
-const uiEvents = createCompletionUIStream(model, {
-  messages,
+const body = (await request.json()) as UIStreamRequest;
+
+const events = createCompletionStream(model, {
+  messages: body.messages,
 });
 ```
 

--- a/packages/core/src/completion/create-completion.ts
+++ b/packages/core/src/completion/create-completion.ts
@@ -1,4 +1,6 @@
 import { toProviderJsonSchema, type ZodSchema } from "../schema/zod-schema";
+import { isUIMessage, uiMessagesToCoreMessages } from "../ui/messages";
+import type { UIMessage } from "../ui/types";
 import type {
   AssistantContent,
   CompletionModel,
@@ -16,11 +18,11 @@ import type {
 } from "./types";
 import { assertCompletionRequestSupported, Message, textFromAssistantContent } from "./types";
 
-export type CreateCompletionInput = string | MessageType | MessageType[];
+export type CreateCompletionInput = string | MessageType | MessageType[] | UIMessage | UIMessage[];
 
 export type CreateCompletionBaseOptions = {
   input?: CreateCompletionInput | undefined;
-  messages?: MessageType[] | undefined;
+  messages?: MessageType[] | UIMessage[] | undefined;
   instructions?: string | undefined;
   documents?: Document[] | undefined;
   tools?: ToolDefinition[] | undefined;
@@ -120,7 +122,10 @@ function toCompletionRequest(
   options: CreateCompletionBaseOptions,
   helperName = "createCompletion",
 ): CompletionRequest {
-  const chatHistory = [...(options.messages ?? []), ...messagesFromInput(options.input)];
+  const chatHistory = [
+    ...messagesFromMessages(options.messages),
+    ...messagesFromInput(options.input),
+  ];
 
   if (chatHistory.length === 0) {
     throw new Error(`${helperName} requires input or messages.`);
@@ -151,10 +156,62 @@ function messagesFromInput(input: CreateCompletionInput | undefined): MessageTyp
   if (typeof input === "string") {
     return [Message.user(input)];
   }
-  return Array.isArray(input) ? [...input] : [input];
+  if (Array.isArray(input)) {
+    return normalizeMessageArray(input, "input");
+  }
+  if (isUIMessage(input)) {
+    return uiMessagesToCoreMessages([input]);
+  }
+  return [input];
 }
 
-export function isStreamingCompletionModel(model: CompletionModel): model is StreamingCompletionModel {
+function messagesFromMessages(messages: MessageType[] | UIMessage[] | undefined): MessageType[] {
+  return messages === undefined ? [] : normalizeMessageArray(messages, "messages");
+}
+
+function normalizeMessageArray(
+  messages: (MessageType | UIMessage)[],
+  fieldName: "input" | "messages",
+): MessageType[] {
+  const hasUIMessage = messages.some(isUIMessage);
+  const hasCoreMessage = messages.some(isCoreMessage);
+
+  if (hasUIMessage && hasCoreMessage) {
+    throw new TypeError(`${fieldName} must contain only Message[] or only UIMessage[].`);
+  }
+
+  if (hasUIMessage) {
+    if (!messages.every(isUIMessage)) {
+      throw new TypeError(`${fieldName} must contain only UIMessage values.`);
+    }
+    return uiMessagesToCoreMessages(messages);
+  }
+
+  if (!messages.every(isCoreMessage)) {
+    throw new TypeError(`${fieldName} must contain only Message values.`);
+  }
+
+  return [...messages];
+}
+
+function isCoreMessage(value: unknown): value is MessageType {
+  return (
+    isRecord(value) &&
+    (value.role === "system" ||
+      value.role === "user" ||
+      value.role === "assistant" ||
+      value.role === "tool") &&
+    "content" in value
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function isStreamingCompletionModel(
+  model: CompletionModel,
+): model is StreamingCompletionModel {
   return typeof (model as { streamCompletion?: unknown }).streamCompletion === "function";
 }
 

--- a/packages/core/src/completion/create-completion.ts
+++ b/packages/core/src/completion/create-completion.ts
@@ -162,6 +162,9 @@ function messagesFromInput(input: CreateCompletionInput | undefined): MessageTyp
   if (isUIMessage(input)) {
     return uiMessagesToCoreMessages([input]);
   }
+  if (!isCoreMessage(input)) {
+    throw new TypeError("input must be a string, Message, Message[], UIMessage, or UIMessage[].");
+  }
   return [input];
 }
 
@@ -195,14 +198,154 @@ function normalizeMessageArray(
 }
 
 function isCoreMessage(value: unknown): value is MessageType {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (value.role === "system") {
+    return typeof value.content === "string";
+  }
+
+  if (value.role === "user") {
+    return Array.isArray(value.content) && value.content.every(isUserContent);
+  }
+
+  if (value.role === "assistant") {
+    return (
+      (value.id === undefined || typeof value.id === "string") &&
+      Array.isArray(value.content) &&
+      value.content.every(isAssistantContent)
+    );
+  }
+
+  if (value.role === "tool") {
+    return Array.isArray(value.content) && value.content.every(isToolContent);
+  }
+
+  return false;
+}
+
+function isUserContent(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (value.type === "text") {
+    return typeof value.text === "string";
+  }
+
+  if (value.type === "image") {
+    return isImageContent(value);
+  }
+
+  if (value.type === "document") {
+    return isDocumentContent(value);
+  }
+
+  return false;
+}
+
+function isAssistantContent(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (value.type === "text") {
+    return typeof value.text === "string";
+  }
+
+  if (value.type === "reasoning") {
+    return (
+      typeof value.text === "string" &&
+      (value.id === undefined || typeof value.id === "string") &&
+      (value.content === undefined || Array.isArray(value.content))
+    );
+  }
+
+  if (value.type === "tool_call") {
+    return (
+      typeof value.id === "string" &&
+      (value.callId === undefined || typeof value.callId === "string") &&
+      isRecord(value.function) &&
+      typeof value.function.name === "string" &&
+      "arguments" in value.function
+    );
+  }
+
+  if (value.type === "image") {
+    return isImageContent(value);
+  }
+
+  return false;
+}
+
+function isToolContent(value: unknown): boolean {
   return (
     isRecord(value) &&
-    (value.role === "system" ||
-      value.role === "user" ||
-      value.role === "assistant" ||
-      value.role === "tool") &&
-    "content" in value
+    value.type === "tool_result" &&
+    typeof value.id === "string" &&
+    (value.callId === undefined || typeof value.callId === "string") &&
+    Array.isArray(value.content) &&
+    value.content.every(isToolResultContent)
   );
+}
+
+function isToolResultContent(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (value.type === "text") {
+    return typeof value.text === "string";
+  }
+
+  if (value.type === "image") {
+    return (
+      typeof value.data === "string" &&
+      (value.mediaType === undefined || typeof value.mediaType === "string")
+    );
+  }
+
+  return false;
+}
+
+function isImageContent(value: Record<string, unknown>): boolean {
+  if (!isRecord(value.source)) {
+    return false;
+  }
+
+  if (value.source.type === "url") {
+    return typeof value.source.url === "string";
+  }
+
+  if (value.source.type === "base64") {
+    return typeof value.source.data === "string" && typeof value.source.mediaType === "string";
+  }
+
+  return false;
+}
+
+function isDocumentContent(value: Record<string, unknown>): boolean {
+  if (!isRecord(value.source)) {
+    return false;
+  }
+
+  if (value.source.type === "url") {
+    return typeof value.source.url === "string" && typeof value.source.mediaType === "string";
+  }
+
+  if (value.source.type === "base64") {
+    return typeof value.source.data === "string" && typeof value.source.mediaType === "string";
+  }
+
+  if (value.source.type === "text") {
+    return (
+      typeof value.source.text === "string" &&
+      (value.source.mediaType === undefined || typeof value.source.mediaType === "string")
+    );
+  }
+
+  return false;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/core/src/ui/index.ts
+++ b/packages/core/src/ui/index.ts
@@ -208,7 +208,7 @@ export async function* agentStreamToUIStream(
     }
 
     if (event.type === "tool_result") {
-      const toolCallId = event.toolCallId ?? event.internalCallId;
+      const toolCallId = event.internalCallId;
       yield {
         type: "tool_update",
         messageId,

--- a/packages/core/src/ui/index.ts
+++ b/packages/core/src/ui/index.ts
@@ -1,114 +1,28 @@
 import type { AgentStreamEvent } from "../agent/request-types";
 import {
-  AssistantContent,
-  type AssistantContent as AssistantContentType,
   type Message as CoreMessage,
   type CreateCompletionStreamOptions,
   createCompletionStream,
   type JsonValue,
-  Message,
-  reasoningDisplayText,
   serializeToolResultOutput,
-  ToolContent,
-  type ToolContent as ToolContentType,
   textFromAssistantContent,
-  type Usage,
-  UserContent,
 } from "../completion";
-import type {
-  CompletionStreamEvent,
-  StreamingCompletionModel,
-  ToolResultContent,
-} from "../completion/types";
+import type { CompletionStreamEvent, StreamingCompletionModel } from "../completion/types";
+import { uiMessagesToCoreMessages } from "./messages";
+import type { UIError, UIMessage, UIStreamEvent } from "./types";
 
-export type UIMessageRole = "system" | "user" | "assistant" | "tool";
-
-export type UIError = {
-  name?: string;
-  message: string;
-};
-
-export type UIMessage = {
-  id: string;
-  role: UIMessageRole;
-  parts: UIMessagePart[];
-  metadata?: JsonValue;
-};
-
-export type UIMessagePart =
-  | {
-      id: string;
-      type: "text";
-      text: string;
-    }
-  | {
-      id: string;
-      type: "reasoning";
-      text: string;
-      reasoningId?: string;
-    }
-  | {
-      id: string;
-      type: "tool";
-      toolName: string;
-      toolCallId: string;
-      callId?: string;
-      state: "input-streaming" | "input-available" | "output-available" | "error";
-      input?: JsonValue;
-      output?: JsonValue;
-      error?: UIError;
-    }
-  | {
-      id: string;
-      type: "data";
-      name: string;
-      data: JsonValue;
-    }
-  | {
-      id: string;
-      type: "error";
-      error: UIError;
-    };
-
-export type UIStreamRequest = {
-  messages: UIMessage[];
-  stream: true;
-  metadata?: JsonValue;
-};
-
-export type UIStreamEvent =
-  | {
-      type: "message_start";
-      message: UIMessage;
-    }
-  | {
-      type: "text_delta";
-      messageId: string;
-      partId: string;
-      delta: string;
-    }
-  | {
-      type: "reasoning_delta";
-      messageId: string;
-      partId: string;
-      delta: string;
-    }
-  | {
-      type: "tool_update";
-      messageId: string;
-      partId: string;
-      part: UIMessagePart;
-    }
-  | {
-      type: "message_end";
-      messageId: string;
-      usage?: Usage;
-      metadata?: JsonValue;
-    }
-  | {
-      type: "error";
-      error: UIError;
-    };
+export {
+  coreMessagesToUIMessages,
+  uiMessagesToCoreMessages,
+} from "./messages";
+export type {
+  UIError,
+  UIMessage,
+  UIMessagePart,
+  UIMessageRole,
+  UIStreamEvent,
+  UIStreamRequest,
+} from "./types";
 
 export type CreateCompletionUIStreamOptions = Omit<
   CreateCompletionStreamOptions,
@@ -126,178 +40,6 @@ export type AgentLike = {
 export type CreateAgentUIStreamOptions = {
   messages: UIMessage[];
 };
-
-export function uiMessagesToCoreMessages(messages: UIMessage[]): CoreMessage[] {
-  const coreMessages: CoreMessage[] = [];
-
-  for (const message of messages) {
-    const text = textFromUIParts(message.parts);
-
-    if (message.role === "system") {
-      if (text.length > 0) {
-        coreMessages.push(Message.system(text));
-      }
-      continue;
-    }
-
-    if (message.role === "user") {
-      const content = message.parts
-        .filter((part): part is Extract<UIMessagePart, { type: "text" }> => part.type === "text")
-        .map((part) => UserContent.text(part.text));
-      if (content.length > 0) {
-        coreMessages.push(Message.user(content));
-      }
-      continue;
-    }
-
-    if (message.role === "assistant") {
-      const content: AssistantContentType[] = [];
-      for (const part of message.parts) {
-        if (part.type === "text" && part.text.length > 0) {
-          content.push(AssistantContent.text(part.text));
-          continue;
-        }
-        if (part.type === "reasoning" && part.text.length > 0) {
-          content.push(AssistantContent.reasoning(part.text, part.reasoningId));
-          continue;
-        }
-        if (
-          part.type === "tool" &&
-          (part.state === "input-streaming" || part.state === "input-available")
-        ) {
-          content.push(
-            AssistantContent.toolCall(
-              part.toolCallId,
-              part.toolName,
-              part.input ?? {},
-              part.callId,
-            ),
-          );
-        }
-      }
-      if (content.length > 0) {
-        coreMessages.push(Message.assistant(content, message.id));
-      }
-      continue;
-    }
-
-    const toolResults: ToolContentType[] = [];
-    for (const part of message.parts) {
-      if (part.type !== "tool" || part.state !== "output-available") {
-        continue;
-      }
-      toolResults.push(
-        ToolContent.toolResult(
-          part.toolCallId,
-          outputToToolResultContent(part.output),
-          part.callId,
-        ),
-      );
-    }
-    if (toolResults.length > 0) {
-      coreMessages.push(Message.tool(toolResults));
-    }
-  }
-
-  return coreMessages;
-}
-
-export function coreMessagesToUIMessages(messages: CoreMessage[]): UIMessage[] {
-  const uiMessages: UIMessage[] = [];
-
-  for (const message of messages) {
-    if (message.role === "system") {
-      uiMessages.push({
-        id: createId("msg"),
-        role: "system",
-        parts: [{ id: createId("part"), type: "text", text: message.content }],
-      });
-      continue;
-    }
-
-    if (message.role === "user") {
-      const parts: UIMessagePart[] = [];
-      for (const content of message.content) {
-        if (content.type === "text") {
-          parts.push({ id: createId("part"), type: "text", text: content.text });
-        } else {
-          parts.push({
-            id: createId("part"),
-            type: "data",
-            name: content.type,
-            data: content as JsonValue,
-          });
-        }
-      }
-      uiMessages.push({ id: createId("msg"), role: "user", parts });
-      continue;
-    }
-
-    if (message.role === "assistant") {
-      const parts: UIMessagePart[] = [];
-      for (const content of message.content) {
-        if (content.type === "text") {
-          parts.push({ id: createId("part"), type: "text", text: content.text });
-          continue;
-        }
-        if (content.type === "reasoning") {
-          const part: UIMessagePart = {
-            id: createId("part"),
-            type: "reasoning",
-            text: reasoningDisplayText(content),
-          };
-          if (content.id !== undefined) {
-            part.reasoningId = content.id;
-          }
-          parts.push(part);
-          continue;
-        }
-        if (content.type === "tool_call") {
-          const part: UIMessagePart = {
-            id: toolPartId(content.id),
-            type: "tool",
-            toolName: content.function.name,
-            toolCallId: content.id,
-            state: "input-available",
-            input: content.function.arguments,
-          };
-          if (content.callId !== undefined) {
-            part.callId = content.callId;
-          }
-          parts.push(part);
-          continue;
-        }
-        parts.push({
-          id: createId("part"),
-          type: "data",
-          name: content.type,
-          data: content as JsonValue,
-        });
-      }
-      uiMessages.push({ id: message.id ?? createId("msg"), role: "assistant", parts });
-      continue;
-    }
-
-    const parts: UIMessagePart[] = [];
-    for (const content of message.content) {
-      const part: UIMessagePart = {
-        id: toolPartId(content.id),
-        type: "tool",
-        toolName: "tool",
-        toolCallId: content.id,
-        state: "output-available",
-        output: toolResultContentToJson(content.content),
-      };
-      if (content.callId !== undefined) {
-        part.callId = content.callId;
-      }
-      parts.push(part);
-    }
-    uiMessages.push({ id: createId("msg"), role: "tool", parts });
-  }
-
-  return uiMessages;
-}
 
 export async function* createCompletionUIStream<Model extends StreamingCompletionModel>(
   model: Model,
@@ -522,21 +264,6 @@ function messageStart(messageId: string): UIStreamEvent {
       parts: [],
     },
   };
-}
-
-function textFromUIParts(parts: UIMessagePart[]): string {
-  return parts.flatMap((part) => (part.type === "text" ? [part.text] : [])).join("");
-}
-
-function outputToToolResultContent(output: JsonValue | undefined): ToolResultContent[] {
-  return [{ type: "text", text: serializeToolResultOutput(output ?? null) }];
-}
-
-function toolResultContentToJson(content: ToolResultContent[]): JsonValue {
-  if (content.length === 1 && content[0]?.type === "text") {
-    return content[0].text;
-  }
-  return content as JsonValue;
 }
 
 function uiError(error: unknown): UIError {

--- a/packages/core/src/ui/messages.ts
+++ b/packages/core/src/ui/messages.ts
@@ -1,0 +1,237 @@
+import {
+  AssistantContent,
+  type AssistantContent as AssistantContentType,
+  type Message as CoreMessage,
+  type JsonValue,
+  Message,
+  reasoningDisplayText,
+  serializeToolResultOutput,
+  ToolContent,
+  type ToolContent as ToolContentType,
+  type ToolResultContent,
+  UserContent,
+} from "../completion/types";
+import type { UIMessage, UIMessagePart } from "./types";
+
+export function uiMessagesToCoreMessages(messages: UIMessage[]): CoreMessage[] {
+  const coreMessages: CoreMessage[] = [];
+
+  for (const message of messages) {
+    const text = textFromUIParts(message.parts);
+
+    if (message.role === "system") {
+      if (text.length > 0) {
+        coreMessages.push(Message.system(text));
+      }
+      continue;
+    }
+
+    if (message.role === "user") {
+      const content = message.parts
+        .filter((part): part is Extract<UIMessagePart, { type: "text" }> => part.type === "text")
+        .map((part) => UserContent.text(part.text));
+      if (content.length > 0) {
+        coreMessages.push(Message.user(content));
+      }
+      continue;
+    }
+
+    if (message.role === "assistant") {
+      const content: AssistantContentType[] = [];
+      for (const part of message.parts) {
+        if (part.type === "text" && part.text.length > 0) {
+          content.push(AssistantContent.text(part.text));
+          continue;
+        }
+        if (part.type === "reasoning" && part.text.length > 0) {
+          content.push(AssistantContent.reasoning(part.text, part.reasoningId));
+          continue;
+        }
+        if (
+          part.type === "tool" &&
+          (part.state === "input-streaming" || part.state === "input-available")
+        ) {
+          content.push(
+            AssistantContent.toolCall(
+              part.toolCallId,
+              part.toolName,
+              part.input ?? {},
+              part.callId,
+            ),
+          );
+        }
+      }
+      if (content.length > 0) {
+        coreMessages.push(Message.assistant(content, message.id));
+      }
+      continue;
+    }
+
+    const toolResults: ToolContentType[] = [];
+    for (const part of message.parts) {
+      if (part.type !== "tool" || part.state !== "output-available") {
+        continue;
+      }
+      toolResults.push(
+        ToolContent.toolResult(
+          part.toolCallId,
+          outputToToolResultContent(part.output),
+          part.callId,
+        ),
+      );
+    }
+    if (toolResults.length > 0) {
+      coreMessages.push(Message.tool(toolResults));
+    }
+  }
+
+  return coreMessages;
+}
+
+export function coreMessagesToUIMessages(messages: CoreMessage[]): UIMessage[] {
+  const uiMessages: UIMessage[] = [];
+
+  for (const message of messages) {
+    if (message.role === "system") {
+      uiMessages.push({
+        id: createId("msg"),
+        role: "system",
+        parts: [{ id: createId("part"), type: "text", text: message.content }],
+      });
+      continue;
+    }
+
+    if (message.role === "user") {
+      const parts: UIMessagePart[] = [];
+      for (const content of message.content) {
+        if (content.type === "text") {
+          parts.push({ id: createId("part"), type: "text", text: content.text });
+        } else {
+          parts.push({
+            id: createId("part"),
+            type: "data",
+            name: content.type,
+            data: content as JsonValue,
+          });
+        }
+      }
+      uiMessages.push({ id: createId("msg"), role: "user", parts });
+      continue;
+    }
+
+    if (message.role === "assistant") {
+      const parts: UIMessagePart[] = [];
+      for (const content of message.content) {
+        if (content.type === "text") {
+          parts.push({ id: createId("part"), type: "text", text: content.text });
+          continue;
+        }
+        if (content.type === "reasoning") {
+          const part: UIMessagePart = {
+            id: createId("part"),
+            type: "reasoning",
+            text: reasoningDisplayText(content),
+          };
+          if (content.id !== undefined) {
+            part.reasoningId = content.id;
+          }
+          parts.push(part);
+          continue;
+        }
+        if (content.type === "tool_call") {
+          const part: UIMessagePart = {
+            id: toolPartId(content.id),
+            type: "tool",
+            toolName: content.function.name,
+            toolCallId: content.id,
+            state: "input-available",
+            input: content.function.arguments,
+          };
+          if (content.callId !== undefined) {
+            part.callId = content.callId;
+          }
+          parts.push(part);
+          continue;
+        }
+        parts.push({
+          id: createId("part"),
+          type: "data",
+          name: content.type,
+          data: content as JsonValue,
+        });
+      }
+      uiMessages.push({ id: message.id ?? createId("msg"), role: "assistant", parts });
+      continue;
+    }
+
+    const parts: UIMessagePart[] = [];
+    for (const content of message.content) {
+      const part: UIMessagePart = {
+        id: toolPartId(content.id),
+        type: "tool",
+        toolName: "tool",
+        toolCallId: content.id,
+        state: "output-available",
+        output: toolResultContentToJson(content.content),
+      };
+      if (content.callId !== undefined) {
+        part.callId = content.callId;
+      }
+      parts.push(part);
+    }
+    uiMessages.push({ id: createId("msg"), role: "tool", parts });
+  }
+
+  return uiMessages;
+}
+
+export function isUIMessage(value: unknown): value is UIMessage {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    isUIMessageRole(value.role) &&
+    Array.isArray(value.parts)
+  );
+}
+
+export function isUIMessageArray(value: unknown): value is UIMessage[] {
+  return Array.isArray(value) && value.every(isUIMessage);
+}
+
+function textFromUIParts(parts: UIMessagePart[]): string {
+  return parts.flatMap((part) => (part.type === "text" ? [part.text] : [])).join("");
+}
+
+function outputToToolResultContent(output: JsonValue | undefined): ToolResultContent[] {
+  return [{ type: "text", text: serializeToolResultOutput(output ?? null) }];
+}
+
+function toolResultContentToJson(content: ToolResultContent[]): JsonValue {
+  if (content.length === 1 && content[0]?.type === "text") {
+    return content[0].text;
+  }
+  return content as JsonValue;
+}
+
+function toolPartId(toolCallId: string): string {
+  return `tool_${toolCallId}`;
+}
+
+let nextId = 0;
+
+function createId(prefix: string): string {
+  const random = globalThis.crypto?.randomUUID?.();
+  if (random !== undefined) {
+    return `${prefix}_${random}`;
+  }
+  nextId += 1;
+  return `${prefix}_${nextId.toString(36)}`;
+}
+
+function isUIMessageRole(value: unknown): value is UIMessage["role"] {
+  return value === "system" || value === "user" || value === "assistant" || value === "tool";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/packages/core/src/ui/messages.ts
+++ b/packages/core/src/ui/messages.ts
@@ -10,6 +10,7 @@ import {
   type ToolContent as ToolContentType,
   type ToolResultContent,
   UserContent,
+  type UserContent as UserContentType,
 } from "../completion/types";
 import type { UIMessage, UIMessagePart } from "./types";
 
@@ -27,9 +28,20 @@ export function uiMessagesToCoreMessages(messages: UIMessage[]): CoreMessage[] {
     }
 
     if (message.role === "user") {
-      const content = message.parts
-        .filter((part): part is Extract<UIMessagePart, { type: "text" }> => part.type === "text")
-        .map((part) => UserContent.text(part.text));
+      const content: UserContentType[] = [];
+      for (const part of message.parts) {
+        if (part.type === "text") {
+          content.push(UserContent.text(part.text));
+          continue;
+        }
+        if (part.type === "data" && isUserContent(part.data)) {
+          content.push(part.data);
+          continue;
+        }
+        throw new TypeError(
+          "User UI messages can only be converted from text parts or image/document data parts.",
+        );
+      }
       if (content.length > 0) {
         coreMessages.push(Message.user(content));
       }
@@ -38,6 +50,7 @@ export function uiMessagesToCoreMessages(messages: UIMessage[]): CoreMessage[] {
 
     if (message.role === "assistant") {
       const content: AssistantContentType[] = [];
+      const toolResults: ToolContentType[] = [];
       for (const part of message.parts) {
         if (part.type === "text" && part.text.length > 0) {
           content.push(AssistantContent.text(part.text));
@@ -49,7 +62,9 @@ export function uiMessagesToCoreMessages(messages: UIMessage[]): CoreMessage[] {
         }
         if (
           part.type === "tool" &&
-          (part.state === "input-streaming" || part.state === "input-available")
+          (part.state === "input-streaming" ||
+            part.state === "input-available" ||
+            part.state === "output-available")
         ) {
           content.push(
             AssistantContent.toolCall(
@@ -59,10 +74,22 @@ export function uiMessagesToCoreMessages(messages: UIMessage[]): CoreMessage[] {
               part.callId,
             ),
           );
+          if (part.state === "output-available") {
+            toolResults.push(
+              ToolContent.toolResult(
+                part.toolCallId,
+                outputToToolResultContent(part.output),
+                part.callId,
+              ),
+            );
+          }
         }
       }
       if (content.length > 0) {
         coreMessages.push(Message.assistant(content, message.id));
+      }
+      if (toolResults.length > 0) {
+        coreMessages.push(Message.tool(toolResults));
       }
       continue;
     }
@@ -211,6 +238,65 @@ function toolResultContentToJson(content: ToolResultContent[]): JsonValue {
     return content[0].text;
   }
   return content as JsonValue;
+}
+
+function isUserContent(value: unknown): value is UserContentType {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (value.type === "text") {
+    return typeof value.text === "string";
+  }
+
+  if (value.type === "image") {
+    return isImageContent(value);
+  }
+
+  if (value.type === "document") {
+    return isDocumentContent(value);
+  }
+
+  return false;
+}
+
+function isImageContent(value: Record<string, unknown>): boolean {
+  if (!isRecord(value.source)) {
+    return false;
+  }
+
+  if (value.source.type === "url") {
+    return typeof value.source.url === "string";
+  }
+
+  if (value.source.type === "base64") {
+    return typeof value.source.data === "string" && typeof value.source.mediaType === "string";
+  }
+
+  return false;
+}
+
+function isDocumentContent(value: Record<string, unknown>): boolean {
+  if (!isRecord(value.source)) {
+    return false;
+  }
+
+  if (value.source.type === "url") {
+    return typeof value.source.url === "string" && typeof value.source.mediaType === "string";
+  }
+
+  if (value.source.type === "base64") {
+    return typeof value.source.data === "string" && typeof value.source.mediaType === "string";
+  }
+
+  if (value.source.type === "text") {
+    return (
+      typeof value.source.text === "string" &&
+      (value.source.mediaType === undefined || typeof value.source.mediaType === "string")
+    );
+  }
+
+  return false;
 }
 
 function toolPartId(toolCallId: string): string {

--- a/packages/core/src/ui/types.ts
+++ b/packages/core/src/ui/types.ts
@@ -49,6 +49,8 @@ export type UIMessagePart =
       error: UIError;
     };
 
+export type UIToolMessagePart = Extract<UIMessagePart, { type: "tool" }>;
+
 export type UIStreamRequest = {
   messages: UIMessage[];
   stream: true;
@@ -76,7 +78,7 @@ export type UIStreamEvent =
       type: "tool_update";
       messageId: string;
       partId: string;
-      part: UIMessagePart;
+      part: UIToolMessagePart;
     }
   | {
       type: "message_end";

--- a/packages/core/src/ui/types.ts
+++ b/packages/core/src/ui/types.ts
@@ -1,0 +1,90 @@
+import type { JsonValue, Usage } from "../completion/types";
+
+export type UIMessageRole = "system" | "user" | "assistant" | "tool";
+
+export type UIError = {
+  name?: string;
+  message: string;
+};
+
+export type UIMessage = {
+  id: string;
+  role: UIMessageRole;
+  parts: UIMessagePart[];
+  metadata?: JsonValue;
+};
+
+export type UIMessagePart =
+  | {
+      id: string;
+      type: "text";
+      text: string;
+    }
+  | {
+      id: string;
+      type: "reasoning";
+      text: string;
+      reasoningId?: string;
+    }
+  | {
+      id: string;
+      type: "tool";
+      toolName: string;
+      toolCallId: string;
+      callId?: string;
+      state: "input-streaming" | "input-available" | "output-available" | "error";
+      input?: JsonValue;
+      output?: JsonValue;
+      error?: UIError;
+    }
+  | {
+      id: string;
+      type: "data";
+      name: string;
+      data: JsonValue;
+    }
+  | {
+      id: string;
+      type: "error";
+      error: UIError;
+    };
+
+export type UIStreamRequest = {
+  messages: UIMessage[];
+  stream: true;
+  metadata?: JsonValue;
+};
+
+export type UIStreamEvent =
+  | {
+      type: "message_start";
+      message: UIMessage;
+    }
+  | {
+      type: "text_delta";
+      messageId: string;
+      partId: string;
+      delta: string;
+    }
+  | {
+      type: "reasoning_delta";
+      messageId: string;
+      partId: string;
+      delta: string;
+    }
+  | {
+      type: "tool_update";
+      messageId: string;
+      partId: string;
+      part: UIMessagePart;
+    }
+  | {
+      type: "message_end";
+      messageId: string;
+      usage?: Usage;
+      metadata?: JsonValue;
+    }
+  | {
+      type: "error";
+      error: UIError;
+    };

--- a/packages/core/test/ui-stream.test.ts
+++ b/packages/core/test/ui-stream.test.ts
@@ -9,12 +9,13 @@ import {
   type CompletionResponse,
   type CompletionStreamEvent,
   createAgentUIStream,
+  createCompletion,
+  createCompletionStream,
   createCompletionUIStream,
   createTool,
   Message,
   type StreamingCompletionModel,
   type UIMessage,
-  type UIStreamEvent,
   Usage,
   uiMessagesToCoreMessages,
 } from "./helpers/imports";
@@ -37,7 +38,8 @@ class StreamModel implements StreamingCompletionModel {
 
   constructor(private readonly turns: CompletionStreamEvent[][]) {}
 
-  async completion(_request: CompletionRequest): Promise<CompletionResponse> {
+  async completion(request: CompletionRequest): Promise<CompletionResponse> {
+    this.requests.push(request);
     return {
       choice: [AssistantContent.text("ok")],
       usage: Usage.empty(),
@@ -89,6 +91,65 @@ describe("UI message adapters", () => {
         "assistant_1",
       ),
     ]);
+  });
+
+  it("accepts UI messages in createCompletionStream options", async () => {
+    const model = new StreamModel([
+      [
+        {
+          type: "final",
+          response: {
+            choice: [AssistantContent.text("Hello")],
+            usage: Usage.empty(),
+            rawResponse: {},
+          },
+        },
+      ],
+    ]);
+
+    await collect(
+      createCompletionStream(model, {
+        messages: [
+          {
+            id: "user_1",
+            role: "user",
+            parts: [{ id: "part_1", type: "text", text: "Hello" }],
+          },
+        ],
+      }),
+    );
+
+    expect(model.requests[0]?.chatHistory).toEqual([Message.user("Hello")]);
+  });
+
+  it("accepts a UI message as createCompletion input", async () => {
+    const model = new StreamModel([]);
+
+    const result = await createCompletion(model, {
+      input: {
+        id: "user_1",
+        role: "user",
+        parts: [{ id: "part_1", type: "text", text: "Hello" }],
+      },
+    });
+
+    expect(result.text).toBe("ok");
+    expect(model.requests[0]?.chatHistory).toEqual([Message.user("Hello")]);
+  });
+
+  it("rejects mixed core and UI message arrays", () => {
+    const model = new StreamModel([]);
+    const uiMessage: UIMessage = {
+      id: "user_1",
+      role: "user",
+      parts: [{ id: "part_1", type: "text", text: "Hello" }],
+    };
+
+    expect(() =>
+      createCompletionStream(model, {
+        messages: [Message.user("Hi"), uiMessage] as never,
+      }),
+    ).toThrow("messages must contain only Message[] or only UIMessage[]");
   });
 
   it("normalizes completion streams into UI stream events", async () => {
@@ -231,9 +292,7 @@ describe("UI message adapters", () => {
   });
 });
 
-async function collect<TEvent extends UIStreamEvent>(
-  events: AsyncIterable<TEvent>,
-): Promise<TEvent[]> {
+async function collect<TEvent>(events: AsyncIterable<TEvent>): Promise<TEvent[]> {
   const collected: TEvent[] = [];
   for await (const event of events) {
     collected.push(event);

--- a/packages/core/test/ui-stream.test.ts
+++ b/packages/core/test/ui-stream.test.ts
@@ -8,6 +8,7 @@ import {
   type CompletionRequest,
   type CompletionResponse,
   type CompletionStreamEvent,
+  coreMessagesToUIMessages,
   createAgentUIStream,
   createCompletion,
   createCompletionStream,
@@ -17,6 +18,7 @@ import {
   type StreamingCompletionModel,
   type UIMessage,
   Usage,
+  UserContent,
   uiMessagesToCoreMessages,
 } from "./helpers/imports";
 
@@ -93,6 +95,60 @@ describe("UI message adapters", () => {
     ]);
   });
 
+  it("preserves supported user data parts when converting back to core messages", () => {
+    const coreMessages = [
+      Message.user([
+        UserContent.text("describe"),
+        UserContent.imageUrl("https://example.test/image.png"),
+      ]),
+    ];
+
+    expect(uiMessagesToCoreMessages(coreMessagesToUIMessages(coreMessages))).toEqual(coreMessages);
+  });
+
+  it("rejects unsupported user UI parts instead of dropping them", () => {
+    const messages: UIMessage[] = [
+      {
+        id: "user_1",
+        role: "user",
+        parts: [{ id: "custom_1", type: "data", name: "custom", data: { value: 1 } }],
+      },
+    ];
+
+    expect(() => uiMessagesToCoreMessages(messages)).toThrow(
+      "User UI messages can only be converted from text parts",
+    );
+  });
+
+  it("preserves completed assistant tool parts as core tool results", () => {
+    const messages: UIMessage[] = [
+      {
+        id: "assistant_1",
+        role: "assistant",
+        parts: [
+          {
+            id: "tool_tool_1",
+            type: "tool",
+            toolName: "add",
+            toolCallId: "tool_1",
+            callId: "call_1",
+            state: "output-available",
+            input: { x: 2, y: 5 },
+            output: "7",
+          },
+        ],
+      },
+    ];
+
+    expect(uiMessagesToCoreMessages(messages)).toEqual([
+      Message.assistant(
+        [AssistantContent.toolCall("tool_1", "add", { x: 2, y: 5 }, "call_1")],
+        "assistant_1",
+      ),
+      Message.toolResult("tool_1", "7", { callId: "call_1" }),
+    ]);
+  });
+
   it("accepts UI messages in createCompletionStream options", async () => {
     const model = new StreamModel([
       [
@@ -150,6 +206,16 @@ describe("UI message adapters", () => {
         messages: [Message.user("Hi"), uiMessage] as never,
       }),
     ).toThrow("messages must contain only Message[] or only UIMessage[]");
+  });
+
+  it("rejects malformed single message input", () => {
+    const model = new StreamModel([]);
+
+    expect(() =>
+      createCompletionStream(model, {
+        input: { role: "user", content: "Hello" } as never,
+      }),
+    ).toThrow("input must be a string, Message, Message[], UIMessage, or UIMessage[]");
   });
 
   it("normalizes completion streams into UI stream events", async () => {

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -62,3 +62,10 @@ type EventTransport<TRequest, TEvent> = {
   send(request: TRequest, options?: TransportOptions): AsyncIterable<TEvent>;
 };
 ```
+
+Default hooks can consume raw `createCompletionStream(...)` events, raw agent stream events, or
+`UIStreamEvent` records. A completion endpoint can return:
+
+```ts
+createEventStream(createCompletionStream(model, { messages: body.messages }));
+```

--- a/packages/react/src/ui-messages.ts
+++ b/packages/react/src/ui-messages.ts
@@ -2,6 +2,8 @@ import type { JsonValue } from "@anvia/core/completion";
 import type { UIError, UIMessage, UIMessagePart, UIStreamEvent } from "@anvia/core/ui";
 import type { SendMessageInput } from "./types";
 
+type UIToolMessagePart = Extract<UIMessagePart, { type: "tool" }>;
+
 export function createUserMessage(input: SendMessageInput): UIMessage | undefined {
   if (isUIMessage(input)) {
     return input;
@@ -105,7 +107,7 @@ export function applyAnviaStreamEvent(
   }
 
   if (event.type === "tool_call_delta" && typeof event.id === "string") {
-    const part: UIMessagePart = {
+    const part: UIToolMessagePart = {
       id: toolPartId(event.id),
       type: "tool",
       toolName: typeof event.name === "string" ? event.name : "",
@@ -118,7 +120,7 @@ export function applyAnviaStreamEvent(
   }
 
   if (event.type === "tool_call" && isToolCall(event.toolCall)) {
-    const part: UIMessagePart = {
+    const part: UIToolMessagePart = {
       id: toolPartId(event.toolCall.id),
       type: "tool",
       toolName: event.toolCall.function.name,
@@ -132,24 +134,25 @@ export function applyAnviaStreamEvent(
 
   if (event.type === "tool_result") {
     const toolCallId =
-      typeof event.toolCallId === "string"
-        ? event.toolCallId
-        : typeof event.internalCallId === "string"
-          ? event.internalCallId
+      typeof event.internalCallId === "string"
+        ? event.internalCallId
+        : typeof event.toolCallId === "string"
+          ? event.toolCallId
           : undefined;
     if (toolCallId === undefined || typeof event.toolName !== "string") {
       return undefined;
     }
-    const part: UIMessagePart = {
+    const part: UIToolMessagePart = {
       id: toolPartId(toolCallId),
       type: "tool",
       toolName: event.toolName,
       toolCallId,
       ...(typeof event.toolCallId === "string" ? { callId: event.toolCallId } : {}),
       state: "output-available",
-      output: Array.isArray(event.structuredResult)
-        ? (event.structuredResult as JsonValue)
-        : valueToJson(event.result),
+      output:
+        "structuredResult" in event && event.structuredResult !== undefined
+          ? valueToJson(event.structuredResult)
+          : valueToJson(event.result),
     };
     return updateAssistantToolPart(messages, part);
   }
@@ -268,6 +271,8 @@ function updateMessagePart(
       (currentPart?.type === "reasoning" && part.type === "reasoning")
     ) {
       parts[partIndex] = { ...currentPart, text: `${currentPart.text}${part.text}` };
+    } else if (currentPart?.type === "tool" && part.type === "tool") {
+      parts[partIndex] = mergeToolPart(currentPart, part);
     } else {
       parts[partIndex] = part;
     }
@@ -275,10 +280,37 @@ function updateMessagePart(
   });
 }
 
-function updateAssistantToolPart(messages: UIMessage[], part: UIMessagePart): UIMessage[] {
+function updateAssistantToolPart(messages: UIMessage[], part: UIToolMessagePart): UIMessage[] {
   const current = ensureAssistantMessage(messages);
   const assistant = current[current.length - 1];
   return assistant === undefined ? current : updateMessagePart(current, assistant.id, part);
+}
+
+function mergeToolPart(
+  currentPart: UIToolMessagePart,
+  nextPart: UIToolMessagePart,
+): UIToolMessagePart {
+  const merged: UIToolMessagePart = { ...currentPart, ...nextPart };
+
+  if (nextPart.toolName.length === 0) {
+    merged.toolName = currentPart.toolName;
+  }
+  if (nextPart.callId === undefined && currentPart.callId !== undefined) {
+    merged.callId = currentPart.callId;
+  }
+  if (nextPart.input === undefined && currentPart.input !== undefined) {
+    merged.input = currentPart.input;
+  } else if (typeof currentPart.input === "string" && typeof nextPart.input === "string") {
+    merged.input = `${currentPart.input}${nextPart.input}`;
+  }
+  if (nextPart.output === undefined && currentPart.output !== undefined) {
+    merged.output = currentPart.output;
+  }
+  if (nextPart.error === undefined && currentPart.error !== undefined) {
+    merged.error = currentPart.error;
+  }
+
+  return merged;
 }
 
 function appendAssistantError(messages: UIMessage[], error: UIError): UIMessage[] {

--- a/packages/react/src/ui-messages.ts
+++ b/packages/react/src/ui-messages.ts
@@ -1,4 +1,5 @@
-import type { UIMessage, UIMessagePart, UIStreamEvent } from "@anvia/core/ui";
+import type { JsonValue } from "@anvia/core/completion";
+import type { UIError, UIMessage, UIMessagePart, UIStreamEvent } from "@anvia/core/ui";
 import type { SendMessageInput } from "./types";
 
 export function createUserMessage(input: SendMessageInput): UIMessage | undefined {
@@ -78,6 +79,109 @@ export function applyUIStreamEvent(messages: UIMessage[], event: UIStreamEvent):
   return messages;
 }
 
+export function applyAnviaStreamEvent(
+  messages: UIMessage[],
+  event: unknown,
+): UIMessage[] | undefined {
+  const uiEvent = asUIStreamEvent(event);
+  if (uiEvent !== undefined) {
+    return applyUIStreamEvent(messages, uiEvent);
+  }
+
+  if (!isRecord(event) || typeof event.type !== "string") {
+    return undefined;
+  }
+
+  if (event.type === "text_delta" && typeof event.delta === "string") {
+    return appendAssistantDelta(messages, event.delta);
+  }
+
+  if (event.type === "reasoning_delta" && typeof event.delta === "string") {
+    return appendAssistantReasoningDelta(
+      messages,
+      event.delta,
+      typeof event.id === "string" ? event.id : undefined,
+    );
+  }
+
+  if (event.type === "tool_call_delta" && typeof event.id === "string") {
+    const part: UIMessagePart = {
+      id: toolPartId(event.id),
+      type: "tool",
+      toolName: typeof event.name === "string" ? event.name : "",
+      toolCallId: event.id,
+      ...(typeof event.callId === "string" ? { callId: event.callId } : {}),
+      state: "input-streaming",
+      ...(typeof event.argumentsDelta === "string" ? { input: event.argumentsDelta } : {}),
+    };
+    return updateAssistantToolPart(messages, part);
+  }
+
+  if (event.type === "tool_call" && isToolCall(event.toolCall)) {
+    const part: UIMessagePart = {
+      id: toolPartId(event.toolCall.id),
+      type: "tool",
+      toolName: event.toolCall.function.name,
+      toolCallId: event.toolCall.id,
+      ...(typeof event.toolCall.callId === "string" ? { callId: event.toolCall.callId } : {}),
+      state: "input-available",
+      input: event.toolCall.function.arguments,
+    };
+    return updateAssistantToolPart(messages, part);
+  }
+
+  if (event.type === "tool_result") {
+    const toolCallId =
+      typeof event.toolCallId === "string"
+        ? event.toolCallId
+        : typeof event.internalCallId === "string"
+          ? event.internalCallId
+          : undefined;
+    if (toolCallId === undefined || typeof event.toolName !== "string") {
+      return undefined;
+    }
+    const part: UIMessagePart = {
+      id: toolPartId(toolCallId),
+      type: "tool",
+      toolName: event.toolName,
+      toolCallId,
+      ...(typeof event.toolCallId === "string" ? { callId: event.toolCallId } : {}),
+      state: "output-available",
+      output: Array.isArray(event.structuredResult)
+        ? (event.structuredResult as JsonValue)
+        : valueToJson(event.result),
+    };
+    return updateAssistantToolPart(messages, part);
+  }
+
+  if (event.type === "message_id" && typeof event.id === "string") {
+    return setLastAssistantMetadata(messages, { providerMessageId: event.id });
+  }
+
+  if (event.type === "final") {
+    if (isRecord(event.response) && Array.isArray(event.response.choice)) {
+      const next = replaceAssistantText(messages, textFromAssistantContent(event.response.choice));
+      const providerMessageId = event.response.messageId;
+      return typeof providerMessageId === "string"
+        ? setLastAssistantMetadata(next, { providerMessageId })
+        : next;
+    }
+
+    if (typeof event.output === "string") {
+      const next = replaceAssistantText(messages, event.output);
+      return typeof event.runId === "string"
+        ? setLastAssistantMetadata(next, { runId: event.runId })
+        : next;
+    }
+  }
+
+  if (event.type === "error" && "error" in event) {
+    return appendAssistantError(messages, errorFromUnknown(event.error));
+  }
+
+  return undefined;
+}
+
 export function assistantText(messages: UIMessage[]): string {
   const assistant = [...messages].reverse().find((message) => message.role === "assistant");
   if (assistant === undefined) {
@@ -103,6 +207,28 @@ export function appendAssistantDelta(messages: UIMessage[], delta: string): UIMe
   });
 }
 
+export function appendAssistantReasoningDelta(
+  messages: UIMessage[],
+  delta: string,
+  reasoningId?: string,
+): UIMessage[] {
+  const current = ensureAssistantMessage(messages);
+  const assistant = current[current.length - 1];
+  if (assistant === undefined) {
+    return current;
+  }
+  const partId =
+    reasoningId === undefined
+      ? `${assistant.id}_reasoning`
+      : `${assistant.id}_reasoning_${reasoningId}`;
+  return updateMessagePart(current, assistant.id, {
+    id: partId,
+    type: "reasoning",
+    text: delta,
+    ...(reasoningId === undefined ? {} : { reasoningId }),
+  });
+}
+
 export function replaceAssistantText(messages: UIMessage[], text: string): UIMessage[] {
   const current = ensureAssistantMessage(messages);
   const assistant = current[current.length - 1];
@@ -110,12 +236,7 @@ export function replaceAssistantText(messages: UIMessage[], text: string): UIMes
     return current;
   }
   return current.map((message) =>
-    message.id === assistant.id
-      ? {
-          ...message,
-          parts: [{ id: `${assistant.id}_text`, type: "text", text }],
-        }
-      : message,
+    message.id === assistant.id ? { ...message, parts: replaceTextPart(message, text) } : message,
   );
 }
 
@@ -154,6 +275,50 @@ function updateMessagePart(
   });
 }
 
+function updateAssistantToolPart(messages: UIMessage[], part: UIMessagePart): UIMessage[] {
+  const current = ensureAssistantMessage(messages);
+  const assistant = current[current.length - 1];
+  return assistant === undefined ? current : updateMessagePart(current, assistant.id, part);
+}
+
+function appendAssistantError(messages: UIMessage[], error: UIError): UIMessage[] {
+  const messageId = createId("msg");
+  return [
+    ...messages,
+    {
+      id: messageId,
+      role: "assistant",
+      parts: [{ id: createId("part"), type: "error", error }],
+    },
+  ];
+}
+
+function setLastAssistantMetadata(messages: UIMessage[], metadata: JsonValue): UIMessage[] {
+  const current = ensureAssistantMessage(messages);
+  const assistant = current[current.length - 1];
+  if (assistant === undefined) {
+    return current;
+  }
+  return current.map((message) =>
+    message.id === assistant.id
+      ? { ...message, metadata: mergeMetadata(message.metadata, metadata) }
+      : message,
+  );
+}
+
+function replaceTextPart(message: UIMessage, text: string): UIMessagePart[] {
+  const index = message.parts.findIndex((part) => part.type === "text");
+  if (index === -1) {
+    return [...message.parts, { id: `${message.id}_text`, type: "text", text }];
+  }
+  const parts = [...message.parts];
+  const current = parts[index];
+  if (current?.type === "text") {
+    parts[index] = { ...current, text };
+  }
+  return parts;
+}
+
 function ensureAssistantMessage(messages: UIMessage[]): UIMessage[] {
   const last = messages.at(-1);
   if (last?.role === "assistant") {
@@ -183,4 +348,125 @@ function createId(prefix: string): string {
 
 function isUIMessage(input: SendMessageInput): input is UIMessage {
   return typeof input !== "string" && "role" in input && Array.isArray(input.parts);
+}
+
+function asUIStreamEvent(event: unknown): UIStreamEvent | undefined {
+  if (!isRecord(event) || typeof event.type !== "string") {
+    return undefined;
+  }
+
+  if (event.type === "message_start" && isStreamMessage(event.message)) {
+    return event as UIStreamEvent;
+  }
+  if (
+    (event.type === "text_delta" || event.type === "reasoning_delta") &&
+    typeof event.messageId === "string" &&
+    typeof event.partId === "string" &&
+    typeof event.delta === "string"
+  ) {
+    return event as UIStreamEvent;
+  }
+  if (
+    event.type === "tool_update" &&
+    typeof event.messageId === "string" &&
+    typeof event.partId === "string" &&
+    isUIMessagePart(event.part)
+  ) {
+    return event as UIStreamEvent;
+  }
+  if (event.type === "message_end" && typeof event.messageId === "string") {
+    return event as UIStreamEvent;
+  }
+  if (event.type === "error" && isUIError(event.error)) {
+    return event as UIStreamEvent;
+  }
+  return undefined;
+}
+
+function isStreamMessage(value: unknown): value is UIMessage {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.role === "string" &&
+    Array.isArray(value.parts)
+  );
+}
+
+function isUIMessagePart(value: unknown): value is UIMessagePart {
+  return isRecord(value) && typeof value.id === "string" && typeof value.type === "string";
+}
+
+function isUIError(value: unknown): value is UIError {
+  return isRecord(value) && typeof value.message === "string";
+}
+
+function isToolCall(value: unknown): value is {
+  id: string;
+  callId?: string;
+  function: { name: string; arguments: JsonValue };
+} {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    isRecord(value.function) &&
+    typeof value.function.name === "string" &&
+    "arguments" in value.function
+  );
+}
+
+function textFromAssistantContent(content: unknown[]): string {
+  return content
+    .flatMap((item) =>
+      isRecord(item) && item.type === "text" && typeof item.text === "string" ? [item.text] : [],
+    )
+    .join("\n");
+}
+
+function errorFromUnknown(error: unknown): UIError {
+  if (error instanceof Error) {
+    return { name: error.name, message: error.message };
+  }
+  return { message: typeof error === "string" ? error : stringifyUnknown(error) };
+}
+
+function stringifyUnknown(value: unknown): string {
+  try {
+    const serialized = JSON.stringify(value);
+    return serialized === undefined ? String(value) : serialized;
+  } catch {
+    return String(value);
+  }
+}
+
+function valueToJson(value: unknown): JsonValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    Array.isArray(value) ||
+    isRecord(value)
+  ) {
+    return value as JsonValue;
+  }
+  return stringifyUnknown(value);
+}
+
+function mergeMetadata(current: UIMessage["metadata"], next: JsonValue): JsonValue {
+  if (isJsonObject(current) && isJsonObject(next)) {
+    return { ...current, ...next };
+  }
+  return next;
+}
+
+function isJsonObject(value: unknown): value is Record<string, JsonValue | undefined> {
+  return isRecord(value) && !Array.isArray(value);
+}
+
+function toolPartId(toolCallId: string): string {
+  return `tool_${toolCallId}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -5,6 +5,7 @@ import { createChatTransport } from "./transport";
 import type { EventTransport, SendMessageInput, UseChatOptions, UseChatResult } from "./types";
 import {
   appendAssistantDelta,
+  applyAnviaStreamEvent,
   applyUIStreamEvent,
   assistantText,
   createUserMessage,
@@ -55,14 +56,25 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
 
   const applyEvent = useCallback(
     (event: TEvent) => {
-      const uiEvent =
-        options.eventToUIEvent === undefined
-          ? eventAsUIStreamEvent(event)
-          : options.eventToUIEvent(event);
-
-      if (uiEvent !== undefined) {
-        setMessages((current) => applyUIStreamEvent(current, uiEvent));
+      const mappedUIEvent = options.eventToUIEvent?.(event);
+      if (mappedUIEvent !== undefined) {
+        setMessages((current) => applyUIStreamEvent(current, mappedUIEvent));
         return;
+      }
+
+      if (options.eventToUIEvent === undefined) {
+        let handled = false;
+        setMessages((current) => {
+          const next = applyAnviaStreamEvent(current, event);
+          if (next === undefined) {
+            return current;
+          }
+          handled = true;
+          return next;
+        });
+        if (handled) {
+          return;
+        }
       }
 
       const delta = options.eventToDelta?.(event);
@@ -186,23 +198,6 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
   };
 }
 
-function eventAsUIStreamEvent(event: unknown): UIStreamEvent | undefined {
-  if (!isRecord(event) || typeof event.type !== "string") {
-    return undefined;
-  }
-  if (
-    event.type === "message_start" ||
-    event.type === "text_delta" ||
-    event.type === "reasoning_delta" ||
-    event.type === "tool_update" ||
-    event.type === "message_end" ||
-    event.type === "error"
-  ) {
-    return event as UIStreamEvent;
-  }
-  return undefined;
-}
-
 function findLastUserIndex(messages: UIStreamRequest["messages"]): number {
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     if (messages[index]?.role === "user") {
@@ -214,8 +209,4 @@ function findLastUserIndex(messages: UIStreamRequest["messages"]): number {
 
 function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === "AbortError";
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
 }

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -62,7 +62,12 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
         return;
       }
 
-      if (options.eventToUIEvent === undefined) {
+      const hasCustomEventMapper =
+        options.eventToUIEvent !== undefined ||
+        options.eventToDelta !== undefined ||
+        options.eventToFinal !== undefined;
+
+      if (!hasCustomEventMapper) {
         let handled = false;
         setMessages((current) => {
           const next = applyAnviaStreamEvent(current, event);

--- a/packages/react/src/use-completion.ts
+++ b/packages/react/src/use-completion.ts
@@ -113,7 +113,12 @@ export function useCompletion<TRequest = UIStreamRequest, TEvent = UIStreamEvent
         return;
       }
 
-      if (options.eventToUIEvent === undefined) {
+      const hasCustomEventMapper =
+        options.eventToUIEvent !== undefined ||
+        options.eventToDelta !== undefined ||
+        options.eventToFinal !== undefined;
+
+      if (!hasCustomEventMapper) {
         let handled = false;
         setMessagesState((current) => {
           const next = applyAnviaStreamEvent(current, event);

--- a/packages/react/src/use-completion.ts
+++ b/packages/react/src/use-completion.ts
@@ -5,6 +5,7 @@ import { createFetchTransport } from "./transport";
 import type { EventStreamFormat, EventTransport } from "./types";
 import {
   appendAssistantDelta,
+  applyAnviaStreamEvent,
   applyUIStreamEvent,
   assistantText,
   createUserMessage,
@@ -102,18 +103,30 @@ export function useCompletion<TRequest = UIStreamRequest, TEvent = UIStreamEvent
 
   const applyEvent = useCallback(
     (event: TEvent) => {
-      const uiEvent =
-        options.eventToUIEvent === undefined
-          ? eventAsUIStreamEvent(event)
-          : options.eventToUIEvent(event);
-
-      if (uiEvent !== undefined) {
+      const mappedUIEvent = options.eventToUIEvent?.(event);
+      if (mappedUIEvent !== undefined) {
         setMessagesState((current) => {
-          const next = applyUIStreamEvent(current, uiEvent);
+          const next = applyUIStreamEvent(current, mappedUIEvent);
           messagesRef.current = next;
           return next;
         });
         return;
+      }
+
+      if (options.eventToUIEvent === undefined) {
+        let handled = false;
+        setMessagesState((current) => {
+          const next = applyAnviaStreamEvent(current, event);
+          if (next === undefined) {
+            return current;
+          }
+          handled = true;
+          messagesRef.current = next;
+          return next;
+        });
+        if (handled) {
+          return;
+        }
       }
 
       const delta = options.eventToDelta?.(event);
@@ -239,27 +252,6 @@ export function useCompletion<TRequest = UIStreamRequest, TEvent = UIStreamEvent
   };
 }
 
-function eventAsUIStreamEvent(event: unknown): UIStreamEvent | undefined {
-  if (!isRecord(event) || typeof event.type !== "string") {
-    return undefined;
-  }
-  if (
-    event.type === "message_start" ||
-    event.type === "text_delta" ||
-    event.type === "reasoning_delta" ||
-    event.type === "tool_update" ||
-    event.type === "message_end" ||
-    event.type === "error"
-  ) {
-    return event as UIStreamEvent;
-  }
-  return undefined;
-}
-
 function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === "AbortError";
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
 }

--- a/packages/react/test/transport.test.ts
+++ b/packages/react/test/transport.test.ts
@@ -1,3 +1,5 @@
+import type { AgentStreamEvent } from "@anvia/core/agent";
+import { AssistantContent, type CompletionStreamEvent, Usage } from "@anvia/core/completion";
 import type { UIStreamEvent, UIStreamRequest } from "@anvia/core/ui";
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -158,8 +160,8 @@ describe("@anvia/react useChat", () => {
         new Response(
           streamFrom(
             `${[
-              '{"type":"message_start","message":{"id":"assistant_1","role":"assistant","parts":[]}}',
-              '{"type":"text_delta","messageId":"assistant_1","partId":"assistant_1_text","delta":"hi"}',
+              '{"type":"text_delta","delta":"hi"}',
+              '{"type":"final","response":{"choice":[{"type":"text","text":"hi"}],"usage":{"inputTokens":0,"outputTokens":0,"totalTokens":0,"cachedInputTokens":0,"cacheCreationInputTokens":0},"rawResponse":{}}}',
             ].join("\n")}\n`,
           ),
           { headers: { "content-type": "application/x-ndjson" } },
@@ -178,6 +180,93 @@ describe("@anvia/react useChat", () => {
       stream: true,
     });
     expect(result.current.text).toBe("hi");
+  });
+
+  it("applies raw completion stream events", async () => {
+    const transport: EventTransport<UIStreamRequest, CompletionStreamEvent> = {
+      send: async function* () {
+        yield { type: "text_delta", delta: "Hel" };
+        yield { type: "text_delta", delta: "lo" };
+        yield {
+          type: "final",
+          response: {
+            choice: [AssistantContent.text("Hello")],
+            usage: Usage.empty(),
+            rawResponse: {},
+            messageId: "provider_1",
+          },
+        };
+      },
+    };
+    const { result } = renderHook(() => useChat({ transport }));
+
+    await act(async () => {
+      await result.current.send("hi");
+    });
+
+    expect(result.current.text).toBe("Hello");
+    expect(result.current.messages).toMatchObject([
+      { role: "user", parts: [{ type: "text", text: "hi" }] },
+      {
+        role: "assistant",
+        parts: [{ type: "text", text: "Hello" }],
+        metadata: { providerMessageId: "provider_1" },
+      },
+    ]);
+  });
+
+  it("applies raw agent stream events", async () => {
+    const transport: EventTransport<UIStreamRequest, AgentStreamEvent> = {
+      send: async function* () {
+        yield {
+          type: "tool_call",
+          turn: 1,
+          toolCall: AssistantContent.toolCall("tool_1", "add", { x: 2, y: 5 }, "call_1"),
+        };
+        yield {
+          type: "tool_result",
+          turn: 1,
+          toolName: "add",
+          toolCallId: "call_1",
+          internalCallId: "tool_1",
+          args: '{"x":2,"y":5}',
+          result: "7",
+        };
+        yield { type: "text_delta", turn: 1, delta: "7" };
+        yield {
+          type: "final",
+          runId: "run_1",
+          output: "7",
+          usage: Usage.empty(),
+          messages: [],
+        };
+      },
+    };
+    const { result } = renderHook(() => useChat({ transport }));
+
+    await act(async () => {
+      await result.current.send("add");
+    });
+
+    expect(result.current.text).toBe("7");
+    expect(result.current.messages).toMatchObject([
+      { role: "user", parts: [{ type: "text", text: "add" }] },
+      {
+        role: "assistant",
+        metadata: { runId: "run_1" },
+      },
+    ]);
+    expect(result.current.messages[1]?.parts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "tool",
+          toolName: "add",
+          state: "output-available",
+          output: "7",
+        }),
+        expect.objectContaining({ type: "text", text: "7" }),
+      ]),
+    );
   });
 
   it("supports custom event mapping for non-UI streams", async () => {

--- a/packages/react/test/transport.test.ts
+++ b/packages/react/test/transport.test.ts
@@ -215,6 +215,39 @@ describe("@anvia/react useChat", () => {
     ]);
   });
 
+  it("merges raw completion tool call deltas", async () => {
+    const transport: EventTransport<UIStreamRequest, CompletionStreamEvent> = {
+      send: async function* () {
+        yield {
+          type: "tool_call_delta",
+          id: "tool_1",
+          name: "lookup",
+          argumentsDelta: '{"query"',
+        };
+        yield {
+          type: "tool_call_delta",
+          id: "tool_1",
+          argumentsDelta: ':"Anvia"}',
+        };
+      },
+    };
+    const { result } = renderHook(() => useChat({ transport }));
+
+    await act(async () => {
+      await result.current.send("lookup");
+    });
+
+    expect(result.current.messages[1]?.parts).toEqual([
+      expect.objectContaining({
+        type: "tool",
+        toolName: "lookup",
+        toolCallId: "tool_1",
+        state: "input-streaming",
+        input: '{"query":"Anvia"}',
+      }),
+    ]);
+  });
+
   it("applies raw agent stream events", async () => {
     const transport: EventTransport<UIStreamRequest, AgentStreamEvent> = {
       send: async function* () {
@@ -231,7 +264,8 @@ describe("@anvia/react useChat", () => {
           internalCallId: "tool_1",
           args: '{"x":2,"y":5}',
           result: "7",
-        };
+          structuredResult: { value: 7 },
+        } as unknown as AgentStreamEvent;
         yield { type: "text_delta", turn: 1, delta: "7" };
         yield {
           type: "final",
@@ -256,16 +290,20 @@ describe("@anvia/react useChat", () => {
         metadata: { runId: "run_1" },
       },
     ]);
+    const toolParts = result.current.messages[1]?.parts.filter((part) => part.type === "tool");
+    expect(toolParts).toEqual([
+      expect.objectContaining({
+        type: "tool",
+        toolName: "add",
+        toolCallId: "tool_1",
+        callId: "call_1",
+        state: "output-available",
+        input: { x: 2, y: 5 },
+        output: { value: 7 },
+      }),
+    ]);
     expect(result.current.messages[1]?.parts).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          type: "tool",
-          toolName: "add",
-          state: "output-available",
-          output: "7",
-        }),
-        expect.objectContaining({ type: "text", text: "7" }),
-      ]),
+      expect.arrayContaining([expect.objectContaining({ type: "text", text: "7" })]),
     );
   });
 
@@ -287,6 +325,26 @@ describe("@anvia/react useChat", () => {
     });
 
     expect(result.current.text).toBe("ok");
+  });
+
+  it("lets custom delta mapping override raw Anvia event names", async () => {
+    const transport: EventTransport<UIStreamRequest, { type: "text_delta"; delta: string }> = {
+      send: async function* () {
+        yield { type: "text_delta", delta: "raw" };
+      },
+    };
+    const { result } = renderHook(() =>
+      useChat({
+        transport,
+        eventToDelta: (event) => (event.type === "text_delta" ? "custom" : undefined),
+      }),
+    );
+
+    await act(async () => {
+      await result.current.send("hi");
+    });
+
+    expect(result.current.text).toBe("custom");
   });
 
   it("aborts active streams when stopped", async () => {

--- a/packages/react/test/use-completion.test.ts
+++ b/packages/react/test/use-completion.test.ts
@@ -111,6 +111,27 @@ describe("@anvia/react useCompletion", () => {
     expect(result.current.completion).toBe("one two");
   });
 
+  it("lets custom delta mapping override raw Anvia event names", async () => {
+    const transport: EventTransport<UIStreamRequest, { type: "text_delta"; delta: string }> = {
+      send: async function* () {
+        yield { type: "text_delta", delta: "raw" };
+      },
+    };
+
+    const { result } = renderHook(() =>
+      useCompletion({
+        transport,
+        eventToDelta: (event) => (event.type === "text_delta" ? "custom" : undefined),
+      }),
+    );
+
+    await act(async () => {
+      await result.current.complete("hi");
+    });
+
+    expect(result.current.completion).toBe("custom");
+  });
+
   it("does not send empty input", async () => {
     const transport: EventTransport<UIStreamRequest, UIStreamEvent> = {
       send: vi.fn(async function* (): AsyncIterable<UIStreamEvent> {

--- a/packages/react/test/use-completion.test.ts
+++ b/packages/react/test/use-completion.test.ts
@@ -1,3 +1,4 @@
+import { AssistantContent, type CompletionStreamEvent, Usage } from "@anvia/core/completion";
 import type { UIStreamEvent, UIStreamRequest } from "@anvia/core/ui";
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -13,29 +14,29 @@ afterEach(() => {
 describe("@anvia/react useCompletion", () => {
   it("streams into UI messages and derives completion text", async () => {
     const onEvent = vi.fn();
-    const transport: EventTransport<UIStreamRequest, UIStreamEvent> = {
+    const transport: EventTransport<UIStreamRequest, CompletionStreamEvent> = {
       send: async function* (request) {
         expect(request.messages).toMatchObject([
           { role: "user", parts: [{ type: "text", text: "hello" }] },
         ]);
         expect(request.stream).toBe(true);
-        yield {
-          type: "message_start",
-          message: { id: "assistant_1", role: "assistant", parts: [] },
-        };
+        yield { type: "message_id", id: "provider_1" };
         yield {
           type: "text_delta",
-          messageId: "assistant_1",
-          partId: "assistant_1_text",
           delta: "Hel",
         };
         yield {
           type: "text_delta",
-          messageId: "assistant_1",
-          partId: "assistant_1_text",
           delta: "lo",
         };
-        yield { type: "message_end", messageId: "assistant_1" };
+        yield {
+          type: "final",
+          response: {
+            choice: [AssistantContent.text("Hello")],
+            usage: Usage.empty(),
+            rawResponse: {},
+          },
+        };
       },
     };
 
@@ -50,7 +51,11 @@ describe("@anvia/react useCompletion", () => {
     expect(result.current.completion).toBe("Hello");
     expect(result.current.messages).toMatchObject([
       { role: "user", parts: [{ type: "text", text: "hello" }] },
-      { id: "assistant_1", role: "assistant", parts: [{ type: "text", text: "Hello" }] },
+      {
+        role: "assistant",
+        parts: [{ type: "text", text: "Hello" }],
+        metadata: { providerMessageId: "provider_1" },
+      },
     ]);
     expect(onEvent).toHaveBeenCalledTimes(4);
   });
@@ -61,8 +66,8 @@ describe("@anvia/react useCompletion", () => {
         new Response(
           streamFrom(
             `${[
-              '{"type":"message_start","message":{"id":"assistant_1","role":"assistant","parts":[]}}',
-              '{"type":"text_delta","messageId":"assistant_1","partId":"assistant_1_text","delta":"hi"}',
+              '{"type":"text_delta","delta":"hi"}',
+              '{"type":"final","response":{"choice":[{"type":"text","text":"hi"}],"usage":{"inputTokens":0,"outputTokens":0,"totalTokens":0,"cachedInputTokens":0,"cacheCreationInputTokens":0},"rawResponse":{}}}',
             ].join("\n")}\n`,
           ),
         ),


### PR DESCRIPTION
## Summary
- allow `createCompletion()` and `createCompletionStream()` to accept React `UIMessage` input directly
- let `useChat` and `useCompletion` consume raw completion streams, raw agent streams, or `UIStreamEvent` records by default
- keep `createCompletionUIStream()` / `createAgentUIStream()` as advanced UI event adapters and update docs/tests

## Validation
- `pnpm exec biome check --write packages/core/src/ui/index.ts packages/core/src/completion/create-completion.ts packages/core/src/ui/messages.ts packages/core/src/ui/types.ts packages/react/src/ui-messages.ts packages/react/src/use-chat.ts packages/react/src/use-completion.ts packages/core/test/ui-stream.test.ts packages/react/test/transport.test.ts packages/react/test/use-completion.test.ts`
- `pnpm --filter @anvia/core typecheck`
- `pnpm --filter @anvia/react typecheck`
- `pnpm exec changeset status --since=main`
- `pnpm --filter @anvia/core test`
- `pnpm --filter @anvia/react test`
- `pnpm --filter @anvia/core build`
- `pnpm --filter @anvia/react build`
- `pnpm --filter www reference-check`
- `pnpm --filter www build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat and completion helpers now accept UI messages directly; React hooks can consume raw completion/agent/UI stream events without a separate UI adapter.
  * Streaming updates now include richer assistant reasoning, tool activity, and provider identifiers.
* **Documentation**
  * Updated React and core guides with revised request/response and streaming shapes, plus updated examples.
* **Bug Fixes**
  * Improved validation for mixed message formats and refined `tool_update` typing.
  * Tool result events now associate using the correct call id.
* **Tests**
  * Expanded streaming and UI message round-trip coverage for the updated event protocol.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->