### PR TITLE
fix: append completion messages

### DIFF
--- a/.changeset/append-completion-messages.md
+++ b/.changeset/append-completion-messages.md
@@ -1,0 +1,5 @@
+---
+"@anvia/react": patch
+---
+
+Append `useCompletion` turns to existing message state before sending requests.

--- a/apps/www/src/content/docs/packages/react/reference.md
+++ b/apps/www/src/content/docs/packages/react/reference.md
@@ -333,9 +333,9 @@ function useCompletion<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
 ): UseCompletionResult<TEvent>;
 ```
 
-Purpose: React hook for single-prompt text completion streaming that also exposes the underlying assistant `messages`.
+Purpose: React hook for text completion streaming that also exposes the underlying assistant `messages`.
 
-By default, `complete(prompt)` creates one user `UIMessage`, converts it to a core `Message`, sends `{ messages, stream: true }`, and consumes raw `CompletionStreamEvent`, raw `AgentStreamEvent`, or `UIStreamEvent` records. Custom request factories receive the UI array as `messages` for compatibility and the converted array as `coreMessages`. `completion` is a convenience string derived from assistant text parts.
+By default, `complete(prompt)` appends one user `UIMessage` to the current messages, converts the full UI history to core messages, sends `{ messages, stream: true }`, and consumes raw `CompletionStreamEvent`, raw `AgentStreamEvent`, or `UIStreamEvent` records. Custom request factories receive the UI array as `messages` for compatibility and the converted array as `coreMessages`. `completion` is a convenience string derived from the latest assistant text parts.
 
 ## createDirectTransport
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -43,7 +43,7 @@ export function Chat() {
 - `createFetchTransport(options)` creates an `EventTransport`.
 - `createChatTransport(options)` creates the default fetch-backed chat transport.
 - `useChat(options)` manages `UIMessage[]` chat state from any `EventTransport`.
-- `useCompletion(options)` manages a single-turn `UIMessage[]` exchange and exposes derived `completion` text.
+- `useCompletion(options)` appends completion turns into `UIMessage[]` state and exposes derived `completion` text.
 
 Default hook requests use one shared wire shape:
 

--- a/packages/react/src/use-completion.ts
+++ b/packages/react/src/use-completion.ts
@@ -174,7 +174,7 @@ export function useCompletion<TRequest = UIStreamRequest, TEvent = UIStreamEvent
       if (userMessage === undefined) {
         return;
       }
-      const nextMessages = [userMessage];
+      const nextMessages = [...messagesRef.current, userMessage];
 
       abortRef.current?.abort();
       const abortController = new AbortController();

--- a/packages/react/src/use-completion.ts
+++ b/packages/react/src/use-completion.ts
@@ -174,9 +174,15 @@ export function useCompletion<TRequest = UIStreamRequest, TEvent = UIStreamEvent
       if (userMessage === undefined) {
         return;
       }
-      const nextMessages = [...messagesRef.current, userMessage];
+      const previousAbortController = abortRef.current;
+      previousAbortController?.abort();
+      const currentMessages = messagesRef.current;
+      const baseMessages =
+        previousAbortController !== undefined && currentMessages.at(-1)?.role === "assistant"
+          ? currentMessages.slice(0, -1)
+          : currentMessages;
+      const nextMessages = [...baseMessages, userMessage];
 
-      abortRef.current?.abort();
       const abortController = new AbortController();
       abortRef.current = abortController;
 
@@ -210,7 +216,9 @@ export function useCompletion<TRequest = UIStreamRequest, TEvent = UIStreamEvent
         }
       } catch (caught) {
         if (isAbortError(caught)) {
-          setStatus("idle");
+          if (abortRef.current === abortController) {
+            setStatus("idle");
+          }
           return;
         }
 

--- a/packages/react/test/use-completion.test.ts
+++ b/packages/react/test/use-completion.test.ts
@@ -89,6 +89,50 @@ describe("@anvia/react useCompletion", () => {
     expect(result.current.completion).toBe("hi");
   });
 
+  it("appends completion turns instead of replacing message state", async () => {
+    const requests: UIStreamRequest[] = [];
+    const transport: EventTransport<UIStreamRequest, CompletionStreamEvent> = {
+      send: async function* (request) {
+        requests.push(request);
+        const text = requests.length === 1 ? "One" : "Two";
+        yield { type: "text_delta", delta: text };
+        yield {
+          type: "final",
+          response: {
+            choice: [AssistantContent.text(text)],
+            usage: Usage.empty(),
+            rawResponse: {},
+            messageId: `provider_${requests.length}`,
+          },
+        };
+      },
+    };
+    const { result } = renderHook(() => useCompletion({ transport }));
+
+    await act(async () => {
+      await result.current.complete("first");
+    });
+    await act(async () => {
+      await result.current.complete("second");
+    });
+
+    expect(result.current.completion).toBe("Two");
+    expect(result.current.messages).toMatchObject([
+      { role: "user", parts: [{ type: "text", text: "first" }] },
+      { role: "assistant", parts: [{ type: "text", text: "One" }] },
+      { role: "user", parts: [{ type: "text", text: "second" }] },
+      { role: "assistant", parts: [{ type: "text", text: "Two" }] },
+    ]);
+    expect(requests[0]?.messages).toMatchObject([
+      { role: "user", content: [{ type: "text", text: "first" }] },
+    ]);
+    expect(requests[1]?.messages).toMatchObject([
+      { role: "user", content: [{ type: "text", text: "first" }] },
+      { role: "assistant", content: [{ type: "text", text: "One" }] },
+      { role: "user", content: [{ type: "text", text: "second" }] },
+    ]);
+  });
+
   it("passes core and UI messages to custom completion request factories", async () => {
     type CustomRequest = {
       messages: unknown[];

--- a/packages/react/test/use-completion.test.ts
+++ b/packages/react/test/use-completion.test.ts
@@ -133,6 +133,63 @@ describe("@anvia/react useCompletion", () => {
     ]);
   });
 
+  it("does not send aborted partial assistant text with the next completion", async () => {
+    const requests: UIStreamRequest[] = [];
+    const transport: EventTransport<UIStreamRequest, CompletionStreamEvent> = {
+      send: async function* (request, options) {
+        requests.push(request);
+
+        if (requests.length === 1) {
+          yield { type: "text_delta", delta: "partial" };
+          await new Promise<void>((_resolve, reject) => {
+            options?.signal?.addEventListener(
+              "abort",
+              () => reject(new DOMException("Aborted", "AbortError")),
+              { once: true },
+            );
+          });
+          return;
+        }
+
+        yield { type: "text_delta", delta: "done" };
+        yield {
+          type: "final",
+          response: {
+            choice: [AssistantContent.text("done")],
+            usage: Usage.empty(),
+            rawResponse: {},
+            messageId: "provider_2",
+          },
+        };
+      },
+    };
+    const { result } = renderHook(() => useCompletion({ transport }));
+
+    let firstComplete!: Promise<void>;
+    act(() => {
+      firstComplete = result.current.complete("first");
+    });
+    await vi.waitFor(() => {
+      expect(result.current.completion).toBe("partial");
+    });
+
+    await act(async () => {
+      await result.current.complete("second");
+    });
+    await firstComplete;
+
+    expect(requests[1]?.messages).toMatchObject([
+      { role: "user", content: [{ type: "text", text: "first" }] },
+      { role: "user", content: [{ type: "text", text: "second" }] },
+    ]);
+    expect(requests[1]?.messages).toHaveLength(2);
+    expect(result.current.messages).toMatchObject([
+      { role: "user", parts: [{ type: "text", text: "first" }] },
+      { role: "user", parts: [{ type: "text", text: "second" }] },
+      { role: "assistant", parts: [{ type: "text", text: "done" }] },
+    ]);
+  });
+
   it("passes core and UI messages to custom completion request factories", async () => {
     type CustomRequest = {
       messages: unknown[];


### PR DESCRIPTION
## Summary
- append useCompletion turns to existing message state before sending requests
- document that completion requests send full converted core history
- add regression coverage for repeated completion calls

## Tests
- pnpm --filter @anvia/react typecheck
- pnpm --filter @anvia/react test
- pnpm --filter www reference-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `useCompletion` now preserves and extends existing message history across consecutive completion requests, so prior conversation context is retained.
  * Aborted in-progress assistant output is no longer carried into the next completion request.
  * The latest completion text and message state updates remain consistent after each request.
* **Documentation**
  * Updated React documentation and reference text to clarify the default `complete(prompt)` behavior and message flow.
* **Tests**
  * Added coverage for message appending across multiple completions and for preventing aborted partial content from affecting subsequent runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->