### PR TITLE
Clarify React UI chat and completion boundaries

### DIFF
--- a/apps/www/scripts/check-reference-coverage.mjs
+++ b/apps/www/scripts/check-reference-coverage.mjs
@@ -7,6 +7,7 @@ const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(scriptDir, "../../..");
 const packagesRoot = join(repoRoot, "packages");
 const referenceRoot = join(repoRoot, "apps/www/src/content/docs/packages");
+const packageIndexMetadataPath = join(repoRoot, "apps/www/src/lib/packages.ts");
 
 function discoverPackages() {
   return readdirSync(packagesRoot)
@@ -103,13 +104,93 @@ function getPublicExports(file) {
     .sort((a, b) => a.localeCompare(b));
 }
 
+function isStringLike(node) {
+  return ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node);
+}
+
+function readPackageIndexMetadata() {
+  const sourceText = readFileSync(packageIndexMetadataPath, "utf8");
+  const sourceFile = ts.createSourceFile(
+    packageIndexMetadataPath,
+    sourceText,
+    ts.ScriptTarget.ES2022,
+    true,
+  );
+  const entries = [];
+
+  function visit(node) {
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+      if (node.expression.text === "definePackage") {
+        const [name, slug, version, sourceDirectory] = node.arguments;
+        if (
+          !isStringLike(name) ||
+          !isStringLike(slug) ||
+          !isStringLike(version) ||
+          !isStringLike(sourceDirectory)
+        ) {
+          throw new Error("definePackage calls in package metadata must use string literals.");
+        }
+
+        entries.push({
+          name: name.text,
+          slug: slug.text,
+          version: version.text,
+          sourceDirectory: sourceDirectory.text,
+        });
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return entries;
+}
+
+function checkPackageIndexMetadata(discoveredPackages) {
+  const packagesByName = new Map(
+    discoveredPackages.map(({ dir, pkg }) => [
+      pkg.name,
+      {
+        version: pkg.version,
+        sourceDirectory: relative(repoRoot, dir),
+      },
+    ]),
+  );
+  const issues = [];
+
+  for (const entry of readPackageIndexMetadata()) {
+    const manifest = packagesByName.get(entry.name);
+    if (!manifest) {
+      issues.push(`${entry.name} is listed in package metadata but has no package.json`);
+      continue;
+    }
+
+    if (entry.version !== manifest.version) {
+      issues.push(
+        `${entry.name} package metadata version is ${entry.version}, package.json is ${manifest.version}`,
+      );
+    }
+
+    if (entry.sourceDirectory !== manifest.sourceDirectory) {
+      issues.push(
+        `${entry.name} package metadata sourceDirectory is ${entry.sourceDirectory}, package.json is in ${manifest.sourceDirectory}`,
+      );
+    }
+  }
+
+  return issues;
+}
+
 let totalMissingEntrypoints = 0;
 let totalMissingSymbols = 0;
 let totalEntrypoints = 0;
 let totalSymbols = 0;
 const lines = [];
+const discoveredPackages = discoverPackages();
+const packageIndexMetadataIssues = checkPackageIndexMetadata(discoveredPackages);
 
-for (const { dir, pkg } of discoverPackages()) {
+for (const { dir, pkg } of discoveredPackages) {
   const docsText = readReferenceDocs(pkg.name);
   const exportEntries = getExportsMap(pkg);
   const entrypoints = [];
@@ -150,12 +231,20 @@ for (const { dir, pkg } of discoverPackages()) {
 
 for (const line of lines) console.log(line);
 console.log(
-  `TOTAL_ENTRYPOINTS=${totalEntrypoints} TOTAL_EXPORTS=${totalSymbols} TOTAL_MISSING_ENTRYPOINTS=${totalMissingEntrypoints} TOTAL_MISSING_EXPORTS=${totalMissingSymbols}`,
+  `TOTAL_ENTRYPOINTS=${totalEntrypoints} TOTAL_EXPORTS=${totalSymbols} TOTAL_MISSING_ENTRYPOINTS=${totalMissingEntrypoints} TOTAL_MISSING_EXPORTS=${totalMissingSymbols} TOTAL_PACKAGE_INDEX_METADATA_ISSUES=${packageIndexMetadataIssues.length}`,
 );
 
-if (totalMissingEntrypoints > 0 || totalMissingSymbols > 0) {
+if (
+  totalMissingEntrypoints > 0 ||
+  totalMissingSymbols > 0 ||
+  packageIndexMetadataIssues.length > 0
+) {
+  for (const issue of packageIndexMetadataIssues) {
+    console.error(`Package index metadata failed: ${issue}`);
+  }
+
   console.error(
-    `Reference coverage failed from ${relative(process.cwd(), fileURLToPath(import.meta.url))}. Document missing public entrypoints or exports before merging.`,
+    `Reference coverage failed from ${relative(process.cwd(), fileURLToPath(import.meta.url))}. Document missing public entrypoints or exports and keep package index metadata aligned before merging.`,
   );
   process.exit(1);
 }

--- a/apps/www/src/content/docs/packages/react-ui/examples.md
+++ b/apps/www/src/content/docs/packages/react-ui/examples.md
@@ -11,6 +11,10 @@ sidebar:
 The package page stays concise for package-reference coverage. The richer recipe set lives in the
 dedicated [React UI examples](/docs/react-ui/examples).
 
+The message snippet below assumes it is rendered by `Thread.Messages` or another message provider
+inside `ChatProvider`. The composer snippet assumes `ChatProvider`. The completion snippet uses its
+own `CompletionProvider`; chat primitives do not read completion context.
+
 ## Quick examples
 
 ```tsx

--- a/apps/www/src/content/docs/packages/react-ui/getting-started.md
+++ b/apps/www/src/content/docs/packages/react-ui/getting-started.md
@@ -17,7 +17,8 @@ pnpm add @anvia/react @anvia/react-ui
 
 Use chat for transcripts, follow-up turns, tools, attachments, and human review. Use completion for
 one prompt input and one generated text result. The hooks can share the same request shape, but their
-providers and primitives are separate.
+providers and primitives are separate. Chat uses `ChatProvider` with `Thread.*`, `Composer.*`,
+`Message.*`, and `HumanInput.*`; completion uses `CompletionProvider` with `Completion.*`.
 
 ## Chat setup
 

--- a/apps/www/src/content/docs/packages/react-ui/getting-started.md
+++ b/apps/www/src/content/docs/packages/react-ui/getting-started.md
@@ -13,6 +13,12 @@ sidebar:
 pnpm add @anvia/react @anvia/react-ui
 ```
 
+## Choose a surface
+
+Use chat for transcripts, follow-up turns, tools, attachments, and human review. Use completion for
+one prompt input and one generated text result. The hooks can share the same request shape, but their
+providers and primitives are separate.
+
 ## Chat setup
 
 ```tsx

--- a/apps/www/src/content/docs/packages/react-ui/overview.md
+++ b/apps/www/src/content/docs/packages/react-ui/overview.md
@@ -22,6 +22,19 @@ The package is intentionally headless. It emits stable `data-anvia-*` attributes
 The browser still calls your application route. That route should accept the React request shape
 `{ messages, stream: true }` and return Anvia stream events.
 
+## Surface families
+
+`@anvia/react-ui` has two separate UI families:
+
+| Surface | Use when | Hook and provider | Primitives |
+| --- | --- | --- | --- |
+| Chat | The user needs a transcript, follow-up turns, tools, attachments, or human review. | `useChat(...)` with `ChatProvider` | `Thread.*`, `Composer.*`, `Message.*`, `HumanInput.*` |
+| Completion | The user submits one prompt and reads one generated text result. | `useCompletion(...)` with `CompletionProvider` | `Completion.*` |
+
+The families can call routes with the same default request shape, but their providers expose
+different contexts. Use `ChatProvider` for chat primitives and `CompletionProvider` for
+`Completion.*`.
+
 ## Public surface
 
 The main documented exports are `ChatProvider`, `CompletionProvider`, `Thread`, `Composer`, `Message`, `Completion`, and `HumanInput`. The reference page lists the package entrypoints and public symbols that are checked by the docs reference coverage script.
@@ -35,5 +48,7 @@ The main documented exports are `ChatProvider`, `CompletionProvider`, `Thread`, 
 - [Reference](/docs/packages/react-ui/reference)
 
 For the dedicated React UI docs menu, start at [React UI](/docs/react-ui/overview). For practical
-copy-paste recipes, see [React UI examples](/docs/react-ui/examples). For a full Vite app, start
-with [TanStack quickstart](/docs/react-ui/quickstart-tanstack).
+copy-paste recipes, see [React UI examples](/docs/react-ui/examples). For the component mental
+model, see [Mental model](/docs/react-ui/mental-model) and
+[Cheat sheet](/docs/react-ui/cheat-sheet). For a full Vite app, start with
+[TanStack quickstart](/docs/react-ui/quickstart-tanstack).

--- a/apps/www/src/content/docs/packages/react-ui/usage-patterns.md
+++ b/apps/www/src/content/docs/packages/react-ui/usage-patterns.md
@@ -18,6 +18,10 @@ sidebar:
 React routes should accept the `@anvia/react` request shape `{ messages, stream: true }`. See
 [React UI server routes](/docs/react-ui/server-routes) for complete examples.
 
+The shared request shape does not mean every primitive can read every provider. `Thread`,
+`Composer`, `Message`, and `HumanInput` read chat context from `ChatProvider`. `Completion.*` reads
+completion context from `CompletionProvider`.
+
 ## Use as headless primitives
 
 Every primitive supports `className` and stable `data-anvia-*` attributes. Button-like primitives also support `asChild`, so applications can attach behavior to design-system components.
@@ -79,7 +83,10 @@ or filter tool parts before wrappers are created:
 
 ## Human input
 
-`HumanInput.Approvals` and `HumanInput.Questions` read `useChat` human-input state and call the matching controller actions. They are meant for tool approval and question workflows emitted by Anvia agents or Studio-compatible streams.
+`HumanInput.Approvals` and `HumanInput.Questions` read `useChat` human-input state and call the
+matching controller actions. They are meant for tool approval and question workflows emitted by
+Anvia agents or Studio-compatible streams, so they belong in chat surfaces rather than completion
+surfaces.
 
 Application code owns the decision and answer routes. See
 [Human review end to end](/docs/react-ui/human-review-end-to-end).
@@ -110,3 +117,10 @@ application state.
 
 Use `Message.Markdown` when text parts should render GitHub-flavored Markdown; pass `components` to
 replace code blocks or other Markdown elements with app-owned components.
+
+## Completion panels
+
+Use `Completion.Root`, `Completion.Output`, `Completion.Form`, `Completion.Input`,
+`Completion.Stop`, and `Completion.Submit` for prompt-to-text panels. Do not add `Thread`,
+`Composer`, `Message`, or `HumanInput` inside `CompletionProvider`; move to a chat surface when the
+product needs those primitives.

--- a/apps/www/src/content/docs/packages/react/examples.md
+++ b/apps/www/src/content/docs/packages/react/examples.md
@@ -18,6 +18,26 @@ export function Chat() {
   return <button onClick={() => void chat.send("Hello")}>{chat.status}</button>;
 }
 ```
+
+## Minimal completion
+
+```tsx
+import { useCompletion } from "@anvia/react";
+
+export function Completion() {
+  const completion = useCompletion({ endpoint: "http://localhost:8787/api/completion" });
+
+  return (
+    <section>
+      <button onClick={() => void completion.complete("Draft a changelog entry")}>
+        {completion.status === "streaming" ? "Writing..." : "Complete"}
+      </button>
+      <pre>{completion.completion}</pre>
+    </section>
+  );
+}
+```
+
 ## Product-shaped transport
 
 ```tsx

--- a/apps/www/src/content/docs/packages/react/getting-started.md
+++ b/apps/www/src/content/docs/packages/react/getting-started.md
@@ -13,6 +13,13 @@ sidebar:
 pnpm add @anvia/react
 ```
 
+## Choose a hook
+
+Use `useChat(...)` for a message transcript with follow-up turns, tool calls, human input, or
+attachments. Use `useCompletion(...)` for one prompt input and one generated text output. Both hooks
+send `{ messages, stream: true }` by default, so the server route can share the same basic request
+parser even when the client state is different.
+
 ## Minimum setup
 
 ```tsx
@@ -40,6 +47,31 @@ export function SupportChat() {
 ```
 The API app endpoint should accept `{ messages, stream: true }` and return Anvia stream events. For
 component primitives on top of this hook, see [React UI](/docs/react-ui/overview).
+
+## Minimal completion
+
+```tsx
+import { useCompletion } from "@anvia/react";
+
+export function DraftBox() {
+  const completion = useCompletion({ endpoint: "http://localhost:8787/api/completion" });
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        const form = new FormData(event.currentTarget);
+        void completion.complete(String(form.get("prompt") ?? ""));
+        event.currentTarget.reset();
+      }}
+    >
+      <textarea name="prompt" />
+      <button disabled={completion.status === "streaming"}>Complete</button>
+      <output>{completion.completion}</output>
+    </form>
+  );
+}
+```
 
 ## Next step
 

--- a/apps/www/src/content/docs/packages/react/overview.md
+++ b/apps/www/src/content/docs/packages/react/overview.md
@@ -11,7 +11,10 @@ sidebar:
 
 React hooks, event transports, and stream readers for Anvia browser clients.
 
-Use @anvia/react when the application needs a browser UI that consumes Anvia stream events without owning server-side model code. It is one of the runtime packages that sit closest to application request handling.
+Use `@anvia/react` when the application needs a browser UI that consumes Anvia stream events
+without owning server-side model code. It provides stateful hooks for chat transcripts and
+single-prompt completion surfaces, plus transport helpers for JSONL, SSE, fetch, and in-process
+test flows.
 
 ## Where it fits
 
@@ -19,9 +22,17 @@ Use @anvia/react when the application needs a browser UI that consumes Anvia str
 
 The package owns client-side chat/completion state and event-stream transport plumbing. Keep server routes, auth, persistence, model selection, and product UI composition in application code.
 
+Use `useChat(...)` for multi-turn transcripts, follow-up turns, tools, attachments, and human
+input. Use `useCompletion(...)` when the surface has one prompt input and one generated text
+result. Both hooks can send the same default request shape, `{ messages, stream: true }`, but they
+maintain different client state.
+
 ## Public surface
 
-The main documented exports are `Types`, `EventTransport`, `readJsonlStream`, `readSseStream`, `fetchEventStream`, `createFetchTransport`. The reference page lists the package entrypoint and public symbols that are checked by the docs reference coverage script.
+The main documented exports include `useChat`, `useCompletion`, `createFetchTransport`,
+`createChatTransport`, `createDirectTransport`, `readJsonlStream`, `readSseStream`, and
+`fetchEventStream`. The reference page lists the package entrypoint and public symbols that are
+checked by the docs reference coverage script.
 
 ## Next pages
 

--- a/apps/www/src/content/docs/packages/react/usage-patterns.md
+++ b/apps/www/src/content/docs/packages/react/usage-patterns.md
@@ -14,13 +14,18 @@ sidebar:
 ## Common composition
 
 - Pair `useChat(...)` with a JSONL or SSE endpoint built with `@anvia/server`.
-- Use `useCompletion(...)` for single-prompt streaming text surfaces.
+- Use `useCompletion(...)` for single-prompt streaming text surfaces without a visible message
+  thread.
 - Use `createDirectTransport(...)` for tests, demos, or in-process examples.
 - Use `@anvia/react-ui` when you want ready-made headless primitives for thread, message,
   composer, completion, tool-call, and human-input UI.
 
 Default hook requests send `{ messages, stream: true }`. Server routes should read
 `body.messages` when they are called by `useChat(...)` or `useCompletion(...)`.
+
+The shared wire shape does not make the hooks interchangeable. `useChat(...)` keeps message
+history, suggestions, attachments, and human-input state. `useCompletion(...)` keeps prompt/output
+state and exposes `completion` as the latest generated text.
 
 ## Do and do not
 

--- a/apps/www/src/content/docs/react-ui/chat.mdx
+++ b/apps/www/src/content/docs/react-ui/chat.mdx
@@ -15,6 +15,10 @@ import { threadVariants, composerVariants } from "../../../lib/react-ui-code-var
 Everything inside the provider reads from the same messages, status, errors, suggestions, human
 input state, and actions.
 
+Use chat when the surface needs a transcript, follow-up turns, tools, attachments, suggestions, or
+human review. Use [Completion](/docs/react-ui/completion) instead when the surface has one prompt and
+one generated text result.
+
 ```tsx
 import { useChat } from "@anvia/react";
 import { ChatProvider } from "@anvia/react-ui";
@@ -136,14 +140,16 @@ Use `Composer.AddAttachment` for a ready-made file-picker button, `Composer.Atta
 design system owns the input trigger, and `Composer.AttachmentDropzone` for drag-and-drop.
 
 ```tsx
-<Composer.AttachmentDropzone className="dropzone">
-  <Composer.Attachments className="attachments" />
-  <Composer.AddAttachment accept="image/*,.pdf" multiple>
-    Attach image or PDF
-  </Composer.AddAttachment>
-  <Composer.Input />
-  <Composer.Submit />
-</Composer.AttachmentDropzone>
+<Composer.Root>
+  <Composer.AttachmentDropzone className="dropzone">
+    <Composer.Attachments className="attachments" />
+    <Composer.AddAttachment accept="image/*,.pdf" multiple>
+      Attach image or PDF
+    </Composer.AddAttachment>
+    <Composer.Input />
+    <Composer.Submit />
+  </Composer.AttachmentDropzone>
+</Composer.Root>
 ```
 
 For a complete attachment recipe, see [Composer attachments](/docs/react-ui/examples/composer-attachments).

--- a/apps/www/src/content/docs/react-ui/cheat-sheet.mdx
+++ b/apps/www/src/content/docs/react-ui/cheat-sheet.mdx
@@ -30,6 +30,16 @@ import { useCompletion } from "@anvia/react";
 import { Completion, CompletionProvider } from "@anvia/react-ui";
 ```
 
+## Chat or completion
+
+| Choose | When | Do not use for |
+| --- | --- | --- |
+| Chat | Multi-turn transcript, follow-up prompts, tools, attachments, suggestions, or human review. | One-shot prompt panels with no transcript. |
+| Completion | One prompt input and one generated text output. | Tool cards, attachments, human review, or message threads. |
+
+Both can send `{ messages, stream: true }` to an API route. The difference is the client state and
+UI context: chat exposes messages and chat actions; completion exposes prompt input and output text.
+
 ## Pick the right primitive
 
 | Need | Use | Must live inside |

--- a/apps/www/src/content/docs/react-ui/completion.mdx
+++ b/apps/www/src/content/docs/react-ui/completion.mdx
@@ -14,6 +14,11 @@ import { completionVariants } from "../../../lib/react-ui-code-variants";
 `CompletionProvider` binds a `useCompletion(...)` controller to completion primitives. Use it for
 prompt-to-text panels, draft generators, rewrite tools, and other one-shot text generation flows.
 
+Use completion when the UI has one prompt and one generated text result. Use
+[Chat and composer](/docs/react-ui/chat) when the user expects a multi-turn transcript, tools,
+attachments, suggestions, or human review. `CompletionProvider` only supports `Completion.*`
+primitives; it does not provide `Thread`, `Composer`, `Message`, or `HumanInput` contexts.
+
 <CodeVariants id="completion-panel" variants={completionVariants} />
 
 The endpoint uses the same React request shape as chat:
@@ -33,9 +38,6 @@ export async function POST(request: Request) {
   );
 }
 ```
-
-Use completion when the UI has one prompt and one generated text result. Use chat when the user
-expects a multi-turn transcript, tools, attachments, or human review.
 
 ## Custom output
 

--- a/apps/www/src/content/docs/react-ui/mental-model.mdx
+++ b/apps/www/src/content/docs/react-ui/mental-model.mdx
@@ -18,6 +18,16 @@ components. Each namespace groups primitives that share the same controller stat
 providers and primitives. Your app owns the server route, styling, auth, persistence, and any
 domain-specific rendering.
 
+There are two surface families:
+
+- Chat: `useChat(...)` -> `ChatProvider` -> `Thread.*`, `Composer.*`, `Message.*`, and
+  `HumanInput.*`.
+- Completion: `useCompletion(...)` -> `CompletionProvider` -> `Completion.*`.
+
+They can share the same wire request shape, but they do not share UI context. Use chat for
+transcripts, tools, attachments, and human review. Use completion for one prompt and one generated
+text result.
+
 <div
   className="mt-6 grid max-w-5xl gap-3 rounded-xl border border-white/10 bg-white/[0.025] p-4"
   aria-label="React UI mental model"
@@ -47,7 +57,9 @@ domain-specific rendering.
             <code>{"Composer.*"}</code>
             {", and "}
             <code>{"Message.*"}</code>
-            {" read nearby context."}
+            {" read chat context; "}
+            <code>{"Completion.*"}</code>
+            {" reads completion context."}
           </div>
         </div>
       </div>
@@ -117,6 +129,9 @@ The first word is the context family. The second word is the primitive rendered 
 
 The same pattern applies to `CompletionProvider` and `Completion.*`, except completion surfaces use
 a `useCompletion(...)` controller instead of a chat controller.
+
+`CompletionProvider` does not provide chat contexts. If a surface needs `Thread`, `Composer`,
+`Message`, tools, attachments, or human input, use `useChat(...)` and `ChatProvider`.
 
 ## The common chat tree
 

--- a/apps/www/src/content/docs/react-ui/overview.md
+++ b/apps/www/src/content/docs/react-ui/overview.md
@@ -29,6 +29,19 @@ to your API app, and your API app runs the model, agent, tools, auth checks, and
 The beginner docs use `http://localhost:5173` for the frontend and `http://localhost:8787` for the
 API app. In production, point the hook endpoint at your deployed API origin.
 
+## Chat vs completion
+
+React UI has two separate surface families:
+
+| Surface | Use when | Controller and provider | UI primitives |
+| --- | --- | --- | --- |
+| Chat | The user expects a transcript, follow-up turns, tools, attachments, or human review. | `useChat(...)` with `ChatProvider` | `Thread.*`, `Composer.*`, `Message.*`, `HumanInput.*` |
+| Completion | The user submits one prompt and reads one generated text result. | `useCompletion(...)` with `CompletionProvider` | `Completion.*` |
+
+Both families can call an API route that accepts `{ messages, stream: true }`, but they expose
+different client state and contexts. Do not mix `Thread`, `Composer`, `Message`, or `HumanInput`
+inside `CompletionProvider`; use the chat family when those primitives are needed.
+
 ## What to build first
 
 Most applications start with a chat surface:

--- a/apps/www/src/content/docs/react-ui/request-shape.mdx
+++ b/apps/www/src/content/docs/react-ui/request-shape.mdx
@@ -27,10 +27,18 @@ type UIStreamRequest = {
 The `messages` field is already converted from browser-side `UIMessage[]` into core Anvia
 `Message[]`.
 
+The shared wire shape does not mean the UI primitives are interchangeable. `useChat(...)` maintains
+a transcript and works with `ChatProvider`, `Thread`, `Composer`, `Message`, and `HumanInput`.
+`useCompletion(...)` maintains prompt/output state and works with `CompletionProvider` and
+`Completion.*`.
+
 ## What createRequest receives
 
 Use `createRequest` when the server needs request-level options such as model, reasoning effort,
 provider, temperature, tenant, or feature flags.
+
+The example below uses `useChat(...)`; the same `createRequest` pattern applies to
+`useCompletion(...)` when a completion route needs request-level options.
 
 ```tsx
 import type { Message } from "@anvia/core/completion";

--- a/apps/www/src/lib/packages.ts
+++ b/apps/www/src/lib/packages.ts
@@ -292,7 +292,7 @@ const packageDefinitions: PackageFamilyDefinition[] = [
       definePackage(
         "@anvia/core",
         "core",
-        "0.8.0",
+        "0.12.2",
         "packages/core",
         "Core runtime primitives for context-aware Anvia agents.",
         true,
@@ -300,7 +300,7 @@ const packageDefinitions: PackageFamilyDefinition[] = [
       definePackage(
         "@anvia/server",
         "server",
-        "0.3.1",
+        "0.4.9",
         "packages/server",
         "Server-side event stream helpers for Anvia applications.",
         true,
@@ -308,7 +308,7 @@ const packageDefinitions: PackageFamilyDefinition[] = [
       definePackage(
         "@anvia/react",
         "react",
-        "0.5.0",
+        "0.7.9",
         "packages/react",
         "React hooks and client transports for Anvia applications.",
         true,
@@ -316,7 +316,7 @@ const packageDefinitions: PackageFamilyDefinition[] = [
       definePackage(
         "@anvia/react-ui",
         "react-ui",
-        "0.1.0",
+        "0.2.0",
         "packages/react-ui",
         "Composable React UI primitives for Anvia chat and completion experiences.",
         true,
@@ -340,7 +340,7 @@ const packageDefinitions: PackageFamilyDefinition[] = [
       definePackage(
         "@anvia/openai",
         "openai",
-        "0.3.14",
+        "0.3.15",
         "packages/provider-openai",
         "OpenAI provider adapter for Anvia.",
         true,
@@ -348,7 +348,7 @@ const packageDefinitions: PackageFamilyDefinition[] = [
       definePackage(
         "@anvia/anthropic",
         "anthropic",
-        "0.3.11",
+        "0.3.13",
         "packages/provider-anthropic",
         "Anthropic provider adapter for Anvia.",
         true,
@@ -356,7 +356,7 @@ const packageDefinitions: PackageFamilyDefinition[] = [
       definePackage(
         "@anvia/gemini",
         "gemini",
-        "0.2.9",
+        "0.2.10",
         "packages/provider-gemini",
         "Gemini provider adapter for Anvia.",
         true,
@@ -364,7 +364,7 @@ const packageDefinitions: PackageFamilyDefinition[] = [
       definePackage(
         "@anvia/mistral",
         "mistral",
-        "0.3.1",
+        "0.3.3",
         "packages/provider-mistral",
         "Mistral provider adapter for Anvia.",
         true,
@@ -428,7 +428,7 @@ const packageDefinitions: PackageFamilyDefinition[] = [
       definePackage(
         "@anvia/redis",
         "redis",
-        "0.2.4",
+        "0.2.5",
         "packages/vector-redis",
         "Redis vector store adapter for Anvia.",
         false,
@@ -436,7 +436,7 @@ const packageDefinitions: PackageFamilyDefinition[] = [
       definePackage(
         "@anvia/chroma",
         "chroma",
-        "0.2.10",
+        "0.2.11",
         "packages/vector-chroma",
         "ChromaDB vector store adapter for Anvia.",
         true,
@@ -476,7 +476,7 @@ const packageDefinitions: PackageFamilyDefinition[] = [
       definePackage(
         "@anvia/langfuse",
         "langfuse",
-        "0.3.2",
+        "0.3.4",
         "packages/observability-langfuse",
         "Langfuse tracing adapter for Anvia.",
         true,
@@ -508,7 +508,7 @@ const packageDefinitions: PackageFamilyDefinition[] = [
       definePackage(
         "@anvia/studio",
         "studio",
-        "0.7.5",
+        "0.7.18",
         "packages/tool-studio",
         "Studio UI and HTTP runtime for Anvia agents.",
         true,


### PR DESCRIPTION
## Summary
- Add explicit Chat vs Completion comparison to the React UI overview and cheat sheet.
- Clarify in the mental model, request-shape, chat, completion, and package getting-started docs that the hooks can share a wire shape but use separate providers, contexts, and primitives.
- Update the package mirror docs under `apps/www/src/content/docs/packages` for `@anvia/react` and `@anvia/react-ui` so their text pages reflect the same hook/provider boundary.
- Update the `/docs/packages/` package-index versions from the current workspace package manifests, including `@anvia/react-ui` from `v0.1.0` to `v0.2.0`.
- Extend `www reference-check` so stale package-index versions fail against package `package.json` metadata.
- Fix the chat attachment dropzone snippet so it shows the required `Composer.Root` context.

## Validation
- `git diff --check`
- `pnpm --filter www exec biome check scripts/check-reference-coverage.mjs src/lib/packages.ts`
- `pnpm --filter www build`
- `pnpm --filter www reference-check`
- Inspected generated docs HTML for the updated React UI copy, package-doc boundary copy, and `/docs/packages/` version text.

## Screenshots
- Not captured; this is docs and metadata text. The static docs build and generated HTML were verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer “Chat vs completion” decision guidance, including “Chat or completion” and “Chat or completion” quick references.
  * Expanded mental model, request-shape, and usage-pattern explanations to reinforce the correct hook/provider pairing and supported UI primitives.
  * Updated chat/completion docs and examples (including attachment/composer structure fixes) to prevent mixing chat primitives into completion providers.
  * Added a “Minimal completion” example and refreshed React/React UI package overview content and recipes.

* **Chores**
  * Bumped package version metadata and strengthened documentation reference coverage checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->