### PR TITLE
docs: add memory and event store examples

### DIFF
--- a/apps/www/src/content/docs/examples/agent-event-store-drizzle.md
+++ b/apps/www/src/content/docs/examples/agent-event-store-drizzle.md
@@ -1,0 +1,230 @@
+---
+title: Drizzle Agent Event Store
+description: Persist Anvia agent stream events with a Drizzle-backed store.
+section: examples
+sidebar:
+  group: Memory and Events
+  label: Drizzle events
+  order: 5
+---
+
+Use an agent event store when your app needs an ordered runtime log for a streamed agent run. Event records are useful for replay, debugging, audit review, and operations screens that need to inspect turns, deltas, tool calls, tool results, nested agent activity, final output, and errors.
+
+This is not memory. Memory stores `Message[]` for future prompts. The event store stores runtime events by `runId`.
+
+## Scenario
+
+A backoffice support workflow streams through tools. The product stores a compact support-run row for the UI, while the event store keeps the detailed stream history for internal investigation.
+
+## Table
+
+This example uses Drizzle's Postgres core. Store the original event payload as JSONB and index the query fields you need.
+
+```ts
+import { index, integer, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+
+export const agentEvents = pgTable(
+  "agent_events",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    runId: text("run_id").notNull(),
+    agentId: text("agent_id").notNull(),
+    agentName: text("agent_name"),
+    turn: integer("turn"),
+    toolName: text("tool_name"),
+    toolCallId: text("tool_call_id"),
+    internalCallId: text("internal_call_id"),
+    event: jsonb("event").$type<unknown>().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    index("agent_events_run_idx").on(table.runId, table.createdAt),
+    index("agent_events_agent_idx").on(table.agentId, table.createdAt),
+    index("agent_events_tool_idx").on(table.toolName, table.createdAt),
+  ],
+);
+
+export const schema = { agentEvents };
+```
+
+## Expected Event Records
+
+`AgentEventStore.load(runId)` returns `Promise<AgentEventRecord[]>`. Each record includes query fields plus the raw stream event JSON.
+
+```json
+[
+  {
+    "runId": "run_123",
+    "agentId": "support",
+    "agentName": "Support",
+    "turn": 1,
+    "event": {
+      "type": "turn_start",
+      "turn": 1,
+      "prompt": {
+        "role": "user",
+        "content": [{ "type": "text", "text": "Where is order A-100?" }]
+      },
+      "history": []
+    },
+    "createdAt": "2026-06-29T02:40:00.000Z"
+  },
+  {
+    "runId": "run_123",
+    "agentId": "support",
+    "agentName": "Support",
+    "turn": 1,
+    "event": {
+      "type": "reasoning_delta",
+      "turn": 1,
+      "delta": "Need live order state.",
+      "id": "rs_1",
+      "contentType": "text"
+    },
+    "createdAt": "2026-06-29T02:40:01.000Z"
+  },
+  {
+    "runId": "run_123",
+    "agentId": "support",
+    "agentName": "Support",
+    "turn": 1,
+    "toolName": "lookup_order",
+    "toolCallId": "fc_1",
+    "internalCallId": "tool_internal_1",
+    "event": {
+      "type": "tool_result",
+      "turn": 1,
+      "toolName": "lookup_order",
+      "toolCallId": "fc_1",
+      "internalCallId": "tool_internal_1",
+      "args": "{\"orderId\":\"A-100\"}",
+      "result": "{\"status\":\"shipped\"}"
+    },
+    "createdAt": "2026-06-29T02:40:02.000Z"
+  },
+  {
+    "runId": "run_123",
+    "agentId": "support",
+    "agentName": "Support",
+    "event": {
+      "type": "final",
+      "runId": "run_123",
+      "output": "Order A-100 has shipped.",
+      "usage": {
+        "inputTokens": 120,
+        "outputTokens": 20,
+        "totalTokens": 140,
+        "cachedInputTokens": 0,
+        "cacheCreationInputTokens": 0
+      },
+      "messages": []
+    },
+    "createdAt": "2026-06-29T02:40:03.000Z"
+  }
+]
+```
+
+Other event payloads can include `text_delta`, `tool_call`, `turn_end`, `agent_tool_event`, and `error`. Store the raw `event` JSON so those variants remain available for replay.
+
+## Event Store
+
+```ts
+import { asc, eq } from "drizzle-orm";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import type { AgentEventAppendInput, AgentEventRecord, AgentEventStore } from "@anvia/core/agent";
+import { agentEvents, schema } from "./schema";
+
+type EventDb = NodePgDatabase<typeof schema>;
+
+function toJsonSafeEvent(value: unknown): unknown {
+  return JSON.parse(
+    JSON.stringify(value, (_key, nested) => {
+      if (nested instanceof Error) {
+        return { name: nested.name, message: nested.message, stack: nested.stack };
+      }
+      return nested;
+    }),
+  );
+}
+
+export class DrizzleAgentEventStore implements AgentEventStore {
+  constructor(private readonly db: EventDb) {}
+
+  async append(input: AgentEventAppendInput): Promise<void> {
+    await this.db.insert(agentEvents).values({
+      runId: input.runId,
+      agentId: input.agentId,
+      agentName: input.agentName ?? null,
+      turn: input.turn ?? null,
+      toolName: input.toolName ?? null,
+      toolCallId: input.toolCallId ?? null,
+      internalCallId: input.internalCallId ?? null,
+      event: toJsonSafeEvent(input.event),
+    });
+  }
+
+  async load(runId: string): Promise<AgentEventRecord[]> {
+    const rows = await this.db
+      .select()
+      .from(agentEvents)
+      .where(eq(agentEvents.runId, runId))
+      .orderBy(asc(agentEvents.createdAt));
+
+    return rows.map((row) => ({
+      runId: row.runId,
+      agentId: row.agentId,
+      agentName: row.agentName ?? undefined,
+      turn: row.turn ?? undefined,
+      toolName: row.toolName ?? undefined,
+      toolCallId: row.toolCallId ?? undefined,
+      internalCallId: row.internalCallId ?? undefined,
+      event: row.event,
+      createdAt: row.createdAt,
+    }));
+  }
+
+  async clear(runId: string): Promise<void> {
+    await this.db.delete(agentEvents).where(eq(agentEvents.runId, runId));
+  }
+}
+```
+
+## Use It
+
+```ts
+import { AgentBuilder } from "@anvia/core";
+
+const eventStore = new DrizzleAgentEventStore(db);
+
+const agent = new AgentBuilder("support", model)
+  .tools(supportTools)
+  .eventStore(eventStore, { include: "all" })
+  .build();
+
+let finalRunId: string | undefined;
+
+for await (const event of agent.prompt("Where is order A-100?").stream()) {
+  if (event.type === "final") {
+    finalRunId = event.runId;
+  }
+}
+
+if (finalRunId === undefined) {
+  throw new Error("Agent stream ended without a final event.");
+}
+
+const events = await eventStore.load(finalRunId);
+```
+
+## Production Checks
+
+- Use `.stream()` and consume the stream when event persistence is required.
+- Store raw event JSON, but apply retention and redaction policies before keeping sensitive events long term.
+- Use product run records for user-facing status and event records for internal replay.
+- Keep event logs separate from memory and traces.
+
+## Next Patterns
+
+- [Prisma Agent Event Store](/docs/examples/agent-event-store-prisma)
+- [Raw SQL Agent Event Store](/docs/examples/agent-event-store-raw-sql)
+- [Streaming Events](/docs/examples/streaming-events)

--- a/apps/www/src/content/docs/examples/agent-event-store-prisma.md
+++ b/apps/www/src/content/docs/examples/agent-event-store-prisma.md
@@ -1,0 +1,227 @@
+---
+title: Prisma Agent Event Store
+description: Persist Anvia agent stream events with Prisma-backed storage.
+section: examples
+sidebar:
+  group: Memory and Events
+  label: Prisma events
+  order: 4
+---
+
+Use an agent event store when your app needs to replay or inspect what happened inside a streamed agent run. Event records answer operational questions: which turn started, which tool was requested, what result came back, whether a nested agent emitted events, what final output was produced, and which run id links to traces.
+
+This is not memory. Memory stores `Message[]` for future prompts. The event store stores runtime events by `runId` for debugging, audit, replay, and internal operations screens.
+
+## Scenario
+
+A support agent streams through tools and retrieval. When an answer looks wrong, the team needs to load the run id and inspect the ordered event log instead of guessing from the final answer.
+
+## Prisma Schema
+
+Store the event payload as JSON and index the fields you need for lookup. The event shape can evolve, so avoid splitting every event field into columns.
+
+```prisma
+model AgentEvent {
+  id             String   @id @default(cuid())
+  runId          String
+  agentId        String
+  agentName      String?
+  turn           Int?
+  toolName       String?
+  toolCallId     String?
+  internalCallId String?
+  event          Json
+  createdAt      DateTime @default(now())
+
+  @@index([runId, createdAt])
+  @@index([agentId, createdAt])
+  @@index([toolName, createdAt])
+}
+```
+
+## Expected Event Records
+
+`AgentEventStore.load(runId)` returns `Promise<AgentEventRecord[]>`. Each record wraps the raw stream event with query fields.
+
+```json
+[
+  {
+    "runId": "run_123",
+    "agentId": "support",
+    "agentName": "Support",
+    "turn": 1,
+    "event": {
+      "type": "turn_start",
+      "turn": 1,
+      "prompt": {
+        "role": "user",
+        "content": [{ "type": "text", "text": "Where is order A-100?" }]
+      },
+      "history": []
+    },
+    "createdAt": "2026-06-29T02:40:00.000Z"
+  },
+  {
+    "runId": "run_123",
+    "agentId": "support",
+    "agentName": "Support",
+    "turn": 1,
+    "event": {
+      "type": "tool_call",
+      "turn": 1,
+      "toolCall": {
+        "type": "tool_call",
+        "id": "call_1",
+        "callId": "fc_1",
+        "function": {
+          "name": "lookup_order",
+          "arguments": { "orderId": "A-100" }
+        }
+      }
+    },
+    "createdAt": "2026-06-29T02:40:01.000Z"
+  },
+  {
+    "runId": "run_123",
+    "agentId": "support",
+    "agentName": "Support",
+    "turn": 1,
+    "toolName": "lookup_order",
+    "toolCallId": "fc_1",
+    "internalCallId": "tool_internal_1",
+    "event": {
+      "type": "tool_result",
+      "turn": 1,
+      "toolName": "lookup_order",
+      "toolCallId": "fc_1",
+      "internalCallId": "tool_internal_1",
+      "args": "{\"orderId\":\"A-100\"}",
+      "result": "{\"status\":\"shipped\"}"
+    },
+    "createdAt": "2026-06-29T02:40:02.000Z"
+  },
+  {
+    "runId": "run_123",
+    "agentId": "support",
+    "agentName": "Support",
+    "event": {
+      "type": "final",
+      "runId": "run_123",
+      "output": "Order A-100 has shipped.",
+      "usage": {
+        "inputTokens": 120,
+        "outputTokens": 20,
+        "totalTokens": 140,
+        "cachedInputTokens": 0,
+        "cacheCreationInputTokens": 0
+      },
+      "messages": []
+    },
+    "createdAt": "2026-06-29T02:40:03.000Z"
+  }
+]
+```
+
+Other event payloads can include `text_delta`, `reasoning_delta`, `turn_end`, `agent_tool_event`, and `error`. Keep the raw `event` JSON so those variants remain replayable.
+
+## Event Store
+
+```ts
+import { Prisma, PrismaClient } from "@prisma/client";
+import type { AgentEventAppendInput, AgentEventRecord, AgentEventStore } from "@anvia/core/agent";
+
+function toJsonValue(value: unknown): Prisma.InputJsonValue {
+  return JSON.parse(
+    JSON.stringify(value, (_key, nested) => {
+      if (nested instanceof Error) {
+        return { name: nested.name, message: nested.message, stack: nested.stack };
+      }
+      return nested;
+    }),
+  ) as Prisma.InputJsonValue;
+}
+
+export class PrismaAgentEventStore implements AgentEventStore {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async append(input: AgentEventAppendInput): Promise<void> {
+    await this.prisma.agentEvent.create({
+      data: {
+        runId: input.runId,
+        agentId: input.agentId,
+        agentName: input.agentName ?? null,
+        turn: input.turn ?? null,
+        toolName: input.toolName ?? null,
+        toolCallId: input.toolCallId ?? null,
+        internalCallId: input.internalCallId ?? null,
+        event: toJsonValue(input.event),
+      },
+    });
+  }
+
+  async load(runId: string): Promise<AgentEventRecord[]> {
+    const rows = await this.prisma.agentEvent.findMany({
+      where: { runId },
+      orderBy: { createdAt: "asc" },
+    });
+
+    return rows.map((row) => ({
+      runId: row.runId,
+      agentId: row.agentId,
+      agentName: row.agentName ?? undefined,
+      turn: row.turn ?? undefined,
+      toolName: row.toolName ?? undefined,
+      toolCallId: row.toolCallId ?? undefined,
+      internalCallId: row.internalCallId ?? undefined,
+      event: row.event,
+      createdAt: row.createdAt,
+    }));
+  }
+
+  async clear(runId: string): Promise<void> {
+    await this.prisma.agentEvent.deleteMany({ where: { runId } });
+  }
+}
+```
+
+## Use It
+
+```ts
+import { AgentBuilder } from "@anvia/core";
+
+const eventStore = new PrismaAgentEventStore(prisma);
+
+const agent = new AgentBuilder("support", model)
+  .instructions("Answer support questions using tools and policy context.")
+  .tools(supportTools)
+  .eventStore(eventStore, { include: "all" })
+  .build();
+
+let final;
+for await (const event of agent.session("thread_123").prompt("Where is order A-100?").stream()) {
+  if (event.type === "final") {
+    final = event;
+  }
+}
+
+if (final === undefined) {
+  throw new Error("Agent stream ended without a final event.");
+}
+
+const replayEvents = await eventStore.load(final.runId);
+```
+
+Use `include: "all"` for full replay. Use `include: "agent_tool_events"` when you only need nested child-agent events from agent tools.
+
+## Production Checks
+
+- Drain `.stream()` when you need event persistence; event records are written as stream events are emitted.
+- Apply retention and redaction policies because events can include prompts, history, tool arguments, tool results, reasoning, provider metadata, and errors.
+- Keep event logs separate from memory, traces, product records, and audit records.
+- Store a smaller product run record for user-facing status; event logs are detailed operational data.
+
+## Next Patterns
+
+- [Drizzle Agent Event Store](/docs/examples/agent-event-store-drizzle)
+- [Raw SQL Agent Event Store](/docs/examples/agent-event-store-raw-sql)
+- [Runtime State and Persistence](/docs/examples/runtime-state-persistence)

--- a/apps/www/src/content/docs/examples/agent-event-store-raw-sql.md
+++ b/apps/www/src/content/docs/examples/agent-event-store-raw-sql.md
@@ -1,0 +1,242 @@
+---
+title: Raw SQL Agent Event Store
+description: Persist Anvia agent stream events with a raw SQL adapter.
+section: examples
+sidebar:
+  group: Memory and Events
+  label: Raw SQL events
+  order: 6
+---
+
+Use a raw SQL event store when your application talks directly to the database and needs replayable runtime events for streamed agent runs.
+
+Event storage is for operational visibility: debugging bad answers, replaying tool behavior, inspecting nested agent activity, and linking a product run to trace metadata. It is not memory and should not be used as the conversation transcript for future prompts.
+
+## Scenario
+
+A Node service uses Postgres through `pg`. The support agent streams to an internal operations surface, and every stream event is persisted under the same run id.
+
+## Table
+
+```sql
+CREATE TABLE agent_events (
+  id bigserial PRIMARY KEY,
+  run_id text NOT NULL,
+  agent_id text NOT NULL,
+  agent_name text,
+  turn integer,
+  tool_name text,
+  tool_call_id text,
+  internal_call_id text,
+  event jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX agent_events_run_idx
+  ON agent_events (run_id, created_at);
+
+CREATE INDEX agent_events_agent_idx
+  ON agent_events (agent_id, created_at);
+
+CREATE INDEX agent_events_tool_idx
+  ON agent_events (tool_name, created_at);
+```
+
+## Expected Event Records
+
+`AgentEventStore.load(runId)` returns `Promise<AgentEventRecord[]>`. Each record contains indexed fields and the original stream event payload.
+
+```json
+[
+  {
+    "runId": "run_123",
+    "agentId": "support",
+    "agentName": "Support",
+    "turn": 1,
+    "event": {
+      "type": "turn_start",
+      "turn": 1,
+      "prompt": {
+        "role": "user",
+        "content": [{ "type": "text", "text": "Where is order A-100?" }]
+      },
+      "history": []
+    },
+    "createdAt": "2026-06-29T02:40:00.000Z"
+  },
+  {
+    "runId": "run_123",
+    "agentId": "support",
+    "agentName": "Support",
+    "turn": 1,
+    "event": {
+      "type": "text_delta",
+      "turn": 1,
+      "delta": "Checking"
+    },
+    "createdAt": "2026-06-29T02:40:01.000Z"
+  },
+  {
+    "runId": "run_123",
+    "agentId": "support",
+    "agentName": "Support",
+    "turn": 1,
+    "toolName": "lookup_order",
+    "toolCallId": "fc_1",
+    "internalCallId": "tool_internal_1",
+    "event": {
+      "type": "tool_result",
+      "turn": 1,
+      "toolName": "lookup_order",
+      "toolCallId": "fc_1",
+      "internalCallId": "tool_internal_1",
+      "args": "{\"orderId\":\"A-100\"}",
+      "result": "{\"status\":\"shipped\"}"
+    },
+    "createdAt": "2026-06-29T02:40:02.000Z"
+  },
+  {
+    "runId": "run_123",
+    "agentId": "support",
+    "agentName": "Support",
+    "event": {
+      "type": "final",
+      "runId": "run_123",
+      "output": "Order A-100 has shipped.",
+      "usage": {
+        "inputTokens": 120,
+        "outputTokens": 20,
+        "totalTokens": 140,
+        "cachedInputTokens": 0,
+        "cacheCreationInputTokens": 0
+      },
+      "messages": []
+    },
+    "createdAt": "2026-06-29T02:40:03.000Z"
+  }
+]
+```
+
+Other event payloads can include `reasoning_delta`, `tool_call`, `turn_end`, `agent_tool_event`, and `error`. Store `event` as JSONB so those variants can be preserved without adding columns.
+
+## Event Store
+
+```ts
+import type { Pool } from "pg";
+import type { AgentEventAppendInput, AgentEventRecord, AgentEventStore } from "@anvia/core/agent";
+
+function toJsonSafeEvent(value: unknown): unknown {
+  return JSON.parse(
+    JSON.stringify(value, (_key, nested) => {
+      if (nested instanceof Error) {
+        return { name: nested.name, message: nested.message, stack: nested.stack };
+      }
+      return nested;
+    }),
+  );
+}
+
+function fromJson(value: unknown): unknown {
+  return typeof value === "string" ? JSON.parse(value) : value;
+}
+
+export class SqlAgentEventStore implements AgentEventStore {
+  constructor(private readonly pool: Pool) {}
+
+  async append(input: AgentEventAppendInput): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO agent_events
+         (run_id, agent_id, agent_name, turn, tool_name, tool_call_id, internal_call_id, event)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)`,
+      [
+        input.runId,
+        input.agentId,
+        input.agentName ?? null,
+        input.turn ?? null,
+        input.toolName ?? null,
+        input.toolCallId ?? null,
+        input.internalCallId ?? null,
+        JSON.stringify(toJsonSafeEvent(input.event)),
+      ],
+    );
+  }
+
+  async load(runId: string): Promise<AgentEventRecord[]> {
+    const { rows } = await this.pool.query<{
+      run_id: string;
+      agent_id: string;
+      agent_name: string | null;
+      turn: number | null;
+      tool_name: string | null;
+      tool_call_id: string | null;
+      internal_call_id: string | null;
+      event: unknown;
+      created_at: Date;
+    }>(
+      `SELECT run_id, agent_id, agent_name, turn, tool_name, tool_call_id,
+              internal_call_id, event, created_at
+       FROM agent_events
+       WHERE run_id = $1
+       ORDER BY created_at ASC, id ASC`,
+      [runId],
+    );
+
+    return rows.map((row) => ({
+      runId: row.run_id,
+      agentId: row.agent_id,
+      agentName: row.agent_name ?? undefined,
+      turn: row.turn ?? undefined,
+      toolName: row.tool_name ?? undefined,
+      toolCallId: row.tool_call_id ?? undefined,
+      internalCallId: row.internal_call_id ?? undefined,
+      event: fromJson(row.event),
+      createdAt: row.created_at,
+    }));
+  }
+
+  async clear(runId: string): Promise<void> {
+    await this.pool.query("DELETE FROM agent_events WHERE run_id = $1", [runId]);
+  }
+}
+```
+
+## Use It
+
+```ts
+import { Pool } from "pg";
+import { AgentBuilder } from "@anvia/core";
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+const eventStore = new SqlAgentEventStore(pool);
+
+const agent = new AgentBuilder("support", model)
+  .tools(supportTools)
+  .eventStore(eventStore, { include: "all" })
+  .build();
+
+let final;
+for await (const event of agent.prompt("Where is order A-100?").stream()) {
+  if (event.type === "final") {
+    final = event;
+  }
+}
+
+if (final === undefined) {
+  throw new Error("Agent stream ended without a final event.");
+}
+
+const eventLog = await eventStore.load(final.runId);
+```
+
+## Production Checks
+
+- Drain the stream to persist events.
+- Keep raw event logs internal unless product policy explicitly allows exposing them.
+- Redact or expire events that include private prompts, history, tool arguments, tool results, reasoning, provider payloads, or errors.
+- Use product tables for user-visible state and event logs for operational replay.
+
+## Next Patterns
+
+- [Prisma Agent Event Store](/docs/examples/agent-event-store-prisma)
+- [Drizzle Agent Event Store](/docs/examples/agent-event-store-drizzle)
+- [Runtime State and Persistence](/docs/examples/runtime-state-persistence)

--- a/apps/www/src/content/docs/examples/agent-memory-drizzle.md
+++ b/apps/www/src/content/docs/examples/agent-memory-drizzle.md
@@ -1,0 +1,312 @@
+---
+title: Drizzle Agent Memory
+description: Persist Anvia agent session memory with a Drizzle-backed store.
+section: examples
+sidebar:
+  group: Memory and Events
+  label: Drizzle history
+  order: 2
+---
+
+Use a Drizzle-backed `MemoryStore` when your application already uses Drizzle for relational data and you want conversation memory to live beside the rest of your product storage.
+
+## Scenario
+
+A tenant-scoped app stores conversations in Postgres through Drizzle. The route passes a stable conversation id into `agent.session(...)`, and the memory adapter handles loading, appending, and clearing messages for that session.
+
+## Table
+
+This example uses Drizzle's Postgres core. The important part is the same for other relational stores: keep a session scope, an append order, and the full Anvia message JSON.
+
+```ts
+import { index, integer, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import type { Message } from "@anvia/core";
+
+export const agentMemoryMessages = pgTable(
+  "agent_memory_messages",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    sessionId: text("session_id").notNull(),
+    userId: text("user_id"),
+    tenantId: text("tenant_id"),
+    runId: text("run_id").notNull(),
+    turn: integer("turn").notNull(),
+    position: integer("position").notNull(),
+    role: text("role").notNull(),
+    message: jsonb("message").$type<Message>().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [index("agent_memory_session_idx").on(table.sessionId, table.userId, table.tenantId, table.position)],
+);
+
+export const schema = { agentMemoryMessages };
+```
+
+## Expected Message JSON
+
+`MemoryStore.load(...)` returns `Promise<Message[]>`. This example stores one Anvia `Message` object per row, then returns the ordered row set as an array.
+
+The message union is:
+
+```ts
+type Message = SystemMessage | UserMessage | AssistantMessage | ToolMessage;
+type UserContent = Text | ImageContent | DocumentContent;
+type AssistantContent = Text | ImageContent | Reasoning | ToolCall;
+type ToolContent = ToolResult;
+```
+
+The full shape returned from `load(...)` is an array. This illustrative array includes every supported message and content variant; real transcripts usually contain only the variants produced by that run.
+
+```json
+[
+  {
+    "role": "system",
+    "content": "Stable runtime instructions."
+  },
+  {
+    "role": "user",
+    "content": [
+      {
+        "type": "text",
+        "text": "Where is order A-100?",
+        "signature": "sig_user_text"
+      },
+      {
+        "type": "image",
+        "source": { "type": "url", "url": "https://files.example.com/photo.png" },
+        "detail": "high"
+      },
+      {
+        "type": "image",
+        "source": {
+          "type": "base64",
+          "data": "iVBORw0KGgo=",
+          "mediaType": "image/png"
+        },
+        "detail": "low"
+      },
+      {
+        "type": "document",
+        "source": {
+          "type": "url",
+          "url": "https://files.example.com/invoice.pdf",
+          "mediaType": "application/pdf",
+          "filename": "invoice.pdf"
+        }
+      },
+      {
+        "type": "document",
+        "source": {
+          "type": "base64",
+          "data": "JVBERi0xLjQ=",
+          "mediaType": "application/pdf",
+          "filename": "invoice-copy.pdf"
+        }
+      },
+      {
+        "type": "document",
+        "source": {
+          "type": "text",
+          "text": "Invoice text extracted upstream.",
+          "mediaType": "text/plain",
+          "filename": "invoice.txt"
+        }
+      }
+    ]
+  },
+  {
+    "role": "assistant",
+    "id": "msg_assistant_1",
+    "content": [
+      {
+        "type": "text",
+        "text": "I will look that up.",
+        "signature": "sig_assistant_text"
+      },
+      {
+        "type": "image",
+        "source": { "type": "url", "url": "https://files.example.com/generated.png" },
+        "detail": "auto"
+      },
+      {
+        "type": "image",
+        "source": {
+          "type": "base64",
+          "data": "iVBORw0KGgo=",
+          "mediaType": "image/png"
+        }
+      },
+      {
+        "type": "reasoning",
+        "id": "rs_1",
+        "text": "Checked order status and summarized the result.",
+        "content": [
+          {
+            "type": "text",
+            "text": "Need live order state.",
+            "signature": "sig_reasoning_text"
+          },
+          {
+            "type": "summary",
+            "text": "Order lookup is required."
+          },
+          {
+            "type": "encrypted",
+            "data": "encrypted_reasoning_blob"
+          },
+          {
+            "type": "redacted",
+            "data": "redacted_reasoning_blob"
+          }
+        ]
+      },
+      {
+        "type": "tool_call",
+        "id": "call_1",
+        "callId": "fc_1",
+        "function": {
+          "name": "lookup_order",
+          "arguments": { "orderId": "A-100" }
+        },
+        "signature": "sig_tool_call",
+        "additionalParams": { "providerToolCallId": "provider_call_1" }
+      }
+    ]
+  },
+  {
+    "role": "tool",
+    "content": [
+      {
+        "type": "tool_result",
+        "id": "call_1",
+        "callId": "fc_1",
+        "content": [
+          {
+            "type": "text",
+            "text": "{\"status\":\"shipped\"}"
+          },
+          {
+            "type": "image",
+            "data": "iVBORw0KGgo=",
+            "mediaType": "image/png"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "role": "assistant",
+    "content": [{ "type": "text", "text": "Order A-100 has shipped." }]
+  }
+]
+```
+
+Each row's `message` column contains one item from that array.
+
+## Memory Store
+
+```ts
+import { and, asc, desc, eq, isNull } from "drizzle-orm";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import { type MemoryStore, type Message } from "@anvia/core";
+import type { MemoryAppendInput, MemoryContext } from "@anvia/core/memory";
+import { agentMemoryMessages, schema } from "./schema";
+
+type MemoryDb = NodePgDatabase<typeof schema>;
+
+function tenantId(context: MemoryContext) {
+  const value = context.metadata?.tenantId;
+  return typeof value === "string" ? value : null;
+}
+
+function scopedWhere(context: MemoryContext) {
+  const tenant = tenantId(context);
+
+  return and(
+    eq(agentMemoryMessages.sessionId, context.sessionId),
+    context.userId === undefined ? isNull(agentMemoryMessages.userId) : eq(agentMemoryMessages.userId, context.userId),
+    tenant === null ? isNull(agentMemoryMessages.tenantId) : eq(agentMemoryMessages.tenantId, tenant),
+  );
+}
+
+export class DrizzleMemoryStore implements MemoryStore {
+  constructor(private readonly db: MemoryDb) {}
+
+  async load(context: MemoryContext): Promise<Message[]> {
+    const rows = await this.db
+      .select({ message: agentMemoryMessages.message })
+      .from(agentMemoryMessages)
+      .where(scopedWhere(context))
+      .orderBy(asc(agentMemoryMessages.position));
+
+    return rows.map((row) => row.message);
+  }
+
+  async append(input: MemoryAppendInput): Promise<void> {
+    if (input.messages.length === 0) {
+      return;
+    }
+
+    await this.db.transaction(async (tx) => {
+      const [last] = await tx
+        .select({ position: agentMemoryMessages.position })
+        .from(agentMemoryMessages)
+        .where(scopedWhere(input.context))
+        .orderBy(desc(agentMemoryMessages.position))
+        .limit(1);
+      const start = (last?.position ?? -1) + 1;
+
+      await tx.insert(agentMemoryMessages).values(
+        input.messages.map((message, index) => ({
+          sessionId: input.context.sessionId,
+          userId: input.context.userId ?? null,
+          tenantId: tenantId(input.context),
+          runId: input.runId,
+          turn: input.turn,
+          position: start + index,
+          role: message.role,
+          message,
+        })),
+      );
+    });
+  }
+
+  async clear(context: MemoryContext): Promise<void> {
+    await this.db.delete(agentMemoryMessages).where(scopedWhere(context));
+  }
+}
+```
+
+## Use It
+
+```ts
+import { AgentBuilder } from "@anvia/core";
+
+const memoryStore = new DrizzleMemoryStore(db);
+
+const agent = new AgentBuilder("support", model)
+  .instructions("Use durable memory to continue the conversation.")
+  .memory(memoryStore, { savePolicy: "turn" })
+  .build();
+
+await agent
+  .session("thread_123", {
+    userId: "user_456",
+    metadata: { tenantId: "tenant_789" },
+  })
+  .prompt("What did we decide last time?")
+  .send();
+```
+
+## Production Checks
+
+- Use one scope helper for `load`, `append`, and `clear` so tenant filtering cannot drift.
+- Store message JSON with the role and original content arrays intact.
+- Add stronger per-session locking or a database-generated sequence if concurrent requests can append to the same conversation.
+- Keep memory separate from event logs, traces, and audit records.
+
+## Next Patterns
+
+- [Prisma Agent Memory](/docs/examples/agent-memory-prisma)
+- [Raw SQL Agent Memory](/docs/examples/agent-memory-raw-sql)
+- [Runtime State and Persistence](/docs/examples/runtime-state-persistence)

--- a/apps/www/src/content/docs/examples/agent-memory-prisma.md
+++ b/apps/www/src/content/docs/examples/agent-memory-prisma.md
@@ -1,0 +1,310 @@
+---
+title: Prisma Agent Memory
+description: Persist Anvia agent session memory with Prisma-backed storage.
+section: examples
+sidebar:
+  group: Memory and Events
+  label: Prisma history
+  order: 1
+---
+
+Use a Prisma-backed `MemoryStore` when your product already owns conversation data through Prisma and you want agent sessions to load the same durable transcript on every turn.
+
+## Scenario
+
+A support chat route uses Prisma for product data. Each request receives a product-owned `conversationId`, authenticated `userId`, and tenant metadata. The agent should load prior messages before the run and append the new runtime messages after each completed turn.
+
+## Prisma Schema
+
+Store full Anvia `Message` objects as JSON. Do not persist only final assistant text; tool-call and tool-result messages are part of the conversation context.
+
+```prisma
+model AgentMemoryMessage {
+  id        String   @id @default(cuid())
+  sessionId String
+  userId    String?
+  tenantId  String?
+  runId     String
+  turn      Int
+  position  Int
+  role      String
+  message   Json
+  createdAt DateTime @default(now())
+
+  @@index([sessionId, userId, tenantId, position])
+}
+```
+
+## Expected Message JSON
+
+`MemoryStore.load(...)` returns `Promise<Message[]>`. This example stores one Anvia `Message` object per row, then returns the ordered row set as an array.
+
+The message union is:
+
+```ts
+type Message = SystemMessage | UserMessage | AssistantMessage | ToolMessage;
+type UserContent = Text | ImageContent | DocumentContent;
+type AssistantContent = Text | ImageContent | Reasoning | ToolCall;
+type ToolContent = ToolResult;
+```
+
+The full shape returned from `load(...)` is an array. This illustrative array includes every supported message and content variant; real transcripts usually contain only the variants produced by that run.
+
+```json
+[
+  {
+    "role": "system",
+    "content": "Stable runtime instructions."
+  },
+  {
+    "role": "user",
+    "content": [
+      {
+        "type": "text",
+        "text": "Where is order A-100?",
+        "signature": "sig_user_text"
+      },
+      {
+        "type": "image",
+        "source": { "type": "url", "url": "https://files.example.com/photo.png" },
+        "detail": "high"
+      },
+      {
+        "type": "image",
+        "source": {
+          "type": "base64",
+          "data": "iVBORw0KGgo=",
+          "mediaType": "image/png"
+        },
+        "detail": "low"
+      },
+      {
+        "type": "document",
+        "source": {
+          "type": "url",
+          "url": "https://files.example.com/invoice.pdf",
+          "mediaType": "application/pdf",
+          "filename": "invoice.pdf"
+        }
+      },
+      {
+        "type": "document",
+        "source": {
+          "type": "base64",
+          "data": "JVBERi0xLjQ=",
+          "mediaType": "application/pdf",
+          "filename": "invoice-copy.pdf"
+        }
+      },
+      {
+        "type": "document",
+        "source": {
+          "type": "text",
+          "text": "Invoice text extracted upstream.",
+          "mediaType": "text/plain",
+          "filename": "invoice.txt"
+        }
+      }
+    ]
+  },
+  {
+    "role": "assistant",
+    "id": "msg_assistant_1",
+    "content": [
+      {
+        "type": "text",
+        "text": "I will look that up.",
+        "signature": "sig_assistant_text"
+      },
+      {
+        "type": "image",
+        "source": { "type": "url", "url": "https://files.example.com/generated.png" },
+        "detail": "auto"
+      },
+      {
+        "type": "image",
+        "source": {
+          "type": "base64",
+          "data": "iVBORw0KGgo=",
+          "mediaType": "image/png"
+        }
+      },
+      {
+        "type": "reasoning",
+        "id": "rs_1",
+        "text": "Checked order status and summarized the result.",
+        "content": [
+          {
+            "type": "text",
+            "text": "Need live order state.",
+            "signature": "sig_reasoning_text"
+          },
+          {
+            "type": "summary",
+            "text": "Order lookup is required."
+          },
+          {
+            "type": "encrypted",
+            "data": "encrypted_reasoning_blob"
+          },
+          {
+            "type": "redacted",
+            "data": "redacted_reasoning_blob"
+          }
+        ]
+      },
+      {
+        "type": "tool_call",
+        "id": "call_1",
+        "callId": "fc_1",
+        "function": {
+          "name": "lookup_order",
+          "arguments": { "orderId": "A-100" }
+        },
+        "signature": "sig_tool_call",
+        "additionalParams": { "providerToolCallId": "provider_call_1" }
+      }
+    ]
+  },
+  {
+    "role": "tool",
+    "content": [
+      {
+        "type": "tool_result",
+        "id": "call_1",
+        "callId": "fc_1",
+        "content": [
+          {
+            "type": "text",
+            "text": "{\"status\":\"shipped\"}"
+          },
+          {
+            "type": "image",
+            "data": "iVBORw0KGgo=",
+            "mediaType": "image/png"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "role": "assistant",
+    "content": [{ "type": "text", "text": "Order A-100 has shipped." }]
+  }
+]
+```
+
+Each row's `message` column contains one item from that array.
+
+## Memory Store
+
+```ts
+import { Prisma, PrismaClient } from "@prisma/client";
+import { type MemoryStore, type Message } from "@anvia/core";
+import type { MemoryAppendInput, MemoryContext } from "@anvia/core/memory";
+
+function tenantId(context: MemoryContext) {
+  const value = context.metadata?.tenantId;
+  return typeof value === "string" ? value : null;
+}
+
+function toPrismaJson(message: Message): Prisma.InputJsonValue {
+  return message as unknown as Prisma.InputJsonValue;
+}
+
+export class PrismaMemoryStore implements MemoryStore {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async load(context: MemoryContext): Promise<Message[]> {
+    const rows = await this.prisma.agentMemoryMessage.findMany({
+      where: {
+        sessionId: context.sessionId,
+        userId: context.userId ?? null,
+        tenantId: tenantId(context),
+      },
+      orderBy: { position: "asc" },
+    });
+
+    return rows.map((row) => row.message as unknown as Message);
+  }
+
+  async append(input: MemoryAppendInput): Promise<void> {
+    if (input.messages.length === 0) {
+      return;
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      const last = await tx.agentMemoryMessage.findFirst({
+        where: {
+          sessionId: input.context.sessionId,
+          userId: input.context.userId ?? null,
+          tenantId: tenantId(input.context),
+        },
+        orderBy: { position: "desc" },
+        select: { position: true },
+      });
+      const start = (last?.position ?? -1) + 1;
+
+      await tx.agentMemoryMessage.createMany({
+        data: input.messages.map((message, index) => ({
+          sessionId: input.context.sessionId,
+          userId: input.context.userId ?? null,
+          tenantId: tenantId(input.context),
+          runId: input.runId,
+          turn: input.turn,
+          position: start + index,
+          role: message.role,
+          message: toPrismaJson(message),
+        })),
+      });
+    });
+  }
+
+  async clear(context: MemoryContext): Promise<void> {
+    await this.prisma.agentMemoryMessage.deleteMany({
+      where: {
+        sessionId: context.sessionId,
+        userId: context.userId ?? null,
+        tenantId: tenantId(context),
+      },
+    });
+  }
+}
+```
+
+## Use It
+
+```ts
+import { AgentBuilder } from "@anvia/core";
+
+const prisma = new PrismaClient();
+const memoryStore = new PrismaMemoryStore(prisma);
+
+const agent = new AgentBuilder("support", model)
+  .instructions("Answer support questions using the durable conversation history.")
+  .memory(memoryStore, { savePolicy: "turn" })
+  .build();
+
+const response = await agent
+  .session("thread_123", {
+    userId: "user_456",
+    metadata: { tenantId: "tenant_789" },
+  })
+  .prompt("Can you summarize where we left off?")
+  .send();
+
+console.log(response.output);
+```
+
+## Production Checks
+
+- Use the same user and tenant scope in `load`, `append`, and `clear`.
+- Keep message JSON intact so future turns can see tool calls and tool results.
+- Wrap appends in a transaction and add stricter ordering or locking if multiple requests can write to the same session concurrently.
+- Keep audit records, run records, and product state in separate tables from memory.
+
+## Next Patterns
+
+- [Drizzle Agent Memory](/docs/examples/agent-memory-drizzle)
+- [Raw SQL Agent Memory](/docs/examples/agent-memory-raw-sql)
+- [Runtime State and Persistence](/docs/examples/runtime-state-persistence)

--- a/apps/www/src/content/docs/examples/agent-memory-raw-sql.md
+++ b/apps/www/src/content/docs/examples/agent-memory-raw-sql.md
@@ -1,0 +1,335 @@
+---
+title: Raw SQL Agent Memory
+description: Persist Anvia agent session memory with a raw SQL adapter.
+section: examples
+sidebar:
+  group: Memory and Events
+  label: Raw SQL history
+  order: 3
+---
+
+Use a raw SQL `MemoryStore` when your application has a direct database client, a small storage layer, or a migration system that does not use an ORM.
+
+## Scenario
+
+A Node service talks to Postgres through `pg`. The agent receives a stable session id from the product route, then the memory store loads and appends full Anvia `Message` objects as JSON.
+
+## Table
+
+```sql
+CREATE TABLE agent_memory_messages (
+  id bigserial PRIMARY KEY,
+  session_id text NOT NULL,
+  user_id text,
+  tenant_id text,
+  run_id text NOT NULL,
+  turn integer NOT NULL,
+  position integer NOT NULL,
+  role text NOT NULL,
+  message jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX agent_memory_session_idx
+  ON agent_memory_messages (session_id, user_id, tenant_id, position);
+```
+
+## Expected Message JSON
+
+`MemoryStore.load(...)` returns `Promise<Message[]>`. This example stores one Anvia `Message` object per row, then returns the ordered row set as an array.
+
+The message union is:
+
+```ts
+type Message = SystemMessage | UserMessage | AssistantMessage | ToolMessage;
+type UserContent = Text | ImageContent | DocumentContent;
+type AssistantContent = Text | ImageContent | Reasoning | ToolCall;
+type ToolContent = ToolResult;
+```
+
+The full shape returned from `load(...)` is an array. This illustrative array includes every supported message and content variant; real transcripts usually contain only the variants produced by that run.
+
+```json
+[
+  {
+    "role": "system",
+    "content": "Stable runtime instructions."
+  },
+  {
+    "role": "user",
+    "content": [
+      {
+        "type": "text",
+        "text": "Where is order A-100?",
+        "signature": "sig_user_text"
+      },
+      {
+        "type": "image",
+        "source": { "type": "url", "url": "https://files.example.com/photo.png" },
+        "detail": "high"
+      },
+      {
+        "type": "image",
+        "source": {
+          "type": "base64",
+          "data": "iVBORw0KGgo=",
+          "mediaType": "image/png"
+        },
+        "detail": "low"
+      },
+      {
+        "type": "document",
+        "source": {
+          "type": "url",
+          "url": "https://files.example.com/invoice.pdf",
+          "mediaType": "application/pdf",
+          "filename": "invoice.pdf"
+        }
+      },
+      {
+        "type": "document",
+        "source": {
+          "type": "base64",
+          "data": "JVBERi0xLjQ=",
+          "mediaType": "application/pdf",
+          "filename": "invoice-copy.pdf"
+        }
+      },
+      {
+        "type": "document",
+        "source": {
+          "type": "text",
+          "text": "Invoice text extracted upstream.",
+          "mediaType": "text/plain",
+          "filename": "invoice.txt"
+        }
+      }
+    ]
+  },
+  {
+    "role": "assistant",
+    "id": "msg_assistant_1",
+    "content": [
+      {
+        "type": "text",
+        "text": "I will look that up.",
+        "signature": "sig_assistant_text"
+      },
+      {
+        "type": "image",
+        "source": { "type": "url", "url": "https://files.example.com/generated.png" },
+        "detail": "auto"
+      },
+      {
+        "type": "image",
+        "source": {
+          "type": "base64",
+          "data": "iVBORw0KGgo=",
+          "mediaType": "image/png"
+        }
+      },
+      {
+        "type": "reasoning",
+        "id": "rs_1",
+        "text": "Checked order status and summarized the result.",
+        "content": [
+          {
+            "type": "text",
+            "text": "Need live order state.",
+            "signature": "sig_reasoning_text"
+          },
+          {
+            "type": "summary",
+            "text": "Order lookup is required."
+          },
+          {
+            "type": "encrypted",
+            "data": "encrypted_reasoning_blob"
+          },
+          {
+            "type": "redacted",
+            "data": "redacted_reasoning_blob"
+          }
+        ]
+      },
+      {
+        "type": "tool_call",
+        "id": "call_1",
+        "callId": "fc_1",
+        "function": {
+          "name": "lookup_order",
+          "arguments": { "orderId": "A-100" }
+        },
+        "signature": "sig_tool_call",
+        "additionalParams": { "providerToolCallId": "provider_call_1" }
+      }
+    ]
+  },
+  {
+    "role": "tool",
+    "content": [
+      {
+        "type": "tool_result",
+        "id": "call_1",
+        "callId": "fc_1",
+        "content": [
+          {
+            "type": "text",
+            "text": "{\"status\":\"shipped\"}"
+          },
+          {
+            "type": "image",
+            "data": "iVBORw0KGgo=",
+            "mediaType": "image/png"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "role": "assistant",
+    "content": [{ "type": "text", "text": "Order A-100 has shipped." }]
+  }
+]
+```
+
+Each row's `message` column contains one item from that array.
+
+## Memory Store
+
+```ts
+import type { Pool } from "pg";
+import { type MemoryStore, type Message } from "@anvia/core";
+import type { MemoryAppendInput, MemoryContext } from "@anvia/core/memory";
+
+function tenantId(context: MemoryContext) {
+  const value = context.metadata?.tenantId;
+  return typeof value === "string" ? value : null;
+}
+
+function scopeValues(context: MemoryContext) {
+  return [context.sessionId, context.userId ?? null, tenantId(context)] as const;
+}
+
+function scopeKey(context: MemoryContext) {
+  return JSON.stringify(scopeValues(context));
+}
+
+function fromJson(value: unknown): Message {
+  return typeof value === "string" ? (JSON.parse(value) as Message) : (value as Message);
+}
+
+export class SqlMemoryStore implements MemoryStore {
+  constructor(private readonly pool: Pool) {}
+
+  async load(context: MemoryContext): Promise<Message[]> {
+    const { rows } = await this.pool.query<{ message: unknown }>(
+      `SELECT message
+       FROM agent_memory_messages
+       WHERE session_id = $1
+         AND user_id IS NOT DISTINCT FROM $2
+         AND tenant_id IS NOT DISTINCT FROM $3
+       ORDER BY position ASC`,
+      scopeValues(context),
+    );
+
+    return rows.map((row) => fromJson(row.message));
+  }
+
+  async append(input: MemoryAppendInput): Promise<void> {
+    if (input.messages.length === 0) {
+      return;
+    }
+
+    const client = await this.pool.connect();
+
+    try {
+      await client.query("BEGIN");
+      await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [scopeKey(input.context)]);
+
+      const { rows } = await client.query<{ position: number }>(
+        `SELECT COALESCE(MAX(position), -1) AS position
+         FROM agent_memory_messages
+         WHERE session_id = $1
+           AND user_id IS NOT DISTINCT FROM $2
+           AND tenant_id IS NOT DISTINCT FROM $3`,
+        scopeValues(input.context),
+      );
+      const start = rows[0]?.position ?? 0;
+
+      for (const [index, message] of input.messages.entries()) {
+        await client.query(
+          `INSERT INTO agent_memory_messages
+             (session_id, user_id, tenant_id, run_id, turn, position, role, message)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)`,
+          [
+            input.context.sessionId,
+            input.context.userId ?? null,
+            tenantId(input.context),
+            input.runId,
+            input.turn,
+            start + index + 1,
+            message.role,
+            JSON.stringify(message),
+          ],
+        );
+      }
+
+      await client.query("COMMIT");
+    } catch (error) {
+      await client.query("ROLLBACK");
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async clear(context: MemoryContext): Promise<void> {
+    await this.pool.query(
+      `DELETE FROM agent_memory_messages
+       WHERE session_id = $1
+         AND user_id IS NOT DISTINCT FROM $2
+         AND tenant_id IS NOT DISTINCT FROM $3`,
+      scopeValues(context),
+    );
+  }
+}
+```
+
+## Use It
+
+```ts
+import { Pool } from "pg";
+import { AgentBuilder } from "@anvia/core";
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+const memoryStore = new SqlMemoryStore(pool);
+
+const agent = new AgentBuilder("support", model)
+  .instructions("Use prior memory before answering.")
+  .memory(memoryStore, { savePolicy: "turn" })
+  .build();
+
+const response = await agent
+  .session("thread_123", {
+    userId: "user_456",
+    metadata: { tenantId: "tenant_789" },
+  })
+  .prompt("Continue from the previous support answer.")
+  .send();
+
+console.log(response.output);
+```
+
+## Production Checks
+
+- Compare nullable user and tenant columns with null-safe SQL such as `IS NOT DISTINCT FROM`.
+- Use a transaction around position lookup and inserts.
+- Add per-session locking or database-generated ordering before allowing concurrent writes to the same conversation.
+- Keep memory rows scoped by product-owned session, user, and tenant values.
+
+## Next Patterns
+
+- [Prisma Agent Memory](/docs/examples/agent-memory-prisma)
+- [Drizzle Agent Memory](/docs/examples/agent-memory-drizzle)
+- [Runtime State and Persistence](/docs/examples/runtime-state-persistence)

--- a/apps/www/src/content/docs/examples/capability-map.md
+++ b/apps/www/src/content/docs/examples/capability-map.md
@@ -18,9 +18,9 @@ The concrete RAG stack used in examples is Mistral OCR, OpenAI embeddings, and C
 | Agents | [Agent App Flow](/docs/examples/agent-app-flow), [Support Agent](/docs/examples/support-agent) | A product request can run through auth, tools, model calls, traces, and persistence. |
 | Runtime composition | [Agent Runtime Composition](/docs/examples/agent-runtime-composition) | Model, instructions, tools, context, memory, observers, and output contracts are assembled at the right boundary. |
 | Request runners | [Agent App Flow](/docs/examples/agent-app-flow), [Pipeline Worker](/docs/examples/pipeline-worker) | Routes, jobs, and tests call the same workflow function. |
-| Memory and sessions | [Context Assembly](/docs/examples/context-assembly), [Runtime State and Persistence](/docs/examples/runtime-state-persistence) | Conversation state is durable without becoming an authorization or audit system. |
+| Memory and sessions | [Memory and Events](/docs/examples/memory-and-events), [Prisma Agent Memory](/docs/examples/agent-memory-prisma), [Drizzle Agent Memory](/docs/examples/agent-memory-drizzle), [Raw SQL Agent Memory](/docs/examples/agent-memory-raw-sql) | Conversation messages are loaded and appended through scoped application storage adapters. |
 | Streaming events | [Fullstack Streaming](/docs/examples/fullstack-streaming), [Streaming Events](/docs/examples/streaming-events) | Browser clients consume completion or agent streams, then product UIs treat text, tools, and final events as workflow state. |
-| Event store | [Runtime State and Persistence](/docs/examples/runtime-state-persistence), [Observability Loop](/docs/examples/observability-loop) | Runtime events are replayable for debugging and audit. |
+| Event store | [Memory and Events](/docs/examples/memory-and-events), [Prisma Agent Event Store](/docs/examples/agent-event-store-prisma), [Drizzle Agent Event Store](/docs/examples/agent-event-store-drizzle), [Raw SQL Agent Event Store](/docs/examples/agent-event-store-raw-sql) | Runtime stream events are persisted by run id for replay, debugging, and audit. |
 
 ## Tools And Actions
 

--- a/apps/www/src/content/docs/examples/memory-and-events.md
+++ b/apps/www/src/content/docs/examples/memory-and-events.md
@@ -1,0 +1,118 @@
+---
+title: Memory and Events
+description: How agent memory and event stores differ, how each maps to database storage, and how they are used together in production.
+section: examples
+sidebar:
+  group: Memory and Events
+  label: Overview
+  order: 0
+---
+
+Production agents often use both memory and event storage, but they solve different problems. Memory is conversation context for future prompts. Event storage is an operational log of what happened during one streamed run.
+
+Do not merge them into one transcript table. A memory store answers "what should the model remember next time?" An event store answers "what happened during run `run_123`?"
+
+## What Each Store Does
+
+| Store | Key | Contract | Contains | Used for |
+| --- | --- | --- | --- | --- |
+| memory | `sessionId`, plus user or tenant scope | `MemoryStore.load(context): Promise<Message[]>` | ordered Anvia `Message[]` values | future prompts, durable conversations, `session.messages()` |
+| event store | `runId` | `AgentEventStore.load(runId): Promise<AgentEventRecord[]>` | ordered stream events with raw `event` JSON | replay, debugging, audit review, operations views |
+
+Memory is loaded before the next run and becomes model context. Event records are not loaded into prompts; they are inspected by humans, eval tooling, dashboards, or replay/debug flows.
+
+## Production Layout
+
+Keep these as separate storage paths:
+
+| Data | Typical table | Why it exists |
+| --- | --- | --- |
+| conversation memory | `agent_memory_messages` | gives the next prompt prior user, assistant, and tool-result messages |
+| runtime events | `agent_events` | preserves turn starts, deltas, tool calls, tool results, nested agent events, final output, and errors by run id |
+| product run record | `support_runs` or `agent_runs` | compact user-facing status, final output, trace id, and usage |
+| audit records | `audit_logs` | records who requested or performed sensitive product actions |
+| traces | tracing backend or trace id fields | connects the run to model/provider/tool observability |
+
+Memory rows are scoped by product-owned session, user, and tenant values. Event rows are scoped by run id and agent metadata. Product run records usually connect both worlds by storing `conversationId`, `runId`, `traceId`, final output, and usage.
+
+## Typical Flow
+
+```ts
+import { AgentBuilder } from "@anvia/core";
+
+export function createSupportAgent(scope: SupportAgentScope) {
+  return new AgentBuilder("support", scope.model)
+    .instructions("Answer support questions using tools and policy context.")
+    .tools(scope.tools)
+    .memory(scope.memoryStore, { savePolicy: "turn" })
+    .eventStore(scope.eventStore, { include: "all" })
+    .build();
+}
+
+export async function runSupportTurn(input: SupportTurnInput) {
+  const user = await input.auth.requireUser();
+  const agent = createSupportAgent({
+    model: input.model,
+    tools: input.tools,
+    memoryStore: input.memoryStore,
+    eventStore: input.eventStore,
+  });
+
+  let final;
+
+  for await (const event of agent
+    .session(input.conversationId, {
+      userId: user.id,
+      metadata: { tenantId: user.tenantId },
+    })
+    .prompt(input.message)
+    .withTrace({
+      name: "support-chat",
+      userId: user.id,
+      metadata: {
+        tenantId: user.tenantId,
+        conversationId: input.conversationId,
+      },
+    })
+    .stream()) {
+    if (event.type === "final") {
+      final = event;
+    }
+  }
+
+  if (final === undefined) {
+    throw new Error("Agent stream ended without a final event.");
+  }
+
+  await input.runs.record({
+    conversationId: input.conversationId,
+    runId: final.runId,
+    traceId: final.trace?.traceId,
+    output: final.output,
+    usage: final.usage,
+  });
+
+  return { output: final.output, runId: final.runId };
+}
+```
+
+The event store records events while the stream is consumed. If you need replayable events, use `.stream()` and drain it even when your API only returns the final answer. Use `.send()` when the caller only needs the final response and event replay is not required.
+
+## Choosing The Adapter
+
+Use the adapter style that matches your product database layer:
+
+| Need | Prisma | Drizzle | Raw SQL |
+| --- | --- | --- | --- |
+| memory | [Prisma Agent Memory](/docs/examples/agent-memory-prisma) | [Drizzle Agent Memory](/docs/examples/agent-memory-drizzle) | [Raw SQL Agent Memory](/docs/examples/agent-memory-raw-sql) |
+| events | [Prisma Agent Event Store](/docs/examples/agent-event-store-prisma) | [Drizzle Agent Event Store](/docs/examples/agent-event-store-drizzle) | [Raw SQL Agent Event Store](/docs/examples/agent-event-store-raw-sql) |
+
+The adapter choice should not change the runtime contract. Memory still returns `Message[]`; event storage still returns `AgentEventRecord[]`.
+
+## Production Checks
+
+- Keep memory, events, audit logs, traces, and product state in separate tables or services.
+- Apply tenant and user scope to memory reads and writes.
+- Store event payloads as JSON/JSONB and index `runId`, `agentId`, `turn`, and tool identifiers.
+- Set retention and redaction policies for both memory and events; event payloads may include prompts, history, tool args, tool results, reasoning, provider metadata, and errors.
+- Store a compact product run record for UI status instead of querying event logs for normal user-facing pages.

--- a/apps/www/src/content/docs/examples/overview.md
+++ b/apps/www/src/content/docs/examples/overview.md
@@ -17,6 +17,7 @@ The examples use concrete defaults where a full flow is easier to understand wit
 | --- | --- | --- |
 | An agent endpoint with auth, history, tools, traces, and persistence | [Agent App Flow](/docs/examples/agent-app-flow) | [Runtime State and Persistence](/docs/examples/runtime-state-persistence) |
 | An agent runtime assembled from model, instructions, tools, context, memory, and observers | [Agent Runtime Composition](/docs/examples/agent-runtime-composition) | [Context Assembly](/docs/examples/context-assembly) |
+| Durable memory and replayable runtime events in your application database | [Memory and Events](/docs/examples/memory-and-events) | [Prisma Agent Memory](/docs/examples/agent-memory-prisma), [Prisma Agent Event Store](/docs/examples/agent-event-store-prisma) |
 | Tools that enforce user, tenant, and action permissions | [Permissioned Tools](/docs/examples/permissioned-tools) | [Tool Validation](/docs/examples/tool-validation), [Guarded Side Effects](/docs/examples/guarded-side-effects) |
 | Typed model output for classification, extraction, or workflow results | [Structured Results](/docs/examples/structured-results) | [Testing Harness](/docs/examples/testing-harness) |
 | RAG over PDFs, images, documents, and product knowledge | [RAG Ingestion](/docs/examples/rag-ingestion) | [Retrieval Agent](/docs/examples/retrieval-agent), [Document Grounding](/docs/examples/document-grounding) |
@@ -31,6 +32,8 @@ The examples use concrete defaults where a full flow is easier to understand wit
 ## Common Flows
 
 Agent applications usually start with [Agent App Flow](/docs/examples/agent-app-flow): a thin route or job calls a runner, the runner resolves product state, the agent runs with scoped tools and context, and the application persists the result.
+
+Memory and event-backed applications usually start with [Memory and Events](/docs/examples/memory-and-events) to keep conversation context separate from replay/debug logs. Then choose the adapter that matches the product database layer: Prisma, Drizzle, or raw SQL.
 
 Knowledge applications usually combine [RAG Ingestion](/docs/examples/rag-ingestion), [Retrieval Agent](/docs/examples/retrieval-agent), and [Document Grounding](/docs/examples/document-grounding). The important flow is source documents to OCR or text extraction, chunks, embeddings, Chroma-backed vector index, dynamic context or retrieval tools, then cited answers.
 

--- a/apps/www/src/lib/docs.ts
+++ b/apps/www/src/lib/docs.ts
@@ -30,6 +30,7 @@ const sidebarGroupOrder: Partial<Record<DocsSection, string[]>> = {
   examples: [
     "Start Here",
     "Foundation Patterns",
+    "Memory and Events",
     "Tool Patterns",
     "Knowledge Patterns",
     "Workflow Patterns",


### PR DESCRIPTION
## Summary
- add a Memory and Events examples overview explaining production usage and the difference between memory and event stores
- add Prisma, Drizzle, and raw SQL examples for agent memory
- add Prisma, Drizzle, and raw SQL examples for agent event stores
- group the pages under a single Memory and Events sidebar section with shorter menu labels

## Verification
- pnpm --filter www build
- biome check --staged --vcs-enabled=true --vcs-client-kind=git --vcs-use-ignore-file=true --no-errors-on-unmatched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new documentation for storing agent memory and streamed events with Prisma, Drizzle, and raw SQL examples.
  * Introduced guidance for replaying run events, persisting session memory, and wiring these stores into agent builds.
  * Added a new “Memory and Events” examples section and updated navigation to surface the new patterns.

* **Documentation**
  * Expanded the overview and capability map with clearer links between memory, event storage, and production usage.
  * Included production checklists and end-to-end usage examples for each storage option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->