### PR TITLE
Generate package changelogs before WWW deploy

### DIFF
--- a/.github/workflows/www-deploy.yml
+++ b/.github/workflows/www-deploy.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Generate package changelog docs
+        run: pnpm --filter www generate:package-changelogs
+
       - name: Check www reference coverage
         run: pnpm --filter www reference-check
 

--- a/apps/www/src/content/docs/packages/core/changelog.md
+++ b/apps/www/src/content/docs/packages/core/changelog.md
@@ -10,6 +10,12 @@ sidebar:
 
 Release history mirrored from `packages/core/CHANGELOG.md`.
 
+## 0.11.1
+
+### Patch Changes
+
+- 9fc55c9: Update upstream runtime dependencies to their latest npm releases.
+
 ## 0.11.0
 
 ### Minor Changes

--- a/apps/www/src/content/docs/packages/langfuse/changelog.md
+++ b/apps/www/src/content/docs/packages/langfuse/changelog.md
@@ -10,6 +10,12 @@ sidebar:
 
 Release history mirrored from `packages/observability-langfuse/CHANGELOG.md`.
 
+## 0.3.3
+
+### Patch Changes
+
+- 9fc55c9: Update upstream runtime dependencies to their latest npm releases.
+
 ## 0.3.2
 
 ### Patch Changes

--- a/apps/www/src/content/docs/packages/react/changelog.md
+++ b/apps/www/src/content/docs/packages/react/changelog.md
@@ -10,6 +10,13 @@ sidebar:
 
 Release history mirrored from `packages/react/CHANGELOG.md`.
 
+## 0.7.3
+
+### Patch Changes
+
+- Updated dependencies [9fc55c9]
+  - @anvia/core@0.11.1
+
 ## 0.7.2
 
 ### Patch Changes

--- a/apps/www/src/content/docs/packages/server/changelog.md
+++ b/apps/www/src/content/docs/packages/server/changelog.md
@@ -10,6 +10,13 @@ sidebar:
 
 Release history mirrored from `packages/server/CHANGELOG.md`.
 
+## 0.4.3
+
+### Patch Changes
+
+- Updated dependencies [9fc55c9]
+  - @anvia/core@0.11.1
+
 ## 0.4.2
 
 ### Patch Changes

--- a/apps/www/src/content/docs/packages/studio/changelog.md
+++ b/apps/www/src/content/docs/packages/studio/changelog.md
@@ -10,6 +10,14 @@ sidebar:
 
 Release history mirrored from `packages/tool-studio/CHANGELOG.md`.
 
+## 0.7.10
+
+### Patch Changes
+
+- 9fc55c9: Update upstream runtime dependencies to their latest npm releases.
+  - @anvia/react@0.7.3
+  - @anvia/server@0.4.3
+
 ## 0.7.9
 
 ### Patch Changes


### PR DESCRIPTION
## Summary
- run `pnpm --filter www generate:package-changelogs` during the WWW deploy workflow before reference checks and deployment
- refresh generated package changelog docs for the latest release entries

## Verification
- `pnpm --filter www generate:package-changelogs`
- `pnpm --filter www reference-check`
- `pnpm check`
- `pnpm --filter www build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new package changelog entries for recent patch releases across core, language, React, server, and studio packages.
  * Updated version histories to reflect the latest dependency updates.

* **Chores**
  * The deployment workflow now generates package changelog documentation automatically during release preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->