### PR TITLE
Refactor agent type definitions

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -22,103 +22,20 @@ import type {
   ToolCallContext,
 } from "../tool/tool";
 import { ToolSet } from "../tool/tool-set";
-import type { VectorFilter, VectorSearchIndex, VectorSearchResult } from "../vector-store";
+import type { VectorSearchIndex } from "../vector-store";
 import type { PromptHook } from "./hooks";
 import { normalizeAgentId } from "./ids";
 import { PromptRequest } from "./request";
+import type {
+  AgentEventStoreRegistration,
+  AgentOptions,
+  AgentToolOptions,
+  DynamicContextRegistration,
+  DynamicToolRegistration,
+} from "./types";
 import { isStreamingCompletionModel } from "./utils";
 
-export type AgentOptions<M extends CompletionModel = CompletionModel> = {
-  id: string;
-  name?: string | undefined;
-  description?: string | undefined;
-  model: M;
-  instructions?: string | undefined;
-  staticContext?: Document[];
-  temperature?: number | undefined;
-  maxTokens?: number | undefined;
-  additionalParams?: JsonValue | undefined;
-  toolSet?: ToolSet | undefined;
-  toolChoice?: ToolChoice | undefined;
-  defaultMaxTurns?: number | undefined;
-  hook?: PromptHook | undefined;
-  outputSchema?: JsonObject | undefined;
-  observers?: AgentObserverRegistration[] | undefined;
-  approvals?: ToolApprovalsOptions | undefined;
-  dynamicContexts?: DynamicContextRegistration[] | undefined;
-  dynamicTools?: DynamicToolRegistration[] | undefined;
-  middlewares?: AgentMiddleware[] | undefined;
-  /**
-   * @deprecated Use `middlewares` instead.
-   */
-  toolMiddlewares?: AgentMiddleware[] | undefined;
-  memory?: MemoryRegistration | undefined;
-  eventStore?: AgentEventStoreRegistration | undefined;
-};
-
 export const DEFAULT_MAX_TURNS = 20;
-
-export type AgentToolOptions = {
-  name: string;
-  description?: string | undefined;
-  maxTurns?: number | undefined;
-  stream?: boolean | undefined;
-};
-
-export type AgentEventStoreInclude = "all" | "agent_tool_events";
-
-export type AgentEventStoreOptions = {
-  include?: AgentEventStoreInclude | undefined;
-};
-
-export type AgentEventAppendInput = {
-  runId: string;
-  agentId: string;
-  agentName?: string | undefined;
-  turn?: number | undefined;
-  toolName?: string | undefined;
-  toolCallId?: string | undefined;
-  internalCallId?: string | undefined;
-  event: unknown;
-};
-
-export type AgentEventRecord = AgentEventAppendInput & {
-  createdAt?: Date | undefined;
-};
-
-export interface AgentEventStore {
-  append(input: AgentEventAppendInput): Promise<void>;
-  load(runId: string): Promise<AgentEventRecord[]>;
-  clear?(runId: string): Promise<void>;
-}
-
-export type AgentEventStoreRegistration = {
-  store: AgentEventStore;
-  options: Required<AgentEventStoreOptions>;
-};
-
-export type DynamicContextOptions<T = unknown> = {
-  topK: number;
-  threshold?: number | undefined;
-  filter?: VectorFilter | undefined;
-  format?: ((result: VectorSearchResult<T>) => Document) | undefined;
-};
-
-export type DynamicContextRegistration<T = unknown> = {
-  index: VectorSearchIndex<T>;
-  options: DynamicContextOptions<T>;
-};
-
-export type DynamicToolOptions = {
-  topK: number;
-  threshold?: number | undefined;
-  filter?: VectorFilter | undefined;
-};
-
-export type DynamicToolRegistration = {
-  index: VectorSearchIndex<ToolSearchDocument>;
-  options: DynamicToolOptions;
-};
 
 export class Agent<M extends CompletionModel = CompletionModel> {
   readonly id: string;

--- a/packages/core/src/agent/builder.ts
+++ b/packages/core/src/agent/builder.ts
@@ -14,18 +14,18 @@ import type { AgentMiddleware, ToolMiddleware } from "../tool/middleware";
 import type { AnyTool, ToolApprovalsOptions } from "../tool/tool";
 import { ToolSet } from "../tool/tool-set";
 import type { VectorSearchIndex } from "../vector-store";
-import {
-  Agent,
-  type AgentEventStore,
-  type AgentEventStoreOptions,
-  type AgentEventStoreRegistration,
-  type DynamicContextOptions,
-  type DynamicContextRegistration,
-  type DynamicToolOptions,
-  type DynamicToolRegistration,
-} from "./agent";
+import { Agent } from "./agent";
 import type { PromptHook } from "./hooks";
 import { normalizeAgentId } from "./ids";
+import type {
+  AgentEventStore,
+  AgentEventStoreOptions,
+  AgentEventStoreRegistration,
+  DynamicContextOptions,
+  DynamicContextRegistration,
+  DynamicToolOptions,
+  DynamicToolRegistration,
+} from "./types";
 
 export class AgentBuilder<M extends CompletionModel = CompletionModel> {
   private readonly agentId: string;

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -17,13 +17,6 @@ export type {
   ToolResultMiddlewareArgs,
 } from "../tool/middleware";
 export { createMiddleware, createToolMiddleware } from "../tool/middleware";
-export type {
-  AgentEventAppendInput,
-  AgentEventRecord,
-  AgentEventStore,
-  AgentEventStoreInclude,
-  AgentEventStoreOptions,
-} from "./agent";
 export { AgentBuilder } from "./builder";
 export { MaxTurnsError, PromptCancelledError, ToolApprovalRequiredError } from "./errors";
 export type {
@@ -61,3 +54,10 @@ export type {
   AgentStreamEvent,
   PromptResponse,
 } from "./request-types";
+export type {
+  AgentEventAppendInput,
+  AgentEventRecord,
+  AgentEventStore,
+  AgentEventStoreInclude,
+  AgentEventStoreOptions,
+} from "./types";

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -1,0 +1,105 @@
+import type {
+  CompletionModel,
+  Document,
+  JsonObject,
+  JsonValue,
+  ToolChoice,
+} from "../completion/index";
+import type { MemoryRegistration } from "../memory";
+import type { AgentObserverRegistration } from "../observability";
+import type { ToolSearchDocument } from "../tool/dynamic-tools";
+import type { AgentMiddleware } from "../tool/middleware";
+import type { ToolApprovalsOptions } from "../tool/tool";
+import type { ToolSet } from "../tool/tool-set";
+import type { VectorFilter, VectorSearchIndex, VectorSearchResult } from "../vector-store";
+import type { PromptHook } from "./hooks";
+
+export type AgentOptions<M extends CompletionModel = CompletionModel> = {
+  id: string;
+  name?: string | undefined;
+  description?: string | undefined;
+  model: M;
+  instructions?: string | undefined;
+  staticContext?: Document[];
+  temperature?: number | undefined;
+  maxTokens?: number | undefined;
+  additionalParams?: JsonValue | undefined;
+  toolSet?: ToolSet | undefined;
+  toolChoice?: ToolChoice | undefined;
+  defaultMaxTurns?: number | undefined;
+  hook?: PromptHook | undefined;
+  outputSchema?: JsonObject | undefined;
+  observers?: AgentObserverRegistration[] | undefined;
+  approvals?: ToolApprovalsOptions | undefined;
+  dynamicContexts?: DynamicContextRegistration[] | undefined;
+  dynamicTools?: DynamicToolRegistration[] | undefined;
+  middlewares?: AgentMiddleware[] | undefined;
+  /**
+   * @deprecated Use `middlewares` instead.
+   */
+  toolMiddlewares?: AgentMiddleware[] | undefined;
+  memory?: MemoryRegistration | undefined;
+  eventStore?: AgentEventStoreRegistration | undefined;
+};
+
+export type AgentToolOptions = {
+  name: string;
+  description?: string | undefined;
+  maxTurns?: number | undefined;
+  stream?: boolean | undefined;
+};
+
+export type AgentEventStoreInclude = "all" | "agent_tool_events";
+
+export type AgentEventStoreOptions = {
+  include?: AgentEventStoreInclude | undefined;
+};
+
+export type AgentEventAppendInput = {
+  runId: string;
+  agentId: string;
+  agentName?: string | undefined;
+  turn?: number | undefined;
+  toolName?: string | undefined;
+  toolCallId?: string | undefined;
+  internalCallId?: string | undefined;
+  event: unknown;
+};
+
+export type AgentEventRecord = AgentEventAppendInput & {
+  createdAt?: Date | undefined;
+};
+
+export interface AgentEventStore {
+  append(input: AgentEventAppendInput): Promise<void>;
+  load(runId: string): Promise<AgentEventRecord[]>;
+  clear?(runId: string): Promise<void>;
+}
+
+export type AgentEventStoreRegistration = {
+  store: AgentEventStore;
+  options: Required<AgentEventStoreOptions>;
+};
+
+export type DynamicContextOptions<T = unknown> = {
+  topK: number;
+  threshold?: number | undefined;
+  filter?: VectorFilter | undefined;
+  format?: ((result: VectorSearchResult<T>) => Document) | undefined;
+};
+
+export type DynamicContextRegistration<T = unknown> = {
+  index: VectorSearchIndex<T>;
+  options: DynamicContextOptions<T>;
+};
+
+export type DynamicToolOptions = {
+  topK: number;
+  threshold?: number | undefined;
+  filter?: VectorFilter | undefined;
+};
+
+export type DynamicToolRegistration = {
+  index: VectorSearchIndex<ToolSearchDocument>;
+  options: DynamicToolOptions;
+};

--- a/packages/core/src/internal/agent.ts
+++ b/packages/core/src/internal/agent.ts
@@ -1,1 +1,2 @@
 export * from "../agent/agent";
+export type * from "../agent/types";


### PR DESCRIPTION
## Change Intention
Extract agent-related type definitions from `packages/core/src/agent/agent.ts` into a dedicated `packages/core/src/agent/types.ts` module, and update agent, builder, public, and internal exports to import those shared types from the new location.

## Reviews
Review passed with no findings. The review confirmed that the type extraction preserves public event-store type exports, restores internal access to moved types, and passes typechecking.

<details>
<summary>Original review output</summary>

```markdown
## Change Intention
The change appears to extract agent-related type definitions out of `packages/core/src/agent/agent.ts` into a new dedicated `packages/core/src/agent/types.ts` module, then update imports/exports accordingly.

Key files involved:
- `packages/core/src/agent/types.ts` — new home for `AgentOptions`, dynamic context/tool types, and event store types.
- `packages/core/src/agent/agent.ts` — now imports those types instead of declaring them inline.
- `packages/core/src/agent/builder.ts` — imports shared types from `./types`.
- `packages/core/src/agent/index.ts` — continues public type exports for event store types from the new module.
- `packages/core/src/internal/agent.ts` — re-exports internal agent types from the new module.

## Findings
No findings.

## Notes
- I ran `lexa --version`, `lexa index .`, `lexa status`, and `lexa audit --since main`. Lexa indexed successfully and reported existing structural risks around agent request cycles/large classes, but nothing in this diff introduces a concrete new defect that should block this refactor.
- I also ran `pnpm --filter @anvia/core typecheck`; it completed successfully.
- Keeping `AgentOptions` and related registrations in `types.ts` is a good direction for reducing responsibility in `agent.ts` and making the shared type surface easier to reuse from `builder.ts` and internal exports.

## Verdicts
- **Verdict:** pass
- **Reason:** The type extraction preserves the existing public event-store type exports, restores internal access to the moved types, and passes typechecking.
```

</details>

## What Fixed
No fix step was required.

<details>
<summary>Fix agent output</summary>

```markdown
(no fix output)
```

</details>

## Lint and Typecheck Status
- Typecheck: passed - `pnpm typecheck`
- Lint: passed - `pnpm lint` (completed with 5 warnings, exit code 0)
- Test: passed - `pnpm test`
- Build: passed - `pnpm build`

<details>
<summary>Verification output</summary>

```markdown
## Verification Summary
- Inspected project scripts and lockfile/package manager: monorepo uses `pnpm` with `pnpm-lock.yaml` and `packageManager: pnpm@11.0.4`.
- Ran available root verification scripts for typecheck, lint, tests, and build.
- All available checks completed successfully. Lint reported warnings for existing unused imports but exited with status 0, so it is recorded as passed.

## Checks
- typecheck: passed - `pnpm typecheck`
- lint: passed - `pnpm lint` (completed with 5 warnings, exit code 0)
- test: passed - `pnpm test`
- build: passed - `pnpm build`

## Verdict
VERDICT: pass
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Cleaned up the agent API surface by moving several agent-related types into a dedicated shared location.
  * Simplified package exports so type definitions are organized more consistently.
  * No behavior changes are expected for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->