### PR TITLE
Fix UI tool result ordering and replay

### DIFF
--- a/.changeset/fresh-cycles-remember.md
+++ b/.changeset/fresh-cycles-remember.md
@@ -1,0 +1,6 @@
+---
+"@anvia/core": patch
+"@anvia/react": patch
+---
+
+Preserve streamed and replayed tool result ordering across text/tool boundaries.

--- a/packages/core/src/ui/messages.ts
+++ b/packages/core/src/ui/messages.ts
@@ -17,6 +17,13 @@ import {
 } from "../completion/types";
 import type { UIAttachment, UIMessage, UIMessagePart } from "./types";
 
+type UIToolPartLocation = {
+  messageIndex: number;
+  partIndex: number;
+};
+
+type UIToolMessagePart = Extract<UIMessagePart, { type: "tool" }>;
+
 export function uiMessagesToCoreMessages(messages: UIMessage[]): CoreMessage[] {
   const coreMessages: CoreMessage[] = [];
 
@@ -123,6 +130,7 @@ export function uiMessagesToCoreMessages(messages: UIMessage[]): CoreMessage[] {
 export function coreMessagesToUIMessages(messages: CoreMessage[]): UIMessage[] {
   const uiMessages: UIMessage[] = [];
   const toolNamesByCallKey = toolCallNameLookup(messages);
+  const toolPartsByCallKey = new Map<string, UIToolPartLocation>();
 
   for (const message of messages) {
     if (message.role === "system") {
@@ -192,13 +200,15 @@ export function coreMessagesToUIMessages(messages: CoreMessage[]): UIMessage[] {
           data: content as JsonValue,
         });
       }
+      const messageIndex = uiMessages.length;
       uiMessages.push({ id: message.id ?? createId("msg"), role: "assistant", parts });
+      registerToolPartLocations(parts, messageIndex, toolPartsByCallKey);
       continue;
     }
 
     const parts: UIMessagePart[] = [];
     for (const content of message.content) {
-      const part: UIMessagePart = {
+      const part: UIToolMessagePart = {
         id: toolPartId(content.id),
         type: "tool",
         toolName: toolNameForResult(content, toolNamesByCallKey),
@@ -209,12 +219,73 @@ export function coreMessagesToUIMessages(messages: CoreMessage[]): UIMessage[] {
       if (content.callId !== undefined) {
         part.callId = content.callId;
       }
+      if (mergeToolResultPart(uiMessages, toolPartsByCallKey, part)) {
+        continue;
+      }
       parts.push(part);
     }
-    uiMessages.push({ id: createId("msg"), role: "tool", parts });
+    if (parts.length > 0) {
+      uiMessages.push({ id: createId("msg"), role: "tool", parts });
+    }
   }
 
   return uiMessages;
+}
+
+function registerToolPartLocations(
+  parts: UIMessagePart[],
+  messageIndex: number,
+  toolPartsByCallKey: Map<string, UIToolPartLocation>,
+): void {
+  for (const [partIndex, part] of parts.entries()) {
+    if (part.type !== "tool") {
+      continue;
+    }
+    const location = { messageIndex, partIndex };
+    toolPartsByCallKey.set(part.toolCallId, location);
+    if (part.callId !== undefined) {
+      toolPartsByCallKey.set(part.callId, location);
+    }
+  }
+}
+
+function mergeToolResultPart(
+  uiMessages: UIMessage[],
+  toolPartsByCallKey: Map<string, UIToolPartLocation>,
+  resultPart: UIMessagePart,
+): boolean {
+  if (resultPart.type !== "tool") {
+    return false;
+  }
+
+  const location =
+    toolPartsByCallKey.get(resultPart.toolCallId) ??
+    (resultPart.callId === undefined ? undefined : toolPartsByCallKey.get(resultPart.callId));
+  if (location === undefined) {
+    return false;
+  }
+
+  const message = uiMessages[location.messageIndex];
+  const currentPart = message?.parts[location.partIndex];
+  if (message === undefined || currentPart?.type !== "tool") {
+    return false;
+  }
+
+  const mergedPart: UIToolMessagePart = {
+    ...currentPart,
+    toolName: resultPart.toolName === "tool" ? currentPart.toolName : resultPart.toolName,
+    state: "output-available",
+    ...(resultPart.output === undefined ? {} : { output: resultPart.output }),
+  };
+  if (currentPart.callId === undefined && resultPart.callId !== undefined) {
+    mergedPart.callId = resultPart.callId;
+    toolPartsByCallKey.set(resultPart.callId, location);
+  }
+
+  const nextParts = [...message.parts];
+  nextParts[location.partIndex] = mergedPart;
+  uiMessages[location.messageIndex] = { ...message, parts: nextParts };
+  return true;
 }
 
 function toolCallNameLookup(messages: CoreMessage[]): Map<string, string> {

--- a/packages/core/test/ui-stream.test.ts
+++ b/packages/core/test/ui-stream.test.ts
@@ -194,17 +194,22 @@ describe("UI message adapters", () => {
       Message.toolResult("tool_1", "7", { callId: "call_1", toolName: "add" }),
     ]);
 
-    expect(coreMessagesToUIMessages(coreMessages)[1]?.parts[0]).toMatchObject({
+    const hydrated = coreMessagesToUIMessages(coreMessages);
+
+    expect(hydrated).toHaveLength(1);
+    expect(hydrated[0]?.parts[0]).toMatchObject({
       type: "tool",
       toolName: "add",
       toolCallId: "tool_1",
       callId: "call_1",
       state: "output-available",
+      input: { x: 2, y: 5 },
       output: "7",
     });
+    expect(uiMessagesToCoreMessages(hydrated)).toEqual(coreMessages);
   });
 
-  it("recovers persisted tool result names by tool call id", () => {
+  it("merges persisted tool results by tool call id", () => {
     const messages = coreMessagesToUIMessages([
       Message.assistant([
         AssistantContent.toolCall("abc", "exec_command", { cmd: "pwd" }, "call_1"),
@@ -212,17 +217,19 @@ describe("UI message adapters", () => {
       Message.toolResult("abc", "done", { callId: "call_1" }),
     ]);
 
-    expect(messages[1]?.parts[0]).toMatchObject({
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.parts[0]).toMatchObject({
       type: "tool",
       toolName: "exec_command",
       toolCallId: "abc",
       callId: "call_1",
       state: "output-available",
+      input: { cmd: "pwd" },
       output: "done",
     });
   });
 
-  it("recovers persisted tool result names by provider callId", () => {
+  it("merges persisted tool results by provider callId", () => {
     const messages = coreMessagesToUIMessages([
       Message.assistant([
         AssistantContent.toolCall("internal_1", "read_file", { path: "README.md" }, "call_1"),
@@ -230,12 +237,14 @@ describe("UI message adapters", () => {
       Message.toolResult("legacy_result", "done", { callId: "call_1" }),
     ]);
 
-    expect(messages[1]?.parts[0]).toMatchObject({
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.parts[0]).toMatchObject({
       type: "tool",
       toolName: "read_file",
-      toolCallId: "legacy_result",
+      toolCallId: "internal_1",
       callId: "call_1",
       state: "output-available",
+      input: { path: "README.md" },
       output: "done",
     });
   });

--- a/packages/react/src/ui-messages.ts
+++ b/packages/react/src/ui-messages.ts
@@ -1,11 +1,12 @@
-import type { JsonValue } from "@anvia/core/completion";
-import type {
-  CreateUIAttachment,
-  UIAttachment,
-  UIError,
-  UIMessage,
-  UIMessagePart,
-  UIStreamEvent,
+import type { Message as CoreMessage, JsonValue } from "@anvia/core/completion";
+import {
+  type CreateUIAttachment,
+  coreMessagesToUIMessages,
+  type UIAttachment,
+  type UIError,
+  type UIMessage,
+  type UIMessagePart,
+  type UIStreamEvent,
 } from "@anvia/core/ui";
 import type { SendMessageInput } from "./types";
 
@@ -180,7 +181,12 @@ export function applyAnviaStreamEvent(
           ? valueToJson(event.structuredResult)
           : valueToJson(event.result),
     };
-    return updateAssistantToolPart(messages, part, [providerCallId, internalCallId]);
+    return updateAssistantToolPart(
+      messages,
+      part,
+      [providerCallId, internalCallId],
+      parseJsonValue(event.args),
+    );
   }
 
   if (event.type === "message_id" && typeof event.id === "string") {
@@ -188,6 +194,14 @@ export function applyAnviaStreamEvent(
   }
 
   if (event.type === "final") {
+    const finalMessages = finalMessagesFromEvent(event);
+    if (finalMessages !== undefined) {
+      const next = replaceCurrentRunMessages(messages, finalMessages);
+      return typeof event.runId === "string"
+        ? setLastAssistantMetadata(next, { runId: event.runId })
+        : next;
+    }
+
     if (isRecord(event.response) && Array.isArray(event.response.choice)) {
       const finalText = textFromAssistantContent(event.response.choice);
       const next = finalText.length > 0 ? replaceAssistantText(messages, finalText) : messages;
@@ -225,6 +239,32 @@ export function messageText(message: UIMessage): string {
   return message.parts.flatMap((part) => (part.type === "text" ? [part.text] : [])).join("");
 }
 
+function assistantTextPartId(assistant: UIMessage): string {
+  const lastPart = assistant.parts.at(-1);
+  if (lastPart?.type === "text") {
+    return lastPart.id;
+  }
+
+  const textCount = assistant.parts.filter((part) => part.type === "text").length;
+  return textCount === 0 ? `${assistant.id}_text` : `${assistant.id}_text_${textCount + 1}`;
+}
+
+function assistantReasoningPartId(assistant: UIMessage, reasoningId?: string): string {
+  if (reasoningId !== undefined) {
+    return `${assistant.id}_reasoning_${reasoningId}`;
+  }
+
+  const lastPart = assistant.parts.at(-1);
+  if (lastPart?.type === "reasoning" && lastPart.reasoningId === undefined) {
+    return lastPart.id;
+  }
+
+  const reasoningCount = assistant.parts.filter((part) => part.type === "reasoning").length;
+  return reasoningCount === 0
+    ? `${assistant.id}_reasoning`
+    : `${assistant.id}_reasoning_${reasoningCount + 1}`;
+}
+
 export function appendAssistantDelta(messages: UIMessage[], delta: string): UIMessage[] {
   const current = ensureAssistantMessage(messages);
   const assistant = current[current.length - 1];
@@ -232,7 +272,7 @@ export function appendAssistantDelta(messages: UIMessage[], delta: string): UIMe
     return current;
   }
   return updateMessagePart(current, assistant.id, {
-    id: `${assistant.id}_text`,
+    id: assistantTextPartId(assistant),
     type: "text",
     text: delta,
   });
@@ -248,12 +288,8 @@ export function appendAssistantReasoningDelta(
   if (assistant === undefined) {
     return current;
   }
-  const partId =
-    reasoningId === undefined
-      ? `${assistant.id}_reasoning`
-      : `${assistant.id}_reasoning_${reasoningId}`;
   return updateMessagePart(current, assistant.id, {
-    id: partId,
+    id: assistantReasoningPartId(assistant, reasoningId),
     type: "reasoning",
     text: delta,
     ...(reasoningId === undefined ? {} : { reasoningId }),
@@ -269,6 +305,45 @@ export function replaceAssistantText(messages: UIMessage[], text: string): UIMes
   return current.map((message) =>
     message.id === assistant.id ? { ...message, parts: replaceTextPart(message, text) } : message,
   );
+}
+
+function finalMessagesFromEvent(event: Record<string, unknown>): UIMessage[] | undefined {
+  if (!Array.isArray(event.messages) || event.messages.length === 0) {
+    return undefined;
+  }
+
+  try {
+    return coreMessagesToUIMessages(event.messages as CoreMessage[]);
+  } catch {
+    return undefined;
+  }
+}
+
+function replaceCurrentRunMessages(messages: UIMessage[], finalMessages: UIMessage[]): UIMessage[] {
+  if (messages.length === 0 || finalMessages.length === 0) {
+    return finalMessages;
+  }
+
+  const lastUserIndex = findLastIndex(messages, (message) => message.role === "user");
+  if (lastUserIndex === -1) {
+    return finalMessages;
+  }
+
+  const finalFirst = finalMessages[0];
+  if (finalFirst?.role !== "user") {
+    return [...messages.slice(0, lastUserIndex + 1), ...finalMessages];
+  }
+
+  const currentPrompt = messages[lastUserIndex];
+  if (currentPrompt === undefined || messageText(currentPrompt) !== messageText(finalFirst)) {
+    return finalMessages;
+  }
+
+  return [
+    ...messages.slice(0, lastUserIndex),
+    { ...finalFirst, id: currentPrompt.id },
+    ...finalMessages.slice(1),
+  ];
 }
 
 function updateMessagePart(
@@ -312,6 +387,7 @@ function updateAssistantToolPart(
   messages: UIMessage[],
   part: UIToolMessagePart,
   aliases: Array<string | undefined> = [],
+  inputMatch?: JsonValue,
 ): UIMessage[] {
   const current = ensureAssistantMessage(messages);
   const assistant = current[current.length - 1];
@@ -319,7 +395,7 @@ function updateAssistantToolPart(
     return current;
   }
 
-  const existingPart = findMatchingToolPart(assistant, part, aliases);
+  const existingPart = findMatchingToolPart(assistant, part, aliases, inputMatch);
   const nextPart =
     existingPart === undefined
       ? part
@@ -341,6 +417,7 @@ function findMatchingToolPart(
   message: UIMessage,
   part: UIToolMessagePart,
   aliases: Array<string | undefined>,
+  inputMatch?: JsonValue,
 ): UIToolMessagePart | undefined {
   const candidates = new Set(
     [part.toolCallId, part.callId, ...aliases].filter(
@@ -348,13 +425,26 @@ function findMatchingToolPart(
     ),
   );
 
-  return message.parts.find(
+  const exactMatch = message.parts.find(
     (item): item is UIToolMessagePart =>
       item.type === "tool" &&
       (item.id === part.id ||
         candidates.has(item.toolCallId) ||
         (item.callId !== undefined && candidates.has(item.callId))),
   );
+  if (exactMatch !== undefined || inputMatch === undefined) {
+    return exactMatch;
+  }
+
+  const inputMatches = message.parts.filter(
+    (item): item is UIToolMessagePart =>
+      item.type === "tool" &&
+      item.toolName === part.toolName &&
+      item.state !== "output-available" &&
+      item.state !== "error" &&
+      jsonEquals(item.input ?? {}, inputMatch),
+  );
+  return inputMatches.length === 1 ? inputMatches[0] : undefined;
 }
 
 function mergeToolPart(
@@ -541,6 +631,20 @@ function stringifyUnknown(value: unknown): string {
   }
 }
 
+function parseJsonValue(value: unknown): JsonValue | undefined {
+  if (typeof value === "string") {
+    try {
+      return valueToJson(JSON.parse(value));
+    } catch {
+      return undefined;
+    }
+  }
+  if (value === undefined) {
+    return undefined;
+  }
+  return valueToJson(value);
+}
+
 function valueToJson(value: unknown): JsonValue {
   if (
     value === null ||
@@ -553,6 +657,29 @@ function valueToJson(value: unknown): JsonValue {
     return value as JsonValue;
   }
   return stringifyUnknown(value);
+}
+
+function jsonEquals(left: JsonValue, right: JsonValue): boolean {
+  try {
+    return JSON.stringify(normalizeJson(left)) === JSON.stringify(normalizeJson(right));
+  } catch {
+    return false;
+  }
+}
+
+function normalizeJson(value: JsonValue): JsonValue {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeJson(item));
+  }
+  if (isJsonObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter((entry): entry is [string, JsonValue] => entry[1] !== undefined)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, normalizeJson(item)]),
+    );
+  }
+  return value;
 }
 
 function mergeMetadata(current: UIMessage["metadata"], next: JsonValue): JsonValue {
@@ -568,6 +695,15 @@ function isJsonObject(value: unknown): value is Record<string, JsonValue | undef
 
 function toolPartId(toolCallId: string): string {
   return `tool_${toolCallId}`;
+}
+
+function findLastIndex<T>(items: T[], predicate: (item: T) => boolean): number {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    if (predicate(items[index] as T)) {
+      return index;
+    }
+  }
+  return -1;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/react/test/transport.test.ts
+++ b/packages/react/test/transport.test.ts
@@ -198,18 +198,8 @@ describe("@anvia/react useChat", () => {
             type: "tool",
             toolName: "lookup_order",
             toolCallId: "call_1",
-            state: "input-available",
-            input: { orderId: "A-100" },
-          },
-        ],
-      },
-      {
-        role: "tool",
-        parts: [
-          {
-            type: "tool",
-            toolCallId: "call_1",
             state: "output-available",
+            input: { orderId: "A-100" },
             output: '{"status":"shipped"}',
           },
         ],
@@ -770,6 +760,336 @@ describe("@anvia/react useChat", () => {
     );
   });
 
+  it("keeps raw text deltas after tool results in chronological order", async () => {
+    const transport: EventTransport<UIStreamRequest, AgentStreamEvent> = {
+      send: async function* () {
+        yield { type: "text_delta", turn: 1, delta: "before" };
+        yield {
+          type: "tool_call",
+          turn: 1,
+          toolCall: AssistantContent.toolCall(
+            "web_1",
+            "webSearch",
+            { query: "AAPL stock price market analysis 2025" },
+            "call_web_1",
+          ),
+        };
+        yield {
+          type: "tool_result",
+          turn: 1,
+          toolName: "webSearch",
+          toolCallId: "call_web_1",
+          internalCallId: "internal_web_1",
+          args: '{"query":"AAPL stock price market analysis 2025"}',
+          result: "price result",
+        } as unknown as AgentStreamEvent;
+        yield { type: "text_delta", turn: 1, delta: "after" };
+      },
+    };
+    const { result } = renderHook(() => useChat({ transport }));
+
+    await act(async () => {
+      await result.current.send("report");
+    });
+
+    expect(assistantPartSummary(result.current.messages)).toEqual([
+      { type: "text", text: "before" },
+      {
+        type: "tool",
+        toolName: "webSearch",
+        toolCallId: "web_1",
+        callId: "call_web_1",
+        state: "output-available",
+        input: { query: "AAPL stock price market analysis 2025" },
+        output: "price result",
+      },
+      { type: "text", text: "after" },
+    ]);
+  });
+
+  it("keeps text after a tool-first assistant run after the completed tool", async () => {
+    const transport: EventTransport<UIStreamRequest, AgentStreamEvent> = {
+      send: async function* () {
+        yield {
+          type: "tool_call",
+          turn: 1,
+          toolCall: AssistantContent.toolCall("exec_1", "exec_command", { command: "ls" }),
+        };
+        yield {
+          type: "tool_result",
+          turn: 1,
+          toolName: "exec_command",
+          internalCallId: "internal_exec_1",
+          args: '{"command":"ls"}',
+          result: "file.txt",
+        } as unknown as AgentStreamEvent;
+        yield { type: "text_delta", turn: 1, delta: "verified" };
+      },
+    };
+    const { result } = renderHook(() => useChat({ transport }));
+
+    await act(async () => {
+      await result.current.send("list");
+    });
+
+    expect(assistantPartSummary(result.current.messages)).toEqual([
+      {
+        type: "tool",
+        toolName: "exec_command",
+        toolCallId: "exec_1",
+        state: "output-available",
+        input: { command: "ls" },
+        output: "file.txt",
+      },
+      { type: "text", text: "verified" },
+    ]);
+  });
+
+  it("preserves ordering across multiple tool calls in one assistant run", async () => {
+    const transport: EventTransport<UIStreamRequest, AgentStreamEvent> = {
+      send: async function* () {
+        yield { type: "reasoning_delta", turn: 1, delta: "thinking..." };
+        yield {
+          type: "text_delta",
+          turn: 1,
+          delta: "Let me gather the latest information.",
+        };
+        yield {
+          type: "tool_call",
+          turn: 1,
+          toolCall: AssistantContent.toolCall(
+            "web_1",
+            "webSearch",
+            { query: "AAPL stock price market analysis 2025" },
+            "call_web_1",
+          ),
+        };
+        yield {
+          type: "tool_result",
+          turn: 1,
+          toolName: "webSearch",
+          toolCallId: "call_web_1",
+          internalCallId: "internal_web_1",
+          args: '{"query":"AAPL stock price market analysis 2025"}',
+          result: "price result",
+        } as unknown as AgentStreamEvent;
+        yield { type: "text_delta", turn: 1, delta: "Let me get a few more details." };
+        yield {
+          type: "tool_call",
+          turn: 1,
+          toolCall: AssistantContent.toolCall(
+            "web_2",
+            "webSearch",
+            { query: "AAPL technical analysis 2025" },
+            "call_web_2",
+          ),
+        };
+        yield {
+          type: "tool_result",
+          turn: 1,
+          toolName: "webSearch",
+          toolCallId: "call_web_2",
+          internalCallId: "internal_web_2",
+          args: '{"query":"AAPL technical analysis 2025"}',
+          result: "technical result",
+        } as unknown as AgentStreamEvent;
+        yield {
+          type: "text_delta",
+          turn: 1,
+          delta: "Excellent. Now let me create the PDF report.",
+        };
+        yield {
+          type: "tool_call",
+          turn: 1,
+          toolCall: AssistantContent.toolCall("exec_1", "exec_command", { command: "ls" }),
+        };
+        yield {
+          type: "tool_result",
+          turn: 1,
+          toolName: "exec_command",
+          internalCallId: "internal_exec_1",
+          args: '{"command":"ls"}',
+          result: "report.pdf",
+        } as unknown as AgentStreamEvent;
+        yield { type: "text_delta", turn: 1, delta: "Let me verify the file." };
+      },
+    };
+    const { result } = renderHook(() => useChat({ transport }));
+
+    await act(async () => {
+      await result.current.send("report");
+    });
+
+    expect(assistantPartSummary(result.current.messages)).toEqual([
+      { type: "text", text: "Let me gather the latest information." },
+      expect.objectContaining({ type: "tool", toolName: "webSearch", toolCallId: "web_1" }),
+      { type: "text", text: "Let me get a few more details." },
+      expect.objectContaining({ type: "tool", toolName: "webSearch", toolCallId: "web_2" }),
+      { type: "text", text: "Excellent. Now let me create the PDF report." },
+      expect.objectContaining({
+        type: "tool",
+        toolName: "exec_command",
+        toolCallId: "exec_1",
+        input: { command: "ls" },
+        output: "report.pdf",
+      }),
+      { type: "text", text: "Let me verify the file." },
+    ]);
+  });
+
+  it("matches final and replay order while keeping sandbox tool results visible", async () => {
+    const finalMessages = [
+      Message.user("report"),
+      Message.assistant([
+        AssistantContent.text("Let me gather the latest information."),
+        AssistantContent.toolCall(
+          "web_1",
+          "webSearch",
+          { query: "AAPL stock price market analysis 2025" },
+          "call_web_1",
+        ),
+      ]),
+      Message.toolResult("web_1", "price result", {
+        callId: "call_web_1",
+        toolName: "webSearch",
+      }),
+      Message.assistant([
+        AssistantContent.text("Let me get a few more details."),
+        AssistantContent.toolCall(
+          "web_2",
+          "webSearch",
+          { query: "AAPL technical analysis 2025" },
+          "call_web_2",
+        ),
+      ]),
+      Message.toolResult("web_2", "technical result", {
+        callId: "call_web_2",
+        toolName: "webSearch",
+      }),
+      Message.assistant([
+        AssistantContent.text("Excellent. Now let me create the PDF report."),
+        AssistantContent.toolCall("exec_1", "exec_command", { command: "ls" }),
+      ]),
+      Message.toolResult("exec_1", "report.pdf", { toolName: "exec_command" }),
+      Message.assistant("Let me verify the file."),
+    ];
+    const transport: EventTransport<UIStreamRequest, AgentStreamEvent> = {
+      send: async function* () {
+        yield {
+          type: "text_delta",
+          turn: 1,
+          delta: "Let me gather the latest information.",
+        };
+        yield {
+          type: "tool_call",
+          turn: 1,
+          toolCall: AssistantContent.toolCall(
+            "web_1",
+            "webSearch",
+            { query: "AAPL stock price market analysis 2025" },
+            "call_web_1",
+          ),
+        };
+        yield {
+          type: "tool_result",
+          turn: 1,
+          toolName: "webSearch",
+          toolCallId: "call_web_1",
+          internalCallId: "internal_web_1",
+          args: '{"query":"AAPL stock price market analysis 2025"}',
+          result: "price result",
+        } as unknown as AgentStreamEvent;
+        yield { type: "text_delta", turn: 1, delta: "Let me get a few more details." };
+        yield {
+          type: "tool_call",
+          turn: 1,
+          toolCall: AssistantContent.toolCall(
+            "web_2",
+            "webSearch",
+            { query: "AAPL technical analysis 2025" },
+            "call_web_2",
+          ),
+        };
+        yield {
+          type: "tool_result",
+          turn: 1,
+          toolName: "webSearch",
+          toolCallId: "call_web_2",
+          internalCallId: "internal_web_2",
+          args: '{"query":"AAPL technical analysis 2025"}',
+          result: "technical result",
+        } as unknown as AgentStreamEvent;
+        yield {
+          type: "text_delta",
+          turn: 1,
+          delta: "Excellent. Now let me create the PDF report.",
+        };
+        yield {
+          type: "tool_call",
+          turn: 1,
+          toolCall: AssistantContent.toolCall("exec_1", "exec_command", { command: "ls" }),
+        };
+        yield {
+          type: "tool_result",
+          turn: 1,
+          toolName: "exec_command",
+          internalCallId: "internal_exec_1",
+          args: '{"command":"ls"}',
+          result: "report.pdf",
+        } as unknown as AgentStreamEvent;
+        yield { type: "text_delta", turn: 1, delta: "Let me verify the file." };
+        yield {
+          type: "final",
+          runId: "run_1",
+          output: "Let me verify the file.",
+          usage: Usage.empty(),
+          messages: finalMessages,
+        };
+      },
+    };
+    const { result } = renderHook(() => useChat({ transport }));
+
+    await act(async () => {
+      await result.current.send("report");
+    });
+
+    const finalSummary = assistantPartSummary(result.current.messages);
+    const replaySummary = assistantPartSummary(initialMessagesFromMemory(finalMessages));
+    expect(finalSummary).toEqual(replaySummary);
+    expect(finalSummary).toEqual([
+      { type: "text", text: "Let me gather the latest information." },
+      expect.objectContaining({
+        type: "tool",
+        toolName: "webSearch",
+        toolCallId: "web_1",
+        callId: "call_web_1",
+        state: "output-available",
+      }),
+      { type: "text", text: "Let me get a few more details." },
+      expect.objectContaining({
+        type: "tool",
+        toolName: "webSearch",
+        toolCallId: "web_2",
+        callId: "call_web_2",
+        state: "output-available",
+      }),
+      { type: "text", text: "Excellent. Now let me create the PDF report." },
+      {
+        type: "tool",
+        toolName: "exec_command",
+        toolCallId: "exec_1",
+        state: "output-available",
+        input: { command: "ls" },
+        output: "report.pdf",
+      },
+      { type: "text", text: "Let me verify the file." },
+    ]);
+    expect(result.current.messages.at(-1)).toMatchObject({
+      role: "assistant",
+      metadata: { runId: "run_1" },
+    });
+  });
+
   it("supports custom event mapping for non-UI streams", async () => {
     const transport: EventTransport<UIStreamRequest, { type: string; delta?: string }> = {
       send: async function* () {
@@ -1224,6 +1544,48 @@ describe("@anvia/react useChat", () => {
     expect(result.current.answeringQuestions.has("question-1")).toBe(false);
   });
 });
+
+type AssistantPartSummary =
+  | {
+      type: "text";
+      text: string;
+    }
+  | {
+      type: "tool";
+      toolName: string;
+      toolCallId: string;
+      callId?: string;
+      state: "input-streaming" | "input-available" | "output-available" | "error";
+      input?: unknown;
+      output?: unknown;
+    };
+
+function assistantPartSummary(messages: UIMessage[]): AssistantPartSummary[] {
+  return messages.flatMap((message) => {
+    if (message.role !== "assistant") {
+      return [];
+    }
+    return message.parts.flatMap((part): AssistantPartSummary[] => {
+      if (part.type === "text") {
+        return [{ type: "text", text: part.text }];
+      }
+      if (part.type === "tool") {
+        return [
+          {
+            type: "tool",
+            toolName: part.toolName,
+            toolCallId: part.toolCallId,
+            ...(part.callId === undefined ? {} : { callId: part.callId }),
+            state: part.state,
+            ...(part.input === undefined ? {} : { input: part.input }),
+            ...(part.output === undefined ? {} : { output: part.output }),
+          },
+        ];
+      }
+      return [];
+    });
+  });
+}
 
 async function collect<T>(events: AsyncIterable<T>): Promise<T[]> {
   const items: T[] = [];


### PR DESCRIPTION
## Summary
- Preserve live text/tool chronology in @anvia/react by creating new text/reasoning parts after tool boundaries instead of always appending to the first fixed part.
- Match sandbox tool_result events back to pending tool calls by exact ids or unique toolName + input when provider call ids are absent.
- Merge persisted role: tool results into matching assistant tool parts during coreMessagesToUIMessages() replay, while keeping orphan fallback behavior.

## Intended behavior
Persisted and live tool rendering should agree: text -> tool -> text ordering is preserved, and sandbox tools such as exec_command remain visible after final/replay with their name, input, output, id, and callId when available.

## Verification
- pnpm --filter @anvia/core test -- test/ui-stream.test.ts
- pnpm --filter @anvia/react test -- test/transport.test.ts
- pnpm --filter @anvia/core typecheck
- pnpm --filter @anvia/react typecheck
- pnpm exec biome check packages/react/src/ui-messages.ts packages/core/src/ui/messages.ts packages/core/test/ui-stream.test.ts packages/react/test/transport.test.ts
- pnpm --filter www reference-check

## Notes
- No generated files changed.
- No screenshots were taken because this is reducer/conversion behavior covered by tests.