### PR TITLE
Preserve OpenAI refusal and failure mappings

### DIFF
--- a/.changeset/quiet-openai-refusals.md
+++ b/.changeset/quiet-openai-refusals.md
@@ -1,0 +1,5 @@
+---
+"@anvia/openai": patch
+---
+
+Preserve OpenAI refusal text and terminal Responses stream failure states in completion mappings.

--- a/packages/provider-openai/src/openai/chat-completion.ts
+++ b/packages/provider-openai/src/openai/chat-completion.ts
@@ -204,6 +204,10 @@ export function fromOpenAIChatCompletionResponse(response: unknown): CompletionR
     choice.push(AssistantContent.text(message.content));
   }
 
+  if (typeof message.refusal === "string" && message.refusal.length > 0) {
+    choice.push(AssistantContent.text(message.refusal));
+  }
+
   const reasoning = stringFrom(message.reasoning) ?? stringFrom(message.reasoning_content);
   if (reasoning !== undefined && reasoning.length > 0) {
     choice.push(AssistantContent.reasoning(reasoning));
@@ -250,6 +254,10 @@ export function fromOpenAIChatCompletionStreamChunk(chunk: unknown): CompletionS
     const delta = choice.delta;
     if (typeof delta.content === "string" && delta.content.length > 0) {
       events.push({ type: "text_delta", delta: delta.content });
+    }
+
+    if (typeof delta.refusal === "string" && delta.refusal.length > 0) {
+      events.push({ type: "text_delta", delta: delta.refusal });
     }
 
     const reasoning = stringFrom(delta.reasoning) ?? stringFrom(delta.reasoning_content);

--- a/packages/provider-openai/src/openai/responses.ts
+++ b/packages/provider-openai/src/openai/responses.ts
@@ -327,14 +327,21 @@ export function fromOpenAIStreamEvent(event: unknown): CompletionStreamEvent | u
     }
   }
 
-  if (event.type === "response.completed" && isPlainObject(event.response)) {
+  if (
+    (event.type === "response.completed" || event.type === "response.incomplete") &&
+    isPlainObject(event.response)
+  ) {
     return {
       type: "final",
       response: fromOpenAIResponse(event.response),
     };
   }
 
-  if (event.type === "response.error") {
+  if (event.type === "response.failed" && isPlainObject(event.response)) {
+    return { type: "error", error: event.response.error ?? event.response };
+  }
+
+  if (event.type === "error" || event.type === "response.error") {
     return { type: "error", error: event.error ?? event };
   }
 
@@ -569,6 +576,10 @@ function messageOutputToAssistantContent(item: Record<string, unknown>): Assista
 
     if (part.type === "text" && typeof part.text === "string") {
       return [AssistantContent.text(part.text)];
+    }
+
+    if (part.type === "refusal" && typeof part.refusal === "string") {
+      return [AssistantContent.text(part.refusal)];
     }
 
     return [];

--- a/packages/provider-openai/test/openai-chat-completion.test.ts
+++ b/packages/provider-openai/test/openai-chat-completion.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 import { OpenAIChatCompletionModel, OpenAIClient } from "../src/index";
 import {
   fromOpenAIChatCompletionResponse,
+  fromOpenAIChatCompletionStreamChunk,
   toOpenAIChatCompletionParams,
 } from "../src/openai/chat-completion";
 
@@ -144,6 +145,39 @@ describe("OpenAI chat-completions client path", () => {
     expect(response.choice).toEqual([
       AssistantContent.text("created"),
       AssistantContent.reasoning("provider reasoning text"),
+    ]);
+  });
+
+  it("maps Chat Completions refusals to visible assistant text", () => {
+    const response = fromOpenAIChatCompletionResponse({
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: null,
+            refusal: "I can't help with that.",
+          },
+        },
+      ],
+      usage: {},
+    });
+
+    expect(response.choice).toEqual([AssistantContent.text("I can't help with that.")]);
+
+    expect(
+      fromOpenAIChatCompletionStreamChunk({
+        id: "cmpl_1",
+        choices: [
+          {
+            delta: {
+              refusal: "I can't help with that.",
+            },
+          },
+        ],
+      }),
+    ).toEqual([
+      { type: "text_delta", delta: "I can't help with that." },
+      { type: "message_id", id: "cmpl_1" },
     ]);
   });
 

--- a/packages/provider-openai/test/openai-responses.test.ts
+++ b/packages/provider-openai/test/openai-responses.test.ts
@@ -230,6 +230,20 @@ describe("OpenAI Responses mapping", () => {
     expect(response.messageId).toBe("resp_1");
   });
 
+  it("maps Responses refusals to visible assistant text", () => {
+    const response = fromOpenAIResponse({
+      output: [
+        {
+          type: "message",
+          content: [{ type: "refusal", refusal: "I can't comply with that." }],
+        },
+      ],
+      usage: {},
+    });
+
+    expect(response.choice).toEqual([AssistantContent.text("I can't comply with that.")]);
+  });
+
   it("maps Responses reasoning content and summaries", () => {
     const response = fromOpenAIResponse({
       output: [
@@ -356,6 +370,69 @@ describe("OpenAI Responses mapping", () => {
     ).toEqual({
       type: "tool_call",
       toolCall: AssistantContent.toolCall("call_1", "lookup", { query: "x" }, "fc_1"),
+    });
+  });
+
+  it("maps Responses terminal stream failure and incomplete events", () => {
+    const errorEvent = {
+      type: "error",
+      code: "rate_limit_exceeded",
+      message: "Too many requests.",
+      param: null,
+      sequence_number: 1,
+    };
+
+    expect(fromOpenAIStreamEvent(errorEvent)).toEqual({
+      type: "error",
+      error: errorEvent,
+    });
+
+    expect(
+      fromOpenAIStreamEvent({
+        type: "response.failed",
+        response: {
+          id: "resp_failed",
+          error: { code: "server_error", message: "The response failed." },
+        },
+        sequence_number: 2,
+      }),
+    ).toEqual({
+      type: "error",
+      error: { code: "server_error", message: "The response failed." },
+    });
+
+    expect(
+      fromOpenAIStreamEvent({
+        type: "response.incomplete",
+        response: {
+          id: "resp_incomplete",
+          output: [
+            {
+              type: "message",
+              content: [{ type: "output_text", text: "partial output" }],
+            },
+          ],
+          usage: {
+            input_tokens: 2,
+            output_tokens: 3,
+            total_tokens: 5,
+          },
+        },
+        sequence_number: 3,
+      }),
+    ).toEqual({
+      type: "final",
+      response: {
+        choice: [AssistantContent.text("partial output")],
+        usage: {
+          ...Usage.empty(),
+          inputTokens: 2,
+          outputTokens: 3,
+          totalTokens: 5,
+        },
+        rawResponse: expect.objectContaining({ id: "resp_incomplete" }),
+        messageId: "resp_incomplete",
+      },
     });
   });
 });


### PR DESCRIPTION
## Summary
- Preserve Chat Completions refusal text in non-streaming and streaming mappings.
- Preserve Responses refusal text and map terminal `error`, `response.failed`, and `response.incomplete` stream events.
- Add OpenAI provider regression tests and a patch changeset.

## Validation
- `pnpm --filter @anvia/openai test`
- `pnpm --filter @anvia/openai typecheck`
- `pnpm --filter @anvia/openai build`
- `git diff --check`

## Generated files
- None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OpenAI refusal messages are now shown as assistant text instead of being dropped.
  * Streamed refusal updates are now surfaced correctly during completion and response handling.
  * Final OpenAI response states, including incomplete and failed terminal events, are now handled more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->