### PR TITLE
docs: sharpen Anvia framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,15 @@
 
 Anvia is a TypeScript runtime for agents, tools, structured extraction, retrieval, pipelines, and observability inside your application code.
 
-It gives teams more structure than raw model calls without forcing a heavyweight orchestration stack. You bring the product, data, permissions, persistence, deployment, and side effects. Anvia gives you typed AI workflow primitives that fit around them.
+It gives teams more structure than raw model calls without forcing a heavyweight orchestration stack. You bring the product, data, permissions, persistence, deployment, and side effects. Anvia gives you small, explicit AI runtime contracts that fit around them.
+
+The core design is dependency-injection oriented: your app creates provider models, typed tools, memory stores, vector indexes, observers, services, and transports, then passes the relevant objects into Anvia agents, runners, or adapters. Anvia runs the model/tool loop; your application keeps ownership of product architecture.
 
 ## Why Anvia
 
 - Provider-neutral clients for OpenAI-compatible APIs, Anthropic, Gemini, and Mistral.
 - Agent and tool APIs that keep application behavior explicit and typed.
+- Embeddable runtime contracts that keep provider, memory, observability, storage, and service choices in application code.
 - Structured extraction and output schemas for turning model responses into usable data.
 - Pipeline primitives for composing functions, agents, extractors, batches, and parallel branches.
 - Retrieval adapters for in-memory search, local embeddings, ChromaDB, Qdrant, and pgvector.

--- a/apps/www/src/content/docs/advanced/runtime-boundaries.md
+++ b/apps/www/src/content/docs/advanced/runtime-boundaries.md
@@ -25,6 +25,19 @@ The provider client owns credentials, base URLs, headers, and SDK setup. A model
 
 Create these objects in startup code, factories, tests, jobs, or request handlers. Anvia does not require a global registry, and you should not need one to make agents discoverable inside your app.
 
+## Dependency Injection Shape
+
+Anvia's runtime boundaries are meant to be dependency-injection friendly. Provider clients
+become model objects before core sees them. Memory is a `MemoryStore` passed into an
+agent. Retrieval is a vector index passed into dynamic context or a tool. Observability is
+an observer passed into `AgentBuilder.observe(...)`. Product services are called from
+tools or runners, not hidden behind prompt text.
+
+This keeps framework ownership narrow. Anvia owns the agent loop, tool execution,
+streaming events, hooks, middleware, approvals, and runtime contracts. Your application
+owns the concrete services, storage systems, permissions, transports, deployment, and
+product response shape.
+
 ## Server, Worker, And Browser Boundaries
 
 Keep provider clients, API keys, file loaders, PDF loaders, vector-store clients, and side-effect tools on the server or in workers.

--- a/apps/www/src/content/docs/basics/overview.md
+++ b/apps/www/src/content/docs/basics/overview.md
@@ -9,6 +9,19 @@ sidebar:
 
 Basics is a guided path from one provider-neutral model call to a working agent that can stream, use tools, remember sessions, use context, and connect to a product UI.
 
+## Design philosophy
+
+Anvia is not different because it has primitives. The difference is the boundary those
+primitives keep. Core is a small, explicit runtime layer that accepts the dependencies
+your application creates: provider models, tools, memory stores, vector indexes, observers,
+services, and transports.
+
+Anvia runs the agent/tool loop and emits runtime events. Your app still owns product
+architecture, auth, permissions, data access, persistence, deployment, and the response
+shape users see. This keeps Anvia dependency-injection oriented: build dependencies in
+application code, pass them into agents, runners, tools, or adapters, and replace them in
+tests.
+
 ## What you will build
 
 By the end of this section, you will have:

--- a/apps/www/src/content/docs/packages/core/overview.md
+++ b/apps/www/src/content/docs/packages/core/overview.md
@@ -1,6 +1,6 @@
 ---
 title: "@anvia/core: Overview"
-description: "Core runtime primitives for agents, tools, completions, extraction, pipelines, retrieval, streaming, MCP, skills, memory, and observability."
+description: "Small, explicit, embeddable runtime contracts for agents, tools, completions, extraction, pipelines, retrieval, streaming, MCP, skills, memory, and observability."
 section: packages
 sidebar:
   group: "@anvia/core"
@@ -9,15 +9,23 @@ sidebar:
 ---
 ## What it is
 
-Core runtime primitives for agents, tools, completions, extraction, pipelines, retrieval, streaming, MCP, skills, memory, and observability.
+Small, explicit, embeddable runtime contracts for agents, tools, completions, extraction,
+pipelines, retrieval, streaming, MCP, skills, memory, and observability.
 
-Use @anvia/core when the application needs provider-neutral runtime primitives before choosing any specific model provider. It is one of the runtime packages that sit closest to application request handling.
+Use @anvia/core when the application needs provider-neutral runtime behavior without
+handing product architecture to the runtime. The app creates provider clients and model
+objects, memory stores, service-backed tools, vector indexes, observers, and transports.
+Core receives those objects and runs the model/tool loop around them.
 
 ## Where it fits
 
 `@anvia/core` is the center of the package set. Provider packages supply models, storage packages supply indexes, and app packages add transport or UI around the core runtime.
 
-The package owns provider-neutral runtime contracts and orchestration primitives. Keep provider credentials, product data access, persistence policy, and deployment wiring in application code.
+The package owns provider-neutral runtime contracts and orchestration primitives. Keep
+provider credentials, product data access, memory and persistence policy, observability
+backends, and deployment wiring in application code. In practice, Anvia should be
+dependency-injection oriented: construct the dependencies your product owns, then pass
+them into agents, prompt requests, tools, runners, or adapters.
 
 ## Public surface
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,8 +1,14 @@
 # @anvia/core
 
-Core runtime primitives for Anvia agents, tools, structured extraction, pipelines, streaming, RAG, MCP, skills, and observability.
+Small, explicit, embeddable runtime contracts for Anvia agents, tools, structured extraction, pipelines, streaming, RAG, MCP, skills, and observability.
 
-This package is provider-neutral. Pair it with a provider adapter such as `@anvia/openai`, `@anvia/anthropic`, or `@anvia/gemini` to create runnable models.
+This package is provider-neutral. Pair it with a provider adapter such as `@anvia/openai`, `@anvia/anthropic`, or `@anvia/gemini` to create runnable model objects, then pass those objects into agents, extractors, pipelines, or direct completion helpers.
+
+## Design Philosophy
+
+`@anvia/core` owns the model/tool loop and the runtime contracts around it. Your application owns provider client construction, credentials, product data access, permissions, storage, deployment, observability backends, and response shape.
+
+The package is dependency-injection oriented: create provider models, typed tools, memory stores, vector indexes, observers, and services in application code, then pass the relevant objects into agents, prompt requests, runners, or adapters. Core receives those objects and coordinates the run without taking over product architecture.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Add Anvia-centered design philosophy to basics docs
- Reframe core docs and READMEs around small, explicit, embeddable runtime contracts
- Clarify dependency-injection boundaries for provider models, memory stores, observers, services, and app-owned architecture

## Validation
- pnpm --filter www reference-check
- pnpm --filter www build
- git diff --check

No screenshots: prose-only docs/README changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Anvia’s design philosophy and runtime boundaries across the docs and package overviews.
  * Added guidance on how apps should wire models, tools, memory, indexes, observability, services, and transports.
  * Expanded the core package overview to emphasize small, explicit, embeddable runtime contracts and dependency-injection-oriented usage.
  * Improved “Why Anvia” messaging in the README to better explain the framework’s role versus app-level responsibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->