### PR TITLE
Add React UI mental model docs

### DIFF
--- a/apps/www/src/content/docs/react-ui/cheat-sheet.mdx
+++ b/apps/www/src/content/docs/react-ui/cheat-sheet.mdx
@@ -1,0 +1,342 @@
+---
+title: Cheat sheet
+description: Quick reference for @anvia/react-ui providers, namespaces, snippets, and common decisions.
+section: react-ui
+sidebar:
+  group: Start Here
+  order: 1.7
+  label: Cheat sheet
+---
+
+Use this page when you already understand the [mental model](/docs/react-ui/mental-model) and need
+the shortest path to the right primitive or snippet.
+
+## Install and import
+
+```sh
+pnpm add @anvia/react @anvia/react-ui
+```
+
+```tsx
+import { useChat } from "@anvia/react";
+import { ChatProvider, Composer, HumanInput, Message, Thread } from "@anvia/react-ui";
+import "@anvia/react-ui/styles.css";
+```
+
+For completion surfaces:
+
+```tsx
+import { useCompletion } from "@anvia/react";
+import { Completion, CompletionProvider } from "@anvia/react-ui";
+```
+
+## Pick the right primitive
+
+| Need | Use | Must live inside |
+| --- | --- | --- |
+| Multi-turn transcript | `useChat(...)` | React component state |
+| Chat UI context | `ChatProvider` | Receives `controller={chat}` |
+| Scrollable transcript | `Thread.Root`, `Thread.Viewport` | `ChatProvider` |
+| Message list | `Thread.Messages` | `Thread.Root` is recommended |
+| Message row and parts | `Message.Root`, `Message.Parts`, `Message.Part` | `Thread.Messages` |
+| Prompt input | `Composer.Root`, `Composer.Input` | `ChatProvider` |
+| Pending attachments | `Composer.Attachments`, `Attachment.*` | `Composer.Root` |
+| Tool cards | `Message.Tool` | `Message.Part` for a tool part |
+| Human review | `HumanInput.*` | `ChatProvider` with `humanInput` configured |
+| One-shot text generation | `useCompletion(...)`, `Completion.*` | `CompletionProvider` |
+
+## Minimal chat
+
+```tsx
+import { useChat } from "@anvia/react";
+import { ChatProvider, Composer, Thread } from "@anvia/react-ui";
+import "@anvia/react-ui/styles.css";
+
+export function ChatSurface() {
+  const chat = useChat({ endpoint: "http://localhost:8787/api/chat" });
+
+  return (
+    <ChatProvider controller={chat}>
+      <Thread.Root>
+        <Thread.Viewport autoScroll>
+          <Thread.Empty>Ask your first question.</Thread.Empty>
+          <Thread.Messages />
+          <Thread.Error />
+          <Thread.ScrollToBottom>Latest</Thread.ScrollToBottom>
+        </Thread.Viewport>
+
+        <Composer.Root>
+          <Composer.Attachments />
+          <Composer.Input placeholder="Message Anvia..." />
+          <Composer.Stop>Stop</Composer.Stop>
+          <Composer.Submit>Send</Composer.Submit>
+        </Composer.Root>
+      </Thread.Root>
+    </ChatProvider>
+  );
+}
+```
+
+Keep `<Thread.Messages />` empty until you need product-specific rows or parts.
+
+## Server route shape
+
+The default hook request sends core messages to your API route:
+
+```ts
+type UIStreamRequest = {
+  messages: Message[];
+  stream: true;
+  metadata?: JsonValue;
+};
+```
+
+The route should read `body.messages` and return an Anvia stream:
+
+```ts
+import type { UIStreamRequest } from "@anvia/core";
+import { createEventStream } from "@anvia/server";
+
+export async function POST(request: Request) {
+  const body = (await request.json()) as UIStreamRequest;
+
+  return createEventStream(agent.prompt(body.messages).stream(), {
+    format: "jsonl",
+  });
+}
+```
+
+## Add request options
+
+Use `createRequest` for model selectors, tenant ids, reasoning effort, feature flags, or any option
+that belongs to the whole request.
+
+```tsx
+import type { Message } from "@anvia/core/completion";
+import { useChat } from "@anvia/react";
+
+type ChatRequest = {
+  messages: Message[];
+  stream: true;
+  metadata: {
+    model: string;
+    reasoningEffort: "low" | "medium" | "high";
+  };
+};
+
+const chat = useChat<ChatRequest>({
+  endpoint: "http://localhost:8787/api/chat",
+  createRequest: ({ coreMessages }) => ({
+    messages: coreMessages,
+    stream: true,
+    metadata: {
+      model,
+      reasoningEffort,
+    },
+  }),
+});
+```
+
+Use `Composer.Root` `submitMessage` only when the submitted message itself needs custom text,
+attachments, or per-message metadata.
+
+## Renderer ladder
+
+| Start here | Move here when | Snippet |
+| --- | --- | --- |
+| Default list | Default parts are enough | `<Thread.Messages />` |
+| Custom row | You need avatars, actions, timestamps, or layout | `Thread.Messages` child function |
+| Custom part | One part type needs product-specific UI | `Message.Parts` child function |
+| Custom route | The server request shape is product-specific | `useChat({ createRequest })` |
+
+Custom row, default parts:
+
+```tsx
+<Thread.Messages>
+  {(message) => (
+    <Message.Root className="message-row">
+      <Message.Content>
+        <Message.Parts />
+      </Message.Content>
+      <Message.Actions>
+        <Message.Copy>Copy</Message.Copy>
+        <Message.Regenerate>Try again</Message.Regenerate>
+      </Message.Actions>
+    </Message.Root>
+  )}
+</Thread.Messages>
+```
+
+Custom part, fallback for everything else:
+
+```tsx
+<Message.Parts>
+  {(part) => {
+    if (part.type === "text") {
+      return (
+        <Message.Part>
+          <Message.Markdown />
+        </Message.Part>
+      );
+    }
+
+    return <Message.Part />;
+  }}
+</Message.Parts>
+```
+
+## Tools
+
+Tools execute on the server. The browser renders streamed tool parts.
+
+```tsx
+<Message.Parts>
+  {(part) =>
+    part.type === "tool" ? (
+      <Message.Part>
+        <Message.Tool className="tool-card" renderWhen="always">
+          <Message.ToolName />
+          <Message.ToolStatus />
+          <Message.ToolInput />
+          <Message.ToolOutput />
+          <Message.ToolError />
+        </Message.Tool>
+      </Message.Part>
+    ) : (
+      <Message.Part />
+    )
+  }
+</Message.Parts>
+```
+
+Useful `renderWhen` values:
+
+| Value | Shows |
+| --- | --- |
+| `always` | Input, output, and errors whenever available. |
+| `pending` | `input-streaming` and `input-available`. |
+| `settled` | `output-available` and `error`. |
+
+## Human input
+
+Configure the review endpoint on `useChat(...)`:
+
+```tsx
+const chat = useChat({
+  endpoint: "http://localhost:8787/api/chat",
+  humanInput: {
+    endpoint: "http://localhost:8787/api/review",
+  },
+});
+```
+
+Then render a review panel anywhere inside `ChatProvider`:
+
+```tsx
+<HumanInput.Panel className="review-panel">
+  <HumanInput.Status />
+  <HumanInput.Approvals />
+  <HumanInput.Questions />
+</HumanInput.Panel>
+```
+
+Use `keepMounted` for persistent lanes:
+
+```tsx
+<aside className="review-lane">
+  <HumanInput.Status />
+  <HumanInput.Approvals keepMounted />
+  <HumanInput.Questions keepMounted />
+</aside>
+```
+
+## Attachments
+
+Use the built-in picker:
+
+```tsx
+<Composer.Root>
+  <Composer.Attachments />
+  <Composer.AddAttachment accept="image/*,.pdf" multiple>
+    Attach
+  </Composer.AddAttachment>
+  <Composer.Input />
+  <Composer.Submit />
+</Composer.Root>
+```
+
+Use a dropzone when the composer region should accept dropped files:
+
+```tsx
+<Composer.Root>
+  <Composer.AttachmentDropzone className="dropzone">
+    <Composer.Attachments />
+    <Composer.Input />
+    <Composer.Submit />
+  </Composer.AttachmentDropzone>
+</Composer.Root>
+```
+
+## Completion
+
+Use completion for one prompt and one generated text result:
+
+```tsx
+import { useCompletion } from "@anvia/react";
+import { Completion, CompletionProvider } from "@anvia/react-ui";
+
+export function CompletionPanel() {
+  const completion = useCompletion({
+    endpoint: "http://localhost:8787/api/complete",
+  });
+
+  return (
+    <CompletionProvider controller={completion}>
+      <Completion.Root>
+        <Completion.Output />
+        <Completion.Form>
+          <Completion.Input placeholder="Draft a product update..." />
+          <Completion.Stop>Stop</Completion.Stop>
+          <Completion.Submit>Generate</Completion.Submit>
+        </Completion.Form>
+      </Completion.Root>
+    </CompletionProvider>
+  );
+}
+```
+
+Use chat instead when the surface needs a transcript, tools, attachments, or human review.
+
+## Styling targets
+
+Style stable attributes from app CSS or Tailwind selectors:
+
+| Attribute | Emitted by | Use |
+| --- | --- | --- |
+| `data-anvia-thread` | `Thread.Root` | Overall chat state. |
+| `data-anvia-thread-viewport` | `Thread.Viewport` | Scroll container state. |
+| `data-anvia-message` | `Message.Root` | Message row. |
+| `data-role` | `Message.Root` | `user`, `assistant`, `system`, or `tool`. |
+| `data-anvia-part` | `Message.Part` | Per-part layout. |
+| `data-part` | `Message.Part` | Part type. |
+| `data-anvia-tool` | `Message.Tool` | Tool-call cards. |
+| `data-anvia-composer` | `Composer.Root` | Composer state. |
+| `data-state` | Many primitives | `idle`, `streaming`, `error`, `enabled`, `disabled`, etc. |
+
+## Defaults to keep
+
+- Keep `<Thread.Messages />` until you need custom rows.
+- Keep `<Message.Part />` as the fallback when branching on part types.
+- Keep request-level options in `createRequest`.
+- Keep server-only work, provider credentials, tools, auth, and persistence in the API route.
+- Keep final layout and visual design in application CSS or your design system.
+
+## Deep dives
+
+- [Mental model](/docs/react-ui/mental-model)
+- [Getting started](/docs/react-ui/getting-started)
+- [Request shape](/docs/react-ui/request-shape)
+- [Messages](/docs/react-ui/messages)
+- [Tool calls](/docs/react-ui/tool-calls)
+- [Human input](/docs/react-ui/human-input)
+- [Completion](/docs/react-ui/completion)

--- a/apps/www/src/content/docs/react-ui/mental-model.mdx
+++ b/apps/www/src/content/docs/react-ui/mental-model.mdx
@@ -212,6 +212,8 @@ Customize individual parts only when one part type needs product-specific UI. Ke
 
 ## Next steps
 
+- [Cheat sheet](/docs/react-ui/cheat-sheet): grab imports, skeletons, renderer rules, and common
+  snippets.
 - [Getting started](/docs/react-ui/getting-started): render the first chat surface.
 - [Request shape](/docs/react-ui/request-shape): add model selectors and metadata.
 - [Messages](/docs/react-ui/messages): choose the right renderer level.

--- a/apps/www/src/content/docs/react-ui/mental-model.mdx
+++ b/apps/www/src/content/docs/react-ui/mental-model.mdx
@@ -1,0 +1,218 @@
+---
+title: Mental model
+description: Understand how @anvia/react controllers, React UI providers, and compound component namespaces fit together.
+section: react-ui
+sidebar:
+  group: Start Here
+  order: 1.5
+  label: Mental model
+---
+
+React UI is easiest to read as a set of context-bound building blocks, not as a closed chat widget.
+The dotted names such as `Thread.Messages`, `Composer.Input`, and `Message.Parts` are compound
+components. Each namespace groups primitives that share the same controller state and local context.
+
+## The shape
+
+`@anvia/react` owns transport and state reduction. `@anvia/react-ui` renders that state through
+providers and primitives. Your app owns the server route, styling, auth, persistence, and any
+domain-specific rendering.
+
+<div
+  className="mt-6 grid max-w-5xl gap-3 rounded-xl border border-white/10 bg-white/[0.025] p-4"
+  aria-label="React UI mental model"
+>
+  <div className="grid gap-3 lg:grid-cols-[1fr_auto_1fr] lg:items-stretch">
+    <div className="grid gap-3">
+      <div className="rounded-lg border border-[#2BF563]/25 bg-[#2BF563]/[0.06] p-4">
+        <div className="font-mono text-[#2BF563] text-xs uppercase tracking-[0.18em]">
+          {"Browser client"}
+        </div>
+        <div className="mt-3 grid gap-2 text-sm text-zinc-200">
+          <div className="rounded-md bg-white/[0.045] px-3 py-2">
+            <code>{"useChat(...)"}</code>
+            {" or "}
+            <code>{"useCompletion(...)"}</code>
+            {" creates a controller."}
+          </div>
+          <div className="rounded-md bg-white/[0.045] px-3 py-2">
+            <code>{"ChatProvider"}</code>
+            {" or "}
+            <code>{"CompletionProvider"}</code>
+            {" exposes it to UI primitives."}
+          </div>
+          <div className="rounded-md bg-white/[0.045] px-3 py-2">
+            <code>{"Thread.*"}</code>
+            {", "}
+            <code>{"Composer.*"}</code>
+            {", and "}
+            <code>{"Message.*"}</code>
+            {" read nearby context."}
+          </div>
+        </div>
+      </div>
+      <div className="rounded-lg border border-white/10 bg-white/[0.035] p-4">
+        <div className="font-mono text-zinc-400 text-xs uppercase tracking-[0.18em]">
+          {"UI actions"}
+        </div>
+        <div className="mt-2 text-sm text-zinc-200">
+          {"Submit, stop, regenerate, approve, reject, and answer controls call controller actions."}
+        </div>
+      </div>
+    </div>
+
+    <div className="flex items-center justify-center font-mono text-[#2BF563] text-xs uppercase tracking-[0.18em] lg:px-1">
+      {"POST / stream"}
+    </div>
+
+    <div className="grid gap-3">
+      <div className="rounded-lg border border-white/10 bg-white/[0.035] p-4">
+        <div className="font-mono text-zinc-400 text-xs uppercase tracking-[0.18em]">
+          {"Application API route"}
+        </div>
+        <div className="mt-3 grid gap-2 text-sm text-zinc-200">
+          <div className="rounded-md bg-white/[0.045] px-3 py-2">
+            {"Reads "}
+            <code>{"{ messages, stream: true }"}</code>
+            {" and request metadata."}
+          </div>
+          <div className="rounded-md bg-white/[0.045] px-3 py-2">
+            {"Runs auth, model selection, agents, tools, and persistence."}
+          </div>
+          <div className="rounded-md bg-white/[0.045] px-3 py-2">
+            {"Returns Anvia stream events to the controller."}
+          </div>
+        </div>
+      </div>
+      <div className="rounded-lg border border-[#2BF563]/25 bg-[#2BF563]/[0.06] p-4">
+        <div className="font-mono text-[#2BF563] text-xs uppercase tracking-[0.18em]">
+          {"Stream reduction"}
+        </div>
+        <div className="mt-2 text-sm text-zinc-200">
+          {"The hook folds stream events into messages, status, errors, suggestions, and human input."}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+Data flows down from the hook controller into providers and primitives. User actions flow back up
+through controller methods such as `sendMessage`, `stop`, `regenerate`, approval handlers, or
+question handlers.
+
+## How to read dotted components
+
+The first word is the context family. The second word is the primitive rendered inside that family.
+
+| Pattern | Meaning |
+| --- | --- |
+| `ChatProvider` | Makes a `useChat(...)` controller available to chat primitives. |
+| `Thread.Root` | Creates thread context around the transcript area and emits thread state. |
+| `Thread.Messages` | Iterates `chat.messages` and installs message context for each row. |
+| `Message.Root` | Reads the current message and emits message attributes such as `data-role`. |
+| `Message.Parts` | Iterates `message.parts` and installs part context for each part. |
+| `Composer.Root` | Creates composer context for draft text, pending attachments, submit, and stop. |
+| `Composer.Input` | Reads and writes the nearest composer draft. |
+| `HumanInput.Panel` | Reads pending approvals and questions from the chat controller. |
+
+The same pattern applies to `CompletionProvider` and `Completion.*`, except completion surfaces use
+a `useCompletion(...)` controller instead of a chat controller.
+
+## The common chat tree
+
+Start with the smallest tree that lets the package render messages for you:
+
+```tsx
+const chat = useChat({ endpoint: "http://localhost:8787/api/chat" });
+
+return (
+  <ChatProvider controller={chat}>
+    <Thread.Root>
+      <Thread.Viewport autoScroll>
+        <Thread.Empty>Ask your first question.</Thread.Empty>
+        <Thread.Messages />
+        <Thread.Error />
+        <Thread.ScrollToBottom>Latest</Thread.ScrollToBottom>
+      </Thread.Viewport>
+
+      <Composer.Root>
+        <Composer.Attachments />
+        <Composer.Input placeholder="Message Anvia..." />
+        <Composer.Stop>Stop</Composer.Stop>
+        <Composer.Submit>Send</Composer.Submit>
+      </Composer.Root>
+    </Thread.Root>
+  </ChatProvider>
+);
+```
+
+`Thread.Messages` has no child function here, so it uses the default row and part renderer. This is
+the preferred starting point because new message part types can render without application changes.
+
+## Rendering levels
+
+Move down one level only when the product needs control at that level.
+
+| Level | You keep | You customize |
+| --- | --- | --- |
+| Default list | `Thread.Messages` | CSS through stable `data-anvia-*` and `data-role` attributes. |
+| Message row | `Message.Parts` | Row layout, avatars, actions, timestamps, copy, regenerate. |
+| Message part | `Message.Part` fallback | Tool cards, Markdown, attachment previews, structured data. |
+| Route request | UI primitives | Model selectors, metadata, auth, persistence, and tool execution. |
+
+For example, customize the row but keep default part rendering:
+
+```tsx
+<Thread.Messages>
+  {(message) => (
+    <Message.Root className="message-row">
+      <Message.Content>
+        <Message.Parts />
+      </Message.Content>
+      <Message.Actions>
+        <Message.Copy>Copy</Message.Copy>
+        <Message.Regenerate>Try again</Message.Regenerate>
+      </Message.Actions>
+    </Message.Root>
+  )}
+</Thread.Messages>
+```
+
+Customize individual parts only when one part type needs product-specific UI. Keep the fallback:
+
+```tsx
+<Message.Parts>
+  {(part) => {
+    if (part.type === "tool") {
+      return (
+        <Message.Part>
+          <Message.Tool className="tool-card" renderWhen="always" />
+        </Message.Part>
+      );
+    }
+
+    return <Message.Part />;
+  }}
+</Message.Parts>
+```
+
+## Boundaries to remember
+
+- The browser renders UI and calls your API route. It should not hold provider credentials or run
+  provider SDKs directly.
+- `@anvia/react-ui` does not create a controller. It expects a `useChat(...)` or
+  `useCompletion(...)` result from `@anvia/react`.
+- Use `createRequest` on `useChat(...)` for request-level options such as model, tenant, or
+  reasoning effort. Use `Composer.Root` `submitMessage` only when the submitted message itself needs
+  custom text, attachments, or metadata.
+- Prefer the default `Thread.Messages` and `Message.Part` fallbacks until a product-specific part
+  needs custom markup.
+- Style stable attributes such as `data-anvia-message`, `data-role`, `data-part`, and `data-state`
+  instead of relying on internal DOM details.
+
+## Next steps
+
+- [Getting started](/docs/react-ui/getting-started): render the first chat surface.
+- [Request shape](/docs/react-ui/request-shape): add model selectors and metadata.
+- [Messages](/docs/react-ui/messages): choose the right renderer level.
+- [Styling](/docs/react-ui/styling): target stable attributes from application CSS.

--- a/apps/www/src/content/docs/react-ui/overview.md
+++ b/apps/www/src/content/docs/react-ui/overview.md
@@ -33,13 +33,15 @@ API app. In production, point the hook endpoint at your deployed API origin.
 
 Most applications start with a chat surface:
 
-1. Build an API route that accepts `{ messages, stream: true }`.
-2. Create a `useChat(...)` controller that points at that route.
-3. Wrap the UI in `ChatProvider`.
-4. Render `Thread.Root`, `Thread.Viewport`, `Thread.Messages`, and `Composer.Root`.
-5. Keep the default message renderer until a part needs product-specific UI.
-6. Add custom Markdown, attachment, tool-card, and human-input rendering one piece at a time.
-7. Move layout, colors, spacing, and cards into application CSS or Tailwind classes.
+1. Read the [mental model](/docs/react-ui/mental-model) for the provider and compound-component
+   structure.
+2. Build an API route that accepts `{ messages, stream: true }`.
+3. Create a `useChat(...)` controller that points at that route.
+4. Wrap the UI in `ChatProvider`.
+5. Render `Thread.Root`, `Thread.Viewport`, `Thread.Messages`, and `Composer.Root`.
+6. Keep the default message renderer until a part needs product-specific UI.
+7. Add custom Markdown, attachment, tool-card, and human-input rendering one piece at a time.
+8. Move layout, colors, spacing, and cards into application CSS or Tailwind classes.
 
 The primitives give you state, accessibility-friendly defaults, and stable attributes. They do not
 try to own your design system.
@@ -58,6 +60,8 @@ Application code still owns:
 
 ## Beginner path
 
+- [Mental model](/docs/react-ui/mental-model): understand providers, compound components, and
+  renderer levels.
 - [TanStack quickstart](/docs/react-ui/quickstart-tanstack): build the frontend app and API app first.
 - [Server routes](/docs/react-ui/server-routes): understand the route contract.
 - [Request shape](/docs/react-ui/request-shape): add model selectors and metadata safely.
@@ -79,6 +83,7 @@ Application code still owns:
 
 ## Next pages
 
+- [Mental model](/docs/react-ui/mental-model)
 - [Getting started](/docs/react-ui/getting-started)
 - [TanStack quickstart](/docs/react-ui/quickstart-tanstack)
 - [Server routes](/docs/react-ui/server-routes)

--- a/apps/www/src/content/docs/react-ui/overview.md
+++ b/apps/www/src/content/docs/react-ui/overview.md
@@ -35,13 +35,14 @@ Most applications start with a chat surface:
 
 1. Read the [mental model](/docs/react-ui/mental-model) for the provider and compound-component
    structure.
-2. Build an API route that accepts `{ messages, stream: true }`.
-3. Create a `useChat(...)` controller that points at that route.
-4. Wrap the UI in `ChatProvider`.
-5. Render `Thread.Root`, `Thread.Viewport`, `Thread.Messages`, and `Composer.Root`.
-6. Keep the default message renderer until a part needs product-specific UI.
-7. Add custom Markdown, attachment, tool-card, and human-input rendering one piece at a time.
-8. Move layout, colors, spacing, and cards into application CSS or Tailwind classes.
+2. Keep the [cheat sheet](/docs/react-ui/cheat-sheet) open while composing the first surface.
+3. Build an API route that accepts `{ messages, stream: true }`.
+4. Create a `useChat(...)` controller that points at that route.
+5. Wrap the UI in `ChatProvider`.
+6. Render `Thread.Root`, `Thread.Viewport`, `Thread.Messages`, and `Composer.Root`.
+7. Keep the default message renderer until a part needs product-specific UI.
+8. Add custom Markdown, attachment, tool-card, and human-input rendering one piece at a time.
+9. Move layout, colors, spacing, and cards into application CSS or Tailwind classes.
 
 The primitives give you state, accessibility-friendly defaults, and stable attributes. They do not
 try to own your design system.
@@ -62,6 +63,8 @@ Application code still owns:
 
 - [Mental model](/docs/react-ui/mental-model): understand providers, compound components, and
   renderer levels.
+- [Cheat sheet](/docs/react-ui/cheat-sheet): grab imports, skeletons, renderer rules, and common
+  snippets.
 - [TanStack quickstart](/docs/react-ui/quickstart-tanstack): build the frontend app and API app first.
 - [Server routes](/docs/react-ui/server-routes): understand the route contract.
 - [Request shape](/docs/react-ui/request-shape): add model selectors and metadata safely.
@@ -84,6 +87,7 @@ Application code still owns:
 ## Next pages
 
 - [Mental model](/docs/react-ui/mental-model)
+- [Cheat sheet](/docs/react-ui/cheat-sheet)
 - [Getting started](/docs/react-ui/getting-started)
 - [TanStack quickstart](/docs/react-ui/quickstart-tanstack)
 - [Server routes](/docs/react-ui/server-routes)


### PR DESCRIPTION
## Summary
- Add a React UI mental model page explaining controllers, providers, compound component namespaces, and renderer levels.
- Include an inline visual flow from browser controller to provider primitives to the API route and stream reduction.
- Link the page from the React UI overview and place it in Start Here after Overview.

## Validation
- pnpm --filter www build
- pnpm --filter www reference-check
- Inspected generated HTML for /docs/react-ui/mental-model. Browser screenshot was not captured because this environment does not have Playwright or a Chrome/Chromium binary available.

## Generated files
- No tracked generated files changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new React UI “mental model” guide explaining how controllers, shared state, and UI primitives work together.
  * Added a React UI cheat sheet with installation/import examples, a minimal end-to-end chat example, renderer ladder guidance, request/tool configuration tips, and styling/target notes.
  * Updated React UI overview navigation and onboarding steps to prioritize the new mental model page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->