### PR TITLE
Align Grok provider behavior with package patterns

### DIFF
--- a/packages/provider-grok/src/grok/client.ts
+++ b/packages/provider-grok/src/grok/client.ts
@@ -92,7 +92,7 @@ async function collectModelsFromResponse(response: unknown): Promise<unknown[]> 
     return response.data;
   }
 
-  throw new Error("Unexpected Grok model listing response shape.");
+  return [];
 }
 
 function toListedModel(model: unknown): ModelList["data"][number] | undefined {

--- a/packages/provider-grok/src/grok/image-generation.ts
+++ b/packages/provider-grok/src/grok/image-generation.ts
@@ -24,12 +24,12 @@ export class GrokImageGenerationModel
     request: ImageGenerationRequest,
   ): Promise<ImageGenerationResponse<unknown>> {
     const params: Record<string, unknown> = {
-      ...sanitizedAdditionalParams(request.additionalParams),
       model: this.defaultModel,
       prompt: request.prompt,
       n: 1,
       response_format: "b64_json",
       aspect_ratio: aspectRatio(request.width, request.height),
+      ...providerAdditionalParams(request.additionalParams),
     };
 
     const response = await this.client.images.generate(params as never);
@@ -124,17 +124,14 @@ async function fetchGeneratedImage(
   };
 }
 
-function sanitizedAdditionalParams(value: unknown): Record<string, unknown> {
+function providerAdditionalParams(value: unknown): Record<string, unknown> {
   if (!isPlainObject(value)) {
     return {};
   }
 
-  const { model, prompt, n, response_format, aspect_ratio, ...params } = value;
-  void model;
-  void prompt;
-  void n;
-  void response_format;
-  void aspect_ratio;
+  const params = { ...value };
+  delete params.model;
+  delete params.prompt;
   return params;
 }
 

--- a/packages/provider-grok/test/client.test.ts
+++ b/packages/provider-grok/test/client.test.ts
@@ -100,7 +100,7 @@ describe("GrokClient", () => {
     });
   });
 
-  it("wraps unexpected model listing payloads", async () => {
+  it("returns an empty model list for unexpected model listing payloads", async () => {
     const client = new GrokClient({
       client: {
         models: {
@@ -109,10 +109,7 @@ describe("GrokClient", () => {
       } as never,
     });
 
-    await expect(client.listModels()).rejects.toMatchObject({
-      name: "ModelListingError",
-      provider: "grok",
-    } satisfies Partial<ModelListingError>);
+    await expect(client.listModels()).resolves.toEqual({ data: [] });
   });
 
   it("wraps model listing failures", async () => {

--- a/packages/provider-grok/test/image-generation.test.ts
+++ b/packages/provider-grok/test/image-generation.test.ts
@@ -3,7 +3,40 @@ import { describe, expect, it } from "vitest";
 import { aspectRatio, GrokImageGenerationModel, imageResponseFromGrok } from "../src/index";
 
 describe("Grok image generation", () => {
-  it("maps core image requests to xAI image generation params", async () => {
+  it("maps core image requests to default xAI image generation params", async () => {
+    const calls: unknown[] = [];
+    const model = new GrokImageGenerationModel(
+      {
+        images: {
+          generate: async (params: unknown) => {
+            calls.push(params);
+            return {
+              data: [{ b64_json: Buffer.from([1, 2, 3]).toString("base64") }],
+            };
+          },
+        },
+      } as never,
+      "grok-image-test",
+    );
+
+    await model.imageGeneration({
+      prompt: "draw a diagram",
+      width: 1024,
+      height: 768,
+    });
+
+    expect(calls).toEqual([
+      {
+        model: "grok-image-test",
+        prompt: "draw a diagram",
+        n: 1,
+        response_format: "b64_json",
+        aspect_ratio: "4:3",
+      },
+    ]);
+  });
+
+  it("maps core image requests while letting native image params override defaults", async () => {
     const calls: unknown[] = [];
     const model = new GrokImageGenerationModel(
       {
@@ -29,6 +62,8 @@ describe("Grok image generation", () => {
       width: 1024,
       height: 768,
       additionalParams: {
+        model: "ignored-model",
+        prompt: "ignored prompt",
         n: 2,
         aspect_ratio: "1:1",
         response_format: "url",
@@ -40,9 +75,9 @@ describe("Grok image generation", () => {
       {
         model: "grok-image-test",
         prompt: "draw a diagram",
-        n: 1,
-        response_format: "b64_json",
-        aspect_ratio: "4:3",
+        n: 2,
+        response_format: "url",
+        aspect_ratio: "1:1",
         resolution: "720p",
       },
     ]);


### PR DESCRIPTION
## Change Intention
Make the Grok provider more permissive by returning an empty model list for unexpected model-listing payload shapes and allowing native Grok image generation parameters from `additionalParams` to override defaults while preserving core-owned `model` and `prompt`.

## Reviews
Review passed with no findings. The change is covered by focused tests and preserves the boundary around core-owned request fields.

<details>
<summary>Original review output</summary>

```markdown
## Change Intention
The change appears to make the Grok provider more permissive in two areas:
- `packages/provider-grok/src/grok/client.ts`: treat unexpected model-listing response shapes as an empty model list instead of throwing a `ModelListingError`.
- `packages/provider-grok/src/grok/image-generation.ts`: allow native Grok image generation parameters from `additionalParams` to override defaults such as `n`, `response_format`, and `aspect_ratio`, while still protecting core-owned `model` and `prompt`.
- Tests in `packages/provider-grok/test/client.test.ts` and `packages/provider-grok/test/image-generation.test.ts` were updated to cover the new behavior.

## Findings
No findings.

## Notes
- The image-generation change is internally consistent: allowing `response_format: "url"` is already supported by `imageResponseFromGrok`, which can fetch and normalize URL-based image responses.
- The remaining guard that strips `model` and `prompt` from provider params is a good boundary: callers can tune native request options without accidentally routing requests to a different model or changing the core prompt.
- Lexa audit reported existing structural warnings in unrelated provider/core areas, but nothing in the changed Grok files that affects this review scope.

## Verdicts
- **Verdict:** pass
- **Reason:** The diff is covered by focused tests and I did not find concrete correctness, security, maintainability, or architecture issues in the changed behavior.
```

</details>

## What Fixed
No fix step was required.

<details>
<summary>Fix agent output</summary>

```markdown
(no fix output)
```

</details>

## Verification Status
- Typecheck: passed - `pnpm --filter @anvia/grok typecheck`
- Lint: passed - `pnpm lint`
- Test: passed - `pnpm --filter @anvia/grok test` — 3 test files passed, 23 tests passed.
- Build: passed - `pnpm --filter @anvia/grok build`
- Playwright UI: skipped - Diff is not UI-related; no browser-rendered behavior, routes, styling, frontend state, or user-visible browser workflows changed.
- Artifacts: `.review-this/verification/grok-reference.png`, `.review-this/verification/grok-provider-guide.png`, `.review-this/verification/xai-gateway.png` — verification reference screenshots for Grok/xAI provider documentation context.

<details>
<summary>Verification output</summary>

```markdown
## Verification Summary
- Inspected the monorepo package scripts and lockfile. Package manager is `pnpm` via `pnpm-lock.yaml` and `packageManager: pnpm@11.0.4`.
- Diff affects the Grok provider package runtime behavior and tests only; it does not affect UI, browser behavior, routes, styling, frontend state, or user-visible browser workflows.
- Ran targeted checks for `@anvia/grok` plus repository lint. All available required checks passed.
- Playwright UI verification was skipped because the diff is non-UI provider/package logic.

## Checks
- typecheck: passed - `pnpm --filter @anvia/grok typecheck`
- lint: passed - `pnpm lint`
- test: passed - `pnpm --filter @anvia/grok test` — 3 test files passed, 23 tests passed.
- build: passed - `pnpm --filter @anvia/grok build`
- playwright-ui: skipped - Diff is not UI-related; no browser-rendered behavior, routes, styling, frontend state, or user-visible browser workflows changed.

## UI Artifacts
- No UI artifacts: Playwright verification was skipped because the changed files are limited to Grok provider implementation and unit tests, with no UI/browser impact.

## Verdict
VERDICT: pass
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model listing now returns an empty result instead of failing when the provider sends an unexpected response format.
  * Image generation now preserves valid extra request settings while ignoring conflicting model and prompt overrides, improving request handling consistency.

* **Tests**
  * Updated coverage to reflect the new model-listing behavior and the revised image generation parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->