### PR TITLE
Refactor vector store type exports

### DIFF
--- a/apps/www/src/content/docs/packages/core/reference/vector-store.md
+++ b/apps/www/src/content/docs/packages/core/reference/vector-store.md
@@ -37,7 +37,14 @@ Notable errors: unsupported metadata comparison types do not match results.
 ## Search Types
 
 ```ts
-type IndexStrategy = { type: "bruteForce" } | { type: "lsh"; numTables: number; numHyperplanes: number; seed?: number };
+type LshOptions = {
+  type: "lsh";
+  numTables: number;
+  numHyperplanes: number;
+  seed?: number;
+};
+
+type IndexStrategy = { type: "bruteForce" } | LshOptions;
 
 type VectorSearchRequest = {
   query: string;

--- a/packages/core/src/vector-store/filter.ts
+++ b/packages/core/src/vector-store/filter.ts
@@ -1,11 +1,7 @@
 import type { VectorMetadata, VectorMetadataValue } from "../embeddings";
+import type { VectorFilter } from "./types";
 
-export type VectorFilter =
-  | { type: "eq"; key: string; value: VectorMetadataValue }
-  | { type: "gt"; key: string; value: VectorMetadataValue }
-  | { type: "lt"; key: string; value: VectorMetadataValue }
-  | { type: "and"; filters: [VectorFilter, VectorFilter] }
-  | { type: "or"; filters: [VectorFilter, VectorFilter] };
+export type { VectorFilter } from "./types";
 
 export const vectorFilter = {
   eq(key: string, value: VectorMetadataValue): VectorFilter {

--- a/packages/core/src/vector-store/index.ts
+++ b/packages/core/src/vector-store/index.ts
@@ -7,62 +7,22 @@ import {
   embedText,
   type VectorMetadata,
 } from "../embeddings";
-import { compact } from "../internal/compact";
 import { createTool } from "../tool/create-tool";
 import type { Tool } from "../tool/tool";
-import { matchesVectorFilter, type VectorFilter } from "./filter";
-import { LshIndex, type LshOptions } from "./lsh";
+import { matchesVectorFilter } from "./filter";
+import { LshIndex } from "./lsh";
+import type {
+  IndexStrategy,
+  VectorInspectPage,
+  VectorInspectRequest,
+  VectorSearchIndex,
+  VectorSearchRequest,
+  VectorSearchResult,
+  VectorSearchToolOptions,
+} from "./types";
 
-export { type VectorFilter, vectorFilter } from "./filter";
-
-export type IndexStrategy = { type: "bruteForce" } | LshOptions;
-
-export type VectorSearchRequest = {
-  query: string;
-  topK: number;
-  threshold?: number | undefined;
-  filter?: VectorFilter | undefined;
-};
-
-export type VectorSearchResult<T = unknown, Metadata extends VectorMetadata = VectorMetadata> = {
-  score: number;
-  id: string;
-  document: T;
-  metadata?: Metadata | undefined;
-};
-
-export type VectorInspectRequest = {
-  limit: number;
-  cursor?: string | undefined;
-  filter?: VectorFilter | undefined;
-};
-
-export type VectorInspectItem<T = unknown, Metadata extends VectorMetadata = VectorMetadata> = {
-  id: string;
-  document: T;
-  metadata?: Metadata | undefined;
-};
-
-export type VectorInspectPage<T = unknown, Metadata extends VectorMetadata = VectorMetadata> = {
-  items: Array<VectorInspectItem<T, Metadata>>;
-  nextCursor?: string | undefined;
-  totalCount?: number | undefined;
-};
-
-export interface VectorSearchIndex<T = unknown, Metadata extends VectorMetadata = VectorMetadata> {
-  search(request: VectorSearchRequest): Promise<Array<VectorSearchResult<T, Metadata>>>;
-  searchIds(request: VectorSearchRequest): Promise<Array<{ score: number; id: string }>>;
-  asTool(options: VectorSearchToolOptions): Tool<{ query: string; topK?: number }, unknown>;
-  inspect?(request: VectorInspectRequest): Promise<VectorInspectPage<T, Metadata>>;
-}
-
-export type VectorSearchToolOptions = {
-  name: string;
-  description?: string | undefined;
-  topK?: number | undefined;
-  threshold?: number | undefined;
-  filter?: VectorFilter | undefined;
-};
+export { vectorFilter } from "./filter";
+export type * from "./types";
 
 type StoredDocument<T, Metadata extends VectorMetadata> = EmbeddedDocument<T, Metadata>;
 

--- a/packages/core/src/vector-store/lsh.ts
+++ b/packages/core/src/vector-store/lsh.ts
@@ -1,9 +1,6 @@
-export type LshOptions = {
-  type: "lsh";
-  numTables: number;
-  numHyperplanes: number;
-  seed?: number | undefined;
-};
+import type { LshOptions } from "./types";
+
+export type { LshOptions } from "./types";
 
 export class LshIndex {
   private readonly hyperplanes: number[][];

--- a/packages/core/src/vector-store/types.ts
+++ b/packages/core/src/vector-store/types.ts
@@ -1,0 +1,65 @@
+import type { VectorMetadata, VectorMetadataValue } from "../embeddings";
+import type { Tool } from "../tool/tool";
+
+export type VectorFilter =
+  | { type: "eq"; key: string; value: VectorMetadataValue }
+  | { type: "gt"; key: string; value: VectorMetadataValue }
+  | { type: "lt"; key: string; value: VectorMetadataValue }
+  | { type: "and"; filters: [VectorFilter, VectorFilter] }
+  | { type: "or"; filters: [VectorFilter, VectorFilter] };
+
+export type LshOptions = {
+  type: "lsh";
+  numTables: number;
+  numHyperplanes: number;
+  seed?: number | undefined;
+};
+
+export type IndexStrategy = { type: "bruteForce" } | LshOptions;
+
+export type VectorSearchRequest = {
+  query: string;
+  topK: number;
+  threshold?: number | undefined;
+  filter?: VectorFilter | undefined;
+};
+
+export type VectorSearchResult<T = unknown, Metadata extends VectorMetadata = VectorMetadata> = {
+  score: number;
+  id: string;
+  document: T;
+  metadata?: Metadata | undefined;
+};
+
+export type VectorInspectRequest = {
+  limit: number;
+  cursor?: string | undefined;
+  filter?: VectorFilter | undefined;
+};
+
+export type VectorInspectItem<T = unknown, Metadata extends VectorMetadata = VectorMetadata> = {
+  id: string;
+  document: T;
+  metadata?: Metadata | undefined;
+};
+
+export type VectorInspectPage<T = unknown, Metadata extends VectorMetadata = VectorMetadata> = {
+  items: Array<VectorInspectItem<T, Metadata>>;
+  nextCursor?: string | undefined;
+  totalCount?: number | undefined;
+};
+
+export interface VectorSearchIndex<T = unknown, Metadata extends VectorMetadata = VectorMetadata> {
+  search(request: VectorSearchRequest): Promise<Array<VectorSearchResult<T, Metadata>>>;
+  searchIds(request: VectorSearchRequest): Promise<Array<{ score: number; id: string }>>;
+  asTool(options: VectorSearchToolOptions): Tool<{ query: string; topK?: number }, unknown>;
+  inspect?(request: VectorInspectRequest): Promise<VectorInspectPage<T, Metadata>>;
+}
+
+export type VectorSearchToolOptions = {
+  name: string;
+  description?: string | undefined;
+  topK?: number | undefined;
+  threshold?: number | undefined;
+  filter?: VectorFilter | undefined;
+};


### PR DESCRIPTION
## Change Intention
Centralize vector-store public type definitions into `packages/core/src/vector-store/types.ts` and re-export them through existing vector-store entry points to preserve the public API.

## Reviews
Review passed with no findings. The reviewer identified this as a type-organization refactor with preserved public exports and no correctness, API, architecture, or maintainability defects.

<details>
<summary>Original review output</summary>

```markdown
## Change Intention
The change appears to centralize vector-store public type definitions into a new `packages/core/src/vector-store/types.ts` module, then re-export those types through existing entry points to preserve the public API. Key files involved:
- `packages/core/src/vector-store/types.ts`
- `packages/core/src/vector-store/index.ts`
- `packages/core/src/vector-store/filter.ts`
- `packages/core/src/vector-store/lsh.ts`

## Findings
No findings.

## Notes
- Lexa was available and indexed successfully. `lexa audit --since main` reported no structural findings, though it showed `0 changed file(s)` for that scope, so the review primarily used the provided diff plus focused inspection.
- Centralizing the shared vector-store contracts in `types.ts` is a good maintainability move: it removes duplicated type ownership from implementation files while keeping existing exports available through `index.ts`, `filter.ts`, and `lsh.ts`.
- Existing imports from `@anvia/core/vector-store` should continue to work because `index.ts` now uses `export type * from "./types"` and still exports `vectorFilter`.

## Verdicts
- **Verdict:** pass
- **Reason:** The change is a type-organization refactor with preserved public type exports, and I did not find concrete correctness, API, architecture, or maintainability defects in the diff.
```

</details>

## What Fixed
No fix step was required.

<details>
<summary>Fix agent output</summary>

```markdown
(no fix output)
```

</details>

## Lint and Typecheck Status
- Typecheck: passed - `pnpm typecheck`
- Lint: passed - `pnpm lint` (completed with 5 warnings, exit code 0)
- Test: passed - `pnpm test`
- Build: passed - `pnpm build`

<details>
<summary>Verification output</summary>

```markdown
## Verification Summary
- Inspected the monorepo package scripts and lockfile/package manager. The project uses `pnpm@11.0.4` with `pnpm-lock.yaml`.
- Available verification commands were run from `/Volumes/indrazm/anvia_hq/anvia`.
- Typecheck, lint, tests, and build all completed successfully. Lint reported warnings, but exited with status 0.

## Checks
- typecheck: passed - `pnpm typecheck`
- lint: passed - `pnpm lint` (completed with 5 warnings, exit code 0)
- test: passed - `pnpm test`
- build: passed - `pnpm build`

## Verdict
VERDICT: pass
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated vector-store TypeScript types into a shared, public type surface for easier reuse across search, inspection, and tool integration.
  * Updated how vector filter and indexing strategy types are exposed, without changing existing search/filter behavior.
* **Documentation**
  * Refreshed vector-store reference docs to reflect the new indexing strategy types (including LSH configuration) and their updated composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->