### PR TITLE
chore: release sandbox peer range fix

### DIFF
--- a/.changeset/fair-sandboxes-jump.md
+++ b/.changeset/fair-sandboxes-jump.md
@@ -1,0 +1,5 @@
+---
+"@anvia/sandbox": patch
+---
+
+Publish the widened `@anvia/core` peer dependency range so current 0.x core releases satisfy the sandbox peer requirement.


### PR DESCRIPTION
## Summary
- Add a patch changeset for `@anvia/sandbox` so the widened `@anvia/core` peer range gets published.
- Keep runtime code unchanged.

## Intent / Assumptions
- The local sandbox manifest already allows current 0.x core releases with `>=0.7.1 <1.0.0`.
- The currently published `@anvia/sandbox@0.3.5` still advertises `@anvia/core: ^0.7.0`, so it needs a patch release to publish the corrected manifest.

## Verification
- `pnpm changeset status`
- `git diff --cached --check`
- Commit hook: `biome check --staged --vcs-enabled=true --vcs-client-kind=git --vcs-use-ignore-file=true --no-errors-on-unmatched`

## Skipped
- Package tests/build skipped because this only adds release metadata and does not change runtime source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded compatibility so the sandbox package works with a wider range of core package versions.
  * Updated release metadata to reflect the broader supported version range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->