### PR TITLE
Document production-grade agent memory storage

### DIFF
--- a/.changeset/react-memory-initial-messages.md
+++ b/.changeset/react-memory-initial-messages.md
@@ -1,0 +1,5 @@
+---
+"@anvia/react": patch
+---
+
+Add `initialMessagesFromMemory` for hydrating React chat state from Anvia memory messages.

--- a/apps/www/src/content/docs/advanced/sessions-and-memory.md
+++ b/apps/www/src/content/docs/advanced/sessions-and-memory.md
@@ -90,12 +90,12 @@ Both operations go through the configured memory store. The store should enforce
 ## Serve Stored Messages To React
 
 Production UIs usually need one route to load saved messages and another route to stream the next
-turn. Store core Anvia `Message[]` on the server, convert them to `UIMessage[]` before sending them
-to the browser, and pass that array to `useChat({ initialMessages })`.
+turn. Store core Anvia `Message[]` on the server, return those messages from your API, then convert
+them with `initialMessagesFromMemory(...)` before passing them to `useChat({ initialMessages })`.
 
 ```ts
 import { type Message } from "@anvia/core";
-import { coreMessagesToUIMessages, type UIStreamRequest } from "@anvia/core/ui";
+import { type UIStreamRequest } from "@anvia/core/ui";
 import { createEventStream } from "@anvia/server";
 
 function sessionScope(user: { id: string; tenantId: string }) {
@@ -118,9 +118,7 @@ export async function GET(request: Request, params: { threadId: string }) {
   const agent = createSupportAgent(user);
   const messages = await agent.session(params.threadId, sessionScope(user)).messages();
 
-  return Response.json({
-    messages: coreMessagesToUIMessages(messages),
-  });
+  return Response.json({ messages });
 }
 
 export async function POST(request: Request, params: { threadId: string }) {
@@ -137,9 +135,11 @@ export async function POST(request: Request, params: { threadId: string }) {
 }
 ```
 
-The loaded `initialMessages` are for UI hydration. The POST route should use the latest user message
-with `agent.session(...).prompt(...)`; the configured `MemoryStore` loads prior history server-side.
-Do not send the full hydrated transcript back as the session prompt. See
+The loaded memory messages are API data. Convert them on the React side with
+`initialMessagesFromMemory(...)` before passing `initialMessages` to `useChat`. The POST route
+should use the latest user message with `agent.session(...).prompt(...)`; the configured
+`MemoryStore` loads prior history server-side. Do not send the full hydrated transcript back as the
+session prompt. See
 [React UI persistence](/docs/react-ui/persistence) for the client-side `initialMessages` pattern.
 
 ## What To Store

--- a/apps/www/src/content/docs/advanced/sessions-and-memory.md
+++ b/apps/www/src/content/docs/advanced/sessions-and-memory.md
@@ -87,6 +87,61 @@ await agent.session("thread_123", { userId: user.id }).clear();
 
 Both operations go through the configured memory store. The store should enforce the same user and tenant rules as your product database.
 
+## Serve Stored Messages To React
+
+Production UIs usually need one route to load saved messages and another route to stream the next
+turn. Store core Anvia `Message[]` on the server, convert them to `UIMessage[]` before sending them
+to the browser, and pass that array to `useChat({ initialMessages })`.
+
+```ts
+import { type Message } from "@anvia/core";
+import { coreMessagesToUIMessages, type UIStreamRequest } from "@anvia/core/ui";
+import { createEventStream } from "@anvia/server";
+
+function sessionScope(user: { id: string; tenantId: string }) {
+  return {
+    userId: user.id,
+    metadata: { tenantId: user.tenantId },
+  };
+}
+
+function latestUserMessage(messages: Message[]): Message {
+  const message = messages.at(-1);
+  if (message?.role !== "user") {
+    throw new Error("Expected the latest chat message to be from the user.");
+  }
+  return message;
+}
+
+export async function GET(request: Request, params: { threadId: string }) {
+  const user = await requireUser(request);
+  const agent = createSupportAgent(user);
+  const messages = await agent.session(params.threadId, sessionScope(user)).messages();
+
+  return Response.json({
+    messages: coreMessagesToUIMessages(messages),
+  });
+}
+
+export async function POST(request: Request, params: { threadId: string }) {
+  const user = await requireUser(request);
+  const agent = createSupportAgent(user);
+  const body = (await request.json()) as UIStreamRequest;
+
+  return createEventStream(
+    agent
+      .session(params.threadId, sessionScope(user))
+      .prompt(latestUserMessage(body.messages))
+      .stream(),
+  );
+}
+```
+
+The loaded `initialMessages` are for UI hydration. The POST route should use the latest user message
+with `agent.session(...).prompt(...)`; the configured `MemoryStore` loads prior history server-side.
+Do not send the full hydrated transcript back as the session prompt. See
+[React UI persistence](/docs/react-ui/persistence) for the client-side `initialMessages` pattern.
+
 ## What To Store
 
 Store the runtime messages needed for future model context: user prompts, assistant responses, assistant tool calls, and tool results. If a tool result includes sensitive data, apply your product retention and redaction policy before long-term persistence.

--- a/apps/www/src/content/docs/examples/agent-memory-drizzle.md
+++ b/apps/www/src/content/docs/examples/agent-memory-drizzle.md
@@ -19,16 +19,43 @@ A tenant-scoped app stores conversations in Postgres through Drizzle. The route 
 This example uses Drizzle's Postgres core. The important part is the same for other relational stores: keep a session scope, an append order, and the full Anvia message JSON.
 
 ```ts
-import { index, integer, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
-import type { Message } from "@anvia/core";
+import {
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import type { JsonObject, Message } from "@anvia/core";
+
+export const agentMemorySessions = pgTable(
+  "agent_memory_sessions",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    scopeKey: text("scope_key").notNull(),
+    sessionId: text("session_id").notNull(),
+    userId: text("user_id"),
+    tenantId: text("tenant_id"),
+    metadata: jsonb("metadata").$type<JsonObject>().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex("agent_memory_sessions_scope_key_idx").on(table.scopeKey),
+    index("agent_memory_sessions_scope_idx").on(table.sessionId, table.userId, table.tenantId),
+  ],
+);
 
 export const agentMemoryMessages = pgTable(
   "agent_memory_messages",
   {
     id: uuid("id").defaultRandom().primaryKey(),
-    sessionId: text("session_id").notNull(),
-    userId: text("user_id"),
-    tenantId: text("tenant_id"),
+    memorySessionId: uuid("memory_session_id")
+      .notNull()
+      .references(() => agentMemorySessions.id, { onDelete: "cascade" }),
     runId: text("run_id").notNull(),
     turn: integer("turn").notNull(),
     position: integer("position").notNull(),
@@ -36,10 +63,12 @@ export const agentMemoryMessages = pgTable(
     message: jsonb("message").$type<Message>().notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
   },
-  (table) => [index("agent_memory_session_idx").on(table.sessionId, table.userId, table.tenantId, table.position)],
+  (table) => [
+    uniqueIndex("agent_memory_messages_position_idx").on(table.memorySessionId, table.position),
+  ],
 );
 
-export const schema = { agentMemoryMessages };
+export const schema = { agentMemorySessions, agentMemoryMessages };
 ```
 
 ## Expected Message JSON
@@ -206,11 +235,11 @@ Each row's `message` column contains one item from that array.
 ## Memory Store
 
 ```ts
-import { and, asc, desc, eq, isNull } from "drizzle-orm";
+import { asc, desc, eq, sql } from "drizzle-orm";
 import type { NodePgDatabase } from "drizzle-orm/node-postgres";
-import { type MemoryStore, type Message } from "@anvia/core";
+import { type JsonObject, type MemoryStore, type Message } from "@anvia/core";
 import type { MemoryAppendInput, MemoryContext } from "@anvia/core/memory";
-import { agentMemoryMessages, schema } from "./schema";
+import { agentMemoryMessages, agentMemorySessions, schema } from "./schema";
 
 type MemoryDb = NodePgDatabase<typeof schema>;
 
@@ -219,14 +248,16 @@ function tenantId(context: MemoryContext) {
   return typeof value === "string" ? value : null;
 }
 
-function scopedWhere(context: MemoryContext) {
-  const tenant = tenantId(context);
+function scopeValues(context: MemoryContext) {
+  return [context.sessionId, context.userId ?? null, tenantId(context)] as const;
+}
 
-  return and(
-    eq(agentMemoryMessages.sessionId, context.sessionId),
-    context.userId === undefined ? isNull(agentMemoryMessages.userId) : eq(agentMemoryMessages.userId, context.userId),
-    tenant === null ? isNull(agentMemoryMessages.tenantId) : eq(agentMemoryMessages.tenantId, tenant),
-  );
+function scopeKey(context: MemoryContext) {
+  return JSON.stringify(scopeValues(context));
+}
+
+function metadata(context: MemoryContext): JsonObject {
+  return context.metadata ?? {};
 }
 
 export class DrizzleMemoryStore implements MemoryStore {
@@ -236,7 +267,11 @@ export class DrizzleMemoryStore implements MemoryStore {
     const rows = await this.db
       .select({ message: agentMemoryMessages.message })
       .from(agentMemoryMessages)
-      .where(scopedWhere(context))
+      .innerJoin(
+        agentMemorySessions,
+        eq(agentMemoryMessages.memorySessionId, agentMemorySessions.id),
+      )
+      .where(eq(agentMemorySessions.scopeKey, scopeKey(context)))
       .orderBy(asc(agentMemoryMessages.position));
 
     return rows.map((row) => row.message);
@@ -248,19 +283,41 @@ export class DrizzleMemoryStore implements MemoryStore {
     }
 
     await this.db.transaction(async (tx) => {
+      const key = scopeKey(input.context);
+      await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${key}))`);
+
+      const [memorySession] = await tx
+        .insert(agentMemorySessions)
+        .values({
+          scopeKey: key,
+          sessionId: input.context.sessionId,
+          userId: input.context.userId ?? null,
+          tenantId: tenantId(input.context),
+          metadata: metadata(input.context),
+        })
+        .onConflictDoUpdate({
+          target: agentMemorySessions.scopeKey,
+          set: {
+            metadata: metadata(input.context),
+            updatedAt: sql`now()`,
+          },
+        })
+        .returning({ id: agentMemorySessions.id });
+      if (memorySession === undefined) {
+        throw new Error("Failed to resolve memory session.");
+      }
+
       const [last] = await tx
         .select({ position: agentMemoryMessages.position })
         .from(agentMemoryMessages)
-        .where(scopedWhere(input.context))
+        .where(eq(agentMemoryMessages.memorySessionId, memorySession.id))
         .orderBy(desc(agentMemoryMessages.position))
         .limit(1);
       const start = (last?.position ?? -1) + 1;
 
       await tx.insert(agentMemoryMessages).values(
         input.messages.map((message, index) => ({
-          sessionId: input.context.sessionId,
-          userId: input.context.userId ?? null,
-          tenantId: tenantId(input.context),
+          memorySessionId: memorySession.id,
           runId: input.runId,
           turn: input.turn,
           position: start + index,
@@ -272,7 +329,9 @@ export class DrizzleMemoryStore implements MemoryStore {
   }
 
   async clear(context: MemoryContext): Promise<void> {
-    await this.db.delete(agentMemoryMessages).where(scopedWhere(context));
+    await this.db
+      .delete(agentMemorySessions)
+      .where(eq(agentMemorySessions.scopeKey, scopeKey(context)));
   }
 }
 ```
@@ -300,9 +359,10 @@ await agent
 
 ## Production Checks
 
-- Use one scope helper for `load`, `append`, and `clear` so tenant filtering cannot drift.
-- Store message JSON with the role and original content arrays intact.
-- Add stronger per-session locking or a database-generated sequence if concurrent requests can append to the same conversation.
+- Use `scopeKey` for one canonical nullable user and tenant scope lookup.
+- Keep session ownership and lifecycle metadata on `agentMemorySessions`.
+- Keep full Anvia message JSON intact on `agentMemoryMessages`.
+- Use transactions and advisory locks before allowing concurrent writes to the same conversation.
 - Keep memory separate from event logs, traces, and audit records.
 
 ## Next Patterns

--- a/apps/www/src/content/docs/examples/agent-memory-prisma.md
+++ b/apps/www/src/content/docs/examples/agent-memory-prisma.md
@@ -19,19 +19,33 @@ A support chat route uses Prisma for product data. Each request receives a produ
 Store full Anvia `Message` objects as JSON. Do not persist only final assistant text; tool-call and tool-result messages are part of the conversation context.
 
 ```prisma
-model AgentMemoryMessage {
+model AgentMemorySession {
   id        String   @id @default(cuid())
+  scopeKey  String   @unique
   sessionId String
   userId    String?
   tenantId  String?
-  runId     String
-  turn      Int
-  position  Int
-  role      String
-  message   Json
+  metadata  Json
   createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-  @@index([sessionId, userId, tenantId, position])
+  messages AgentMemoryMessage[]
+
+  @@index([sessionId, userId, tenantId])
+}
+
+model AgentMemoryMessage {
+  id              String             @id @default(cuid())
+  memorySessionId String
+  memorySession   AgentMemorySession @relation(fields: [memorySessionId], references: [id], onDelete: Cascade)
+  runId           String
+  turn            Int
+  position        Int
+  role            String
+  message         Json
+  createdAt       DateTime           @default(now())
+
+  @@unique([memorySessionId, position])
 }
 ```
 
@@ -208,8 +222,20 @@ function tenantId(context: MemoryContext) {
   return typeof value === "string" ? value : null;
 }
 
+function scopeValues(context: MemoryContext) {
+  return [context.sessionId, context.userId ?? null, tenantId(context)] as const;
+}
+
+function scopeKey(context: MemoryContext) {
+  return JSON.stringify(scopeValues(context));
+}
+
 function toPrismaJson(message: Message): Prisma.InputJsonValue {
   return message as unknown as Prisma.InputJsonValue;
+}
+
+function metadataJson(context: MemoryContext): Prisma.InputJsonValue {
+  return (context.metadata ?? {}) as Prisma.InputJsonValue;
 }
 
 export class PrismaMemoryStore implements MemoryStore {
@@ -217,11 +243,7 @@ export class PrismaMemoryStore implements MemoryStore {
 
   async load(context: MemoryContext): Promise<Message[]> {
     const rows = await this.prisma.agentMemoryMessage.findMany({
-      where: {
-        sessionId: context.sessionId,
-        userId: context.userId ?? null,
-        tenantId: tenantId(context),
-      },
+      where: { memorySession: { scopeKey: scopeKey(context) } },
       orderBy: { position: "asc" },
     });
 
@@ -233,39 +255,46 @@ export class PrismaMemoryStore implements MemoryStore {
       return;
     }
 
-    await this.prisma.$transaction(async (tx) => {
-      const last = await tx.agentMemoryMessage.findFirst({
-        where: {
-          sessionId: input.context.sessionId,
-          userId: input.context.userId ?? null,
-          tenantId: tenantId(input.context),
-        },
-        orderBy: { position: "desc" },
-        select: { position: true },
-      });
-      const start = (last?.position ?? -1) + 1;
+    await this.prisma.$transaction(
+      async (tx) => {
+        const memorySession = await tx.agentMemorySession.upsert({
+          where: { scopeKey: scopeKey(input.context) },
+          update: { metadata: metadataJson(input.context) },
+          create: {
+            scopeKey: scopeKey(input.context),
+            sessionId: input.context.sessionId,
+            userId: input.context.userId ?? null,
+            tenantId: tenantId(input.context),
+            metadata: metadataJson(input.context),
+          },
+        });
 
-      await tx.agentMemoryMessage.createMany({
-        data: input.messages.map((message, index) => ({
-          sessionId: input.context.sessionId,
-          userId: input.context.userId ?? null,
-          tenantId: tenantId(input.context),
-          runId: input.runId,
-          turn: input.turn,
-          position: start + index,
-          role: message.role,
-          message: toPrismaJson(message),
-        })),
-      });
-    });
+        const last = await tx.agentMemoryMessage.findFirst({
+          where: { memorySessionId: memorySession.id },
+          orderBy: { position: "desc" },
+          select: { position: true },
+        });
+        const start = (last?.position ?? -1) + 1;
+
+        await tx.agentMemoryMessage.createMany({
+          data: input.messages.map((message, index) => ({
+            memorySessionId: memorySession.id,
+            runId: input.runId,
+            turn: input.turn,
+            position: start + index,
+            role: message.role,
+            message: toPrismaJson(message),
+          })),
+        });
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    );
   }
 
   async clear(context: MemoryContext): Promise<void> {
-    await this.prisma.agentMemoryMessage.deleteMany({
+    await this.prisma.agentMemorySession.deleteMany({
       where: {
-        sessionId: context.sessionId,
-        userId: context.userId ?? null,
-        tenantId: tenantId(context),
+        scopeKey: scopeKey(context),
       },
     });
   }
@@ -298,9 +327,10 @@ console.log(response.output);
 
 ## Production Checks
 
-- Use the same user and tenant scope in `load`, `append`, and `clear`.
-- Keep message JSON intact so future turns can see tool calls and tool results.
-- Wrap appends in a transaction and add stricter ordering or locking if multiple requests can write to the same session concurrently.
+- Use `scopeKey` for one canonical nullable user and tenant scope lookup.
+- Keep session ownership and lifecycle metadata on `AgentMemorySession`.
+- Keep full Anvia message JSON intact on `AgentMemoryMessage`.
+- Use serializable transactions or retry failed writes if multiple requests can append concurrently.
 - Keep audit records, run records, and product state in separate tables from memory.
 
 ## Next Patterns

--- a/apps/www/src/content/docs/examples/agent-memory-raw-sql.md
+++ b/apps/www/src/content/docs/examples/agent-memory-raw-sql.md
@@ -17,11 +17,25 @@ A Node service talks to Postgres through `pg`. The agent receives a stable sessi
 ## Table
 
 ```sql
-CREATE TABLE agent_memory_messages (
-  id bigserial PRIMARY KEY,
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE agent_memory_sessions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  scope_key text NOT NULL UNIQUE,
   session_id text NOT NULL,
   user_id text,
   tenant_id text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX agent_memory_sessions_scope_idx
+  ON agent_memory_sessions (session_id, user_id, tenant_id);
+
+CREATE TABLE agent_memory_messages (
+  id bigserial PRIMARY KEY,
+  memory_session_id uuid NOT NULL REFERENCES agent_memory_sessions(id) ON DELETE CASCADE,
   run_id text NOT NULL,
   turn integer NOT NULL,
   position integer NOT NULL,
@@ -30,8 +44,8 @@ CREATE TABLE agent_memory_messages (
   created_at timestamptz NOT NULL DEFAULT now()
 );
 
-CREATE INDEX agent_memory_session_idx
-  ON agent_memory_messages (session_id, user_id, tenant_id, position);
+CREATE UNIQUE INDEX agent_memory_messages_position_idx
+  ON agent_memory_messages (memory_session_id, position);
 ```
 
 ## Expected Message JSON
@@ -215,6 +229,10 @@ function scopeKey(context: MemoryContext) {
   return JSON.stringify(scopeValues(context));
 }
 
+function metadataJson(context: MemoryContext) {
+  return JSON.stringify(context.metadata ?? {});
+}
+
 function fromJson(value: unknown): Message {
   return typeof value === "string" ? (JSON.parse(value) as Message) : (value as Message);
 }
@@ -224,13 +242,13 @@ export class SqlMemoryStore implements MemoryStore {
 
   async load(context: MemoryContext): Promise<Message[]> {
     const { rows } = await this.pool.query<{ message: unknown }>(
-      `SELECT message
-       FROM agent_memory_messages
-       WHERE session_id = $1
-         AND user_id IS NOT DISTINCT FROM $2
-         AND tenant_id IS NOT DISTINCT FROM $3
-       ORDER BY position ASC`,
-      scopeValues(context),
+      `SELECT messages.message
+       FROM agent_memory_sessions sessions
+       JOIN agent_memory_messages messages
+         ON messages.memory_session_id = sessions.id
+       WHERE sessions.scope_key = $1
+       ORDER BY messages.position ASC`,
+      [scopeKey(context)],
     );
 
     return rows.map((row) => fromJson(row.message));
@@ -245,27 +263,45 @@ export class SqlMemoryStore implements MemoryStore {
 
     try {
       await client.query("BEGIN");
-      await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [scopeKey(input.context)]);
+      const key = scopeKey(input.context);
+      await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [key]);
+
+      const { rows: sessionRows } = await client.query<{ id: string }>(
+        `INSERT INTO agent_memory_sessions
+           (scope_key, session_id, user_id, tenant_id, metadata)
+         VALUES ($1, $2, $3, $4, $5::jsonb)
+         ON CONFLICT (scope_key) DO UPDATE
+           SET updated_at = now(),
+               metadata = EXCLUDED.metadata
+         RETURNING id`,
+        [
+          key,
+          input.context.sessionId,
+          input.context.userId ?? null,
+          tenantId(input.context),
+          metadataJson(input.context),
+        ],
+      );
+      const memorySessionId = sessionRows[0]?.id;
+      if (memorySessionId === undefined) {
+        throw new Error("Failed to resolve memory session.");
+      }
 
       const { rows } = await client.query<{ position: number }>(
         `SELECT COALESCE(MAX(position), -1) AS position
          FROM agent_memory_messages
-         WHERE session_id = $1
-           AND user_id IS NOT DISTINCT FROM $2
-           AND tenant_id IS NOT DISTINCT FROM $3`,
-        scopeValues(input.context),
+         WHERE memory_session_id = $1`,
+        [memorySessionId],
       );
-      const start = rows[0]?.position ?? 0;
+      const start = rows[0]?.position ?? -1;
 
       for (const [index, message] of input.messages.entries()) {
         await client.query(
           `INSERT INTO agent_memory_messages
-             (session_id, user_id, tenant_id, run_id, turn, position, role, message)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)`,
+             (memory_session_id, run_id, turn, position, role, message)
+           VALUES ($1, $2, $3, $4, $5, $6::jsonb)`,
           [
-            input.context.sessionId,
-            input.context.userId ?? null,
-            tenantId(input.context),
+            memorySessionId,
             input.runId,
             input.turn,
             start + index + 1,
@@ -286,11 +322,9 @@ export class SqlMemoryStore implements MemoryStore {
 
   async clear(context: MemoryContext): Promise<void> {
     await this.pool.query(
-      `DELETE FROM agent_memory_messages
-       WHERE session_id = $1
-         AND user_id IS NOT DISTINCT FROM $2
-         AND tenant_id IS NOT DISTINCT FROM $3`,
-      scopeValues(context),
+      `DELETE FROM agent_memory_sessions
+       WHERE scope_key = $1`,
+      [scopeKey(context)],
     );
   }
 }
@@ -323,10 +357,10 @@ console.log(response.output);
 
 ## Production Checks
 
-- Compare nullable user and tenant columns with null-safe SQL such as `IS NOT DISTINCT FROM`.
-- Use a transaction around position lookup and inserts.
-- Add per-session locking or database-generated ordering before allowing concurrent writes to the same conversation.
-- Keep memory rows scoped by product-owned session, user, and tenant values.
+- Use `scope_key` for one canonical nullable user and tenant scope lookup.
+- Keep session ownership and lifecycle metadata on `agent_memory_sessions`.
+- Keep full prompt history rows in `agent_memory_messages`.
+- Use transactions and advisory locks before allowing concurrent writes to the same conversation.
 
 ## Next Patterns
 

--- a/apps/www/src/content/docs/examples/memory-and-events.md
+++ b/apps/www/src/content/docs/examples/memory-and-events.md
@@ -27,13 +27,17 @@ Keep these as separate storage paths:
 
 | Data | Typical table | Why it exists |
 | --- | --- | --- |
-| conversation memory | `agent_memory_messages` | gives the next prompt prior user, assistant, and tool-result messages |
+| memory sessions | `agent_memory_sessions` | owns product session scope, tenant/user ownership, lifecycle metadata, and cascade cleanup |
+| memory messages | `agent_memory_messages` | gives the next prompt prior user, assistant, and tool-result messages |
 | runtime events | `agent_events` | preserves turn starts, deltas, tool calls, tool results, nested agent events, final output, and errors by run id |
 | product run record | `support_runs` or `agent_runs` | compact user-facing status, final output, trace id, and usage |
 | audit records | `audit_logs` | records who requested or performed sensitive product actions |
 | traces | tracing backend or trace id fields | connects the run to model/provider/tool observability |
 
-Memory rows are scoped by product-owned session, user, and tenant values. Event rows are scoped by run id and agent metadata. Product run records usually connect both worlds by storing `conversationId`, `runId`, `traceId`, final output, and usage.
+Memory session rows are scoped by product-owned session, user, and tenant values. Memory message
+rows keep the ordered Anvia `Message` JSON used as future prompt context. Event rows are scoped by
+run id and agent metadata. Product run records usually connect both worlds by storing
+`conversationId`, `runId`, `traceId`, final output, and usage.
 
 ## Typical Flow
 

--- a/apps/www/src/content/docs/packages/react/reference.md
+++ b/apps/www/src/content/docs/packages/react/reference.md
@@ -308,6 +308,18 @@ function createChatTransport<TRequest, TEvent>(
 
 Purpose: named chat transport helper built on the fetch transport.
 
+## initialMessagesFromMemory
+
+```ts
+function initialMessagesFromMemory(messages: Message[]): UIMessage[];
+```
+
+Purpose: convert stored Anvia memory messages into the `UIMessage[]` shape accepted by
+`useChat({ initialMessages })`.
+
+The helper adapts core message data for React state. It does not depend on a specific database
+schema.
+
 ## useChat
 
 ```ts

--- a/apps/www/src/content/docs/react-ui/persistence.mdx
+++ b/apps/www/src/content/docs/react-ui/persistence.mdx
@@ -65,6 +65,30 @@ export function LocalChat() {
 A production route usually receives a thread id, authenticates the user, and stores messages or
 runtime events after the stream completes.
 
+For memory-backed chats, load the saved core messages on the server, convert them with
+`coreMessagesToUIMessages(...)`, and return them as `UIMessage[]`. The React page can pass that
+array directly to `initialMessages`.
+
+```tsx
+import type { UIMessage } from "@anvia/react";
+import { useChat } from "@anvia/react";
+
+export function ServerBackedChat({
+  threadId,
+  initialMessages,
+}: {
+  threadId: string;
+  initialMessages: UIMessage[];
+}) {
+  const chat = useChat({
+    endpoint: `http://localhost:8787/api/conversations/${threadId}/chat`,
+    initialMessages,
+  });
+
+  return <ChatProvider controller={chat}>{/* thread */}</ChatProvider>;
+}
+```
+
 ```tsx
 const chat = useChat({
   endpoint: "http://localhost:8787/api/chat",
@@ -91,6 +115,11 @@ export async function POST(request: Request) {
   );
 }
 ```
+
+When the server route is backed by `agent.session(...)`, treat `initialMessages` as browser
+hydration. On the POST route, run only the latest user message through the session prompt; the
+server-side `MemoryStore` loads prior history. See
+[Sessions and memory](/docs/advanced/sessions-and-memory) for a complete route example.
 
 ## Reset
 

--- a/apps/www/src/content/docs/react-ui/persistence.mdx
+++ b/apps/www/src/content/docs/react-ui/persistence.mdx
@@ -65,24 +65,24 @@ export function LocalChat() {
 A production route usually receives a thread id, authenticates the user, and stores messages or
 runtime events after the stream completes.
 
-For memory-backed chats, load the saved core messages on the server, convert them with
-`coreMessagesToUIMessages(...)`, and return them as `UIMessage[]`. The React page can pass that
-array directly to `initialMessages`.
+For memory-backed chats, load the saved core messages on the server and return them from your API as
+Anvia `Message[]`. The React page can convert that payload with `initialMessagesFromMemory(...)`
+before passing it to `useChat`.
 
 ```tsx
-import type { UIMessage } from "@anvia/react";
-import { useChat } from "@anvia/react";
+import type { Message } from "@anvia/core/completion";
+import { initialMessagesFromMemory, useChat } from "@anvia/react";
 
 export function ServerBackedChat({
   threadId,
-  initialMessages,
+  messages,
 }: {
   threadId: string;
-  initialMessages: UIMessage[];
+  messages: Message[];
 }) {
   const chat = useChat({
     endpoint: `http://localhost:8787/api/conversations/${threadId}/chat`,
-    initialMessages,
+    initialMessages: initialMessagesFromMemory(messages),
   });
 
   return <ChatProvider controller={chat}>{/* thread */}</ChatProvider>;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -7,6 +7,7 @@ export {
   defaultEventToApproval,
   defaultEventToQuestion,
 } from "./human-input";
+export { initialMessagesFromMemory } from "./memory";
 export { readJsonlStream, readSseStream } from "./streams";
 export type { CreateFetchTransportOptions } from "./transport";
 export { createChatTransport, createFetchTransport } from "./transport";

--- a/packages/react/src/memory.ts
+++ b/packages/react/src/memory.ts
@@ -1,0 +1,6 @@
+import type { Message } from "@anvia/core/completion";
+import { coreMessagesToUIMessages, type UIMessage } from "@anvia/core/ui";
+
+export function initialMessagesFromMemory(messages: Message[]): UIMessage[] {
+  return coreMessagesToUIMessages(messages);
+}

--- a/packages/react/test/transport.test.ts
+++ b/packages/react/test/transport.test.ts
@@ -1,4 +1,9 @@
-import { AssistantContent, type CompletionStreamEvent, Usage } from "@anvia/core/completion";
+import {
+  AssistantContent,
+  type CompletionStreamEvent,
+  Message,
+  Usage,
+} from "@anvia/core/completion";
 import type { AgentStreamEvent } from "@anvia/core/request";
 import type { UIMessage, UIStreamEvent, UIStreamRequest } from "@anvia/core/ui";
 import { act, renderHook } from "@testing-library/react";
@@ -11,6 +16,7 @@ import {
   EventStreamHttpError,
   type EventTransport,
   fetchEventStream,
+  initialMessagesFromMemory,
   readJsonlStream,
   readSseStream,
   useChat,
@@ -168,6 +174,61 @@ describe("@anvia/react transports", () => {
 });
 
 describe("@anvia/react useChat", () => {
+  it("creates initial UI messages from memory messages", () => {
+    const memoryMessages = [
+      Message.user("Where is order A-100?"),
+      Message.assistant([
+        AssistantContent.toolCall("call_1", "lookup_order", { orderId: "A-100" }),
+      ]),
+      Message.toolResult("call_1", { status: "shipped" }),
+      Message.assistant("Order A-100 has shipped."),
+    ];
+
+    const initialMessages = initialMessagesFromMemory(memoryMessages);
+
+    expect(initialMessages).toMatchObject([
+      { role: "user", parts: [{ type: "text", text: "Where is order A-100?" }] },
+      {
+        role: "assistant",
+        parts: [
+          {
+            type: "tool",
+            toolName: "lookup_order",
+            toolCallId: "call_1",
+            state: "input-available",
+            input: { orderId: "A-100" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        parts: [
+          {
+            type: "tool",
+            toolCallId: "call_1",
+            state: "output-available",
+            output: '{"status":"shipped"}',
+          },
+        ],
+      },
+      { role: "assistant", parts: [{ type: "text", text: "Order A-100 has shipped." }] },
+    ]);
+  });
+
+  it("hydrates useChat with initial messages created from memory", () => {
+    const memoryMessages = [Message.user("hello"), Message.assistant("hi")];
+    const initialMessages = initialMessagesFromMemory(memoryMessages);
+    const transport: EventTransport<UIStreamRequest, UIStreamEvent> = {
+      send: vi.fn(async function* (): AsyncIterable<UIStreamEvent> {
+        yield* [];
+      }),
+    };
+
+    const { result } = renderHook(() => useChat({ transport, initialMessages }));
+
+    expect(result.current.messages).toEqual(initialMessages);
+  });
+
   it("sends converted core messages and applies UI stream events", async () => {
     const onEvent = vi.fn();
     const transport: EventTransport<UIStreamRequest, UIStreamEvent> = {


### PR DESCRIPTION
## Summary
- update agent memory examples to use production-grade session and message tables
- document scope keys, cascade cleanup, ordered message rows, and concurrency guidance for Prisma, Drizzle, and raw SQL
- add guidance for serving stored memory messages to React via `coreMessagesToUIMessages(...)` and `useChat({ initialMessages })`

## Validation
- `pnpm --filter www build`
- `pnpm --filter www reference-check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new React helper to convert stored chat history into the format needed for initial UI hydration.
  * React chat screens can now start with previously saved messages loaded from memory.

* **Documentation**
  * Expanded guidance for serving stored messages to chat UIs.
  * Added updated examples for memory-backed persistence and session-based message loading.

* **Tests**
  * Added coverage for converting stored messages and initializing chat state from them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->