### PR TITLE
Refactor shared loader types

### DIFF
--- a/apps/www/src/content/docs/packages/core/reference/loaders.md
+++ b/apps/www/src/content/docs/packages/core/reference/loaders.md
@@ -20,8 +20,12 @@ type LoaderResult<T> =
   | { ok: true; value: T }
   | { ok: false; error: unknown };
 
+type LoaderValue<T> = T extends { ok: true; value: infer Value } ? Value : never;
+type UnwrapLoaderResult<T> = [LoaderValue<T>] extends [never] ? T : LoaderValue<T>;
+
 type FileSource = { path: string } | { path: "<memory>"; bytes: Uint8Array };
 type FileReadWithPath = { path: string; text: string };
+type FileMode = "source" | "read" | "readWithPath";
 
 type PdfSource = { path: string } | { path: "<memory>"; bytes: Uint8Array };
 type PdfReadWithPath = { path: string; text: string };

--- a/packages/core/src/loaders/file.ts
+++ b/packages/core/src/loaders/file.ts
@@ -1,11 +1,13 @@
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { err, ok, sortedGlob, toUint8Array } from "./shared";
-import type { FileReadWithPath, FileSource, LoaderResult } from "./types";
-
-type FileMode = "source" | "read" | "readWithPath";
-type LoaderValue<T> = T extends { ok: true; value: infer Value } ? Value : never;
-type UnwrapLoaderResult<T> = [LoaderValue<T>] extends [never] ? T : LoaderValue<T>;
+import type {
+  FileMode,
+  FileReadWithPath,
+  FileSource,
+  LoaderResult,
+  UnwrapLoaderResult,
+} from "./types";
 
 export class FileLoader<T = LoaderResult<FileSource>> implements AsyncIterable<T> {
   private constructor(

--- a/packages/core/src/loaders/types.ts
+++ b/packages/core/src/loaders/types.ts
@@ -1,7 +1,10 @@
 export type LoaderResult<T> = { ok: true; value: T } | { ok: false; error: unknown };
+export type LoaderValue<T> = T extends { ok: true; value: infer Value } ? Value : never;
+export type UnwrapLoaderResult<T> = [LoaderValue<T>] extends [never] ? T : LoaderValue<T>;
 
 export type FileSource = { path: string } | { path: "<memory>"; bytes: Uint8Array };
 export type FileReadWithPath = { path: string; text: string };
+export type FileMode = "source" | "read" | "readWithPath";
 
 export type PdfSource = { path: string } | { path: "<memory>"; bytes: Uint8Array };
 export type PdfReadWithPath = { path: string; text: string };


### PR DESCRIPTION
## Change Intention
Centralize file loader-related type aliases by moving `FileMode`, `LoaderValue`, and `UnwrapLoaderResult` into `packages/core/src/loaders/types.ts` and importing the shared aliases from `packages/core/src/loaders/file.ts`.

## Reviews
Review passed with no findings. The change was assessed as a low-risk type-only extraction that improves reuse potential.

<details>
<summary>Original review output</summary>

```markdown
## Change Intention
The change appears to centralize file loader-related type aliases by moving `FileMode`, `LoaderValue`, and `UnwrapLoaderResult` from `packages/core/src/loaders/file.ts` into the shared loader type module `packages/core/src/loaders/types.ts`, then importing them back into `file.ts`.

Key files involved:
- `packages/core/src/loaders/file.ts`
- `packages/core/src/loaders/types.ts`

## Findings
No findings.

## Notes
- Lexa was available and indexing completed successfully. `lexa outline` showed the expected changed symbols in `file.ts` and `types.ts`; `lexa audit --since main` reported no structural findings, though it reported `0 changed file(s)` for that audit scope, so I treated it as architecture context rather than verification.
- This refactor is low-risk and improves reuse potential for `LoaderValue` / `UnwrapLoaderResult`. There is still a duplicate local definition in `packages/core/src/loaders/pdf.ts`; if the intent is broader loader type reuse, a follow-up could import the shared aliases there too.

## Verdicts
- **Verdict:** pass
- **Reason:** The change is a type-only extraction with no identified runtime or API correctness issues.
```

</details>

## What Fixed
No code changes were required by the fix step. Review reported no findings, and rerun typecheck passed without edits.

<details>
<summary>Fix agent output</summary>

```markdown
## Fix Summary
- No code changes were made.
- Review output reported **no findings**.
- The verification failure was from the full workspace `pnpm typecheck` in `packages/provider-mistral`, but rerunning typecheck showed the workspace now passes without requiring code edits.
- No out-of-diff files were edited.

## Verification
- `lexa --version` — passed (`lexa 0.8.0`).
- `lexa index .` — passed; indexed 1179 files.
- `lexa outline packages/core/src/loaders/file.ts` — passed; inspected affected loader file structure.
- `lexa outline packages/core/src/loaders/types.ts` — passed; inspected affected shared type file structure.
- `pnpm --filter @anvia/core typecheck` — passed.
- `pnpm typecheck` — passed across workspace packages.

## Remaining Risks
- Full lint, test, and build were not rerun in this fix attempt because the prior verification already reported them passing and the only failed check (`pnpm typecheck`) now passes.
- `pnpm typecheck` triggered workspace build steps that may regenerate ignored `dist` artifacts, but `git status --short` shows only the two originally changed source files remain modified.

## Verdict
FIX_VERDICT: fixed
```

</details>

## Verification Status
- Typecheck: passed - `pnpm typecheck`
- Lint: passed - `pnpm lint`
- Test: passed - `pnpm test`
- Build: passed - `pnpm build`
- Playwright UI: skipped - Diff is non-UI TypeScript loader/type export changes; no browser verification required.
- Artifacts: none

<details>
<summary>Verification output</summary>

```markdown
## Verification Summary
- Inspected the pnpm monorepo scripts and lockfile. The current diff only moves loader type aliases/exports in `packages/core/src/loaders`, so it is not UI-related.
- Ran available typecheck, lint, test, and build commands successfully.
- Skipped Playwright UI verification because the changed files affect TypeScript loader types only, not browser behavior, rendered UI, routes, styling, frontend state, or user-visible workflows.

## Checks
- typecheck: passed - `pnpm typecheck`
- lint: passed - `pnpm lint`
- test: passed - `pnpm test`
- build: passed - `pnpm build`
- playwright-ui: skipped - Diff is non-UI TypeScript loader/type export changes; no browser verification required.

## UI Artifacts
- No UI artifacts: Playwright UI verification was skipped because the diff is not UI-related.

## Verdict
VERDICT: pass
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized shared loader-related type definitions for consistency across the project.
  * Added reusable helper types to extract loader result values and unwrap result types.
  * Introduced a shared `FileMode` type covering supported file-loading modes.
* **Documentation**
  * Updated the core loaders reference docs to reflect the new helper and file-mode types.
* **Chores**
  * No runtime behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->