### PR TITLE
Remove experimental tool guardrails

### DIFF
--- a/.changeset/clean-guards-leave.md
+++ b/.changeset/clean-guards-leave.md
@@ -1,0 +1,5 @@
+---
+"@anvia/core": patch
+---
+
+Remove experimental tool and tool-result guardrails. Guardrail policies now cover input and final output boundaries only; use tool approvals, hooks, middleware, and service-level validation for tool execution behavior.

--- a/apps/www/src/content/docs/advanced/production-guardrails.md
+++ b/apps/www/src/content/docs/advanced/production-guardrails.md
@@ -1,26 +1,39 @@
 ---
 title: Production guardrails
-description: Enforce input, tool, tool-result, and output policy around agent runs.
+description: Enforce input and output policy around agent runs.
 section: advanced
 sidebar:
   group: Quality and operations
   order: 53
 ---
 
-Guardrails are runtime policy checks around agent boundaries. They can block unsafe input, rewrite tool arguments, request approval for sensitive tools, redact tool results, and sanitize final output.
+Guardrails are runtime policy checks around agent text boundaries. They can block or
+rewrite unsafe input before model work, and they can sanitize final output before it is
+returned, streamed, or committed to memory.
 
 Guardrails do not replace product authorization, idempotency, audit records, or service-level validation. Keep those checks in your tools and services.
+
+The mental model is simple: guardrails decide automatically, approvals ask a person or
+external workflow, and tools/services enforce product truth.
+
+## Guardrails Or Approvals
+
+Use guardrails when policy can run automatically from runtime context. They are best for
+model-boundary text decisions: redact secrets, block unsafe input, or sanitize final
+assistant output.
+
+Use tool approvals when the next step is a decision from a human or external reviewer.
+Approval means the runtime may attempt the tool call. It does not mean the business
+operation is authorized or valid.
 
 ## Policy Setup
 
 ```ts
 import {
   AgentBuilder,
-  createTool,
   defineGuardrailPolicy,
   defineInputGuardrail,
   defineOutputGuardrail,
-  defineToolGuardrail,
 } from "@anvia/core";
 
 const redactInput = defineInputGuardrail({
@@ -30,16 +43,6 @@ const redactInput = defineInputGuardrail({
     return inputText === ctx.inputText
       ? allow()
       : rewrite({ inputText, reason: "card_number_redacted" });
-  },
-});
-
-const refundApproval = defineToolGuardrail<{ amountCents: number }>({
-  id: "large-refund-approval",
-  tool: "issue_refund",
-  check(ctx, { allow, requestApproval }) {
-    return ctx.args.amountCents > 10_000
-      ? requestApproval({ reason: "Large refunds require review." })
-      : allow();
   },
 });
 
@@ -56,7 +59,6 @@ const redactOutput = defineOutputGuardrail({
 const policy = defineGuardrailPolicy({
   id: "support-production",
   input: [redactInput],
-  tools: [refundApproval],
   output: [redactOutput],
 });
 
@@ -70,7 +72,8 @@ const agent = new AgentBuilder("support", model)
 
 ## Boundaries
 
-Input guardrails run before memory and model work. Tool guardrails run after tool-call hooks and tool input middleware, then before approvals and tool execution. Tool-result guardrails run before results return to the model. Output guardrails run before final responses are returned, streamed, or committed to memory.
+Input guardrails run before memory and model work. Output guardrails run before final
+responses are returned, streamed, or committed to memory.
 
 During streaming, enforced output guardrails buffer text and reasoning deltas until the final output is checked. This prevents unsafe raw output from being emitted before redaction or blocking.
 
@@ -86,7 +89,7 @@ const policy = defineGuardrailPolicy({
 });
 ```
 
-Observe mode records guardrail decisions but does not block, rewrite, or request approval.
+Observe mode records guardrail decisions but does not block or rewrite.
 
 ## Side Effects Still Need Product Checks
 
@@ -108,7 +111,8 @@ const issueRefund = createTool({
 });
 ```
 
-The model can request a tool call. Guardrails can gate it. The service still decides whether the actor can perform the operation and how duplicate writes are prevented.
+The model can request a tool call. Tool approvals can pause it. The service still decides
+whether the actor can perform the operation and how duplicate writes are prevented.
 
 ## Decision Records
 

--- a/apps/www/src/content/docs/advanced/tool-approvals.md
+++ b/apps/www/src/content/docs/advanced/tool-approvals.md
@@ -11,6 +11,30 @@ Approvals pause sensitive tool execution until application code returns a decisi
 
 Approvals are a runtime gate. They do not replace handler-level authorization, validation, idempotency, or audit logging.
 
+## Approvals Or Guardrails
+
+Use tool approvals when the right next step is a decision: approve or reject this
+specific tool call before it executes. An approved decision lets the runtime attempt the
+tool call. It does not guarantee the product operation will succeed.
+
+Use guardrails when the right next step can be automatic: block unsafe input, rewrite
+unsafe input, or sanitize the final assistant response.
+
+| Situation | Prefer |
+| --- | --- |
+| A reviewer must approve a sensitive side effect | tool approval |
+| A tool always knows its own approval threshold | tool-level `approval` policy |
+| A run-specific policy may pause several tools | hook-driven approval |
+| User input should be blocked or redacted before the model sees it | input guardrail |
+| Final assistant text should be blocked or redacted before the user sees it | output guardrail |
+
+Neither approvals nor guardrails are product authorization. The tool implementation must
+still check the current actor, tenant, target resource, business state, idempotency, and
+audit requirements.
+
+In practice, approval answers "should this run continue into the tool?" The tool still
+answers "is this actor allowed to perform this operation on this resource right now?"
+
 ## Tool-Level Approval Policy
 
 Add an `approval` policy to a tool when the tool itself knows when approval is required:

--- a/apps/www/src/content/docs/packages/core/reference.md
+++ b/apps/www/src/content/docs/packages/core/reference.md
@@ -22,7 +22,7 @@ sidebar:
 | `@anvia/core/audio-generation` | Provider-neutral audio generation contracts and request builders |
 | `@anvia/core/transcription` | Provider-neutral audio transcription contracts and request builders |
 | `@anvia/core/tool` | Tool definitions, registries, tool sets, serialization, and tool errors |
-| `@anvia/core/guardrails` | Experimental input, tool, tool-result, and output policy APIs |
+| `@anvia/core/guardrails` | Experimental input and output policy APIs |
 | `@anvia/core/pipeline` | Typed pipelines and batch execution |
 | `@anvia/core/extractor` | Structured extraction helpers |
 | `@anvia/core/evals` | Eval suites, metrics, agent targets, and reporters |

--- a/apps/www/src/content/docs/packages/core/reference/guardrails.md
+++ b/apps/www/src/content/docs/packages/core/reference/guardrails.md
@@ -1,6 +1,6 @@
 ---
 title: "Guardrails"
-description: "Experimental policy APIs for input, tool, tool-result, and output guardrails."
+description: "Experimental policy APIs for input and output guardrails."
 section: packages
 sidebar:
   group: "Reference"
@@ -9,7 +9,14 @@ sidebar:
 ---
 Import from `@anvia/core` or `@anvia/core/guardrails`.
 
-Guardrails are an experimental policy layer for enforcing application boundaries around an agent run. They are not prompt instructions. They run in product code and can allow, block, rewrite, or request tool approval.
+Guardrails are an experimental policy layer for the text boundaries around an agent run.
+They are not prompt instructions. They run in product code and can allow, block, or
+rewrite user input and final assistant output.
+
+Guardrails do not replace product authorization, idempotency, audit records, service-level
+validation, or tool approvals. Tools and services still own product permissions and
+business state. Use guardrails to control text that enters the model and text that leaves
+the model.
 
 ## defineGuardrailPolicy
 
@@ -20,17 +27,18 @@ type GuardrailPolicyOptions = {
   id: string;
   mode?: GuardrailMode;
   input?: InputGuardrail[];
-  tools?: ToolGuardrail[];
-  toolResults?: ToolResultGuardrail[];
   output?: OutputGuardrail[];
 };
 
 function defineGuardrailPolicy(options: GuardrailPolicyOptions): GuardrailPolicy;
 ```
 
-Purpose: group guardrails into a policy that can be attached to an agent or prompt request.
+Purpose: group input and output guardrails into a policy that can be attached to an agent
+or prompt request.
 
-Return behavior: missing `mode` defaults to `"enforce"`. Agent-level policies run before request-level policies. In `"observe"` mode, decisions are recorded but do not block, rewrite, or request approval.
+Return behavior: missing `mode` defaults to `"enforce"`. Agent-level policies run before
+request-level policies. In `"observe"` mode, decisions are recorded but do not block or
+rewrite.
 
 ## Guardrail Factories
 
@@ -40,40 +48,31 @@ function defineInputGuardrail(options: {
   check(ctx: InputGuardrailContext, actions: InputGuardrailActions): InputGuardrailResult | Promise<InputGuardrailResult>;
 }): InputGuardrail;
 
-function defineToolGuardrail<Args = unknown>(options: {
-  id: string;
-  tool?: string | string[];
-  check(ctx: ToolGuardrailContext<Args>, actions: ToolGuardrailActions): ToolGuardrailResult | Promise<ToolGuardrailResult>;
-}): ToolGuardrail<Args>;
-
-function defineToolResultGuardrail<Args = unknown>(options: {
-  id: string;
-  tool?: string | string[];
-  check(ctx: ToolResultGuardrailContext<Args>, actions: ToolResultGuardrailActions): ToolResultGuardrailResult | Promise<ToolResultGuardrailResult>;
-}): ToolResultGuardrail<Args>;
-
 function defineOutputGuardrail(options: {
   id: string;
   check(ctx: OutputGuardrailContext, actions: OutputGuardrailActions): OutputGuardrailResult | Promise<OutputGuardrailResult>;
 }): OutputGuardrail;
 ```
 
-Purpose: create typed checks for each runtime boundary.
+Purpose: create typed checks for the supported runtime boundaries.
 
-Return behavior: `check(ctx, actions)` receives pure context data plus injected actions such as `allow()`, `block(...)`, `rewrite(...)`, and, for tool guardrails, `requestApproval(...)`.
+Return behavior: `check(ctx, actions)` receives pure context data plus injected actions:
+`allow()`, `block(...)`, and `rewrite(...)`.
 
 ## Boundary Order
 
 ```txt
-input -> model request -> tool -> tool result -> model continuation -> output
+input -> model and tools -> output
 ```
 
 - input guardrails run before memory and model work
-- tool guardrails run after tool-call hooks and tool input middleware, then before approvals and execution
-- tool-result guardrails run after tool output middleware and before the result returns to the model
 - output guardrails run before final response return, final stream event, and final assistant memory commit
 
-When enforced output guardrails are active during streaming, text and reasoning deltas are buffered so unsafe raw output is not emitted before the final output is checked.
+When enforced output guardrails are active during streaming, text and reasoning deltas are
+buffered so unsafe raw output is not emitted before the final output is checked.
+
+Tool execution is not guarded by this API. Use tool approvals, hooks, middleware, and
+service-level validation for tool behavior.
 
 ## Example
 
@@ -81,17 +80,17 @@ When enforced output guardrails are active during streaming, text and reasoning 
 import {
   AgentBuilder,
   defineGuardrailPolicy,
+  defineInputGuardrail,
   defineOutputGuardrail,
-  defineToolGuardrail,
 } from "@anvia/core";
 
-const largeRefundApproval = defineToolGuardrail<{ amountCents: number }>({
-  id: "large-refund-approval",
-  tool: "issue_refund",
-  check(ctx, { allow, requestApproval }) {
-    return ctx.args.amountCents > 10_000
-      ? requestApproval({ reason: "Large refund requires review." })
-      : allow();
+const redactInput = defineInputGuardrail({
+  id: "redact-card-numbers",
+  check(ctx, { allow, rewrite }) {
+    const inputText = ctx.inputText.replace(/\b\d{16}\b/g, "[redacted]");
+    return inputText === ctx.inputText
+      ? allow()
+      : rewrite({ inputText, reason: "card_number_redacted" });
   },
 });
 
@@ -107,14 +106,13 @@ const redactOutput = defineOutputGuardrail({
 
 const policy = defineGuardrailPolicy({
   id: "support-production",
-  tools: [largeRefundApproval],
+  input: [redactInput],
   output: [redactOutput],
 });
 
 const agent = new AgentBuilder("support", model)
   .tools(supportTools)
   .guardrails(policy)
-  .approvals({ handler: approvalRuntime.decide })
   .build();
 ```
 
@@ -130,15 +128,16 @@ guardrails.blockText({
 });
 
 guardrails.redactText({
-  id: "redact-tool-secret",
-  boundary: "tool_result",
+  id: "redact-output-secret",
+  boundary: "output",
   patterns: [/token=[^\s]+/gi],
   replacement: "token=[redacted]",
   reason: "secret_redacted",
 });
 ```
 
-Purpose: deterministic pattern-based blocking and redaction for input, tool-result, and output boundaries.
+Purpose: deterministic pattern-based blocking and redaction for input and output
+boundaries.
 
 ## Decisions
 
@@ -146,9 +145,9 @@ Purpose: deterministic pattern-based blocking and redaction for input, tool-resu
 type GuardrailDecisionRecord = {
   policyId: string;
   guardrailId: string;
-  boundary: "input" | "tool" | "tool_result" | "output";
+  boundary: "input" | "output";
   mode: "enforce" | "observe";
-  action: "allow" | "block" | "rewrite" | "request_approval" | "error";
+  action: "allow" | "block" | "rewrite" | "error";
   applied: boolean;
   reason?: string;
   message?: string;
@@ -157,41 +156,50 @@ type GuardrailDecisionRecord = {
 };
 ```
 
-Return behavior: prompt responses and final stream events include `guardrails?: GuardrailDecisionRecord[]`. Streams also emit `guardrail_decision` events. Observers receive `guardrail.decision` events.
+Return behavior: prompt responses and final stream events include
+`guardrails?: GuardrailDecisionRecord[]`. Streams also emit `guardrail_decision` events.
+Observers receive `guardrail.decision` events.
 
 ## Advanced Exported Types
 
-These symbols are exported for integration packages, tests, and advanced composition. App code should usually use `defineGuardrailPolicy(...)`, the boundary factories, and injected `actions`.
+These symbols are exported for integration packages, tests, and advanced composition. App
+code should usually use `defineGuardrailPolicy(...)`, the boundary factories, and injected
+`actions`.
 
 ```ts
-type GuardrailBoundary = "input" | "tool" | "tool_result" | "output";
+type GuardrailBoundary = "input" | "output";
 type GuardrailRunContext = { agentId: string; runId: string; sessionId?: string; metadata?: JsonObject };
+type GuardrailPolicy = unknown;
 type GuardrailPolicyInput = GuardrailPolicy | GuardrailPolicy[];
+type GuardrailPolicyOptions = unknown;
 
-type GuardrailActionName = "allow" | "block" | "rewrite" | "request_approval" | "error";
+type GuardrailActionName = "allow" | "block" | "rewrite" | "error";
 type GuardrailActionBase = { reason?: string; metadata?: JsonObject };
 type GuardrailAllow = GuardrailActionBase & { action: "allow" };
 type GuardrailBlock = GuardrailActionBase & { action: "block"; reason: string; message?: string };
 type GuardrailCommonActions = { allow(...): GuardrailAllow; block(...): GuardrailBlock };
 
+type InputGuardrail = unknown;
+type InputGuardrailContext = unknown;
+type InputGuardrailActions = GuardrailCommonActions & { rewrite(...): InputGuardrailRewrite };
+type InputGuardrailResult = GuardrailAllow | GuardrailBlock | InputGuardrailRewrite;
 type InputGuardrailRewrite = GuardrailActionBase & { action: "rewrite"; prompt?: Message; inputText?: string };
-type ToolGuardrailRewrite = GuardrailActionBase & { action: "rewrite"; args: JsonValue | string };
-type ToolGuardrailApprovalRequest = GuardrailActionBase & { action: "request_approval"; rejectMessage?: string };
-type ToolResultGuardrailRewrite = GuardrailActionBase & { action: "rewrite"; result?: string; structuredResult?: ToolResultContent[] };
-type OutputGuardrailRewrite = GuardrailActionBase & { action: "rewrite"; outputText: string };
-
 type InputGuardrailRunResult = unknown;
-type ToolGuardrailRunResult = unknown;
-type ToolResultGuardrailRunResult = unknown;
+
+type OutputGuardrail = unknown;
+type OutputGuardrailContext = unknown;
+type OutputGuardrailActions = GuardrailCommonActions & { rewrite(...): OutputGuardrailRewrite };
+type OutputGuardrailResult = GuardrailAllow | GuardrailBlock | OutputGuardrailRewrite;
+type OutputGuardrailRewrite = GuardrailActionBase & { action: "rewrite"; outputText: string };
 type OutputGuardrailRunResult = unknown;
 ```
 
 ```ts
+function allow(...): GuardrailAllow;
+function block(...): GuardrailBlock;
 function normalizeGuardrailPolicies(...): GuardrailPolicy[];
 function appendGuardrailPolicies(...): GuardrailPolicy[];
 function hasEnforcedOutputGuardrails(...): boolean;
 function runInputGuardrails(...): Promise<InputGuardrailRunResult>;
-function runToolGuardrails(...): Promise<ToolGuardrailRunResult>;
-function runToolResultGuardrails(...): Promise<ToolResultGuardrailRunResult>;
 function runOutputGuardrails(...): Promise<OutputGuardrailRunResult>;
 ```

--- a/apps/www/src/content/docs/packages/core/reference/tools.md
+++ b/apps/www/src/content/docs/packages/core/reference/tools.md
@@ -15,8 +15,6 @@ Import from `@anvia/core` or `@anvia/core/tool`.
 interface Tool<Args = unknown, Output = unknown> {
   readonly name: string;
   readonly approval?: ToolApprovalPolicy<Args>;
-  readonly inputGuardrails?: ToolGuardrail<Args>[];
-  readonly outputGuardrails?: ToolResultGuardrail<Args>[];
   definition(prompt: string): ToolDefinition | Promise<ToolDefinition>;
   call(args: Args, context?: ToolCallContext): Output | Promise<Output>;
   parseApprovalArgs?(args: unknown): Args;
@@ -39,7 +37,7 @@ type ToolCallContext = {
 
 Purpose: normalized callable tool contract.
 
-Return behavior: `definition(...)` exposes provider JSON schema; `call(...)` executes local logic. The optional context is used by runtime-managed tools such as streaming agent-tools. Approval and guardrail metadata is passive and is not included in provider tool definitions.
+Return behavior: `definition(...)` exposes provider JSON schema; `call(...)` executes local logic. The optional context is used by runtime-managed tools such as streaming agent-tools. Approval metadata is passive and is not included in provider tool definitions.
 
 Notable errors: tool implementations can throw arbitrary errors.
 
@@ -52,8 +50,6 @@ type CreateToolOptions<InputSchema extends ZodSchema, OutputSchema extends ZodSc
   input: InputSchema;
   output?: OutputSchema;
   approval?: ToolApprovalPolicy<z.output<InputSchema>>;
-  inputGuardrails?: ToolGuardrail<z.output<InputSchema>>[];
-  outputGuardrails?: ToolResultGuardrail<z.output<InputSchema>>[];
   execute(args: z.output<InputSchema>, context: ToolCallContext): unknown | Promise<unknown>;
 };
 

--- a/apps/www/src/lib/packages.ts
+++ b/apps/www/src/lib/packages.ts
@@ -154,7 +154,7 @@ export const packageReferencePagesBySlug: Record<string, PackageReferencePage[]>
       "reference/guardrails",
       "Guardrails",
       "Guardrails",
-      "Experimental input, tool, tool-result, and output policy APIs.",
+      "Experimental input and output policy APIs.",
     ),
     defineReferencePage(
       "reference/pipeline",

--- a/packages/core/src/guardrails/index.ts
+++ b/packages/core/src/guardrails/index.ts
@@ -1,10 +1,10 @@
-import type { JsonObject, JsonValue, Message, ToolResultContent, Usage } from "../completion";
+import type { JsonObject, Message, Usage } from "../completion";
 
 type MaybePromise<T> = T | Promise<T>;
 
 export type GuardrailMode = "enforce" | "observe";
 
-export type GuardrailBoundary = "input" | "tool" | "tool_result" | "output";
+export type GuardrailBoundary = "input" | "output";
 
 export type GuardrailRunContext = {
   agentId: string;
@@ -26,7 +26,7 @@ export type GuardrailDecisionRecord = {
   latencyMs: number;
 };
 
-export type GuardrailActionName = "allow" | "block" | "rewrite" | "request_approval" | "error";
+export type GuardrailActionName = "allow" | "block" | "rewrite" | "error";
 
 export type GuardrailActionBase = {
   reason?: string | undefined;
@@ -49,38 +49,12 @@ export type InputGuardrailRewrite = GuardrailActionBase & {
   inputText?: string | undefined;
 };
 
-export type ToolGuardrailRewrite = GuardrailActionBase & {
-  action: "rewrite";
-  args: JsonValue | string;
-};
-
-export type ToolResultGuardrailRewrite = GuardrailActionBase & {
-  action: "rewrite";
-  result?: string | undefined;
-  structuredResult?: ToolResultContent[] | undefined;
-};
-
 export type OutputGuardrailRewrite = GuardrailActionBase & {
   action: "rewrite";
   outputText: string;
 };
 
-export type ToolGuardrailApprovalRequest = GuardrailActionBase & {
-  action: "request_approval";
-  reason?: string | undefined;
-  rejectMessage?: string | undefined;
-};
-
 export type InputGuardrailResult = GuardrailAllow | GuardrailBlock | InputGuardrailRewrite;
-export type ToolGuardrailResult =
-  | GuardrailAllow
-  | GuardrailBlock
-  | ToolGuardrailRewrite
-  | ToolGuardrailApprovalRequest;
-export type ToolResultGuardrailResult =
-  | GuardrailAllow
-  | GuardrailBlock
-  | ToolResultGuardrailRewrite;
 export type OutputGuardrailResult = GuardrailAllow | GuardrailBlock | OutputGuardrailRewrite;
 
 export type GuardrailCommonActions = {
@@ -92,17 +66,6 @@ export type InputGuardrailActions = GuardrailCommonActions & {
   rewrite(options: Omit<InputGuardrailRewrite, "action">): InputGuardrailRewrite;
 };
 
-export type ToolGuardrailActions = GuardrailCommonActions & {
-  rewrite(options: Omit<ToolGuardrailRewrite, "action">): ToolGuardrailRewrite;
-  requestApproval(
-    options?: Omit<ToolGuardrailApprovalRequest, "action">,
-  ): ToolGuardrailApprovalRequest;
-};
-
-export type ToolResultGuardrailActions = GuardrailCommonActions & {
-  rewrite(options: Omit<ToolResultGuardrailRewrite, "action">): ToolResultGuardrailRewrite;
-};
-
 export type OutputGuardrailActions = GuardrailCommonActions & {
   rewrite(options: Omit<OutputGuardrailRewrite, "action">): OutputGuardrailRewrite;
 };
@@ -111,28 +74,6 @@ export type InputGuardrailContext = {
   prompt: Message;
   history: Message[];
   inputText: string;
-  run: GuardrailRunContext;
-};
-
-export type ToolGuardrailContext<Args = unknown> = {
-  toolName: string;
-  args: Args;
-  rawArgs: string;
-  toolCallId?: string | undefined;
-  internalCallId: string;
-  turn: number;
-  run: GuardrailRunContext;
-};
-
-export type ToolResultGuardrailContext<Args = unknown> = {
-  toolName: string;
-  args: Args;
-  rawArgs: string;
-  result: string;
-  structuredResult?: ToolResultContent[] | undefined;
-  toolCallId?: string | undefined;
-  internalCallId: string;
-  turn: number;
   run: GuardrailRunContext;
 };
 
@@ -151,24 +92,6 @@ export type InputGuardrail = {
   ): MaybePromise<InputGuardrailResult | undefined>;
 };
 
-export type ToolGuardrail<Args = unknown> = {
-  id: string;
-  tool?: string | string[] | undefined;
-  check(
-    context: ToolGuardrailContext<Args>,
-    actions: ToolGuardrailActions,
-  ): MaybePromise<ToolGuardrailResult | undefined>;
-};
-
-export type ToolResultGuardrail<Args = unknown> = {
-  id: string;
-  tool?: string | string[] | undefined;
-  check(
-    context: ToolResultGuardrailContext<Args>,
-    actions: ToolResultGuardrailActions,
-  ): MaybePromise<ToolResultGuardrailResult | undefined>;
-};
-
 export type OutputGuardrail = {
   id: string;
   check(
@@ -181,8 +104,6 @@ export type GuardrailPolicy = {
   id: string;
   mode: GuardrailMode;
   input: InputGuardrail[];
-  tools: ToolGuardrail[];
-  toolResults: ToolResultGuardrail[];
   output: OutputGuardrail[];
 };
 
@@ -190,8 +111,6 @@ export type GuardrailPolicyOptions = {
   id: string;
   mode?: GuardrailMode | undefined;
   input?: InputGuardrail[] | undefined;
-  tools?: ToolGuardrail[] | undefined;
-  toolResults?: ToolResultGuardrail[] | undefined;
   output?: OutputGuardrail[] | undefined;
 };
 
@@ -200,22 +119,6 @@ export type GuardrailPolicyInput = GuardrailPolicy | GuardrailPolicy[];
 export type InputGuardrailRunResult = {
   prompt: Message;
   inputText: string;
-  blocked: boolean;
-  message?: string | undefined;
-  decisions: GuardrailDecisionRecord[];
-};
-
-export type ToolGuardrailRunResult = {
-  rawArgs: string;
-  blocked: boolean;
-  message?: string | undefined;
-  approval?: { reason?: string | undefined; rejectMessage?: string | undefined } | undefined;
-  decisions: GuardrailDecisionRecord[];
-};
-
-export type ToolResultGuardrailRunResult = {
-  result: string;
-  structuredResult?: ToolResultContent[] | undefined;
   blocked: boolean;
   message?: string | undefined;
   decisions: GuardrailDecisionRecord[];
@@ -233,25 +136,11 @@ export function defineGuardrailPolicy(options: GuardrailPolicyOptions): Guardrai
     id: options.id,
     mode: options.mode ?? "enforce",
     input: options.input ?? [],
-    tools: options.tools ?? [],
-    toolResults: options.toolResults ?? [],
     output: options.output ?? [],
   };
 }
 
 export function defineInputGuardrail(guardrail: InputGuardrail): InputGuardrail {
-  return guardrail;
-}
-
-export function defineToolGuardrail<Args = unknown>(
-  guardrail: ToolGuardrail<Args>,
-): ToolGuardrail<Args> {
-  return guardrail;
-}
-
-export function defineToolResultGuardrail<Args = unknown>(
-  guardrail: ToolResultGuardrail<Args>,
-): ToolResultGuardrail<Args> {
   return guardrail;
 }
 
@@ -333,105 +222,6 @@ export async function runInputGuardrails(
   }
 
   return { prompt, inputText, blocked: false, decisions };
-}
-
-export async function runToolGuardrails<Args>(
-  policies: GuardrailPolicy[],
-  toolGuardrails: ToolGuardrail<Args>[],
-  context: ToolGuardrailContext<Args>,
-): Promise<ToolGuardrailRunResult> {
-  let rawArgs = context.rawArgs;
-  let args = context.args;
-  const decisions: GuardrailDecisionRecord[] = [];
-
-  for (const entry of toolGuardrailEntries(policies, toolGuardrails, context.toolName)) {
-    const currentContext = { ...context, rawArgs, args };
-    const result = await runGuardrail(entry.policy, entry.guardrail.id, "tool", () =>
-      entry.guardrail.check(currentContext, toolActions),
-    );
-    decisions.push(result.decision);
-
-    if (entry.policy.mode === "observe") {
-      continue;
-    }
-    if (result.action.action === "block") {
-      return {
-        rawArgs,
-        blocked: true,
-        message: result.action.message,
-        decisions,
-      };
-    }
-    if (result.action.action === "request_approval") {
-      return {
-        rawArgs,
-        blocked: false,
-        approval: {
-          reason: result.action.reason,
-          rejectMessage: result.action.rejectMessage,
-        },
-        decisions,
-      };
-    }
-    if (result.action.action === "rewrite") {
-      rawArgs =
-        typeof result.action.args === "string"
-          ? result.action.args
-          : JSON.stringify(result.action.args);
-      try {
-        args = JSON.parse(rawArgs) as Args;
-      } catch {
-        args = rawArgs as Args;
-      }
-    }
-  }
-
-  return { rawArgs, blocked: false, decisions };
-}
-
-export async function runToolResultGuardrails<Args>(
-  policies: GuardrailPolicy[],
-  toolGuardrails: ToolResultGuardrail<Args>[],
-  context: ToolResultGuardrailContext<Args>,
-): Promise<ToolResultGuardrailRunResult> {
-  let result = context.result;
-  let structuredResult = context.structuredResult;
-  const decisions: GuardrailDecisionRecord[] = [];
-
-  for (const entry of toolResultGuardrailEntries(policies, toolGuardrails, context.toolName)) {
-    const currentContext = { ...context, result, structuredResult };
-    const guardrailResult = await runGuardrail(
-      entry.policy,
-      entry.guardrail.id,
-      "tool_result",
-      () => entry.guardrail.check(currentContext, toolResultActions),
-    );
-    decisions.push(guardrailResult.decision);
-
-    if (entry.policy.mode === "observe") {
-      continue;
-    }
-    if (guardrailResult.action.action === "block") {
-      return {
-        result,
-        structuredResult,
-        blocked: true,
-        message: guardrailResult.action.message,
-        decisions,
-      };
-    }
-    if (guardrailResult.action.action === "rewrite") {
-      if (guardrailResult.action.structuredResult !== undefined) {
-        structuredResult = guardrailResult.action.structuredResult;
-        result = textFromToolResultContent(structuredResult);
-      } else if (guardrailResult.action.result !== undefined) {
-        result = guardrailResult.action.result;
-        structuredResult = undefined;
-      }
-    }
-  }
-
-  return { result, structuredResult, blocked: false, decisions };
 }
 
 export async function runOutputGuardrails(
@@ -551,23 +341,6 @@ const inputActions: InputGuardrailActions = {
   },
 };
 
-const toolActions: ToolGuardrailActions = {
-  ...commonActions,
-  rewrite(options) {
-    return { action: "rewrite", ...options };
-  },
-  requestApproval(options = {}) {
-    return { action: "request_approval", ...options };
-  },
-};
-
-const toolResultActions: ToolResultGuardrailActions = {
-  ...commonActions,
-  rewrite(options) {
-    return { action: "rewrite", ...options };
-  },
-};
-
 const outputActions: OutputGuardrailActions = {
   ...commonActions,
   rewrite(options) {
@@ -575,62 +348,11 @@ const outputActions: OutputGuardrailActions = {
   },
 };
 
-function toolGuardrailEntries<Args>(
-  policies: GuardrailPolicy[],
-  toolGuardrails: ToolGuardrail<Args>[],
-  toolName: string,
-): Array<{ policy: GuardrailPolicy; guardrail: ToolGuardrail<Args> }> {
-  return [
-    ...policies.flatMap((policy) =>
-      policy.tools
-        .filter((guardrail) => matchesTool(guardrail.tool, toolName))
-        .map((guardrail) => ({ policy, guardrail: guardrail as ToolGuardrail<Args> })),
-    ),
-    ...toolGuardrails.map((guardrail) => ({
-      policy: defineGuardrailPolicy({
-        id: `tool:${toolName}:${guardrail.id}`,
-        tools: [guardrail],
-      }),
-      guardrail,
-    })),
-  ];
-}
-
-function toolResultGuardrailEntries<Args>(
-  policies: GuardrailPolicy[],
-  toolGuardrails: ToolResultGuardrail<Args>[],
-  toolName: string,
-): Array<{ policy: GuardrailPolicy; guardrail: ToolResultGuardrail<Args> }> {
-  return [
-    ...policies.flatMap((policy) =>
-      policy.toolResults
-        .filter((guardrail) => matchesTool(guardrail.tool, toolName))
-        .map((guardrail) => ({ policy, guardrail: guardrail as ToolResultGuardrail<Args> })),
-    ),
-    ...toolGuardrails.map((guardrail) => ({
-      policy: defineGuardrailPolicy({
-        id: `tool:${toolName}:${guardrail.id}`,
-        toolResults: [guardrail],
-      }),
-      guardrail,
-    })),
-  ];
-}
-
-function matchesTool(tool: string | string[] | undefined, toolName: string): boolean {
-  if (tool === undefined) {
-    return true;
-  }
-  return Array.isArray(tool) ? tool.includes(toolName) : tool === toolName;
-}
-
-type TextPatternBoundary = "input" | "output" | "tool_result";
+type TextPatternBoundary = "input" | "output";
 
 type TextPatternGuardrailFor<Boundary extends TextPatternBoundary> = Boundary extends "input"
   ? InputGuardrail
-  : Boundary extends "output"
-    ? OutputGuardrail
-    : ToolResultGuardrail;
+  : OutputGuardrail;
 
 type TextPatternGuardrailOptions<Boundary extends TextPatternBoundary = TextPatternBoundary> = {
   id: string;
@@ -669,21 +391,11 @@ function textPatternGuardrail<Boundary extends TextPatternBoundary>(
       },
     }) as TextPatternGuardrailFor<Boundary>;
   }
-  if (options.boundary === "output") {
-    return defineOutputGuardrail({
-      id: options.id,
-      check(ctx, actions) {
-        return textPatternAction(ctx.outputText, options, action, (value) =>
-          actions.rewrite({ outputText: value, reason: options.reason }),
-        );
-      },
-    }) as TextPatternGuardrailFor<Boundary>;
-  }
-  return defineToolResultGuardrail({
+  return defineOutputGuardrail({
     id: options.id,
     check(ctx, actions) {
-      return textPatternAction(ctx.result, options, action, (value) =>
-        actions.rewrite({ result: value, reason: options.reason }),
+      return textPatternAction(ctx.outputText, options, action, (value) =>
+        actions.rewrite({ outputText: value, reason: options.reason }),
       );
     },
   }) as TextPatternGuardrailFor<Boundary>;
@@ -769,8 +481,4 @@ function rewriteMessageText(message: Message, text: string): Message {
     return { ...message, content: [{ type: "text", text }] };
   }
   return message;
-}
-
-function textFromToolResultContent(content: ToolResultContent[]): string {
-  return content.map((item) => (item.type === "text" ? item.text : "[image]")).join("\n");
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,14 +35,6 @@ export {
   Usage,
   UserContent,
 } from "./completion/index";
-export {
-  cancelPrompt,
-  createHook,
-  requestToolApproval,
-  runControl,
-  skipTool,
-  toolCallControl,
-} from "./hooks";
 export type {
   GuardrailBoundary,
   GuardrailDecisionRecord,
@@ -56,12 +48,6 @@ export type {
   OutputGuardrail,
   OutputGuardrailActions,
   OutputGuardrailContext,
-  ToolGuardrail,
-  ToolGuardrailActions,
-  ToolGuardrailContext,
-  ToolResultGuardrail,
-  ToolResultGuardrailActions,
-  ToolResultGuardrailContext,
 } from "./guardrails";
 export {
   allow,
@@ -69,10 +55,16 @@ export {
   defineGuardrailPolicy,
   defineInputGuardrail,
   defineOutputGuardrail,
-  defineToolGuardrail,
-  defineToolResultGuardrail,
   guardrails,
 } from "./guardrails";
+export {
+  cancelPrompt,
+  createHook,
+  requestToolApproval,
+  runControl,
+  skipTool,
+  toolCallControl,
+} from "./hooks";
 export type { MemoryStore } from "./memory";
 export { MaxTurnsError, PromptCancelledError, ToolApprovalRequiredError } from "./request/errors";
 export type {

--- a/packages/core/src/internal/prompt-runtime/tool-execution.ts
+++ b/packages/core/src/internal/prompt-runtime/tool-execution.ts
@@ -7,17 +7,6 @@ import type {
   ToolResultContent,
 } from "../../completion";
 import { ToolContent } from "../../completion";
-import {
-  type GuardrailDecisionRecord,
-  type GuardrailPolicy,
-  type GuardrailRunContext,
-  runToolGuardrails,
-  runToolResultGuardrails,
-  type ToolGuardrail,
-  type ToolGuardrailContext,
-  type ToolResultGuardrail,
-  type ToolResultGuardrailContext,
-} from "../../guardrails";
 import type { PromptHook, ToolApprovalRequestOptions, ToolHookArgs } from "../../hooks";
 import { runControl, toolCallControl } from "../../hooks";
 import type { ActiveAgentRunObservers, ActiveToolObservers } from "../../observability/group";
@@ -64,15 +53,7 @@ export type AgentToolEventPayload = {
   event: AgentChildStreamEvent;
 };
 
-export type GuardrailDecisionEventPayload = {
-  type: "guardrail_decision";
-  decision: GuardrailDecisionRecord;
-};
-
-export type ToolExecutionEventPayload =
-  | ToolResultEventPayload
-  | AgentToolEventPayload
-  | GuardrailDecisionEventPayload;
+export type ToolExecutionEventPayload = ToolResultEventPayload | AgentToolEventPayload;
 
 export type ToolExecutionObservation = {
   turn: number;
@@ -91,14 +72,10 @@ export class ToolCallExecutor {
     private readonly agent: Agent,
     private readonly activeHook: PromptHook | undefined,
     private readonly approvals: ToolApprovalsOptions | undefined,
-    private readonly guardrails: GuardrailPolicy[],
     private readonly runContext: ToolExecutionRunContext,
     private readonly concurrency: number,
     private readonly requestMiddlewares: AgentMiddleware[],
     private readonly cancel: (reason: string) => Error,
-    private readonly onGuardrailDecision:
-      | ((decision: GuardrailDecisionRecord) => void | Promise<void>)
-      | undefined,
   ) {}
 
   async execute(
@@ -169,54 +146,25 @@ export class ToolCallExecutor {
           });
           hookArgs.args = effectiveArgs;
 
-          const inputGuardrailResult = await runToolGuardrails(
-            this.guardrails,
-            (tool?.inputGuardrails ?? []) as ToolGuardrail[],
-            toolGuardrailContext(
-              tool,
-              hookArgs,
-              this.agent,
-              this.runContext,
-              observation?.turn ?? 0,
-            ),
-          );
-          await this.recordGuardrailDecisions(inputGuardrailResult.decisions);
-          effectiveArgs = inputGuardrailResult.rawArgs;
-          hookArgs.args = effectiveArgs;
-
-          if (inputGuardrailResult.blocked) {
-            output = inputGuardrailResult.message ?? "Tool call blocked by guardrail.";
+          approvalDecision =
+            callAction?.type === "approval_request"
+              ? await this.requestApproval(tool, hookArgs, callAction)
+              : ((await this.evaluateToolApproval(tool, hookArgs)) ?? { approved: true });
+          if (!approvalDecision.approved) {
+            output = approvalDecision.result;
             skipped = true;
           } else {
-            approvalDecision =
-              inputGuardrailResult.approval !== undefined
-                ? await this.requestApproval(
-                    tool,
-                    hookArgs,
-                    compact({
-                      reason: inputGuardrailResult.approval.reason,
-                      rejectMessage: inputGuardrailResult.approval.rejectMessage,
-                    }),
-                  )
-                : callAction?.type === "approval_request"
-                  ? await this.requestApproval(tool, hookArgs, callAction)
-                  : ((await this.evaluateToolApproval(tool, hookArgs)) ?? { approved: true });
-            if (!approvalDecision.approved) {
-              output = approvalDecision.result;
-              skipped = true;
-            } else {
-              output = await this.runApprovedToolCall(
-                toolCall,
-                hookArgs,
-                effectiveArgs,
-                args,
-                toolObservers,
-                observation,
-                onStreamEvent,
-                false,
-              );
-              effectiveArgs = hookArgs.args;
-            }
+            output = await this.runApprovedToolCall(
+              toolCall,
+              hookArgs,
+              effectiveArgs,
+              args,
+              toolObservers,
+              observation,
+              onStreamEvent,
+              false,
+            );
+            effectiveArgs = hookArgs.args;
           }
         } catch (error) {
           await recordToolError(
@@ -248,33 +196,6 @@ export class ToolCallExecutor {
           result = toolOutputToText(middlewareReplacement);
           structuredResult = toolOutputToStructuredResult(middlewareReplacement);
         }
-      }
-
-      const resultGuardrailResult = await runToolResultGuardrails(
-        this.guardrails,
-        (tool?.outputGuardrails ?? []) as ToolResultGuardrail[],
-        toolResultGuardrailContext(
-          tool,
-          hookArgs,
-          result,
-          structuredResult,
-          this.agent,
-          this.runContext,
-          observation?.turn ?? 0,
-        ),
-      );
-      await this.recordGuardrailDecisions(resultGuardrailResult.decisions);
-      if (resultGuardrailResult.blocked) {
-        output = resultGuardrailResult.message ?? "Tool result blocked by guardrail.";
-        result = toolOutputToText(output);
-        structuredResult = toolOutputToStructuredResult(output);
-      } else if (
-        resultGuardrailResult.result !== result ||
-        resultGuardrailResult.structuredResult !== structuredResult
-      ) {
-        output = resultGuardrailResult.structuredResult ?? resultGuardrailResult.result;
-        result = resultGuardrailResult.result;
-        structuredResult = resultGuardrailResult.structuredResult;
       }
 
       const resultAction = await this.activeHook?.onToolResult?.({
@@ -374,12 +295,6 @@ export class ToolCallExecutor {
         throw this.cancel(errorAction.reason);
       }
       return error instanceof Error ? error.toString() : String(error);
-    }
-  }
-
-  private async recordGuardrailDecisions(decisions: GuardrailDecisionRecord[]): Promise<void> {
-    for (const decision of decisions) {
-      await this.onGuardrailDecision?.(decision);
     }
   }
 
@@ -515,74 +430,6 @@ function approvalContext(
   }) as ToolApprovalContext;
 }
 
-function toolGuardrailContext(
-  tool: AnyTool | undefined,
-  hookArgs: ToolHookArgs,
-  agent: Agent,
-  run: ToolExecutionRunContext,
-  turn: number,
-): ToolGuardrailContext {
-  const parsedArgs = parseGuardrailContextArgs(tool, hookArgs.args);
-  return compact({
-    toolName: hookArgs.toolName,
-    args: parsedArgs,
-    rawArgs: hookArgs.args,
-    toolCallId: hookArgs.toolCallId,
-    internalCallId: hookArgs.internalCallId,
-    turn,
-    run: guardrailRunContext(agent, run),
-  }) as ToolGuardrailContext;
-}
-
-function toolResultGuardrailContext(
-  tool: AnyTool | undefined,
-  hookArgs: ToolHookArgs,
-  result: string,
-  structuredResult: ToolResultContent[] | undefined,
-  agent: Agent,
-  run: ToolExecutionRunContext,
-  turn: number,
-): ToolResultGuardrailContext {
-  const parsedArgs = parseGuardrailContextArgs(tool, hookArgs.args);
-  return compact({
-    toolName: hookArgs.toolName,
-    args: parsedArgs,
-    rawArgs: hookArgs.args,
-    result,
-    structuredResult,
-    toolCallId: hookArgs.toolCallId,
-    internalCallId: hookArgs.internalCallId,
-    turn,
-    run: guardrailRunContext(agent, run),
-  }) as ToolResultGuardrailContext;
-}
-
-function parseGuardrailContextArgs(tool: AnyTool | undefined, rawArgs: string): unknown {
-  const parsedArgs = parseGuardrailArgs(rawArgs);
-  try {
-    return tool?.parseApprovalArgs?.(parsedArgs) ?? parsedArgs;
-  } catch {
-    return parsedArgs;
-  }
-}
-
-function parseGuardrailArgs(args: string): unknown {
-  try {
-    return parseToolArgs(args);
-  } catch {
-    return args;
-  }
-}
-
-function guardrailRunContext(agent: Agent, run: ToolExecutionRunContext): GuardrailRunContext {
-  return compact({
-    agentId: agent.id,
-    runId: run.runId,
-    sessionId: run.sessionId,
-    metadata: run.metadata,
-  }) as GuardrailRunContext;
-}
-
 function normalizeApprovalDecision(decision: ToolApprovalDecision): {
   approved: boolean;
   reason?: string;
@@ -622,8 +469,6 @@ function toolTraceMetadata(tool: AnyTool | undefined): JsonObject | undefined {
       : undefined;
   return {
     approvalRequired: tool.approval !== undefined,
-    inputGuardrailCount: tool.inputGuardrails?.length ?? 0,
-    outputGuardrailCount: tool.outputGuardrails?.length ?? 0,
     ...(typeof mcpMetadata?.serverName === "string" && mcpMetadata.serverName.length > 0
       ? { mcpServerName: mcpMetadata.serverName }
       : {}),

--- a/packages/core/src/request/prompt-request.ts
+++ b/packages/core/src/request/prompt-request.ts
@@ -311,9 +311,6 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
             runObservers,
             toolDefinitions: request.tools,
           },
-          async (decision) => {
-            await this.recordGuardrailDecision(decision, runObservers);
-          },
         );
         const toolMessage = Message.tool(toolResults);
         newMessages.push(toolMessage);
@@ -614,10 +611,6 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
             runObservers,
             toolDefinitions: request.tools,
           },
-          async (decision) => {
-            await this.recordGuardrailDecision(decision, runObservers);
-            toolResultEvents.enqueue({ type: "guardrail_decision", decision });
-          },
         );
         toolResultsPromise.then(
           () => toolResultEvents.close(),
@@ -707,13 +700,11 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
       runObservers: ActiveAgentRunObservers;
       toolDefinitions?: ToolDefinition[];
     },
-    onGuardrailDecision?: (decision: GuardrailDecisionRecord) => void | Promise<void>,
   ): Promise<ToolResult[]> {
     const executor = new ToolCallExecutor(
       this.agent,
       this.activeHook,
       this.approvalOptions,
-      this.guardrailPolicies,
       {
         runId,
         sessionId: this.memoryContext?.sessionId,
@@ -722,7 +713,6 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
       this.concurrency,
       this.requestMiddlewares,
       (reason) => this.cancelled(newMessages, reason),
-      onGuardrailDecision,
     );
     return executor.execute(toolCalls, onResult, onStreamEvent, observation);
   }

--- a/packages/core/src/tool/create-tool.ts
+++ b/packages/core/src/tool/create-tool.ts
@@ -1,5 +1,4 @@
 import type { z } from "zod";
-import type { ToolGuardrail, ToolResultGuardrail } from "../guardrails";
 import { compact } from "../internal/compact";
 import { toProviderJsonSchema, type ZodSchema } from "../schema/zod-schema";
 import type { Tool, ToolApprovalPolicy, ToolCallContext } from "./tool";
@@ -14,8 +13,6 @@ export type CreateToolOptions<
   input: InputSchema;
   output?: OutputSchema;
   approval?: ToolApprovalPolicy<z.output<InputSchema>>;
-  inputGuardrails?: ToolGuardrail<z.output<InputSchema>>[] | undefined;
-  outputGuardrails?: ToolResultGuardrail<z.output<InputSchema>>[] | undefined;
   execute(
     args: z.output<InputSchema>,
     context: ToolCallContext,
@@ -50,10 +47,6 @@ export function createTool<
     ...compact({
       name: options.name,
       approval: options.approval,
-      inputGuardrails:
-        options.inputGuardrails === undefined ? undefined : [...options.inputGuardrails],
-      outputGuardrails:
-        options.outputGuardrails === undefined ? undefined : [...options.outputGuardrails],
     }),
     definition() {
       return {

--- a/packages/core/src/tool/tool.ts
+++ b/packages/core/src/tool/tool.ts
@@ -3,7 +3,6 @@ import {
   isToolResultContentArray,
   serializeToolResultOutput as serializeToolOutput,
 } from "../completion/types";
-import type { ToolGuardrail, ToolResultGuardrail } from "../guardrails";
 
 export type ToolApprovalRunContext = {
   agentId: string;
@@ -54,8 +53,6 @@ export type ToolCallContext = {
 export interface Tool<Args = unknown, Output = unknown> {
   readonly name: string;
   readonly approval?: ToolApprovalPolicy<Args>;
-  readonly inputGuardrails?: ToolGuardrail<Args>[] | undefined;
-  readonly outputGuardrails?: ToolResultGuardrail<Args>[] | undefined;
   definition(prompt: string): ToolDefinition | Promise<ToolDefinition>;
   call(args: Args, context?: ToolCallContext): Output | Promise<Output>;
   parseApprovalArgs?(args: unknown): Args;

--- a/packages/core/test/guardrails.test.ts
+++ b/packages/core/test/guardrails.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { z } from "zod";
 import {
   AgentBuilder,
   type AgentStreamEvent,
@@ -9,20 +8,15 @@ import {
   type CompletionResponse,
   type CompletionStreamEvent,
   createHook,
-  createMiddleware,
   createObserver,
-  createTool,
   defineGuardrailPolicy,
   defineInputGuardrail,
   defineOutputGuardrail,
-  defineToolGuardrail,
-  defineToolResultGuardrail,
   guardrails,
   type InputGuardrail,
   Message,
   type OutputGuardrail,
   type StreamingCompletionModel,
-  type ToolResultGuardrail,
   Usage,
 } from "./helpers/imports";
 
@@ -104,16 +98,9 @@ describe("guardrails", () => {
       patterns: ["secret"],
       reason: "secret_output",
     });
-    const toolResultGuardrail: ToolResultGuardrail = guardrails.redactText({
-      id: "redact-tool-result-text",
-      boundary: "tool_result",
-      patterns: ["token"],
-      reason: "secret_tool_result",
-    });
 
     expect(inputGuardrail.id).toBe("block-input-text");
     expect(outputGuardrail.id).toBe("redact-output-text");
-    expect(toolResultGuardrail.id).toBe("redact-tool-result-text");
   });
 
   it("rewrites input before model execution", async () => {
@@ -235,152 +222,6 @@ describe("guardrails", () => {
       Message.user("[redacted] [redacted]\n[redacted] doc"),
     );
     expect(model.requests[1]?.chatHistory[0]).toEqual(Message.user("[redacted]"));
-  });
-
-  it("routes tool guardrail approval through the existing approval handler", async () => {
-    let executed = false;
-    const guardedTool = createTool({
-      name: "issue_refund",
-      description: "Issue a refund.",
-      input: z.object({ amountCents: z.number() }),
-      output: z.string(),
-      execute({ amountCents }) {
-        executed = true;
-        return `issued ${amountCents}`;
-      },
-    });
-    const toolGuardrail = defineToolGuardrail<{ amountCents: number }>({
-      id: "large-refund",
-      tool: "issue_refund",
-      check(ctx, { requestApproval, allow }) {
-        return ctx.args.amountCents > 10_000
-          ? requestApproval({ reason: "Large refund." })
-          : allow();
-      },
-    });
-    const model = new QueueModel([
-      response([AssistantContent.toolCall("call_1", "issue_refund", { amountCents: 20_000 })]),
-      response([AssistantContent.text("done")]),
-    ]);
-    const approvalRequests: unknown[] = [];
-    const agent = new AgentBuilder("test-agent", model)
-      .tool(guardedTool)
-      .guardrails(defineGuardrailPolicy({ id: "policy", tools: [toolGuardrail] }))
-      .approvals({
-        handler(request) {
-          approvalRequests.push(request);
-          return true;
-        },
-      })
-      .build();
-
-    const result = await agent.prompt("refund").send();
-
-    expect(result.output).toBe("done");
-    expect(executed).toBe(true);
-    expect(approvalRequests).toMatchObject([
-      { toolName: "issue_refund", args: { amountCents: 20_000 }, reason: "Large refund." },
-    ]);
-    expect(result.guardrails).toMatchObject([
-      { guardrailId: "large-refund", action: "request_approval", applied: true },
-    ]);
-  });
-
-  it("runs tool guardrails against middleware-rewritten args", async () => {
-    let executed = false;
-    const guardedTool = createTool({
-      name: "guarded_amount",
-      description: "Run a guarded amount.",
-      input: z.object({ amount: z.number() }),
-      output: z.string(),
-      execute({ amount }) {
-        executed = true;
-        return `ran ${amount}`;
-      },
-    });
-    const toolGuardrail = defineToolGuardrail<{ amount: number }>({
-      id: "block-large-amount",
-      tool: "guarded_amount",
-      check(ctx, { block, allow }) {
-        return ctx.args.amount > 100
-          ? block({ reason: "amount_too_large", message: "Amount blocked." })
-          : allow();
-      },
-    });
-    const model = new QueueModel([
-      response([AssistantContent.toolCall("call_1", "guarded_amount", { amount: 10 })]),
-      response([AssistantContent.text("done")]),
-    ]);
-    const agent = new AgentBuilder("test-agent", model)
-      .tool(guardedTool)
-      .middleware(
-        createMiddleware({
-          onToolInput() {
-            return { args: { amount: 250 } };
-          },
-        }),
-      )
-      .guardrails(defineGuardrailPolicy({ id: "policy", tools: [toolGuardrail] }))
-      .build();
-
-    const result = await agent.prompt("run").send();
-
-    expect(result.output).toBe("done");
-    expect(executed).toBe(false);
-    expect(model.requests[1]?.chatHistory.at(-1)).toEqual(
-      Message.tool([
-        {
-          type: "tool_result",
-          id: "call_1",
-          content: [{ type: "text", text: "Amount blocked." }],
-        },
-      ]),
-    );
-    expect(result.guardrails).toMatchObject([
-      { guardrailId: "block-large-amount", action: "block", applied: true },
-    ]);
-  });
-
-  it("redacts tool results before they return to the model", async () => {
-    const lookupSecret = createTool({
-      name: "lookup_secret",
-      description: "Look up a secret.",
-      input: z.object({}),
-      output: z.string(),
-      execute() {
-        return "token=abc";
-      },
-    });
-    const resultGuardrail = defineToolResultGuardrail({
-      id: "redact-tool-result",
-      tool: "lookup_secret",
-      check(ctx, { rewrite }) {
-        return rewrite({
-          result: ctx.result.replace("abc", "[redacted]"),
-          reason: "secret_redacted",
-        });
-      },
-    });
-    const model = new QueueModel([
-      response([AssistantContent.toolCall("call_1", "lookup_secret", {})]),
-      response([AssistantContent.text("done")]),
-    ]);
-    const agent = new AgentBuilder("test-agent", model)
-      .tool(lookupSecret)
-      .guardrails(defineGuardrailPolicy({ id: "policy", toolResults: [resultGuardrail] }))
-      .build();
-
-    await agent.prompt("lookup").send();
-
-    expect(model.requests[1]?.chatHistory.at(-1)).toEqual(
-      Message.tool([
-        {
-          type: "tool_result",
-          id: "call_1",
-          content: [{ type: "text", text: "token=[redacted]" }],
-        },
-      ]),
-    );
   });
 
   it("rewrites final output before returning and committing the assistant message", async () => {

--- a/packages/core/test/public-exports.test.ts
+++ b/packages/core/test/public-exports.test.ts
@@ -111,7 +111,9 @@ describe("public exports", () => {
     expect(extractor).toHaveProperty("ExtractorBuilder");
     expect(guardrails).toHaveProperty("defineGuardrailPolicy");
     expect(guardrails).toHaveProperty("defineInputGuardrail");
-    expect(guardrails).toHaveProperty("defineToolGuardrail");
+    expect(guardrails).toHaveProperty("defineOutputGuardrail");
+    expect(guardrails).not.toHaveProperty("defineToolGuardrail");
+    expect(guardrails).not.toHaveProperty("defineToolResultGuardrail");
     expect(guardrails).toHaveProperty("guardrails");
     expect(guardrails.guardrails).toMatchObject({
       blockText: expect.any(Function),
@@ -138,7 +140,10 @@ describe("public exports", () => {
 
   it("exposes guardrail helpers from the root entrypoint", () => {
     expect("defineGuardrailPolicy" in publicCore).toBe(true);
-    expect("defineToolGuardrail" in publicCore).toBe(true);
+    expect("defineInputGuardrail" in publicCore).toBe(true);
+    expect("defineOutputGuardrail" in publicCore).toBe(true);
+    expect("defineToolGuardrail" in publicCore).toBe(false);
+    expect("defineToolResultGuardrail" in publicCore).toBe(false);
     expect(publicCore).toHaveProperty("guardrails");
     expect(publicCore.guardrails).toMatchObject({
       blockText: expect.any(Function),


### PR DESCRIPTION
## Summary
- remove experimental tool and tool-result guardrail APIs
- keep guardrails scoped to input and final output boundaries
- keep tool approvals, hooks, middleware, and service validation as the tool safety mechanisms
- update docs/reference coverage and add a patch changeset

## Validation
- pnpm --filter @anvia/core typecheck
- pnpm --filter @anvia/core test
- pnpm --filter @anvia/core build
- pnpm --filter www reference-check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Guardrails now focus on input and output boundaries, with clearer guidance for when to use approvals versus guardrails.
  * Added support and documentation for output guardrails.

* **Bug Fixes**
  * Removed tool-related guardrail behavior so tool execution is handled through approvals and normal validation instead.
  * Updated examples and references to match the simplified guardrail flow.

* **Documentation**
  * Revised core and advanced docs to reflect the new guardrail scope and updated API examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->