### PR TITLE
Fix persisted tool result names

### DIFF
--- a/.changeset/persisted-tool-result-names.md
+++ b/.changeset/persisted-tool-result-names.md
@@ -1,0 +1,8 @@
+---
+"@anvia/core": patch
+"@anvia/gemini": patch
+"@anvia/memory-prisma": patch
+"@anvia/memory-sqlite": patch
+---
+
+Preserve tool result names when rehydrating persisted UI messages from core messages.

--- a/apps/www/src/content/docs/packages/core/reference/completion.md
+++ b/apps/www/src/content/docs/packages/core/reference/completion.md
@@ -56,7 +56,7 @@ type Reasoning = { type: "reasoning"; text: string; id?: string; content?: Reaso
 type ToolFunction = { name: string; arguments: JsonValue };
 type ToolCall = { type: "tool_call"; id: string; callId?: string; function: ToolFunction; signature?: string; additionalParams?: JsonValue };
 type ToolResultContent = { type: "text"; text: string } | { type: "image"; data: string; mediaType?: string };
-type ToolResult = { type: "tool_result"; id: string; callId?: string; content: ToolResultContent[] };
+type ToolResult = { type: "tool_result"; id: string; callId?: string; toolName?: string; content: ToolResultContent[] };
 type ToolContent = ToolResult;
 ```
 
@@ -80,7 +80,7 @@ const Message: {
   user(content: string | UserContent[]): Message;
   assistant(content: string | AssistantContent[], id?: string): Message;
   tool(content: ToolContent | ToolContent[]): Message;
-  toolResult(id: string, output: unknown, options?: { callId?: string | undefined }): Message;
+  toolResult(id: string, output: unknown, options?: { callId?: string | undefined; toolName?: string | undefined }): Message;
 };
 ```
 
@@ -115,7 +115,7 @@ const AssistantContent: {
 };
 
 const ToolContent: {
-  toolResult(id: string, content: string | ToolResultContent[], callId?: string): ToolResult;
+  toolResult(id: string, content: string | ToolResultContent[], callIdOrOptions?: string | { callId?: string | undefined; toolName?: string | undefined }, toolName?: string): ToolResult;
 };
 ```
 
@@ -128,6 +128,8 @@ For normal manual tool execution, prefer:
 ```ts
 messages.push(Message.toolResult(toolCall.id, result, { callId: toolCall.callId }));
 ```
+
+Set `toolName` on persisted tool results when the result is created without a nearby assistant tool call. UI message rehydration also recovers tool names from matching assistant tool calls by `id` or `callId`.
 
 `AssistantContent.reasoning(text, id?)` keeps the legacy shape. Provider adapters can populate `reasoning.content` with structured text, summary, encrypted, or redacted blocks; `reasoning.text` remains the display-safe text made from text and summary blocks.
 

--- a/packages/core/src/completion/create-completion.ts
+++ b/packages/core/src/completion/create-completion.ts
@@ -266,6 +266,7 @@ function isToolContent(value: unknown): boolean {
     value.type === "tool_result" &&
     typeof value.id === "string" &&
     (value.callId === undefined || typeof value.callId === "string") &&
+    (value.toolName === undefined || typeof value.toolName === "string") &&
     Array.isArray(value.content) &&
     value.content.every(isToolResultContent)
   );

--- a/packages/core/src/completion/types.ts
+++ b/packages/core/src/completion/types.ts
@@ -104,7 +104,13 @@ export type ToolResult = {
   type: "tool_result";
   id: string;
   callId?: string;
+  toolName?: string;
   content: ToolResultContent[];
+};
+
+type ToolResultOptions = {
+  callId?: string | undefined;
+  toolName?: string | undefined;
 };
 
 export type UserContent = Text | ImageContent | DocumentContent;
@@ -191,14 +197,40 @@ export const UserContent = {
 };
 
 export const ToolContent = {
-  toolResult(id: string, content: string | ToolResultContent[], callId?: string): ToolResult {
+  toolResult(
+    id: string,
+    content: string | ToolResultContent[],
+    callIdOrOptions?: string | ToolResultOptions,
+    toolName?: string,
+  ): ToolResult {
     const normalized =
       typeof content === "string" ? [{ type: "text" as const, text: content }] : content;
-    return callId === undefined
-      ? { type: "tool_result", id, content: normalized }
-      : { type: "tool_result", id, callId, content: normalized };
+    const options = normalizeToolResultOptions(callIdOrOptions, toolName);
+    const result: ToolResult = { type: "tool_result", id, content: normalized };
+    if (options.callId !== undefined) {
+      result.callId = options.callId;
+    }
+    if (options.toolName !== undefined) {
+      result.toolName = options.toolName;
+    }
+    return result;
   },
 };
+
+function normalizeToolResultOptions(
+  callIdOrOptions?: string | ToolResultOptions,
+  toolName?: string,
+): ToolResultOptions {
+  if (callIdOrOptions === undefined) {
+    return toolName === undefined ? {} : { toolName };
+  }
+  if (typeof callIdOrOptions === "string") {
+    return toolName === undefined
+      ? { callId: callIdOrOptions }
+      : { callId: callIdOrOptions, toolName };
+  }
+  return toolName === undefined ? callIdOrOptions : { ...callIdOrOptions, toolName };
+}
 
 export function serializeToolResultOutput(output: unknown): string {
   if (typeof output === "string") {
@@ -330,9 +362,9 @@ export const Message = {
       content: Array.isArray(content) ? content : [content],
     };
   },
-  toolResult(id: string, output: unknown, options: { callId?: string | undefined } = {}): Message {
+  toolResult(id: string, output: unknown, options: ToolResultOptions = {}): Message {
     const content = isToolResultContentArray(output) ? output : serializeToolResultOutput(output);
-    return Message.tool(ToolContent.toolResult(id, content, options.callId));
+    return Message.tool(ToolContent.toolResult(id, content, options));
   },
 };
 

--- a/packages/core/src/ui/messages.ts
+++ b/packages/core/src/ui/messages.ts
@@ -83,11 +83,10 @@ export function uiMessagesToCoreMessages(messages: UIMessage[]): CoreMessage[] {
           );
           if (part.state === "output-available") {
             toolResults.push(
-              ToolContent.toolResult(
-                part.toolCallId,
-                outputToToolResultContent(part.output),
-                part.callId,
-              ),
+              ToolContent.toolResult(part.toolCallId, outputToToolResultContent(part.output), {
+                callId: part.callId,
+                toolName: part.toolName,
+              }),
             );
           }
         }
@@ -107,11 +106,10 @@ export function uiMessagesToCoreMessages(messages: UIMessage[]): CoreMessage[] {
         continue;
       }
       toolResults.push(
-        ToolContent.toolResult(
-          part.toolCallId,
-          outputToToolResultContent(part.output),
-          part.callId,
-        ),
+        ToolContent.toolResult(part.toolCallId, outputToToolResultContent(part.output), {
+          callId: part.callId,
+          toolName: part.toolName,
+        }),
       );
     }
     if (toolResults.length > 0) {
@@ -124,6 +122,7 @@ export function uiMessagesToCoreMessages(messages: UIMessage[]): CoreMessage[] {
 
 export function coreMessagesToUIMessages(messages: CoreMessage[]): UIMessage[] {
   const uiMessages: UIMessage[] = [];
+  const toolNamesByCallKey = toolCallNameLookup(messages);
 
   for (const message of messages) {
     if (message.role === "system") {
@@ -202,7 +201,7 @@ export function coreMessagesToUIMessages(messages: CoreMessage[]): UIMessage[] {
       const part: UIMessagePart = {
         id: toolPartId(content.id),
         type: "tool",
-        toolName: "tool",
+        toolName: toolNameForResult(content, toolNamesByCallKey),
         toolCallId: content.id,
         state: "output-available",
         output: toolResultContentToJson(content.content),
@@ -216,6 +215,39 @@ export function coreMessagesToUIMessages(messages: CoreMessage[]): UIMessage[] {
   }
 
   return uiMessages;
+}
+
+function toolCallNameLookup(messages: CoreMessage[]): Map<string, string> {
+  const toolNamesByCallKey = new Map<string, string>();
+
+  for (const message of messages) {
+    if (message.role !== "assistant") {
+      continue;
+    }
+    for (const content of message.content) {
+      if (content.type !== "tool_call") {
+        continue;
+      }
+      toolNamesByCallKey.set(content.id, content.function.name);
+      if (content.callId !== undefined) {
+        toolNamesByCallKey.set(content.callId, content.function.name);
+      }
+    }
+  }
+
+  return toolNamesByCallKey;
+}
+
+function toolNameForResult(
+  content: ToolContentType,
+  toolNamesByCallKey: Map<string, string>,
+): string {
+  return (
+    content.toolName ??
+    toolNamesByCallKey.get(content.id) ??
+    (content.callId === undefined ? undefined : toolNamesByCallKey.get(content.callId)) ??
+    "tool"
+  );
 }
 
 export function isUIMessage(value: unknown): value is UIMessage {

--- a/packages/core/test/message-content.test.ts
+++ b/packages/core/test/message-content.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { AssistantContent, Message, reasoningDisplayText, UserContent } from "./helpers/imports";
+import {
+  AssistantContent,
+  Message,
+  reasoningDisplayText,
+  ToolContent,
+  UserContent,
+} from "./helpers/imports";
 
 describe("message attachment content", () => {
   it("creates user image and document attachments", () => {
@@ -104,6 +110,39 @@ describe("message attachment content", () => {
           content: [{ type: "text", text: '{"ok":true}' }],
         },
       ],
+    });
+  });
+
+  it("creates a tool result message with toolName metadata", () => {
+    expect(
+      Message.toolResult("abc", { ok: true }, { callId: "call_123", toolName: "exec_command" }),
+    ).toEqual({
+      role: "tool",
+      content: [
+        {
+          type: "tool_result",
+          id: "abc",
+          callId: "call_123",
+          toolName: "exec_command",
+          content: [{ type: "text", text: '{"ok":true}' }],
+        },
+      ],
+    });
+  });
+
+  it("supports positional tool result toolName metadata", () => {
+    expect(ToolContent.toolResult("abc", "hello", undefined, "read_file")).toEqual({
+      type: "tool_result",
+      id: "abc",
+      toolName: "read_file",
+      content: [{ type: "text", text: "hello" }],
+    });
+    expect(ToolContent.toolResult("abc", "hello", "call_123", "read_file")).toEqual({
+      type: "tool_result",
+      id: "abc",
+      callId: "call_123",
+      toolName: "read_file",
+      content: [{ type: "text", text: "hello" }],
     });
   });
 

--- a/packages/core/test/ui-stream.test.ts
+++ b/packages/core/test/ui-stream.test.ts
@@ -184,13 +184,86 @@ describe("UI message adapters", () => {
       },
     ];
 
-    expect(uiMessagesToCoreMessages(messages)).toEqual([
+    const coreMessages = uiMessagesToCoreMessages(messages);
+
+    expect(coreMessages).toEqual([
       Message.assistant(
         [AssistantContent.toolCall("tool_1", "add", { x: 2, y: 5 }, "call_1")],
         "assistant_1",
       ),
-      Message.toolResult("tool_1", "7", { callId: "call_1" }),
+      Message.toolResult("tool_1", "7", { callId: "call_1", toolName: "add" }),
     ]);
+
+    expect(coreMessagesToUIMessages(coreMessages)[1]?.parts[0]).toMatchObject({
+      type: "tool",
+      toolName: "add",
+      toolCallId: "tool_1",
+      callId: "call_1",
+      state: "output-available",
+      output: "7",
+    });
+  });
+
+  it("recovers persisted tool result names by tool call id", () => {
+    const messages = coreMessagesToUIMessages([
+      Message.assistant([
+        AssistantContent.toolCall("abc", "exec_command", { cmd: "pwd" }, "call_1"),
+      ]),
+      Message.toolResult("abc", "done", { callId: "call_1" }),
+    ]);
+
+    expect(messages[1]?.parts[0]).toMatchObject({
+      type: "tool",
+      toolName: "exec_command",
+      toolCallId: "abc",
+      callId: "call_1",
+      state: "output-available",
+      output: "done",
+    });
+  });
+
+  it("recovers persisted tool result names by provider callId", () => {
+    const messages = coreMessagesToUIMessages([
+      Message.assistant([
+        AssistantContent.toolCall("internal_1", "read_file", { path: "README.md" }, "call_1"),
+      ]),
+      Message.toolResult("legacy_result", "done", { callId: "call_1" }),
+    ]);
+
+    expect(messages[1]?.parts[0]).toMatchObject({
+      type: "tool",
+      toolName: "read_file",
+      toolCallId: "legacy_result",
+      callId: "call_1",
+      state: "output-available",
+      output: "done",
+    });
+  });
+
+  it("uses stored tool result names before falling back to lookup", () => {
+    const messages = coreMessagesToUIMessages([
+      Message.toolResult("orphan_result", "done", { toolName: "write_file" }),
+    ]);
+
+    expect(messages[0]?.parts[0]).toMatchObject({
+      type: "tool",
+      toolName: "write_file",
+      toolCallId: "orphan_result",
+      state: "output-available",
+      output: "done",
+    });
+  });
+
+  it("falls back to a generic tool name for unmatched legacy tool results", () => {
+    const messages = coreMessagesToUIMessages([Message.toolResult("orphan_result", "done")]);
+
+    expect(messages[0]?.parts[0]).toMatchObject({
+      type: "tool",
+      toolName: "tool",
+      toolCallId: "orphan_result",
+      state: "output-available",
+      output: "done",
+    });
   });
 
   it("accepts core messages in createCompletionStream options", async () => {

--- a/packages/memory-prisma/src/message.ts
+++ b/packages/memory-prisma/src/message.ts
@@ -145,6 +145,7 @@ function isToolContent(value: unknown): boolean {
     value.type === "tool_result" &&
     typeof value.id === "string" &&
     (value.callId === undefined || typeof value.callId === "string") &&
+    (value.toolName === undefined || typeof value.toolName === "string") &&
     Array.isArray(value.content) &&
     value.content.every(isToolResultContent)
   );

--- a/packages/memory-sqlite/src/message.ts
+++ b/packages/memory-sqlite/src/message.ts
@@ -145,6 +145,7 @@ function isToolContent(value: unknown): boolean {
     value.type === "tool_result" &&
     typeof value.id === "string" &&
     (value.callId === undefined || typeof value.callId === "string") &&
+    (value.toolName === undefined || typeof value.toolName === "string") &&
     Array.isArray(value.content) &&
     value.content.every(isToolResultContent)
   );

--- a/packages/provider-gemini/src/gemini/completion.ts
+++ b/packages/provider-gemini/src/gemini/completion.ts
@@ -371,7 +371,7 @@ function toolContentToGeminiPart(
 ): GeminiPart {
   const id = content.callId ?? content.id;
   const functionResponse: Record<string, unknown> = {
-    name: toolNamesById.get(id) ?? content.id,
+    name: content.toolName ?? toolNamesById.get(id) ?? content.id,
     response: toolResultResponse(content.content),
   };
   if (content.callId !== undefined) {


### PR DESCRIPTION
## Summary
- Recover persisted UI tool result names in `coreMessagesToUIMessages()` from stored `toolName`, matching assistant tool call `id`, or matching provider `callId`.
- Add optional `toolName` support to `ToolResult`, `ToolContent.toolResult()`, and `Message.toolResult()` while preserving the old `callId` shape and fallback behavior.
- Update validators, Gemini function response naming fallback, focused tests, core docs, and changeset.

## Behavior
- Persisted tool results now render with names such as `exec_command`, `read_file`, or `write_file` after reload when the corresponding assistant tool call is present.
- Old saved messages without a stored name or matching call continue to fall back to `tool`.
- Live stream handling remains unchanged; React transport tests still cover streamed `tool_result.toolName`.

## Verification
- `pnpm exec biome check ...`
- `pnpm --filter @anvia/core test -- test/ui-stream.test.ts test/message-content.test.ts`
- `pnpm --filter @anvia/core typecheck`
- `pnpm --filter @anvia/core build`
- `pnpm --filter @anvia/react test -- test/transport.test.ts`
- `pnpm --filter @anvia/gemini typecheck`
- `pnpm --filter @anvia/memory-sqlite typecheck`
- `pnpm --filter @anvia/memory-prisma typecheck`
- `pnpm --filter www reference-check`
- `pnpm --filter www build`
- `git diff --check`

## Notes
- `apps/www/scripts/check-reference-coverage.mjs` passes; it checks entrypoint/export coverage, so the manual core completion reference was also updated for the new `toolName` field and helper signatures.
- No tracked generated files were intentionally changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool results now preserve and display tool names when messages are saved and later restored.
  * Tool-result metadata can now include a tool name alongside the existing call reference.

* **Bug Fixes**
  * Improved conversion between UI and core messages so tool names are recovered more reliably.
  * Added fallback behavior for older or unmatched tool results, ensuring a sensible generic name is shown when needed.

* **Documentation**
  * Updated API docs to reflect the new tool-name support for tool results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->