### PR TITLE
docs: add fullstack streaming example

### DIFF
--- a/apps/www/src/content/docs/examples/capability-map.md
+++ b/apps/www/src/content/docs/examples/capability-map.md
@@ -19,7 +19,7 @@ The concrete RAG stack used in examples is Mistral OCR, OpenAI embeddings, and C
 | Runtime composition | [Agent Runtime Composition](/docs/examples/agent-runtime-composition) | Model, instructions, tools, context, memory, observers, and output contracts are assembled at the right boundary. |
 | Request runners | [Agent App Flow](/docs/examples/agent-app-flow), [Pipeline Worker](/docs/examples/pipeline-worker) | Routes, jobs, and tests call the same workflow function. |
 | Memory and sessions | [Context Assembly](/docs/examples/context-assembly), [Runtime State and Persistence](/docs/examples/runtime-state-persistence) | Conversation state is durable without becoming an authorization or audit system. |
-| Streaming events | [Streaming Events](/docs/examples/streaming-events) | UIs consume text, tool progress, and final events as workflow state. |
+| Streaming events | [Fullstack Streaming](/docs/examples/fullstack-streaming), [Streaming Events](/docs/examples/streaming-events) | Browser clients consume completion or agent streams, then product UIs treat text, tools, and final events as workflow state. |
 | Event store | [Runtime State and Persistence](/docs/examples/runtime-state-persistence), [Observability Loop](/docs/examples/observability-loop) | Runtime events are replayable for debugging and audit. |
 
 ## Tools And Actions

--- a/apps/www/src/content/docs/examples/fullstack-streaming.md
+++ b/apps/www/src/content/docs/examples/fullstack-streaming.md
@@ -1,0 +1,209 @@
+---
+title: Fullstack Streaming
+description: A minimal server and React flow for streaming completions and agents into UI messages.
+section: examples
+sidebar:
+  group: Workflow Patterns
+  order: 2
+---
+
+Fullstack streaming connects a browser UI to server-owned model and agent execution. The browser keeps `UIMessage[]` state. The React hooks send converted core `Message[]` requests, and the server returns JSONL runtime events.
+
+Use this shape when you want to test direct completion streaming and agent streaming from the same frontend before adding auth, persistence, tools, or trace storage.
+
+## Scenario
+
+A local React app needs two panels:
+
+- completion: one direct model stream through `createCompletionStream(...)`
+- agent: one reusable agent stream through `agent.prompt(messages).stream()`
+
+Both panels should append into message state and show the same UI message structure.
+
+## Flow
+
+| Step | Owner |
+| --- | --- |
+| keep `UIMessage[]` state | React hook |
+| convert and send `{ messages, stream: true }` | `@anvia/react` |
+| run model or agent | server route |
+| return JSONL events | `@anvia/server` |
+| reduce events back into `UIMessage[]` | `@anvia/react` |
+
+## Server
+
+This example uses Hono because it keeps the routes small. The same handlers work in any server framework that can return a `Response`.
+
+```ts
+import { AgentBuilder, createCompletionStream } from "@anvia/core";
+import type { UIStreamRequest } from "@anvia/core/ui";
+import { OpenAIClient } from "@anvia/openai";
+import { createEventStream } from "@anvia/server";
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+import "dotenv/config";
+
+const instructions = "Answer clearly and concisely.";
+
+const client = new OpenAIClient({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+
+const model = client.completionModel("gpt-5");
+const agent = new AgentBuilder("assistant", model)
+  .instructions(instructions)
+  .maxTokens(500)
+  .build();
+
+const app = new Hono()
+  .use(cors())
+  .get("/", (c) => c.json({ ok: true }))
+  .post("/completion", async (c) => {
+    const body = (await c.req.json()) as UIStreamRequest;
+
+    return createEventStream(
+      createCompletionStream(model, {
+        instructions,
+        messages: body.messages,
+        maxTokens: 500,
+      }),
+      { format: "jsonl" },
+    );
+  })
+  .post("/agent", async (c) => {
+    const body = (await c.req.json()) as UIStreamRequest;
+
+    return createEventStream(agent.prompt(body.messages).stream(), {
+      format: "jsonl",
+    });
+  });
+
+serve({
+  fetch: app.fetch,
+  port: Number(process.env.PORT ?? 8000),
+});
+```
+
+The request body is the default React wire shape:
+
+```ts
+type UIStreamRequest = {
+  messages: Message[];
+  stream: true;
+  metadata?: JsonValue;
+};
+```
+
+## React Client
+
+Use `useCompletion` for the direct completion route and `useChat` for the agent route. Both hooks expose `messages`, `status`, `stop`, and reset behavior around the same UI message state.
+
+```tsx
+import { useChat, useCompletion } from "@anvia/react";
+import { useState } from "react";
+
+const apiUrl = "http://localhost:8000";
+
+export function App() {
+  const completion = useCompletion({
+    endpoint: `${apiUrl}/completion`,
+    format: "jsonl",
+  });
+  const agent = useChat({
+    endpoint: `${apiUrl}/agent`,
+    format: "jsonl",
+  });
+  const [agentInput, setAgentInput] = useState("");
+
+  return (
+    <main>
+      <section>
+        <h2>Completion</h2>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            void completion.complete();
+          }}
+        >
+          <textarea
+            value={completion.input}
+            onChange={(event) => completion.setInput(event.target.value)}
+          />
+          <button disabled={completion.status === "streaming"}>Send</button>
+          <button type="button" onClick={completion.stop}>
+            Stop
+          </button>
+          <button type="button" onClick={() => completion.reset()}>
+            Reset
+          </button>
+        </form>
+        <p>Status: {completion.status}</p>
+        <pre>{JSON.stringify(completion.messages, null, 2)}</pre>
+      </section>
+
+      <section>
+        <h2>Agent</h2>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            void agent.sendMessage(agentInput);
+            setAgentInput("");
+          }}
+        >
+          <textarea
+            value={agentInput}
+            onChange={(event) => setAgentInput(event.target.value)}
+          />
+          <button disabled={agent.status === "streaming"}>Send</button>
+          <button type="button" onClick={agent.stop}>
+            Stop
+          </button>
+          <button type="button" onClick={() => agent.reset()}>
+            Reset
+          </button>
+        </form>
+        <p>Status: {agent.status}</p>
+        <pre>{JSON.stringify(agent.messages, null, 2)}</pre>
+      </section>
+    </main>
+  );
+}
+```
+
+## What To Look For
+
+`useCompletion.complete()` appends each prompt into the current message state. The completion server receives the full converted core message history on each request.
+
+`useChat.sendMessage()` does the same for the agent route. Raw agent stream events are reduced into assistant message parts. Text appears as `type: "text"`, reasoning appears as `type: "reasoning"`, and tool calls appear as `type: "tool"`.
+
+An agent tool call becomes part of the assistant message:
+
+```ts
+{
+  id: "tool_tool_1",
+  type: "tool",
+  toolName: "lookup_order",
+  toolCallId: "tool_1",
+  callId: "call_1",
+  state: "output-available",
+  input: { orderId: "A-100" },
+  output: { status: "shipped" }
+}
+```
+
+The agent final event adds run metadata to the assistant message:
+
+```ts
+{
+  role: "assistant",
+  parts: [{ type: "text", text: "Order A-100 has shipped." }],
+  metadata: { runId: "run_123" }
+}
+```
+
+## Next Patterns
+
+- [Streaming Events](/docs/examples/streaming-events) for filtering and persisting runtime events.
+- [Runtime State and Persistence](/docs/examples/runtime-state-persistence) for storing messages, events, traces, and run records.
+- [Agent App Flow](/docs/examples/agent-app-flow) for adding auth, tools, memory, and product persistence around the stream.

--- a/apps/www/src/content/docs/examples/long-running-jobs.md
+++ b/apps/www/src/content/docs/examples/long-running-jobs.md
@@ -4,7 +4,7 @@ description: A pattern for status, retries, and durable results around backgroun
 section: examples
 sidebar:
   group: Workflow Patterns
-  order: 3
+  order: 4
 ---
 
 Long-running jobs need durable status, retry policy, progress, and result storage outside the model run. BullMQ is a good queue backend for this shape, but the application job record is still the UI contract. Runtime events, traces, and BullMQ internals are debugging and operations data.

--- a/apps/www/src/content/docs/examples/multi-agent-coordination.md
+++ b/apps/www/src/content/docs/examples/multi-agent-coordination.md
@@ -4,7 +4,7 @@ description: A pattern for coordinating specialist agents inside one parent work
 section: examples
 sidebar:
   group: Workflow Patterns
-  order: 4
+  order: 5
 ---
 
 Multi-agent coordination should keep one parent workflow in charge. Specialists can do focused work, but the coordinator owns the final response, trace, turn limit, and product persistence.

--- a/apps/www/src/content/docs/examples/overview.md
+++ b/apps/www/src/content/docs/examples/overview.md
@@ -21,6 +21,7 @@ The examples use concrete defaults where a full flow is easier to understand wit
 | Typed model output for classification, extraction, or workflow results | [Structured Results](/docs/examples/structured-results) | [Testing Harness](/docs/examples/testing-harness) |
 | RAG over PDFs, images, documents, and product knowledge | [RAG Ingestion](/docs/examples/rag-ingestion) | [Retrieval Agent](/docs/examples/retrieval-agent), [Document Grounding](/docs/examples/document-grounding) |
 | A support agent with account tools and policy evidence | [Support Agent](/docs/examples/support-agent) | [Permissioned Tools](/docs/examples/permissioned-tools), [Retrieval Agent](/docs/examples/retrieval-agent) |
+| A browser UI that streams completions and agents from server routes | [Fullstack Streaming](/docs/examples/fullstack-streaming) | [Streaming Events](/docs/examples/streaming-events), [Runtime State and Persistence](/docs/examples/runtime-state-persistence) |
 | A background document or research workflow | [Pipeline Worker](/docs/examples/pipeline-worker) | [Long-running Jobs](/docs/examples/long-running-jobs) |
 | A coding or file agent with command boundaries | [Coding Agent](/docs/examples/coding-agent) | [Sandbox Execution](/docs/examples/sandbox-execution) |
 | A workflow that needs human approval before writes | [Guarded Side Effects](/docs/examples/guarded-side-effects) | [Human Input](/docs/examples/human-input) |

--- a/apps/www/src/content/docs/examples/pipeline-worker.md
+++ b/apps/www/src/content/docs/examples/pipeline-worker.md
@@ -4,7 +4,7 @@ description: A pattern for running structured work outside the request path.
 section: examples
 sidebar:
   group: Workflow Patterns
-  order: 2
+  order: 3
 ---
 
 Pipeline workers handle work that should not block the request path: research reports, enrichment jobs, document processing, batch analysis, and ingestion refreshes. The request creates a job; the worker runs the pipeline and persists status.


### PR DESCRIPTION
## Summary
- add a Fullstack Streaming example for server + React streaming wiring
- show completion and agent routes using JSONL event streams
- link the new example from the examples overview and capability map

## Tests
- pnpm www:reference-check
- pnpm www:build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Fullstack Streaming” guide showing how to stream model completions and agent updates into a React UI.
  * Expanded the examples overview with a new browser streaming workflow entry and related links.
  * Updated the capability map to include the new streaming example.

* **Documentation**
  * Adjusted example ordering in the sidebar for several workflow docs to improve navigation and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->