### PR TITLE
Send core messages from React hooks

### DIFF
--- a/.changeset/react-core-message-requests.md
+++ b/.changeset/react-core-message-requests.md
@@ -1,5 +1,5 @@
 ---
-"@anvia/core": patch
+"@anvia/core": minor
 "@anvia/react": patch
 ---
 

--- a/.changeset/react-core-message-requests.md
+++ b/.changeset/react-core-message-requests.md
@@ -1,0 +1,6 @@
+---
+"@anvia/core": patch
+"@anvia/react": patch
+---
+
+Send converted core messages from React hooks and keep completion helpers limited to core `Message` input.

--- a/apps/www/src/content/docs/basics/react-client.md
+++ b/apps/www/src/content/docs/basics/react-client.md
@@ -61,13 +61,13 @@ export function Chat() {
 
 ```ts
 type UIStreamRequest = {
-  messages: UIMessage[];
+  messages: Message[];
   stream: true;
   metadata?: JsonValue;
 };
 ```
 
-It reads JSONL by default and updates message state from raw completion streams, raw agent streams, or UI stream events.
+It converts local `UIMessage[]` state to core `Message[]` before sending, reads JSONL by default, and updates UI message state from raw completion streams, raw agent streams, or UI stream events.
 
 Use `createRequest` or a custom transport when your server expects a different request shape or event mapping.
 

--- a/apps/www/src/content/docs/packages/core/reference/completion.md
+++ b/apps/www/src/content/docs/packages/core/reference/completion.md
@@ -281,11 +281,11 @@ Notable errors: throws `CompletionCapabilityError` for unsupported tools, tool c
 ## Direct Completion Helpers
 
 ```ts
-type CreateCompletionInput = string | Message | Message[] | UIMessage | UIMessage[];
+type CreateCompletionInput = string | Message | Message[];
 
 type CreateCompletionBaseOptions = {
   input?: CreateCompletionInput;
-  messages?: Message[] | UIMessage[];
+  messages?: Message[];
   instructions?: string;
   documents?: Document[];
   tools?: ToolDefinition[];
@@ -337,9 +337,9 @@ Return behavior: `createCompletion(...)` always returns a promise for the final 
 
 `createParsedCompletion(...)` converts `schema` to `outputSchema`, calls the model once, parses the assistant text as JSON, validates it with the same schema, and returns `data` plus the normal completion result fields.
 
-`messages` supplies an existing transcript. It can be core `Message[]` or React-facing `UIMessage[]`. `input` accepts a string, one message, or multiple messages and is appended after `messages`. At least one of `input` or `messages` is required.
+`messages` supplies an existing core message transcript. `input` accepts a string, one message, or multiple messages and is appended after `messages`. At least one of `input` or `messages` is required.
 
-`UIMessage[]` is normalized internally, so endpoints used by `@anvia/react` can pass `body.messages` directly to `createCompletion(...)`, `createCompletionStream(...)`, or `createParsedCompletion(...)`.
+`@anvia/react` hooks convert UI message state into core messages before sending requests, so endpoints can pass `body.messages` directly to `createCompletion(...)`, `createCompletionStream(...)`, or `createParsedCompletion(...)`.
 
 `params` maps to `CompletionRequest.additionalParams` for provider-specific options.
 

--- a/apps/www/src/content/docs/packages/core/reference/ui.md
+++ b/apps/www/src/content/docs/packages/core/reference/ui.md
@@ -44,7 +44,7 @@ type UIMessagePart =
   | { id: string; type: "error"; error: UIError };
 
 type UIStreamRequest = {
-  messages: UIMessage[];
+  messages: Message[];
   stream: true;
   metadata?: JsonValue;
 };
@@ -80,7 +80,7 @@ type CreateAgentUIStreamOptions = {
 };
 ```
 
-Purpose: shared UI message shape for React-facing completion and chat state. The request always carries `messages`. React hooks can consume raw completion streams, raw agent streams, or `UIStreamEvent` records.
+Purpose: shared UI message shape for React-facing completion and chat state. The default request carries converted core `messages`. React hooks can consume raw completion streams, raw agent streams, or `UIStreamEvent` records.
 
 ## uiMessagesToCoreMessages
 
@@ -98,7 +98,7 @@ Return behavior: text, reasoning, tool call, and tool output parts are mapped in
 function coreMessagesToUIMessages(messages: Message[]): UIMessage[];
 ```
 
-Purpose: convert existing core message history into the UI message shape used by React hooks and UI stream requests.
+Purpose: convert existing core message history into the UI message shape used by React hooks.
 
 Return behavior: generated IDs are assigned where the core message format does not already provide one.
 
@@ -111,11 +111,11 @@ function createCompletionUIStream<Model extends StreamingCompletionModel>(
 ): AsyncIterable<UIStreamEvent>;
 ```
 
-Purpose: advanced adapter that runs `createCompletionStream(...)` from UI messages and adapts the completion stream into UI stream events.
+Purpose: advanced adapter that runs `createCompletionStream(...)` from server-side UI messages and adapts the completion stream into UI stream events.
 
 Return behavior: yields an assistant `message_start`, text or reasoning deltas, tool updates, `message_end`, and error events.
 
-For normal React completion routes, prefer calling `createCompletionStream(model, { messages: body.messages })` directly.
+For normal React completion routes, the request already contains core messages, so prefer calling `createCompletionStream(model, { messages: body.messages })` directly.
 
 ## createAgentUIStream
 

--- a/apps/www/src/content/docs/packages/react/reference.md
+++ b/apps/www/src/content/docs/packages/react/reference.md
@@ -79,8 +79,9 @@ type SendMessageInput =
     };
 
 type CreateChatRequestArgs = {
-  messages: Message[];
+  messages: UIMessage[];
   uiMessages: UIMessage[];
+  coreMessages: Message[];
 };
 
 type UseChatStatus = "idle" | "streaming" | "error";
@@ -287,7 +288,7 @@ function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(options?: {
 
 Purpose: React chat state machine that sends `UIStreamRequest` by default and accumulates response events into `UIMessage[]`.
 
-Passing `endpoint` creates a default JSONL fetch transport. Passing `transport` makes the hook independent of HTTP. `sendMessage(...)` appends a user message, keeps the full UI message history in state, and sends the converted core message history. The hook applies raw `CompletionStreamEvent`, raw `AgentStreamEvent`, or `UIStreamEvent` records as the assistant response arrives.
+Passing `endpoint` creates a default JSONL fetch transport. Passing `transport` makes the hook independent of HTTP. `sendMessage(...)` appends a user message, keeps the full UI message history in state, and sends the converted core message history. Custom request factories receive the UI array as `messages` for compatibility and the converted array as `coreMessages`. The hook applies raw `CompletionStreamEvent`, raw `AgentStreamEvent`, or `UIStreamEvent` records as the assistant response arrives.
 
 ## useCompletion
 
@@ -295,8 +296,9 @@ Passing `endpoint` creates a default JSONL fetch transport. Passing `transport` 
 type UseCompletionStatus = "idle" | "streaming" | "error";
 
 type UseCompletionRequestArgs = {
-  messages: Message[];
+  messages: UIMessage[];
   uiMessages: UIMessage[];
+  coreMessages: Message[];
 };
 
 type UseCompletionOptions<TRequest = UIStreamRequest, TEvent = UIStreamEvent> = {
@@ -333,7 +335,7 @@ function useCompletion<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
 
 Purpose: React hook for single-prompt text completion streaming that also exposes the underlying assistant `messages`.
 
-By default, `complete(prompt)` creates one user `UIMessage`, converts it to a core `Message`, sends `{ messages, stream: true }`, and consumes raw `CompletionStreamEvent`, raw `AgentStreamEvent`, or `UIStreamEvent` records. `completion` is a convenience string derived from assistant text parts.
+By default, `complete(prompt)` creates one user `UIMessage`, converts it to a core `Message`, sends `{ messages, stream: true }`, and consumes raw `CompletionStreamEvent`, raw `AgentStreamEvent`, or `UIStreamEvent` records. Custom request factories receive the UI array as `messages` for compatibility and the converted array as `coreMessages`. `completion` is a convenience string derived from assistant text parts.
 
 ## createDirectTransport
 

--- a/apps/www/src/content/docs/packages/react/reference.md
+++ b/apps/www/src/content/docs/packages/react/reference.md
@@ -51,7 +51,7 @@ type UIMessagePart =
   | { id: string; type: "error"; error: UIError };
 
 type UIStreamRequest = {
-  messages: UIMessage[];
+  messages: Message[];
   stream: true;
   metadata?: unknown;
 };
@@ -79,7 +79,8 @@ type SendMessageInput =
     };
 
 type CreateChatRequestArgs = {
-  messages: UIMessage[];
+  messages: Message[];
+  uiMessages: UIMessage[];
 };
 
 type UseChatStatus = "idle" | "streaming" | "error";
@@ -286,12 +287,17 @@ function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(options?: {
 
 Purpose: React chat state machine that sends `UIStreamRequest` by default and accumulates response events into `UIMessage[]`.
 
-Passing `endpoint` creates a default JSONL fetch transport. Passing `transport` makes the hook independent of HTTP. `sendMessage(...)` appends a user message and sends the full UI message history. The hook applies raw `CompletionStreamEvent`, raw `AgentStreamEvent`, or `UIStreamEvent` records as the assistant response arrives.
+Passing `endpoint` creates a default JSONL fetch transport. Passing `transport` makes the hook independent of HTTP. `sendMessage(...)` appends a user message, keeps the full UI message history in state, and sends the converted core message history. The hook applies raw `CompletionStreamEvent`, raw `AgentStreamEvent`, or `UIStreamEvent` records as the assistant response arrives.
 
 ## useCompletion
 
 ```ts
 type UseCompletionStatus = "idle" | "streaming" | "error";
+
+type UseCompletionRequestArgs = {
+  messages: Message[];
+  uiMessages: UIMessage[];
+};
 
 type UseCompletionOptions<TRequest = UIStreamRequest, TEvent = UIStreamEvent> = {
   transport?: EventTransport<TRequest, TEvent>;
@@ -299,7 +305,7 @@ type UseCompletionOptions<TRequest = UIStreamRequest, TEvent = UIStreamEvent> = 
   format?: "jsonl" | "sse";
   initialMessages?: UIMessage[];
   initialCompletion?: string;
-  createRequest?: (args: { messages: UIMessage[] }) => TRequest;
+  createRequest?: (args: UseCompletionRequestArgs) => TRequest;
   eventToUIEvent?: (event: TEvent) => UIStreamEvent | undefined;
   eventToDelta?: (event: TEvent) => string | undefined;
   eventToFinal?: (event: TEvent) => string | undefined;
@@ -327,7 +333,7 @@ function useCompletion<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
 
 Purpose: React hook for single-prompt text completion streaming that also exposes the underlying assistant `messages`.
 
-By default, `complete(prompt)` creates one user `UIMessage`, sends `{ messages, stream: true }`, and consumes raw `CompletionStreamEvent`, raw `AgentStreamEvent`, or `UIStreamEvent` records. `completion` is a convenience string derived from assistant text parts.
+By default, `complete(prompt)` creates one user `UIMessage`, converts it to a core `Message`, sends `{ messages, stream: true }`, and consumes raw `CompletionStreamEvent`, raw `AgentStreamEvent`, or `UIStreamEvent` records. `completion` is a convenience string derived from assistant text parts.
 
 ## createDirectTransport
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -96,8 +96,8 @@ for await (const event of createCompletionStream(model, {
 }
 ```
 
-React hooks send standardized `UIMessage[]` in their request body. Pass those messages directly to
-`createCompletionStream`; the helper normalizes them before calling the provider:
+React hooks keep `UIMessage[]` state locally, but send core `Message[]` in their request body. Pass
+those messages directly to `createCompletionStream`:
 
 ```ts
 import { createCompletionStream } from "@anvia/core";

--- a/packages/core/src/completion/create-completion.ts
+++ b/packages/core/src/completion/create-completion.ts
@@ -1,6 +1,4 @@
 import { toProviderJsonSchema, type ZodSchema } from "../schema/zod-schema";
-import { isUIMessage, uiMessagesToCoreMessages } from "../ui/messages";
-import type { UIMessage } from "../ui/types";
 import type {
   AssistantContent,
   CompletionModel,
@@ -18,11 +16,11 @@ import type {
 } from "./types";
 import { assertCompletionRequestSupported, Message, textFromAssistantContent } from "./types";
 
-export type CreateCompletionInput = string | MessageType | MessageType[] | UIMessage | UIMessage[];
+export type CreateCompletionInput = string | MessageType | MessageType[];
 
 export type CreateCompletionBaseOptions = {
   input?: CreateCompletionInput | undefined;
-  messages?: MessageType[] | UIMessage[] | undefined;
+  messages?: MessageType[] | undefined;
   instructions?: string | undefined;
   documents?: Document[] | undefined;
   tools?: ToolDefinition[] | undefined;
@@ -159,37 +157,20 @@ function messagesFromInput(input: CreateCompletionInput | undefined): MessageTyp
   if (Array.isArray(input)) {
     return normalizeMessageArray(input, "input");
   }
-  if (isUIMessage(input)) {
-    return uiMessagesToCoreMessages([input]);
-  }
   if (!isCoreMessage(input)) {
-    throw new TypeError("input must be a string, Message, Message[], UIMessage, or UIMessage[].");
+    throw new TypeError("input must be a string, Message, or Message[].");
   }
   return [input];
 }
 
-function messagesFromMessages(messages: MessageType[] | UIMessage[] | undefined): MessageType[] {
+function messagesFromMessages(messages: MessageType[] | undefined): MessageType[] {
   return messages === undefined ? [] : normalizeMessageArray(messages, "messages");
 }
 
 function normalizeMessageArray(
-  messages: (MessageType | UIMessage)[],
+  messages: MessageType[],
   fieldName: "input" | "messages",
 ): MessageType[] {
-  const hasUIMessage = messages.some(isUIMessage);
-  const hasCoreMessage = messages.some(isCoreMessage);
-
-  if (hasUIMessage && hasCoreMessage) {
-    throw new TypeError(`${fieldName} must contain only Message[] or only UIMessage[].`);
-  }
-
-  if (hasUIMessage) {
-    if (!messages.every(isUIMessage)) {
-      throw new TypeError(`${fieldName} must contain only UIMessage values.`);
-    }
-    return uiMessagesToCoreMessages(messages);
-  }
-
   if (!messages.every(isCoreMessage)) {
     throw new TypeError(`${fieldName} must contain only Message values.`);
   }

--- a/packages/core/src/ui/types.ts
+++ b/packages/core/src/ui/types.ts
@@ -1,4 +1,4 @@
-import type { JsonValue, Usage } from "../completion/types";
+import type { JsonValue, Message, Usage } from "../completion/types";
 
 export type UIMessageRole = "system" | "user" | "assistant" | "tool";
 
@@ -52,7 +52,7 @@ export type UIMessagePart =
 export type UIToolMessagePart = Extract<UIMessagePart, { type: "tool" }>;
 
 export type UIStreamRequest = {
-  messages: UIMessage[];
+  messages: Message[];
   stream: true;
   metadata?: JsonValue;
 };

--- a/packages/core/test/ui-stream.test.ts
+++ b/packages/core/test/ui-stream.test.ts
@@ -149,7 +149,7 @@ describe("UI message adapters", () => {
     ]);
   });
 
-  it("accepts UI messages in createCompletionStream options", async () => {
+  it("accepts core messages in createCompletionStream options", async () => {
     const model = new StreamModel([
       [
         {
@@ -165,35 +165,25 @@ describe("UI message adapters", () => {
 
     await collect(
       createCompletionStream(model, {
-        messages: [
-          {
-            id: "user_1",
-            role: "user",
-            parts: [{ id: "part_1", type: "text", text: "Hello" }],
-          },
-        ],
+        messages: [Message.user("Hello")],
       }),
     );
 
     expect(model.requests[0]?.chatHistory).toEqual([Message.user("Hello")]);
   });
 
-  it("accepts a UI message as createCompletion input", async () => {
+  it("accepts a core message as createCompletion input", async () => {
     const model = new StreamModel([]);
 
     const result = await createCompletion(model, {
-      input: {
-        id: "user_1",
-        role: "user",
-        parts: [{ id: "part_1", type: "text", text: "Hello" }],
-      },
+      input: Message.user("Hello"),
     });
 
     expect(result.text).toBe("ok");
     expect(model.requests[0]?.chatHistory).toEqual([Message.user("Hello")]);
   });
 
-  it("rejects mixed core and UI message arrays", () => {
+  it("rejects non-core message arrays", () => {
     const model = new StreamModel([]);
     const uiMessage: UIMessage = {
       id: "user_1",
@@ -205,7 +195,7 @@ describe("UI message adapters", () => {
       createCompletionStream(model, {
         messages: [Message.user("Hi"), uiMessage] as never,
       }),
-    ).toThrow("messages must contain only Message[] or only UIMessage[]");
+    ).toThrow("messages must contain only Message values.");
   });
 
   it("rejects malformed single message input", () => {
@@ -215,7 +205,7 @@ describe("UI message adapters", () => {
       createCompletionStream(model, {
         input: { role: "user", content: "Hello" } as never,
       }),
-    ).toThrow("input must be a string, Message, Message[], UIMessage, or UIMessage[]");
+    ).toThrow("input must be a string, Message, or Message[].");
   });
 
   it("normalizes completion streams into UI stream events", async () => {

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -56,7 +56,8 @@ type UIStreamRequest = {
 ```
 
 Hooks convert their local `UIMessage[]` state into core messages before sending. Custom
-`createRequest` callbacks receive both `{ messages, uiMessages }`.
+`createRequest` callbacks receive `{ messages, uiMessages, coreMessages }`, where `messages` and
+`uiMessages` are UI-shaped for compatibility and `coreMessages` is the default wire payload.
 
 The shared boundary is:
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -49,11 +49,14 @@ Default hook requests use one shared wire shape:
 
 ```ts
 type UIStreamRequest = {
-  messages: UIMessage[];
+  messages: Message[];
   stream: true;
   metadata?: JsonValue;
 };
 ```
+
+Hooks convert their local `UIMessage[]` state into core messages before sending. Custom
+`createRequest` callbacks receive both `{ messages, uiMessages }`.
 
 The shared boundary is:
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -5,6 +5,7 @@ export { readJsonlStream, readSseStream } from "./streams";
 export type { CreateFetchTransportOptions } from "./transport";
 export { createChatTransport, createFetchTransport } from "./transport";
 export type {
+  CreateChatRequestArgs,
   EventStreamFormat,
   EventTransport,
   HumanInputOptions,
@@ -33,6 +34,7 @@ export type {
 export { useChat } from "./use-chat";
 export type {
   UseCompletionOptions,
+  UseCompletionRequestArgs,
   UseCompletionResult,
   UseCompletionStatus,
 } from "./use-completion";

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -117,8 +117,9 @@ export type SendMessageInput =
     };
 
 export type CreateChatRequestArgs = {
-  messages: Message[];
+  messages: UIMessage[];
   uiMessages: UIMessage[];
+  coreMessages: Message[];
 };
 
 export type UseChatStatus = "idle" | "streaming" | "error";

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,3 +1,4 @@
+import type { Message } from "@anvia/core/completion";
 import type { UIMessage, UIStreamEvent, UIStreamRequest } from "@anvia/core/ui";
 
 export type {
@@ -116,7 +117,8 @@ export type SendMessageInput =
     };
 
 export type CreateChatRequestArgs = {
-  messages: UIMessage[];
+  messages: Message[];
+  uiMessages: UIMessage[];
 };
 
 export type UseChatStatus = "idle" | "streaming" | "error";

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -1,8 +1,15 @@
-import type { UIStreamEvent, UIStreamRequest } from "@anvia/core/ui";
+import type { UIMessage, UIStreamEvent, UIStreamRequest } from "@anvia/core/ui";
+import { uiMessagesToCoreMessages } from "@anvia/core/ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { createChatTransport } from "./transport";
-import type { EventTransport, SendMessageInput, UseChatOptions, UseChatResult } from "./types";
+import type {
+  CreateChatRequestArgs,
+  EventTransport,
+  SendMessageInput,
+  UseChatOptions,
+  UseChatResult,
+} from "./types";
 import {
   appendAssistantDelta,
   applyAnviaStreamEvent,
@@ -96,7 +103,7 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
   );
 
   const sendMessages = useCallback(
-    async (nextMessages: UIStreamRequest["messages"]) => {
+    async (nextMessages: UIMessage[]) => {
       if (transport === undefined) {
         throw new Error("useChat requires either transport or endpoint");
       }
@@ -107,9 +114,9 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
 
       const createRequest =
         options.createRequest ??
-        ((args: { messages: UIStreamRequest["messages"] }) =>
-          ({ messages: args.messages, stream: true }) as TRequest);
-      const request = createRequest({ messages: nextMessages });
+        ((args: CreateChatRequestArgs) => ({ messages: args.messages, stream: true }) as TRequest);
+      const requestMessages = uiMessagesToCoreMessages(nextMessages);
+      const request = createRequest({ messages: requestMessages, uiMessages: nextMessages });
 
       setMessages(nextMessages);
       setEvents([]);
@@ -177,7 +184,7 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
   }, []);
 
   const reset = useCallback(
-    (nextMessages: UIStreamRequest["messages"] = []) => {
+    (nextMessages: UIMessage[] = []) => {
       abortRef.current?.abort();
       abortRef.current = undefined;
       setMessages(nextMessages);
@@ -203,7 +210,7 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
   };
 }
 
-function findLastUserIndex(messages: UIStreamRequest["messages"]): number {
+function findLastUserIndex(messages: UIMessage[]): number {
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     if (messages[index]?.role === "user") {
       return index;

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -1,5 +1,5 @@
+import { uiMessagesToCoreMessages } from "@anvia/core";
 import type { UIMessage, UIStreamEvent, UIStreamRequest } from "@anvia/core/ui";
-import { uiMessagesToCoreMessages } from "@anvia/core/ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { createChatTransport } from "./transport";
@@ -114,9 +114,8 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
 
       const createRequest =
         options.createRequest ??
-        ((args: CreateChatRequestArgs) => ({ messages: args.messages, stream: true }) as TRequest);
-      const requestMessages = uiMessagesToCoreMessages(nextMessages);
-      const request = createRequest({ messages: requestMessages, uiMessages: nextMessages });
+        ((args: CreateChatRequestArgs) =>
+          ({ messages: args.coreMessages, stream: true }) as TRequest);
 
       setMessages(nextMessages);
       setEvents([]);
@@ -124,6 +123,13 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
       setStatus("streaming");
 
       try {
+        const coreMessages = uiMessagesToCoreMessages(nextMessages);
+        const request = createRequest({
+          messages: nextMessages,
+          uiMessages: nextMessages,
+          coreMessages,
+        });
+
         for await (const event of transport.send(request, { signal: abortController.signal })) {
           setEvents((current) => [...current, event]);
           options.onEvent?.(event);

--- a/packages/react/src/use-completion.ts
+++ b/packages/react/src/use-completion.ts
@@ -1,4 +1,6 @@
+import type { Message } from "@anvia/core/completion";
 import type { UIMessage, UIStreamEvent, UIStreamRequest } from "@anvia/core/ui";
+import { uiMessagesToCoreMessages } from "@anvia/core/ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { createFetchTransport } from "./transport";
@@ -14,13 +16,18 @@ import {
 
 export type UseCompletionStatus = "idle" | "streaming" | "error";
 
+export type UseCompletionRequestArgs = {
+  messages: Message[];
+  uiMessages: UIMessage[];
+};
+
 export type UseCompletionOptions<TRequest = UIStreamRequest, TEvent = UIStreamEvent> = {
   transport?: EventTransport<TRequest, TEvent>;
   endpoint?: string | URL;
   format?: EventStreamFormat;
   initialMessages?: UIMessage[];
   initialCompletion?: string;
-  createRequest?: (args: { messages: UIMessage[] }) => TRequest;
+  createRequest?: (args: UseCompletionRequestArgs) => TRequest;
   eventToUIEvent?: (event: TEvent) => UIStreamEvent | undefined;
   eventToDelta?: (event: TEvent) => string | undefined;
   eventToFinal?: (event: TEvent) => string | undefined;
@@ -174,9 +181,10 @@ export function useCompletion<TRequest = UIStreamRequest, TEvent = UIStreamEvent
 
       const createRequest =
         options.createRequest ??
-        ((args: { messages: UIMessage[] }) =>
+        ((args: UseCompletionRequestArgs) =>
           ({ messages: args.messages, stream: true }) as TRequest);
-      const request = createRequest({ messages: nextMessages });
+      const requestMessages = uiMessagesToCoreMessages(nextMessages);
+      const request = createRequest({ messages: requestMessages, uiMessages: nextMessages });
 
       setMessages(nextMessages);
       setInput("");

--- a/packages/react/src/use-completion.ts
+++ b/packages/react/src/use-completion.ts
@@ -1,6 +1,6 @@
+import { uiMessagesToCoreMessages } from "@anvia/core";
 import type { Message } from "@anvia/core/completion";
 import type { UIMessage, UIStreamEvent, UIStreamRequest } from "@anvia/core/ui";
-import { uiMessagesToCoreMessages } from "@anvia/core/ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { createFetchTransport } from "./transport";
@@ -17,8 +17,9 @@ import {
 export type UseCompletionStatus = "idle" | "streaming" | "error";
 
 export type UseCompletionRequestArgs = {
-  messages: Message[];
+  messages: UIMessage[];
   uiMessages: UIMessage[];
+  coreMessages: Message[];
 };
 
 export type UseCompletionOptions<TRequest = UIStreamRequest, TEvent = UIStreamEvent> = {
@@ -182,9 +183,7 @@ export function useCompletion<TRequest = UIStreamRequest, TEvent = UIStreamEvent
       const createRequest =
         options.createRequest ??
         ((args: UseCompletionRequestArgs) =>
-          ({ messages: args.messages, stream: true }) as TRequest);
-      const requestMessages = uiMessagesToCoreMessages(nextMessages);
-      const request = createRequest({ messages: requestMessages, uiMessages: nextMessages });
+          ({ messages: args.coreMessages, stream: true }) as TRequest);
 
       setMessages(nextMessages);
       setInput("");
@@ -193,6 +192,13 @@ export function useCompletion<TRequest = UIStreamRequest, TEvent = UIStreamEvent
       setStatus("streaming");
 
       try {
+        const coreMessages = uiMessagesToCoreMessages(nextMessages);
+        const request = createRequest({
+          messages: nextMessages,
+          uiMessages: nextMessages,
+          coreMessages,
+        });
+
         for await (const event of transport.send(request, { signal: abortController.signal })) {
           setEvents((current) => [...current, event]);
           options.onEvent?.(event);

--- a/packages/react/test/direct.test.ts
+++ b/packages/react/test/direct.test.ts
@@ -85,7 +85,7 @@ describe("@anvia/react createDirectTransport", () => {
       async function* (request) {
         expect(request.messages[0]).toMatchObject({
           role: "user",
-          parts: [{ type: "text", text: "hello" }],
+          content: [{ type: "text", text: "hello" }],
         });
         yield {
           type: "message_start",
@@ -115,7 +115,7 @@ describe("@anvia/react createDirectTransport", () => {
       async function* (request) {
         expect(request.messages[0]).toMatchObject({
           role: "user",
-          parts: [{ type: "text", text: "hi" }],
+          content: [{ type: "text", text: "hi" }],
         });
         yield {
           type: "message_start",

--- a/packages/react/test/transport.test.ts
+++ b/packages/react/test/transport.test.ts
@@ -5,6 +5,7 @@ import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  type CreateChatRequestArgs,
   createChatTransport,
   createFetchTransport,
   EventStreamHttpError,
@@ -98,14 +99,14 @@ describe("@anvia/react transports", () => {
 });
 
 describe("@anvia/react useChat", () => {
-  it("sends full UI messages and applies UI stream events", async () => {
+  it("sends converted core messages and applies UI stream events", async () => {
     const onEvent = vi.fn();
     const transport: EventTransport<UIStreamRequest, UIStreamEvent> = {
       send: async function* (request) {
         expect(request.messages).toHaveLength(1);
         expect(request.messages[0]).toMatchObject({
           role: "user",
-          parts: [{ type: "text", text: "hi" }],
+          content: [{ type: "text", text: "hi" }],
         });
         expect(request.stream).toBe(true);
         yield {
@@ -176,10 +177,53 @@ describe("@anvia/react useChat", () => {
 
     const [, init] = fetchMock.mock.calls[0] ?? [];
     expect(JSON.parse(String(init?.body))).toMatchObject({
-      messages: [{ role: "user", parts: [{ type: "text", text: "hello" }] }],
+      messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
       stream: true,
     });
     expect(result.current.text).toBe("hi");
+  });
+
+  it("passes core and UI messages to custom chat request factories", async () => {
+    type CustomRequest = {
+      messages: unknown[];
+      uiMessages: unknown[];
+      stream: true;
+    };
+    const createRequest = vi.fn((args: CreateChatRequestArgs) => ({
+      ...args,
+      stream: true as const,
+    }));
+    const transport: EventTransport<CustomRequest, UIStreamEvent> = {
+      send: async function* (request) {
+        expect(request.messages[0]).toMatchObject({
+          role: "user",
+          content: [{ type: "text", text: "hello" }],
+        });
+        expect(request.uiMessages[0]).toMatchObject({
+          role: "user",
+          parts: [{ type: "text", text: "hello" }],
+        });
+        yield {
+          type: "message_start",
+          message: { id: "assistant_1", role: "assistant", parts: [] },
+        };
+      },
+    };
+    const { result } = renderHook(() => useChat<CustomRequest>({ transport, createRequest }));
+
+    await act(async () => {
+      await result.current.send("hello");
+    });
+
+    expect(createRequest).toHaveBeenCalledWith({
+      messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+      uiMessages: [
+        expect.objectContaining({
+          role: "user",
+          parts: [expect.objectContaining({ type: "text", text: "hello" })],
+        }),
+      ],
+    });
   });
 
   it("applies raw completion stream events", async () => {

--- a/packages/react/test/transport.test.ts
+++ b/packages/react/test/transport.test.ts
@@ -1,6 +1,6 @@
 import type { AgentStreamEvent } from "@anvia/core/agent";
 import { AssistantContent, type CompletionStreamEvent, Usage } from "@anvia/core/completion";
-import type { UIStreamEvent, UIStreamRequest } from "@anvia/core/ui";
+import type { UIMessage, UIStreamEvent, UIStreamRequest } from "@anvia/core/ui";
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -190,7 +190,8 @@ describe("@anvia/react useChat", () => {
       stream: true;
     };
     const createRequest = vi.fn((args: CreateChatRequestArgs) => ({
-      ...args,
+      messages: args.coreMessages,
+      uiMessages: args.uiMessages,
       stream: true as const,
     }));
     const transport: EventTransport<CustomRequest, UIStreamEvent> = {
@@ -216,14 +217,53 @@ describe("@anvia/react useChat", () => {
     });
 
     expect(createRequest).toHaveBeenCalledWith({
-      messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+      messages: [
+        expect.objectContaining({
+          role: "user",
+          parts: [expect.objectContaining({ type: "text", text: "hello" })],
+        }),
+      ],
       uiMessages: [
         expect.objectContaining({
           role: "user",
           parts: [expect.objectContaining({ type: "text", text: "hello" })],
         }),
       ],
+      coreMessages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
     });
+  });
+
+  it("reports UI conversion errors before sending chat requests", async () => {
+    const onError = vi.fn();
+    const transport: EventTransport<UIStreamRequest, UIStreamEvent> = {
+      send: vi.fn(async function* (): AsyncIterable<UIStreamEvent> {
+        yield {
+          type: "message_start",
+          message: { id: "assistant_1", role: "assistant", parts: [] },
+        };
+      }),
+    };
+    const invalidMessage: UIMessage = {
+      id: "bad_user",
+      role: "user",
+      parts: [{ id: "bad_part", type: "data", name: "custom", data: { value: 1 } }],
+    };
+    const { result } = renderHook(() =>
+      useChat({
+        transport,
+        initialMessages: [invalidMessage],
+        onError,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.send("hello");
+    });
+
+    expect(transport.send).not.toHaveBeenCalled();
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toBeInstanceOf(TypeError);
+    expect(onError).toHaveBeenCalledWith(result.current.error);
   });
 
   it("applies raw completion stream events", async () => {

--- a/packages/react/test/use-completion.test.ts
+++ b/packages/react/test/use-completion.test.ts
@@ -3,7 +3,7 @@ import type { UIStreamEvent, UIStreamRequest } from "@anvia/core/ui";
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { EventTransport } from "../src";
+import type { EventTransport, UseCompletionRequestArgs } from "../src";
 import { useCompletion } from "../src";
 
 afterEach(() => {
@@ -17,7 +17,7 @@ describe("@anvia/react useCompletion", () => {
     const transport: EventTransport<UIStreamRequest, CompletionStreamEvent> = {
       send: async function* (request) {
         expect(request.messages).toMatchObject([
-          { role: "user", parts: [{ type: "text", text: "hello" }] },
+          { role: "user", content: [{ type: "text", text: "hello" }] },
         ]);
         expect(request.stream).toBe(true);
         yield { type: "message_id", id: "provider_1" };
@@ -83,10 +83,54 @@ describe("@anvia/react useCompletion", () => {
 
     const [, init] = fetchMock.mock.calls[0] ?? [];
     expect(JSON.parse(String(init?.body))).toMatchObject({
-      messages: [{ role: "user", parts: [{ type: "text", text: "hello" }] }],
+      messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
       stream: true,
     });
     expect(result.current.completion).toBe("hi");
+  });
+
+  it("passes core and UI messages to custom completion request factories", async () => {
+    type CustomRequest = {
+      messages: unknown[];
+      uiMessages: unknown[];
+      stream: true;
+    };
+    const createRequest = vi.fn((args: UseCompletionRequestArgs) => ({
+      ...args,
+      stream: true as const,
+    }));
+    const transport: EventTransport<CustomRequest, UIStreamEvent> = {
+      send: async function* (request) {
+        expect(request.messages[0]).toMatchObject({
+          role: "user",
+          content: [{ type: "text", text: "hello" }],
+        });
+        expect(request.uiMessages[0]).toMatchObject({
+          role: "user",
+          parts: [{ type: "text", text: "hello" }],
+        });
+        yield {
+          type: "message_start",
+          message: { id: "assistant_1", role: "assistant", parts: [] },
+        };
+      },
+    };
+
+    const { result } = renderHook(() => useCompletion<CustomRequest>({ transport, createRequest }));
+
+    await act(async () => {
+      await result.current.complete("hello");
+    });
+
+    expect(createRequest).toHaveBeenCalledWith({
+      messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+      uiMessages: [
+        expect.objectContaining({
+          role: "user",
+          parts: [expect.objectContaining({ type: "text", text: "hello" })],
+        }),
+      ],
+    });
   });
 
   it("keeps streamed text when the raw completion final choice is empty", async () => {

--- a/packages/react/test/use-completion.test.ts
+++ b/packages/react/test/use-completion.test.ts
@@ -96,7 +96,8 @@ describe("@anvia/react useCompletion", () => {
       stream: true;
     };
     const createRequest = vi.fn((args: UseCompletionRequestArgs) => ({
-      ...args,
+      messages: args.coreMessages,
+      uiMessages: args.uiMessages,
       stream: true as const,
     }));
     const transport: EventTransport<CustomRequest, UIStreamEvent> = {
@@ -123,13 +124,19 @@ describe("@anvia/react useCompletion", () => {
     });
 
     expect(createRequest).toHaveBeenCalledWith({
-      messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+      messages: [
+        expect.objectContaining({
+          role: "user",
+          parts: [expect.objectContaining({ type: "text", text: "hello" })],
+        }),
+      ],
       uiMessages: [
         expect.objectContaining({
           role: "user",
           parts: [expect.objectContaining({ type: "text", text: "hello" })],
         }),
       ],
+      coreMessages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
     });
   });
 


### PR DESCRIPTION
## Summary
- Convert React hook UI state to core messages before creating default transport requests
- Limit createCompletion/createCompletionStream inputs back to core Message values
- Update public docs and add patch changeset for @anvia/core and @anvia/react

## Verification
- pnpm --filter @anvia/core typecheck
- pnpm --filter @anvia/react typecheck
- pnpm --filter @anvia/core test
- pnpm --filter @anvia/react test
- pnpm --filter @anvia/core build
- pnpm --filter @anvia/react build
- pnpm --filter www reference-check
- pnpm --filter www build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * React chat and completion hooks now provide custom request builders with both UI message history and converted core messages.
  * Added/expanded exported request-argument types to support this customization.

* **Bug Fixes**
  * Outbound chat/completion and streaming requests now consistently use core message shapes.

* **Documentation**
  * Updated guides and reference docs to reflect the core-vs-UI message separation and the recommended request payloads.

* **Tests**
  * Updated assertions and added coverage for the stricter core-message-only completion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->