### PR TITLE
docs: explain sandbox artifact serving

### DIFF
--- a/apps/www/src/content/docs/packages/sandbox/examples.md
+++ b/apps/www/src/content/docs/packages/sandbox/examples.md
@@ -50,6 +50,61 @@ const agent = new AgentBuilder("debugger", model)
   })
   .build();
 ```
+
+## Serve a generated artifact
+
+Use `session.readFile(...)` from application code when a sandbox command produces an image or
+another binary artifact. Keep the public route narrow and copy artifacts to durable storage before
+destroying the session if the URL needs to outlive the sandbox.
+
+```ts
+import type { SandboxSession } from "@anvia/sandbox";
+
+export async function serveSandboxArtifact(
+  session: SandboxSession,
+  requestedPath: string,
+): Promise<Response> {
+  const artifactPath = normalizeArtifactPath(requestedPath);
+
+  if (artifactPath === undefined || !artifactPath.startsWith("artifacts/")) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const contentType = imageContentType(artifactPath);
+
+  if (contentType === undefined) {
+    return new Response("Unsupported artifact type", { status: 415 });
+  }
+
+  const bytes = await session.readFile(artifactPath);
+
+  return new Response(bytes, {
+    headers: {
+      "cache-control": "private, max-age=60",
+      "content-type": contentType,
+    },
+  });
+}
+
+function normalizeArtifactPath(path: string): string | undefined {
+  const parts = path.split(/[\\/]+/).filter(Boolean);
+
+  if (parts.some((part) => part === "." || part === "..")) {
+    return undefined;
+  }
+
+  return parts.join("/");
+}
+
+function imageContentType(path: string): string | undefined {
+  if (path.endsWith(".png")) return "image/png";
+  if (path.endsWith(".jpg") || path.endsWith(".jpeg")) return "image/jpeg";
+  if (path.endsWith(".webp")) return "image/webp";
+  if (path.endsWith(".gif")) return "image/gif";
+  return undefined;
+}
+```
+
 ## Harness shape
 
 ```ts

--- a/apps/www/src/content/docs/packages/sandbox/usage-patterns.md
+++ b/apps/www/src/content/docs/packages/sandbox/usage-patterns.md
@@ -17,8 +17,32 @@ sidebar:
 - Pair with tool approvals when commands or file writes need human review.
 - Pair with observability packages to record command lifecycle and failures.
 
+## Generated artifacts
+
+When a sandbox command produces images, reports, or other binary files, keep the model-facing
+tools and the application-facing artifact flow separate. `createSandboxTools(...)` exposes
+text-oriented `read_file` and `write_file` tools for the agent. Application code should read
+binary artifacts directly from the live `SandboxSession` with `session.readFile(...)`.
+
+Use a predictable artifact directory and serve only files that your application explicitly
+allows:
+
+1. Have the agent or command write generated files under a directory such as `artifacts/`.
+2. List or track the generated paths from application code.
+3. Validate the requested path, prefix, extension, user, and run before reading bytes.
+4. Read bytes with `session.readFile("artifacts/image.png")`.
+5. Return a short-lived preview response, or copy the bytes to durable storage for public URLs.
+
+Do not treat the sandbox as a static asset server. Ephemeral workspaces are removed when the
+session is destroyed, so long-lived links should point to host storage, object storage, or another
+artifact store that your application owns.
+
 ## Do and do not
 
-Do set explicit workspace, file-size, timeout, and lifecycle policy. Do keep secrets out of sandbox-visible files unless the task requires them. Do treat command execution as a privileged side effect.
+Do set explicit workspace, file-size, timeout, and lifecycle policy. Do keep secrets out of
+sandbox-visible files unless the task requires them. Do treat command execution as a privileged
+side effect.
 
-Do not mount broad host paths by default. Do not let model prompts override sandbox policy. Do not use the sandbox as the only production isolation boundary without infrastructure controls.
+Do not mount broad host paths by default. Do not let model prompts override sandbox policy. Do not
+expose arbitrary sandbox paths as static files. Do not use the sandbox as the only production
+isolation boundary without infrastructure controls.


### PR DESCRIPTION
## Summary
- document the generated artifact flow for @anvia/sandbox
- explain when to use app-level `session.readFile(...)` for binary assets
- add a framework-neutral `Response` example for serving image artifacts safely

## Validation
- `pnpm --filter www reference-check`
- `pnpm --filter www build`

## Notes
- Docs-only change; no changeset needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for serving generated sandbox artifacts through a controlled public route.
  * Included an example showing how to read binary outputs from a live sandbox session and return them with the correct headers.
  * Expanded usage notes with recommended patterns for handling generated files, validating paths, and keeping artifacts in a safe directory.
  * Improved formatting and clarity in the sandbox usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->