### PR TITLE
Preserve streamed text on empty completion finals

### DIFF
--- a/packages/react/src/ui-messages.ts
+++ b/packages/react/src/ui-messages.ts
@@ -163,7 +163,8 @@ export function applyAnviaStreamEvent(
 
   if (event.type === "final") {
     if (isRecord(event.response) && Array.isArray(event.response.choice)) {
-      const next = replaceAssistantText(messages, textFromAssistantContent(event.response.choice));
+      const finalText = textFromAssistantContent(event.response.choice);
+      const next = finalText.length > 0 ? replaceAssistantText(messages, finalText) : messages;
       const providerMessageId = event.response.messageId;
       return typeof providerMessageId === "string"
         ? setLastAssistantMetadata(next, { providerMessageId })
@@ -171,7 +172,8 @@ export function applyAnviaStreamEvent(
     }
 
     if (typeof event.output === "string") {
-      const next = replaceAssistantText(messages, event.output);
+      const next =
+        event.output.length > 0 ? replaceAssistantText(messages, event.output) : messages;
       return typeof event.runId === "string"
         ? setLastAssistantMetadata(next, { runId: event.runId })
         : next;

--- a/packages/react/test/use-completion.test.ts
+++ b/packages/react/test/use-completion.test.ts
@@ -89,6 +89,72 @@ describe("@anvia/react useCompletion", () => {
     expect(result.current.completion).toBe("hi");
   });
 
+  it("keeps streamed text when the raw completion final choice is empty", async () => {
+    const transport: EventTransport<UIStreamRequest, CompletionStreamEvent> = {
+      send: async function* () {
+        yield { type: "text_delta", delta: "Hai" };
+        yield {
+          type: "final",
+          response: {
+            choice: [],
+            usage: Usage.empty(),
+            rawResponse: {},
+            messageId: "provider_1",
+          },
+        };
+      },
+    };
+
+    const { result } = renderHook(() => useCompletion({ transport }));
+
+    await act(async () => {
+      await result.current.complete("hey");
+    });
+
+    expect(result.current.completion).toBe("Hai");
+    expect(result.current.messages).toMatchObject([
+      { role: "user", parts: [{ type: "text", text: "hey" }] },
+      {
+        role: "assistant",
+        parts: [{ type: "text", text: "Hai" }],
+        metadata: { providerMessageId: "provider_1" },
+      },
+    ]);
+  });
+
+  it("does not add empty text for reasoning-only raw completion finals", async () => {
+    const transport: EventTransport<UIStreamRequest, CompletionStreamEvent> = {
+      send: async function* () {
+        yield { type: "reasoning_delta", delta: "Think first." };
+        yield {
+          type: "final",
+          response: {
+            choice: [],
+            usage: Usage.empty(),
+            rawResponse: {},
+            messageId: "provider_1",
+          },
+        };
+      },
+    };
+
+    const { result } = renderHook(() => useCompletion({ transport }));
+
+    await act(async () => {
+      await result.current.complete("hey");
+    });
+
+    expect(result.current.completion).toBe("");
+    expect(result.current.messages).toMatchObject([
+      { role: "user", parts: [{ type: "text", text: "hey" }] },
+      {
+        role: "assistant",
+        parts: [{ type: "reasoning", text: "Think first." }],
+        metadata: { providerMessageId: "provider_1" },
+      },
+    ]);
+  });
+
   it("supports custom event mapping for non-UI streams", async () => {
     const transport: EventTransport<UIStreamRequest, { type: string; delta?: string }> = {
       send: async function* () {


### PR DESCRIPTION
## Summary
- avoid replacing assistant text when a raw completion final event has an empty `response.choice`
- avoid adding empty text parts for reasoning-only completion streams
- add regression coverage for OpenAI-compatible usage-final chunks that carry metadata but no final text choice

## Context
The fullstack sample at `/Volumes/indrazm/anvia_hq/rnd/fullstack` streams raw `createCompletionStream` events from `@anvia/openai`. For chat-completions streams, the provider usage chunk is mapped to `{ type: "final", response: { choice: [] } }`. The React reducer was treating that empty final as authoritative and writing `text: ""` after reasoning/text deltas.

## Validation
- `pnpm exec biome check --write packages/react/src/ui-messages.ts packages/react/test/use-completion.test.ts`
- `pnpm --filter @anvia/react test`
- `pnpm --filter @anvia/react typecheck`
- `pnpm --filter @anvia/react build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of final streamed responses so empty final output no longer overwrites previously shown assistant text.
  * Preserved completed message content when the last server response is empty.
  * Prevented empty text segments from being appended when only prior reasoning content is present.

* **Tests**
  * Added coverage for empty final responses and reasoning-only completions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->