### PR TITLE
Add resumable chat streams

### DIFF
--- a/.changeset/resumable-chat-streams.md
+++ b/.changeset/resumable-chat-streams.md
@@ -1,0 +1,7 @@
+---
+"@anvia/react": minor
+"@anvia/server": minor
+---
+
+Add resumable chat stream support with server-side resumable event envelopes, replay/tail helpers,
+an in-memory resumable stream store, and `useChat({ resume })` client resume state.

--- a/apps/www/src/content/docs/advanced/resumable-streams.md
+++ b/apps/www/src/content/docs/advanced/resumable-streams.md
@@ -1,0 +1,238 @@
+---
+title: Resumable streams
+description: Recover chat streams after navigation, reloads, and dropped browser connections.
+section: advanced
+sidebar:
+  group: Agent runtime
+  order: 20
+  label: Resume
+---
+
+Resumable streams let a browser recover a running chat stream after navigation, reload, or a
+temporary connection drop. The model or agent keeps running on the server, emitted events are stored
+with ordered cursors, and the client reconnects to the same endpoint with the last event it saw.
+
+This is not a WebSocket requirement. The important parts are a stable stream id, ordered event ids,
+server-side replay, and client-side cursor persistence. Anvia provides the stream envelope and React
+bookkeeping; your application still owns authentication, durable storage, worker ownership, and
+retention.
+
+## End-To-End Shape
+
+Use one POST route for both starting and resuming:
+
+```ts
+type ChatBody = UIStreamRequest & {
+  resume?: {
+    streamId: string;
+    after: number;
+  };
+};
+```
+
+When `resume` is missing, start a new run and return a resumable event stream. When `resume` is
+present, replay stored events after `after` and then tail live events until the stream ends.
+
+The wire response is wrapped in resumable envelopes:
+
+```json
+{"type":"stream_start","streamId":"run_123","eventId":0}
+{"type":"stream_event","streamId":"run_123","eventId":1,"event":{"type":"text_delta","turn":1,"delta":"Hello"}}
+{"type":"stream_end","streamId":"run_123","eventId":42,"status":"completed"}
+```
+
+`useChat` unwraps these envelopes before applying events, so UI code still receives normal Anvia
+stream events.
+
+## Server Route
+
+Create a resumable stream store outside the request handler. `createMemoryResumableStreamStore()` is
+useful for local development and single-process examples. Use a durable store for production.
+
+```ts
+import { AgentBuilder, type Message } from "@anvia/core";
+import type { UIStreamRequest } from "@anvia/core/ui";
+import {
+  createEventStream,
+  createMemoryResumableStreamStore,
+  resumeStreamEvents,
+} from "@anvia/server";
+
+const resumableStore = createMemoryResumableStreamStore();
+
+type ChatBody = UIStreamRequest & {
+  resume?: {
+    streamId: string;
+    after: number;
+  };
+};
+
+function latestUserMessage(messages: Message[]): Message {
+  const message = messages.at(-1);
+  if (message?.role !== "user") {
+    throw new Error("Expected the latest chat message to be from the user.");
+  }
+  return message;
+}
+
+export async function POST(request: Request, params: { threadId: string }) {
+  const user = await requireUser(request);
+  const body = (await request.json()) as ChatBody;
+  const agent = createSupportAgent(user);
+
+  if (body.resume !== undefined) {
+    return createEventStream(
+      resumeStreamEvents({
+        id: body.resume.streamId,
+        after: body.resume.after,
+        store: resumableStore,
+      }),
+      { format: "jsonl" },
+    );
+  }
+
+  const runId = crypto.randomUUID();
+
+  return createEventStream(
+    agent
+      .session(params.threadId, {
+        userId: user.id,
+        metadata: { tenantId: user.tenantId },
+      })
+      .prompt(latestUserMessage(body.messages))
+      .stream(),
+    {
+      format: "jsonl",
+      resumable: {
+        id: runId,
+        store: resumableStore,
+      },
+    },
+  );
+}
+```
+
+The response reader can disconnect while the run continues. The resumable server wrapper keeps
+draining the source stream into the store, so a later request can replay missed events.
+
+## React Client
+
+Enable resume on `useChat` with a stable key for the conversation. The key is local browser state;
+the server still uses the `streamId` it generated.
+
+```tsx
+import type { Message } from "@anvia/core";
+import { initialMessagesFromMemory, useChat } from "@anvia/react";
+
+export function SupportChat({
+  threadId,
+  messages,
+}: {
+  threadId: string;
+  messages: Message[];
+}) {
+  const chat = useChat({
+    endpoint: `/api/threads/${threadId}/chat`,
+    initialMessages: initialMessagesFromMemory(messages),
+    resume: {
+      key: threadId,
+    },
+  });
+
+  return <ChatProvider controller={chat}>{/* thread */}</ChatProvider>;
+}
+```
+
+By default, React stores active resume metadata in `sessionStorage` under an Anvia-prefixed key. The
+stored value contains the current `streamId`, last event id, and current UI messages. On mount,
+`useChat` automatically sends the same endpoint a POST body with:
+
+```json
+{
+  "messages": [{ "role": "user", "content": [{ "type": "text", "text": "Hello" }] }],
+  "stream": true,
+  "resume": {
+    "streamId": "run_123",
+    "after": 17
+  }
+}
+```
+
+You can use `localStorage` or an explicit `Storage` object when a product needs a different browser
+state policy:
+
+```tsx
+const chat = useChat({
+  endpoint: `/api/threads/${threadId}/chat`,
+  resume: {
+    key: threadId,
+    storage: "localStorage",
+  },
+});
+```
+
+Set `auto: false` when the page should not resume until the user explicitly asks:
+
+```tsx
+const chat = useChat({
+  endpoint: `/api/threads/${threadId}/chat`,
+  resume: {
+    key: threadId,
+    auto: false,
+  },
+});
+
+await chat.resume();
+```
+
+`stop()`, `reset()`, and starting a new send clear the active resume cursor.
+
+## Production Store
+
+The memory store is not durable and does not work across multiple server processes. Production
+deployments should implement `ResumableStreamStore` on top of the system that owns running jobs,
+such as Redis, Postgres, or a workflow runtime.
+
+```ts
+import type { ResumableStreamStore } from "@anvia/server";
+
+export const resumableStore: ResumableStreamStore = {
+  async open(input) {
+    return openRunStream(input.streamId);
+  },
+  async append(input) {
+    return appendRunEvent(input.streamId, input.event);
+  },
+  subscribe(input) {
+    return replayThenTailRunEvents({
+      streamId: input.streamId,
+      after: input.after ?? 0,
+    });
+  },
+  async status(input) {
+    return readRunStreamStatus(input.streamId);
+  },
+  async close(input) {
+    return closeRunStream(input.streamId, input.status);
+  },
+};
+```
+
+`subscribe(...)` is the key operation. It must first yield stored records after the requested cursor,
+then keep yielding live records while the stream is still running. Once the run closes, the iterable
+finishes and `resumeStreamEvents(...)` emits `stream_end`.
+
+## Operational Rules
+
+Treat the resume cursor as a transport recovery mechanism, not as product authorization. The resume
+route must still authenticate the user, authorize access to the thread and stream id, and verify that
+the stream belongs to the requested tenant or user.
+
+Use memory for future model context and resumable streams for transport replay. They are related but
+not interchangeable. A completed conversation should still be persisted through the agent memory
+store or your product database.
+
+Choose retention based on your UX. Short retention, such as a few minutes after completion, is often
+enough for page reloads and navigation. Longer retention is useful for mobile networks and workflow
+surfaces, but the stored events may include prompts, tool arguments, tool results, and errors, so
+apply the same redaction and retention rules you use for runtime event logs.

--- a/apps/www/src/content/docs/packages/react/reference.md
+++ b/apps/www/src/content/docs/packages/react/reference.md
@@ -107,9 +107,40 @@ type CreateChatRequestArgs = {
   messages: UIMessage[];
   uiMessages: UIMessage[];
   coreMessages: Message[];
+  resume?: ChatResumeCursor;
 };
 
 type UseChatStatus = "idle" | "streaming" | "error";
+
+type ChatResumeCursor = {
+  streamId: string;
+  after: number;
+};
+
+type ChatResumeStorage = "sessionStorage" | "localStorage" | Storage;
+
+type ChatResumeOptions = {
+  key: string;
+  storage?: ChatResumeStorage;
+  auto?: boolean;
+};
+
+type ChatResumeState = {
+  version: 1;
+  streamId: string;
+  lastEventId: number;
+  messages: UIMessage[];
+};
+
+type ResumableStreamEnvelope<TEvent> =
+  | { type: "stream_start"; streamId: string; eventId: 0 }
+  | { type: "stream_event"; streamId: string; eventId: number; event: TEvent }
+  | {
+      type: "stream_end";
+      streamId: string;
+      eventId: number;
+      status: "running" | "completed" | "error" | "missing";
+    };
 
 type ToolApprovalStatus = "pending" | "approved" | "rejected" | "timed_out";
 
@@ -328,6 +359,7 @@ type UseChatOptions<TRequest = UIStreamRequest, TEvent = UIStreamEvent> = {
   endpoint?: string | URL;
   format?: "jsonl" | "sse";
   initialMessages?: UIMessage[];
+  resume?: ChatResumeOptions;
   createRequest?: (args: CreateChatRequestArgs) => TRequest;
   eventToUIEvent?: (event: TEvent) => UIStreamEvent | undefined;
   eventToDelta?: (event: TEvent) => string | undefined;
@@ -351,6 +383,9 @@ type UseChatResult<TEvent = UIStreamEvent> = {
   status: UseChatStatus;
   error: unknown;
   text: string;
+  streamId?: string;
+  isResuming: boolean;
+  resume(): Promise<void>;
   humanInput: HumanInputState;
   decidingApprovals: Set<string>;
   answeringQuestions: Set<string>;
@@ -364,6 +399,7 @@ function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(options?: {
   endpoint?: string | URL;
   format?: "jsonl" | "sse";
   initialMessages?: UIMessage[];
+  resume?: ChatResumeOptions;
   createRequest?: (args: CreateChatRequestArgs) => TRequest;
   eventToUIEvent?: (event: TEvent) => UIStreamEvent | undefined;
   eventToDelta?: (event: TEvent) => string | undefined;
@@ -380,6 +416,12 @@ Purpose: React chat state machine that sends `UIStreamRequest` by default and ac
 Passing `endpoint` creates a default JSONL fetch transport. Passing `transport` makes the hook independent of HTTP. `sendMessage(...)` appends a user message, keeps the full UI message history in state, and sends the converted core message history. Custom request factories receive the UI array as `messages` for compatibility and the converted array as `coreMessages`. The hook applies raw `CompletionStreamEvent`, raw `AgentStreamEvent`, or `UIStreamEvent` records as the assistant response arrives.
 
 Passing `humanInput` tracks streamed tool approval and question events in `humanInput.approvals` and `humanInput.questions`. The action helpers submit approval decisions and question answers through custom handlers or the default `/approvals/:id/decision` and `/questions/:id/answer` endpoint paths.
+
+Passing `resume: { key }` stores the active `streamId`, last event cursor, and current messages in
+`sessionStorage` by default. On mount, `useChat` sends the same endpoint a POST body with
+`resume: { streamId, after }`, unwraps `ResumableStreamEnvelope` records, replays missed events, and
+continues tailing live events until `stream_end`. Custom `createRequest` callbacks receive
+`args.resume` and should forward it when using resumable server routes.
 
 ## useCompletion
 

--- a/apps/www/src/content/docs/packages/server/reference.md
+++ b/apps/www/src/content/docs/packages/server/reference.md
@@ -24,6 +24,7 @@ type CreateEventStreamOptions<TEvent> = {
   headers?: HeadersInit;
   status?: number;
   statusText?: string;
+  resumable?: CreateResumableStreamOptions<TEvent>;
   jsonl?: JsonlStreamOptions<TEvent>;
   sse?: SseStreamOptions<TEvent>;
 };
@@ -37,6 +38,54 @@ type SseStreamOptions<TEvent> = {
   serialize?: (event: TEvent | EventStreamErrorEvent) => string;
   retry?: number;
 };
+
+type ResumableStreamFinalStatus = "completed" | "error";
+type ResumableStreamStatus = "running" | ResumableStreamFinalStatus | "missing";
+
+type ResumableStreamState = {
+  status: ResumableStreamStatus;
+  lastEventId: number;
+};
+
+type ResumableStreamRecord<TEvent> = {
+  streamId: string;
+  eventId: number;
+  event: TEvent | EventStreamErrorEvent;
+  createdAt?: Date;
+};
+
+type ResumableStreamEnvelope<TEvent> =
+  | { type: "stream_start"; streamId: string; eventId: 0 }
+  | { type: "stream_event"; streamId: string; eventId: number; event: TEvent | EventStreamErrorEvent }
+  | { type: "stream_end"; streamId: string; eventId: number; status: ResumableStreamStatus };
+
+type CreateResumableStreamOptions<TEvent> = {
+  id: string;
+  store: ResumableStreamStore<TEvent>;
+};
+
+type ResumeStreamEventsOptions<TEvent> = {
+  id: string;
+  after?: number;
+  store: ResumableStreamStore<TEvent>;
+};
+
+type ResumableStreamOpenInput = { streamId: string };
+type ResumableStreamAppendInput<TEvent> = {
+  streamId: string;
+  event: TEvent | EventStreamErrorEvent;
+};
+type ResumableStreamSubscribeInput = { streamId: string; after?: number };
+type ResumableStreamStatusInput = { streamId: string };
+type ResumableStreamCloseInput = { streamId: string; status: ResumableStreamFinalStatus };
+
+interface ResumableStreamStore<TEvent = unknown> {
+  open(input: ResumableStreamOpenInput): Promise<ResumableStreamState>;
+  append(input: ResumableStreamAppendInput<TEvent>): Promise<ResumableStreamRecord<TEvent>>;
+  subscribe(input: ResumableStreamSubscribeInput): AsyncIterable<ResumableStreamRecord<TEvent>>;
+  status(input: ResumableStreamStatusInput): Promise<ResumableStreamState>;
+  close(input: ResumableStreamCloseInput): Promise<ResumableStreamState>;
+}
 ```
 
 ## createEventStream
@@ -49,6 +98,7 @@ function createEventStream<TEvent>(
     headers?: HeadersInit;
     status?: number;
     statusText?: string;
+    resumable?: CreateResumableStreamOptions<TEvent>;
     jsonl?: JsonlStreamOptions<TEvent>;
     sse?: SseStreamOptions<TEvent>;
   },
@@ -60,6 +110,54 @@ Purpose: convert an async iterable of events into an HTTP `Response`.
 Default behavior: writes JSONL with `content-type: application/x-ndjson; charset=utf-8`, `cache-control: no-cache, no-transform`, `connection: keep-alive`, and `x-accel-buffering: no`.
 
 Use `format: "sse"` to emit `text/event-stream`.
+
+Pass `resumable: { id, store }` to wrap events in `stream_start`, `stream_event`, and
+`stream_end` envelopes and persist ordered events for later replay.
+
+## createResumableStream
+
+```ts
+function createResumableStream<TEvent>(
+  events: AsyncIterable<TEvent>,
+  options: CreateResumableStreamOptions<TEvent>,
+): AsyncIterable<ResumableStreamEnvelope<TEvent>>;
+```
+
+Purpose: wrap an event iterable in resumable envelopes and persist events to a
+`ResumableStreamStore`.
+
+## resumeStreamEvents
+
+```ts
+function resumeStreamEvents<TEvent>(
+  options: ResumeStreamEventsOptions<TEvent>,
+): AsyncIterable<ResumableStreamEnvelope<TEvent>>;
+```
+
+Purpose: replay stored events after `after`, then tail live events until the stream closes.
+
+Use it from the same route that starts a stream:
+
+```ts
+if (body.resume !== undefined) {
+  return createEventStream(
+    resumeStreamEvents({
+      id: body.resume.streamId,
+      after: body.resume.after,
+      store,
+    }),
+  );
+}
+```
+
+## createMemoryResumableStreamStore
+
+```ts
+function createMemoryResumableStreamStore<TEvent = unknown>(): ResumableStreamStore<TEvent>;
+```
+
+Purpose: create an in-memory resumable stream store for examples, tests, and single-process
+development. It is not durable and is not safe for multi-worker production replay.
 
 ## createUIStreamResponse
 

--- a/packages/react-ui/test/helpers.tsx
+++ b/packages/react-ui/test/helpers.tsx
@@ -31,6 +31,8 @@ export function createChatController(
     status: "idle",
     error: undefined,
     text: "",
+    isResuming: false,
+    resume: vi.fn(async () => {}),
     humanInput: {
       approvals: { all: [], pending: [] },
       questions: { all: [], pending: [] },

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -42,7 +42,7 @@ export function Chat() {
 - `fetchEventStream(url, options)` fetches JSONL or SSE streams as `AsyncIterable`.
 - `createFetchTransport(options)` creates an `EventTransport`; it defaults to POST JSON and omits implicit bodies for GET/HEAD.
 - `createChatTransport(options)` creates the default fetch-backed chat transport.
-- `useChat(options)` manages `UIMessage[]` chat state from any `EventTransport`, including optional human-input approval/question state.
+- `useChat(options)` manages `UIMessage[]` chat state from any `EventTransport`, including optional human-input approval/question state and opt-in stream resume.
 - `useCompletion(options)` appends completion turns into `UIMessage[]` state and exposes derived `completion` text.
 
 Default hook requests use one shared wire shape:
@@ -73,3 +73,7 @@ Default hooks can consume raw `createCompletionStream(...)` events, raw agent st
 ```ts
 createEventStream(createCompletionStream(model, { messages: body.messages }));
 ```
+
+For chat streams that should survive navigation or reload, pair `useChat({ resume: { key } })` with
+an endpoint that returns `createEventStream(events, { resumable: { id, store } })` and handles
+resume bodies containing `{ resume: { streamId, after } }`.

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -12,6 +12,10 @@ export { readJsonlStream, readSseStream } from "./streams";
 export type { CreateFetchTransportOptions } from "./transport";
 export { createChatTransport, createFetchTransport } from "./transport";
 export type {
+  ChatResumeCursor,
+  ChatResumeOptions,
+  ChatResumeState,
+  ChatResumeStorage,
   ChatSuggestion,
   CreateChatRequestArgs,
   CreateUIAttachment,
@@ -19,6 +23,7 @@ export type {
   EventTransport,
   HumanInputOptions,
   HumanInputState,
+  ResumableStreamEnvelope,
   SendMessageInput,
   ToolApproval,
   ToolApprovalDecisionInput,

--- a/packages/react/src/resume.ts
+++ b/packages/react/src/resume.ts
@@ -16,7 +16,13 @@ export function loadChatResumeState(
     return undefined;
   }
 
-  const raw = storage.getItem(key);
+  let raw: string | null;
+  try {
+    raw = storage.getItem(key);
+  } catch {
+    return undefined;
+  }
+
   if (raw === null) {
     return undefined;
   }
@@ -39,7 +45,11 @@ export function saveChatResumeState(
     return;
   }
 
-  storage.setItem(key, JSON.stringify(state));
+  try {
+    storage.setItem(key, JSON.stringify(state));
+  } catch {
+    // Resume state is an optimization; storage failures should not break streaming.
+  }
 }
 
 export function clearChatResumeState(options: ChatResumeOptions | undefined): void {
@@ -49,7 +59,11 @@ export function clearChatResumeState(options: ChatResumeOptions | undefined): vo
     return;
   }
 
-  storage.removeItem(key);
+  try {
+    storage.removeItem(key);
+  } catch {
+    // Resume state is an optimization; storage failures should not break streaming.
+  }
 }
 
 export function isResumableStreamEnvelope<TEvent>(
@@ -102,7 +116,11 @@ function resolveResumeStorage(options: ChatResumeOptions | undefined): Storage |
     return undefined;
   }
 
-  return storageName === "localStorage" ? window.localStorage : window.sessionStorage;
+  try {
+    return storageName === "localStorage" ? window.localStorage : window.sessionStorage;
+  } catch {
+    return undefined;
+  }
 }
 
 function isChatResumeState(value: unknown): value is ChatResumeState {

--- a/packages/react/src/resume.ts
+++ b/packages/react/src/resume.ts
@@ -1,0 +1,132 @@
+import type {
+  ChatResumeOptions,
+  ChatResumeState,
+  ResumableStreamEnvelope,
+  UIMessage,
+} from "./types";
+
+const storageKeyPrefix = "anvia:chat-resume:";
+
+export function loadChatResumeState(
+  options: ChatResumeOptions | undefined,
+): ChatResumeState | undefined {
+  const storage = resolveResumeStorage(options);
+  const key = resumeStorageKey(options);
+  if (storage === undefined || key === undefined) {
+    return undefined;
+  }
+
+  const raw = storage.getItem(key);
+  if (raw === null) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return isChatResumeState(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function saveChatResumeState(
+  options: ChatResumeOptions | undefined,
+  state: ChatResumeState,
+): void {
+  const storage = resolveResumeStorage(options);
+  const key = resumeStorageKey(options);
+  if (storage === undefined || key === undefined) {
+    return;
+  }
+
+  storage.setItem(key, JSON.stringify(state));
+}
+
+export function clearChatResumeState(options: ChatResumeOptions | undefined): void {
+  const storage = resolveResumeStorage(options);
+  const key = resumeStorageKey(options);
+  if (storage === undefined || key === undefined) {
+    return;
+  }
+
+  storage.removeItem(key);
+}
+
+export function isResumableStreamEnvelope<TEvent>(
+  value: unknown,
+): value is ResumableStreamEnvelope<TEvent> {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (value.type === "stream_start" && typeof value.streamId === "string" && value.eventId === 0) {
+    return true;
+  }
+
+  if (
+    value.type === "stream_event" &&
+    typeof value.streamId === "string" &&
+    typeof value.eventId === "number" &&
+    "event" in value
+  ) {
+    return true;
+  }
+
+  return (
+    value.type === "stream_end" &&
+    typeof value.streamId === "string" &&
+    typeof value.eventId === "number" &&
+    typeof value.status === "string"
+  );
+}
+
+function resumeStorageKey(options: ChatResumeOptions | undefined): string | undefined {
+  if (options === undefined) {
+    return undefined;
+  }
+
+  return `${storageKeyPrefix}${options.key}`;
+}
+
+function resolveResumeStorage(options: ChatResumeOptions | undefined): Storage | undefined {
+  if (options === undefined) {
+    return undefined;
+  }
+
+  if (typeof options.storage === "object") {
+    return options.storage;
+  }
+
+  const storageName = options.storage ?? "sessionStorage";
+  if (typeof globalThis.window === "undefined") {
+    return undefined;
+  }
+
+  return storageName === "localStorage" ? window.localStorage : window.sessionStorage;
+}
+
+function isChatResumeState(value: unknown): value is ChatResumeState {
+  return (
+    isRecord(value) &&
+    value.version === 1 &&
+    typeof value.streamId === "string" &&
+    typeof value.lastEventId === "number" &&
+    Number.isFinite(value.lastEventId) &&
+    value.lastEventId >= 0 &&
+    Array.isArray(value.messages) &&
+    value.messages.every(isUIMessage)
+  );
+}
+
+function isUIMessage(value: unknown): value is UIMessage {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.role === "string" &&
+    Array.isArray(value.parts)
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -23,6 +23,45 @@ export type EventTransport<TRequest, TEvent> = {
   send(request: TRequest, options?: TransportOptions): AsyncIterable<TEvent>;
 };
 
+export type ChatResumeCursor = {
+  streamId: string;
+  after: number;
+};
+
+export type ChatResumeStorage = "sessionStorage" | "localStorage" | Storage;
+
+export type ChatResumeOptions = {
+  key: string;
+  storage?: ChatResumeStorage;
+  auto?: boolean;
+};
+
+export type ChatResumeState = {
+  version: 1;
+  streamId: string;
+  lastEventId: number;
+  messages: UIMessage[];
+};
+
+export type ResumableStreamEnvelope<TEvent> =
+  | {
+      type: "stream_start";
+      streamId: string;
+      eventId: 0;
+    }
+  | {
+      type: "stream_event";
+      streamId: string;
+      eventId: number;
+      event: TEvent;
+    }
+  | {
+      type: "stream_end";
+      streamId: string;
+      eventId: number;
+      status: "running" | "completed" | "error" | "missing";
+    };
+
 export type ToolApprovalStatus = "pending" | "approved" | "rejected" | "timed_out";
 
 export type ToolApproval = {
@@ -130,6 +169,7 @@ export type CreateChatRequestArgs = {
   messages: UIMessage[];
   uiMessages: UIMessage[];
   coreMessages: Message[];
+  resume?: ChatResumeCursor | undefined;
 };
 
 export type UseChatStatus = "idle" | "streaming" | "error";
@@ -139,6 +179,7 @@ export type UseChatOptions<TRequest = UIStreamRequest, TEvent = UIStreamEvent> =
   endpoint?: string | URL;
   format?: EventStreamFormat;
   initialMessages?: UIMessage[];
+  resume?: ChatResumeOptions;
   createRequest?: (args: CreateChatRequestArgs) => TRequest;
   eventToUIEvent?: (event: TEvent) => UIStreamEvent | undefined;
   eventToDelta?: (event: TEvent) => string | undefined;
@@ -166,6 +207,9 @@ export type UseChatResult<TEvent = UIStreamEvent> = {
   status: UseChatStatus;
   error: unknown;
   text: string;
+  streamId?: string | undefined;
+  isResuming: boolean;
+  resume(): Promise<void>;
   humanInput: HumanInputState;
   decidingApprovals: ReadonlySet<string>;
   answeringQuestions: ReadonlySet<string>;

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -13,8 +13,15 @@ import {
   defaultEventToQuestion,
   upsertById,
 } from "./human-input";
+import {
+  clearChatResumeState,
+  isResumableStreamEnvelope,
+  loadChatResumeState,
+  saveChatResumeState,
+} from "./resume";
 import { createChatTransport } from "./transport";
 import type {
+  ChatResumeCursor,
   CreateChatRequestArgs,
   EventTransport,
   SendMessageInput,
@@ -44,12 +51,17 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
   const [questions, setQuestions] = useState<ToolQuestion[]>([]);
   const [decidingApprovals, setDecidingApprovals] = useState<Set<string>>(() => new Set());
   const [answeringQuestions, setAnsweringQuestions] = useState<Set<string>>(() => new Set());
+  const [streamId, setStreamIdState] = useState<string | undefined>();
+  const [isResuming, setIsResuming] = useState(false);
   const abortRef = useRef<AbortController | undefined>(undefined);
   const messagesRef = useRef(messages);
   const approvalsRef = useRef(approvals);
   const questionsRef = useRef(questions);
   const decidingApprovalsRef = useRef(decidingApprovals);
   const answeringQuestionsRef = useRef(answeringQuestions);
+  const streamIdRef = useRef<string | undefined>(undefined);
+  const lastEventIdRef = useRef(0);
+  const autoResumeStartedRef = useRef(false);
   const humanInputVersionRef = useRef(0);
 
   useEffect(() => {
@@ -98,6 +110,31 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
     messagesRef.current = next;
     setMessagesState(next);
   }, []);
+
+  const setStreamId = useCallback((nextStreamId: string | undefined) => {
+    streamIdRef.current = nextStreamId;
+    setStreamIdState(nextStreamId);
+  }, []);
+
+  const persistResumeState = useCallback(() => {
+    const currentStreamId = streamIdRef.current;
+    if (currentStreamId === undefined) {
+      return;
+    }
+
+    saveChatResumeState(options.resume, {
+      version: 1,
+      streamId: currentStreamId,
+      lastEventId: lastEventIdRef.current,
+      messages: messagesRef.current,
+    });
+  }, [options.resume]);
+
+  const clearResumeState = useCallback(() => {
+    lastEventIdRef.current = 0;
+    setStreamId(undefined);
+    clearChatResumeState(options.resume);
+  }, [options.resume, setStreamId]);
 
   const updateApproval = useCallback((approval: ToolApproval) => {
     setApprovals((current) => {
@@ -191,7 +228,7 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
   );
 
   const sendMessages = useCallback(
-    async (nextMessages: UIMessage[]) => {
+    async (nextMessages: UIMessage[], runOptions: SendMessagesRunOptions = {}) => {
       if (transport === undefined) {
         throw new Error("useChat requires either transport or endpoint");
       }
@@ -203,13 +240,25 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
       const createRequest =
         options.createRequest ??
         ((args: CreateChatRequestArgs) =>
-          ({ messages: args.coreMessages, stream: true }) as TRequest);
+          ({
+            messages: args.coreMessages,
+            stream: true,
+            ...(args.resume === undefined ? {} : { resume: args.resume }),
+          }) as TRequest);
+
+      if (runOptions.resume === undefined) {
+        clearResumeState();
+      } else {
+        lastEventIdRef.current = runOptions.resume.after;
+        setStreamId(runOptions.resume.streamId);
+      }
 
       setMessages(nextMessages);
       setEvents([]);
       setError(undefined);
       clearHumanInput();
       setStatus("streaming");
+      setIsResuming(runOptions.isResuming === true);
 
       try {
         const coreMessages = uiMessagesToCoreMessages(nextMessages);
@@ -217,12 +266,40 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
           messages: nextMessages,
           uiMessages: nextMessages,
           coreMessages,
+          resume: runOptions.resume,
         });
 
-        for await (const event of transport.send(request, { signal: abortController.signal })) {
+        for await (const rawEvent of transport.send(request, { signal: abortController.signal })) {
           if (abortRef.current !== abortController || abortController.signal.aborted) {
             return;
           }
+          if (isResumableStreamEnvelope<TEvent>(rawEvent)) {
+            if (rawEvent.type === "stream_start") {
+              setStreamId(rawEvent.streamId);
+              persistResumeState();
+              continue;
+            }
+
+            if (rawEvent.type === "stream_end") {
+              lastEventIdRef.current = rawEvent.eventId;
+              clearResumeState();
+              continue;
+            }
+
+            lastEventIdRef.current = rawEvent.eventId;
+            const event = rawEvent.event;
+            setEvents((current) => [...current, event]);
+            applyHumanInputEvent(event);
+            options.onEvent?.(event);
+            if (abortRef.current !== abortController || abortController.signal.aborted) {
+              return;
+            }
+            applyEvent(event);
+            persistResumeState();
+            continue;
+          }
+
+          const event = rawEvent;
           setEvents((current) => [...current, event]);
           applyHumanInputEvent(event);
           options.onEvent?.(event);
@@ -252,11 +329,46 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
       } finally {
         if (abortRef.current === abortController) {
           abortRef.current = undefined;
+          setIsResuming(false);
         }
       }
     },
-    [applyEvent, applyHumanInputEvent, clearHumanInput, options, setMessages, transport],
+    [
+      applyEvent,
+      applyHumanInputEvent,
+      clearHumanInput,
+      clearResumeState,
+      options,
+      persistResumeState,
+      setMessages,
+      setStreamId,
+      transport,
+    ],
   );
+
+  const resume = useCallback(async () => {
+    const resumeState = loadChatResumeState(options.resume);
+    if (resumeState === undefined) {
+      return;
+    }
+
+    await sendMessages(resumeState.messages, {
+      resume: {
+        streamId: resumeState.streamId,
+        after: resumeState.lastEventId,
+      },
+      isResuming: true,
+    });
+  }, [options.resume, sendMessages]);
+
+  useEffect(() => {
+    if (options.resume?.auto === false || autoResumeStartedRef.current) {
+      return;
+    }
+
+    autoResumeStartedRef.current = true;
+    void resume();
+  }, [options.resume?.auto, resume]);
 
   const sendMessage = useCallback(
     async (input: SendMessageInput) => {
@@ -292,8 +404,10 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
   const stop = useCallback(() => {
     abortRef.current?.abort();
     abortRef.current = undefined;
+    clearResumeState();
     setStatus("idle");
-  }, []);
+    setIsResuming(false);
+  }, [clearResumeState]);
 
   const decideToolApproval = useCallback(
     async (approvalId: string, approved: boolean, reason?: string) => {
@@ -394,13 +508,15 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
     (nextMessages: UIMessage[] = []) => {
       abortRef.current?.abort();
       abortRef.current = undefined;
+      clearResumeState();
       setMessages(nextMessages);
       setEvents([]);
       clearHumanInput();
       setError(undefined);
       setStatus("idle");
+      setIsResuming(false);
     },
-    [clearHumanInput, setMessages],
+    [clearHumanInput, clearResumeState, setMessages],
   );
 
   return {
@@ -416,6 +532,9 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
     status,
     error,
     text: assistantText(messages),
+    streamId,
+    isResuming,
+    resume,
     humanInput: {
       approvals: {
         all: approvals,
@@ -433,6 +552,11 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
     answerToolQuestion,
   };
 }
+
+type SendMessagesRunOptions = {
+  resume?: ChatResumeCursor;
+  isResuming?: boolean;
+};
 
 function findLastUserIndex(messages: UIMessage[]): number {
   for (let index = messages.length - 1; index >= 0; index -= 1) {

--- a/packages/react/test/transport.test.ts
+++ b/packages/react/test/transport.test.ts
@@ -17,6 +17,7 @@ import {
   type EventTransport,
   fetchEventStream,
   initialMessagesFromMemory,
+  type ResumableStreamEnvelope,
   readJsonlStream,
   readSseStream,
   useChat,
@@ -25,6 +26,8 @@ import {
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
+  window.sessionStorage.clear();
+  window.localStorage.clear();
 });
 
 describe("@anvia/react transports", () => {
@@ -311,6 +314,142 @@ describe("@anvia/react useChat", () => {
       stream: true,
     });
     expect(result.current.text).toBe("hi");
+  });
+
+  it("unwraps resumable stream envelopes and persists active chat resume state", async () => {
+    let continueStream!: () => void;
+    const onEvent = vi.fn();
+    const transport: EventTransport<
+      UIStreamRequest,
+      UIStreamEvent | ResumableStreamEnvelope<UIStreamEvent>
+    > = {
+      send: async function* () {
+        yield { type: "stream_start", streamId: "run_1", eventId: 0 };
+        yield {
+          type: "stream_event",
+          streamId: "run_1",
+          eventId: 1,
+          event: {
+            type: "message_start",
+            message: { id: "assistant_1", role: "assistant", parts: [] },
+          },
+        };
+        yield {
+          type: "stream_event",
+          streamId: "run_1",
+          eventId: 2,
+          event: {
+            type: "text_delta",
+            messageId: "assistant_1",
+            partId: "assistant_1_text",
+            delta: "Hi",
+          },
+        };
+        await new Promise<void>((resolve) => {
+          continueStream = resolve;
+        });
+        yield { type: "stream_end", streamId: "run_1", eventId: 2, status: "completed" };
+      },
+    };
+    const { result } = renderHook(() =>
+      useChat({ transport, resume: { key: "thread_1" }, onEvent }),
+    );
+
+    let sendPromise!: Promise<void>;
+    act(() => {
+      sendPromise = result.current.send("hello");
+    });
+    await vi.waitFor(() => {
+      expect(result.current.text).toBe("Hi");
+    });
+
+    const stored = JSON.parse(
+      window.sessionStorage.getItem("anvia:chat-resume:thread_1") ?? "null",
+    ) as { streamId?: string; lastEventId?: number; messages?: UIMessage[] } | null;
+    expect(stored).toMatchObject({
+      streamId: "run_1",
+      lastEventId: 2,
+    });
+    expect(stored?.messages?.at(-1)).toMatchObject({
+      id: "assistant_1",
+      role: "assistant",
+      parts: [{ type: "text", text: "Hi" }],
+    });
+    expect(result.current.streamId).toBe("run_1");
+    expect(result.current.events).toEqual([
+      { type: "message_start", message: { id: "assistant_1", role: "assistant", parts: [] } },
+      {
+        type: "text_delta",
+        messageId: "assistant_1",
+        partId: "assistant_1_text",
+        delta: "Hi",
+      },
+    ]);
+    expect(onEvent).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      continueStream();
+      await sendPromise;
+    });
+
+    expect(result.current.streamId).toBeUndefined();
+    expect(window.sessionStorage.getItem("anvia:chat-resume:thread_1")).toBeNull();
+  });
+
+  it("auto-resumes chat streams with the same endpoint request body", async () => {
+    window.sessionStorage.setItem(
+      "anvia:chat-resume:thread_1",
+      JSON.stringify({
+        version: 1,
+        streamId: "run_1",
+        lastEventId: 1,
+        messages: [
+          {
+            id: "user_1",
+            role: "user",
+            parts: [{ id: "part_1", type: "text", text: "hello" }],
+          },
+        ],
+      }),
+    );
+    const fetchMock = vi.fn(
+      async (_input: string | URL | Request, _init?: RequestInit) =>
+        new Response(
+          streamFrom(
+            `${[
+              '{"type":"stream_start","streamId":"run_1","eventId":0}',
+              '{"type":"stream_event","streamId":"run_1","eventId":2,"event":{"type":"message_start","message":{"id":"assistant_1","role":"assistant","parts":[]}}}',
+              '{"type":"stream_event","streamId":"run_1","eventId":3,"event":{"type":"text_delta","messageId":"assistant_1","partId":"assistant_1_text","delta":"there"}}',
+              '{"type":"stream_end","streamId":"run_1","eventId":3,"status":"completed"}',
+            ].join("\n")}\n`,
+          ),
+          { headers: { "content-type": "application/x-ndjson" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() =>
+      useChat({
+        endpoint: "https://example.test/chat",
+        resume: { key: "thread_1" },
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(result.current.text).toBe("there");
+    });
+
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+      stream: true,
+      resume: {
+        streamId: "run_1",
+        after: 1,
+      },
+    });
+    expect(result.current.isResuming).toBe(false);
+    expect(window.sessionStorage.getItem("anvia:chat-resume:thread_1")).toBeNull();
   });
 
   it("sends attachment-only messages", async () => {

--- a/packages/react/test/transport.test.ts
+++ b/packages/react/test/transport.test.ts
@@ -452,6 +452,66 @@ describe("@anvia/react useChat", () => {
     expect(window.sessionStorage.getItem("anvia:chat-resume:thread_1")).toBeNull();
   });
 
+  it("ignores resume storage failures", async () => {
+    const storage: Storage = {
+      length: 0,
+      clear: vi.fn(),
+      getItem: vi.fn(() => {
+        throw new Error("storage blocked");
+      }),
+      key: vi.fn(() => null),
+      removeItem: vi.fn(() => {
+        throw new Error("storage blocked");
+      }),
+      setItem: vi.fn(() => {
+        throw new Error("storage blocked");
+      }),
+    };
+    const transport: EventTransport<
+      UIStreamRequest,
+      UIStreamEvent | ResumableStreamEnvelope<UIStreamEvent>
+    > = {
+      send: async function* () {
+        yield { type: "stream_start", streamId: "run_1", eventId: 0 };
+        yield {
+          type: "stream_event",
+          streamId: "run_1",
+          eventId: 1,
+          event: {
+            type: "message_start",
+            message: { id: "assistant_1", role: "assistant", parts: [] },
+          },
+        };
+        yield {
+          type: "stream_event",
+          streamId: "run_1",
+          eventId: 2,
+          event: {
+            type: "text_delta",
+            messageId: "assistant_1",
+            partId: "assistant_1_text",
+            delta: "Hi",
+          },
+        };
+        yield { type: "stream_end", streamId: "run_1", eventId: 2, status: "completed" };
+      },
+    };
+    const { result } = renderHook(() =>
+      useChat({ transport, resume: { key: "thread_1", storage } }),
+    );
+
+    await act(async () => {
+      await result.current.send("hello");
+    });
+
+    expect(result.current.status).toBe("idle");
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.text).toBe("Hi");
+    expect(storage.getItem).toHaveBeenCalled();
+    expect(storage.setItem).toHaveBeenCalled();
+    expect(storage.removeItem).toHaveBeenCalled();
+  });
+
   it("sends attachment-only messages", async () => {
     const transport: EventTransport<UIStreamRequest, UIStreamEvent> = {
       send: async function* (request) {

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -16,5 +16,10 @@ return createUIStreamResponse(uiEvents, {
 - `createUIStreamResponse(events, options)` returns a streaming `Response` for `UIStreamEvent` values.
 - `createJsonlStream(events, options)` returns a JSONL `ReadableStream<Uint8Array>`.
 - `createSseStream(events, options)` returns a Server-Sent Event `ReadableStream<Uint8Array>`.
+- `createResumableStream(events, options)` wraps events in resumable stream envelopes.
+- `resumeStreamEvents(options)` replays and tails events from a `ResumableStreamStore`.
+- `createMemoryResumableStreamStore()` creates a single-process, non-durable resumable stream store.
 
 JSONL is the default transport format. Use `format: "sse"` when you need `text/event-stream` compatibility.
+Pass `resumable: { id, store }` to `createEventStream` when clients need to recover streams after
+navigation or reload.

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,10 +1,28 @@
 export { createJsonlStream } from "./jsonl";
 export { createEventStream, createUIStreamResponse } from "./response";
+export {
+  createMemoryResumableStreamStore,
+  createResumableStream,
+  resumeStreamEvents,
+} from "./resumable";
 export { createSseStream } from "./sse";
 export type {
   CreateEventStreamOptions,
+  CreateResumableStreamOptions,
   EventStreamErrorEvent,
   EventStreamFormat,
   JsonlStreamOptions,
+  ResumableStreamAppendInput,
+  ResumableStreamCloseInput,
+  ResumableStreamEnvelope,
+  ResumableStreamFinalStatus,
+  ResumableStreamOpenInput,
+  ResumableStreamRecord,
+  ResumableStreamState,
+  ResumableStreamStatus,
+  ResumableStreamStatusInput,
+  ResumableStreamStore,
+  ResumableStreamSubscribeInput,
+  ResumeStreamEventsOptions,
   SseStreamOptions,
 } from "./types";

--- a/packages/server/src/response.ts
+++ b/packages/server/src/response.ts
@@ -1,7 +1,15 @@
 import type { UIStreamEvent } from "@anvia/core/ui";
 import { createJsonlStream } from "./jsonl";
+import { createResumableStream } from "./resumable";
 import { createSseStream } from "./sse";
-import type { CreateEventStreamOptions } from "./types";
+import type {
+  CreateEventStreamOptions,
+  JsonlStreamOptions,
+  ResumableStreamEnvelope,
+  SseStreamOptions,
+} from "./types";
+
+type ResponseStreamEvent<TEvent> = TEvent | ResumableStreamEnvelope<TEvent>;
 
 export function createEventStream<TEvent>(
   events: AsyncIterable<TEvent>,
@@ -20,10 +28,20 @@ export function createEventStream<TEvent>(
     headers.set("x-accel-buffering", "no");
   }
 
+  const eventsForResponse: AsyncIterable<ResponseStreamEvent<TEvent>> =
+    options.resumable === undefined
+      ? (events as AsyncIterable<ResponseStreamEvent<TEvent>>)
+      : createResumableStream(events, options.resumable);
   const body =
     format === "sse"
-      ? createSseStream(events, options.sse)
-      : createJsonlStream(events, options.jsonl);
+      ? createSseStream(
+          eventsForResponse,
+          options.sse as SseStreamOptions<ResponseStreamEvent<TEvent>> | undefined,
+        )
+      : createJsonlStream(
+          eventsForResponse,
+          options.jsonl as JsonlStreamOptions<ResponseStreamEvent<TEvent>> | undefined,
+        );
 
   if (!headers.has("content-type")) {
     headers.set(

--- a/packages/server/src/resumable.ts
+++ b/packages/server/src/resumable.ts
@@ -1,0 +1,307 @@
+import { errorEvent } from "./errors";
+import type {
+  CreateResumableStreamOptions,
+  ResumableStreamEnvelope,
+  ResumableStreamRecord,
+  ResumableStreamState,
+  ResumableStreamStatus,
+  ResumableStreamStore,
+  ResumeStreamEventsOptions,
+} from "./types";
+
+type Subscriber<TEvent> = {
+  after: number;
+  queue: AsyncQueue<ResumableStreamRecord<TEvent>>;
+};
+
+type MemoryStream<TEvent> = {
+  records: ResumableStreamRecord<TEvent>[];
+  status: ResumableStreamStatus;
+  subscribers: Set<Subscriber<TEvent>>;
+};
+
+type AsyncQueue<T> = AsyncIterable<T> & {
+  enqueue(value: T): void;
+  close(): void;
+  throw(error: unknown): void;
+};
+
+export function createResumableStream<TEvent>(
+  events: AsyncIterable<TEvent>,
+  options: CreateResumableStreamOptions<TEvent>,
+): AsyncIterable<ResumableStreamEnvelope<TEvent>> {
+  const streamId = options.id;
+  let openPromise: Promise<void> | undefined;
+
+  function start(): Promise<void> {
+    if (openPromise !== undefined) {
+      return openPromise;
+    }
+
+    openPromise = options.store.open({ streamId }).then(() => undefined);
+    void drainResumableStream(events, options, openPromise);
+    return openPromise;
+  }
+
+  return {
+    async *[Symbol.asyncIterator]() {
+      await start();
+      yield* resumeStreamEvents({ id: streamId, store: options.store });
+    },
+  };
+}
+
+export async function* resumeStreamEvents<TEvent>(
+  options: ResumeStreamEventsOptions<TEvent>,
+): AsyncIterable<ResumableStreamEnvelope<TEvent>> {
+  const streamId = options.id;
+  yield { type: "stream_start", streamId, eventId: 0 };
+
+  for await (const record of options.store.subscribe({
+    streamId,
+    ...(options.after === undefined ? {} : { after: options.after }),
+  })) {
+    yield recordToEnvelope(record);
+  }
+
+  const state = await options.store.status({ streamId });
+  yield stateToEndEnvelope<TEvent>(streamId, state);
+}
+
+export function createMemoryResumableStreamStore<TEvent = unknown>(): ResumableStreamStore<TEvent> {
+  const streams = new Map<string, MemoryStream<TEvent>>();
+
+  function state(stream: MemoryStream<TEvent> | undefined): ResumableStreamState {
+    if (stream === undefined) {
+      return { status: "missing", lastEventId: 0 };
+    }
+    return {
+      status: stream.status,
+      lastEventId: stream.records.at(-1)?.eventId ?? 0,
+    };
+  }
+
+  return {
+    async open(input) {
+      const existing = streams.get(input.streamId);
+      if (existing !== undefined) {
+        closeSubscribers(existing);
+      }
+
+      const stream: MemoryStream<TEvent> = {
+        records: [],
+        status: "running",
+        subscribers: new Set(),
+      };
+      streams.set(input.streamId, stream);
+      return state(stream);
+    },
+
+    async append(input) {
+      const stream = streams.get(input.streamId);
+      if (stream === undefined) {
+        throw new Error(`Resumable stream "${input.streamId}" is not open`);
+      }
+      if (stream.status !== "running") {
+        throw new Error(`Resumable stream "${input.streamId}" is already ${stream.status}`);
+      }
+
+      const record: ResumableStreamRecord<TEvent> = {
+        streamId: input.streamId,
+        eventId: stream.records.length + 1,
+        event: input.event,
+        createdAt: new Date(),
+      };
+      stream.records.push(record);
+
+      for (const subscriber of stream.subscribers) {
+        if (record.eventId > subscriber.after) {
+          subscriber.queue.enqueue(record);
+        }
+      }
+
+      return record;
+    },
+
+    subscribe(input) {
+      const after = input.after ?? 0;
+      return {
+        [Symbol.asyncIterator](): AsyncIterator<ResumableStreamRecord<TEvent>> {
+          const stream = streams.get(input.streamId);
+          const queue = createAsyncQueue<ResumableStreamRecord<TEvent>>();
+          if (stream === undefined) {
+            queue.close();
+            return queue[Symbol.asyncIterator]();
+          }
+
+          for (const record of stream.records) {
+            if (record.eventId > after) {
+              queue.enqueue(record);
+            }
+          }
+
+          if (stream.status !== "running") {
+            queue.close();
+            return queue[Symbol.asyncIterator]();
+          }
+
+          const subscriber: Subscriber<TEvent> = { after, queue };
+          stream.subscribers.add(subscriber);
+          const iterator = queue[Symbol.asyncIterator]();
+
+          return {
+            next: () => iterator.next(),
+            async return() {
+              stream.subscribers.delete(subscriber);
+              queue.close();
+              return { value: undefined, done: true };
+            },
+          };
+        },
+      };
+    },
+
+    async status(input) {
+      return state(streams.get(input.streamId));
+    },
+
+    async close(input) {
+      const stream = streams.get(input.streamId);
+      if (stream === undefined) {
+        return { status: input.status, lastEventId: 0 };
+      }
+      stream.status = input.status;
+      closeSubscribers(stream);
+      return state(stream);
+    },
+  };
+}
+
+async function drainResumableStream<TEvent>(
+  events: AsyncIterable<TEvent>,
+  options: CreateResumableStreamOptions<TEvent>,
+  openPromise: Promise<void>,
+): Promise<void> {
+  const streamId = options.id;
+  try {
+    await openPromise;
+    for await (const event of events) {
+      await options.store.append({ streamId, event });
+    }
+    await options.store.close({ streamId, status: "completed" });
+  } catch (error) {
+    const event = errorEvent(error);
+    try {
+      await options.store.append({ streamId, event });
+    } catch {
+      // The response iterator reports store-open failures; avoid a background rejection.
+    }
+    try {
+      await options.store.close({ streamId, status: "error" });
+    } catch {
+      // The store may not have opened.
+    }
+  }
+}
+
+function recordToEnvelope<TEvent>(
+  record: ResumableStreamRecord<TEvent>,
+): ResumableStreamEnvelope<TEvent> {
+  return {
+    type: "stream_event",
+    streamId: record.streamId,
+    eventId: record.eventId,
+    event: record.event,
+  };
+}
+
+function stateToEndEnvelope<TEvent>(
+  streamId: string,
+  state: ResumableStreamState,
+): ResumableStreamEnvelope<TEvent> {
+  return {
+    type: "stream_end",
+    streamId,
+    eventId: state.lastEventId,
+    status: state.status,
+  };
+}
+
+function closeSubscribers<TEvent>(stream: MemoryStream<TEvent>): void {
+  for (const subscriber of stream.subscribers) {
+    subscriber.queue.close();
+  }
+  stream.subscribers.clear();
+}
+
+function createAsyncQueue<T>(): AsyncQueue<T> {
+  const values: T[] = [];
+  const waiters: Array<{
+    resolve: (result: IteratorResult<T>) => void;
+    reject: (error: unknown) => void;
+  }> = [];
+  let closed = false;
+  let error: unknown;
+
+  function flush(): void {
+    while (waiters.length > 0 && values.length > 0) {
+      const waiter = waiters.shift();
+      const value = values.shift() as T;
+      waiter?.resolve({ value, done: false });
+    }
+
+    if (values.length > 0 || waiters.length === 0 || !closed) {
+      return;
+    }
+
+    while (waiters.length > 0) {
+      const waiter = waiters.shift();
+      if (waiter === undefined) {
+        continue;
+      }
+      if (error !== undefined) {
+        waiter.reject(error);
+      } else {
+        waiter.resolve({ value: undefined, done: true });
+      }
+    }
+  }
+
+  return {
+    enqueue(value) {
+      if (closed) {
+        return;
+      }
+      values.push(value);
+      flush();
+    },
+    close() {
+      closed = true;
+      flush();
+    },
+    throw(thrown) {
+      closed = true;
+      error = thrown;
+      flush();
+    },
+    [Symbol.asyncIterator]() {
+      return {
+        next() {
+          if (values.length > 0) {
+            const value = values.shift() as T;
+            return Promise.resolve({ value, done: false });
+          }
+          if (error !== undefined) {
+            return Promise.reject(error);
+          }
+          if (closed) {
+            return Promise.resolve({ value: undefined, done: true });
+          }
+          return new Promise((resolve, reject) => {
+            waiters.push({ resolve, reject });
+          });
+        },
+      };
+    },
+  };
+}

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -10,6 +10,7 @@ export type CreateEventStreamOptions<TEvent> = {
   headers?: HeadersInit;
   status?: number;
   statusText?: string;
+  resumable?: CreateResumableStreamOptions<TEvent>;
   jsonl?: JsonlStreamOptions<TEvent>;
   sse?: SseStreamOptions<TEvent>;
 };
@@ -23,3 +24,79 @@ export type SseStreamOptions<TEvent> = {
   serialize?: (event: TEvent | EventStreamErrorEvent) => string;
   retry?: number;
 };
+
+export type ResumableStreamFinalStatus = "completed" | "error";
+export type ResumableStreamStatus = "running" | ResumableStreamFinalStatus | "missing";
+
+export type ResumableStreamState = {
+  status: ResumableStreamStatus;
+  lastEventId: number;
+};
+
+export type ResumableStreamRecord<TEvent> = {
+  streamId: string;
+  eventId: number;
+  event: TEvent | EventStreamErrorEvent;
+  createdAt?: Date;
+};
+
+export type ResumableStreamEnvelope<TEvent> =
+  | {
+      type: "stream_start";
+      streamId: string;
+      eventId: 0;
+    }
+  | {
+      type: "stream_event";
+      streamId: string;
+      eventId: number;
+      event: TEvent | EventStreamErrorEvent;
+    }
+  | {
+      type: "stream_end";
+      streamId: string;
+      eventId: number;
+      status: ResumableStreamStatus;
+    };
+
+export type CreateResumableStreamOptions<TEvent> = {
+  id: string;
+  store: ResumableStreamStore<TEvent>;
+};
+
+export type ResumeStreamEventsOptions<TEvent> = {
+  id: string;
+  after?: number;
+  store: ResumableStreamStore<TEvent>;
+};
+
+export type ResumableStreamOpenInput = {
+  streamId: string;
+};
+
+export type ResumableStreamAppendInput<TEvent> = {
+  streamId: string;
+  event: TEvent | EventStreamErrorEvent;
+};
+
+export type ResumableStreamSubscribeInput = {
+  streamId: string;
+  after?: number;
+};
+
+export type ResumableStreamStatusInput = {
+  streamId: string;
+};
+
+export type ResumableStreamCloseInput = {
+  streamId: string;
+  status: ResumableStreamFinalStatus;
+};
+
+export interface ResumableStreamStore<TEvent = unknown> {
+  open(input: ResumableStreamOpenInput): Promise<ResumableStreamState>;
+  append(input: ResumableStreamAppendInput<TEvent>): Promise<ResumableStreamRecord<TEvent>>;
+  subscribe(input: ResumableStreamSubscribeInput): AsyncIterable<ResumableStreamRecord<TEvent>>;
+  status(input: ResumableStreamStatusInput): Promise<ResumableStreamState>;
+  close(input: ResumableStreamCloseInput): Promise<ResumableStreamState>;
+}

--- a/packages/server/test/streams.test.ts
+++ b/packages/server/test/streams.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from "vitest";
 import {
   createEventStream,
   createJsonlStream,
+  createMemoryResumableStreamStore,
   createSseStream,
   createUIStreamResponse,
+  resumeStreamEvents,
 } from "../src";
 
 describe("@anvia/server streams", () => {
@@ -57,6 +59,128 @@ describe("@anvia/server streams", () => {
 
     expect(response.headers.get("content-type")).toBe("text/event-stream; charset=utf-8");
     expect(await response.text()).toBe('data: {"type":"one"}\n\n');
+  });
+
+  it("creates resumable event stream responses", async () => {
+    const store = createMemoryResumableStreamStore<{ type: string }>();
+    const response = createEventStream(events([{ type: "one" }, { type: "two" }]), {
+      resumable: {
+        id: "run_1",
+        store,
+      },
+    });
+
+    const parsed = parseJsonl(await response.text());
+
+    expect(parsed).toEqual([
+      { type: "stream_start", streamId: "run_1", eventId: 0 },
+      { type: "stream_event", streamId: "run_1", eventId: 1, event: { type: "one" } },
+      { type: "stream_event", streamId: "run_1", eventId: 2, event: { type: "two" } },
+      { type: "stream_end", streamId: "run_1", eventId: 2, status: "completed" },
+    ]);
+    await expect(store.status({ streamId: "run_1" })).resolves.toMatchObject({
+      status: "completed",
+      lastEventId: 2,
+    });
+  });
+
+  it("resumes stored events and tails live resumable stream events", async () => {
+    const store = createMemoryResumableStreamStore<{ type: string }>();
+    await store.open({ streamId: "run_1" });
+    await store.append({ streamId: "run_1", event: { type: "one" } });
+
+    const iterator = resumeStreamEvents({
+      id: "run_1",
+      after: 0,
+      store,
+    })[Symbol.asyncIterator]();
+
+    await expect(nextValue(iterator)).resolves.toEqual({
+      type: "stream_start",
+      streamId: "run_1",
+      eventId: 0,
+    });
+    await expect(nextValue(iterator)).resolves.toEqual({
+      type: "stream_event",
+      streamId: "run_1",
+      eventId: 1,
+      event: { type: "one" },
+    });
+
+    const nextEvent = nextValue(iterator);
+    await store.append({ streamId: "run_1", event: { type: "two" } });
+    await expect(nextEvent).resolves.toEqual({
+      type: "stream_event",
+      streamId: "run_1",
+      eventId: 2,
+      event: { type: "two" },
+    });
+
+    const endEvent = nextValue(iterator);
+    await store.close({ streamId: "run_1", status: "completed" });
+    await expect(endEvent).resolves.toEqual({
+      type: "stream_end",
+      streamId: "run_1",
+      eventId: 2,
+      status: "completed",
+    });
+  });
+
+  it("stores and emits resumable stream errors", async () => {
+    const store = createMemoryResumableStreamStore<{ type: string }>();
+    const response = createEventStream(failingEvents<{ type: string }>(new Error("nope")), {
+      resumable: {
+        id: "run_1",
+        store,
+      },
+    });
+
+    const parsed = parseJsonl(await response.text());
+
+    expect(parsed).toMatchObject([
+      { type: "stream_start", streamId: "run_1", eventId: 0 },
+      {
+        type: "stream_event",
+        streamId: "run_1",
+        eventId: 1,
+        event: { type: "error", error: { name: "Error", message: "nope" } },
+      },
+      { type: "stream_end", streamId: "run_1", eventId: 1, status: "error" },
+    ]);
+  });
+
+  it("keeps storing resumable events after response cancellation", async () => {
+    const store = createMemoryResumableStreamStore<{ type: string }>();
+    let continueEvents!: () => void;
+    const response = createEventStream(
+      (async function* () {
+        yield { type: "one" };
+        await new Promise<void>((resolve) => {
+          continueEvents = resolve;
+        });
+        yield { type: "two" };
+      })(),
+      {
+        resumable: {
+          id: "run_1",
+          store,
+        },
+      },
+    );
+    const reader = response.body?.getReader();
+    if (reader === undefined) {
+      throw new Error("Expected response body");
+    }
+
+    await reader.read();
+    await reader.read();
+    await reader.cancel();
+    continueEvents();
+
+    await waitFor(async () => {
+      const state = await store.status({ streamId: "run_1" });
+      return state.status === "completed" && state.lastEventId === 2;
+    });
   });
 
   it("creates UI stream responses", async () => {
@@ -169,6 +293,33 @@ async function* events<T>(items: T[]): AsyncIterable<T> {
 
 async function readText(stream: ReadableStream<Uint8Array>): Promise<string> {
   return new Response(stream).text();
+}
+
+function parseJsonl(text: string): unknown[] {
+  return text
+    .trim()
+    .split(/\r?\n/)
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as unknown);
+}
+
+async function nextValue<T>(iterator: AsyncIterator<T>): Promise<T> {
+  const next = await iterator.next();
+  if (next.done === true) {
+    throw new Error("Expected iterator value");
+  }
+  return next.value;
+}
+
+async function waitFor(predicate: () => Promise<boolean>): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (await predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+
+  throw new Error("Timed out waiting for condition");
 }
 
 function failingEvents<TEvent = unknown>(error: unknown): AsyncIterable<TEvent> {


### PR DESCRIPTION
## Summary
- Add server-side resumable stream envelopes and replay/tail helpers through createEventStream(..., { resumable: { id, store } }).
- Add an in-memory resumable store and exported store contracts for durable implementations.
- Add React useChat resume support with browser cursor persistence and auto-resume on mount.
- Document end-to-end resumable streams in one advanced docs page and update package references.

## Intended behavior and assumptions
- Uses the same POST endpoint for start and resume; resume requests include streamId and after in the request body.
- The memory store is development and single-process only; production apps provide a durable ResumableStreamStore.
- Application routes still own authorization and tenant checks for stream ids.

## Verification
- pnpm check
- pnpm --filter @anvia/server typecheck
- pnpm --filter @anvia/react typecheck
- pnpm --filter @anvia/server test (16 passed)
- pnpm --filter @anvia/react test (50 passed)
- pnpm --filter @anvia/server build
- pnpm --filter @anvia/react build
- pnpm --filter www reference-check
- pnpm --filter www build

## Notes
- No generated build artifacts are committed.
- The first sandboxed package pnpm commands failed before execution due package-manager registry signature verification fetch failures; reran successfully outside the restricted sandbox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resumable chat streaming support for both client and server workflows.
  * Chat sessions can now continue after interruptions, replay missed events, and resume live updates.
  * New options and status indicators were added to help track and manually restart resumed chats.

* **Documentation**
  * Expanded docs and API references with end-to-end examples for setting up resumable streams.
  * Added guidance for persistent chat behavior across refreshes and navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->