### PR TITLE
Scope live UI tool matching by turn

### DIFF
--- a/.changeset/calm-tools-turn.md
+++ b/.changeset/calm-tools-turn.md
@@ -1,0 +1,6 @@
+---
+"@anvia/core": patch
+"@anvia/react": patch
+---
+
+Scope live UI tool result matching by turn when reducer events include turn metadata.

--- a/packages/core/src/ui/types.ts
+++ b/packages/core/src/ui/types.ts
@@ -48,6 +48,7 @@ export type UIMessagePart =
       toolName: string;
       toolCallId: string;
       callId?: string;
+      turn?: number;
       state: "input-streaming" | "input-available" | "output-available" | "error";
       input?: JsonValue;
       output?: JsonValue;

--- a/packages/react/src/ui-messages.ts
+++ b/packages/react/src/ui-messages.ts
@@ -136,12 +136,14 @@ export function applyAnviaStreamEvent(
   }
 
   if (event.type === "tool_call_delta" && typeof event.id === "string") {
+    const turn = eventTurn(event);
     const part: UIToolMessagePart = {
-      id: toolPartId(event.id),
+      id: toolPartId(event.id, turn),
       type: "tool",
       toolName: typeof event.name === "string" ? event.name : "",
       toolCallId: event.id,
       ...(typeof event.callId === "string" ? { callId: event.callId } : {}),
+      ...(turn === undefined ? {} : { turn }),
       state: "input-streaming",
       ...(typeof event.argumentsDelta === "string" ? { input: event.argumentsDelta } : {}),
     };
@@ -149,12 +151,14 @@ export function applyAnviaStreamEvent(
   }
 
   if (event.type === "tool_call" && isToolCall(event.toolCall)) {
+    const turn = eventTurn(event);
     const part: UIToolMessagePart = {
-      id: toolPartId(event.toolCall.id),
+      id: toolPartId(event.toolCall.id, turn),
       type: "tool",
       toolName: event.toolCall.function.name,
       toolCallId: event.toolCall.id,
       ...(typeof event.toolCall.callId === "string" ? { callId: event.toolCall.callId } : {}),
+      ...(turn === undefined ? {} : { turn }),
       state: "input-available",
       input: event.toolCall.function.arguments,
     };
@@ -169,12 +173,14 @@ export function applyAnviaStreamEvent(
     if (toolCallId === undefined || typeof event.toolName !== "string") {
       return undefined;
     }
+    const turn = eventTurn(event);
     const part: UIToolMessagePart = {
-      id: toolPartId(toolCallId),
+      id: toolPartId(toolCallId, turn),
       type: "tool",
       toolName: event.toolName,
       toolCallId,
       ...(providerCallId === undefined ? {} : { callId: providerCallId }),
+      ...(turn === undefined ? {} : { turn }),
       state: "output-available",
       output:
         "structuredResult" in event && event.structuredResult !== undefined
@@ -428,6 +434,7 @@ function findMatchingToolPart(
   const exactMatch = message.parts.find(
     (item): item is UIToolMessagePart =>
       item.type === "tool" &&
+      hasCompatibleTurn(item, part) &&
       (item.id === part.id ||
         candidates.has(item.toolCallId) ||
         (item.callId !== undefined && candidates.has(item.callId))),
@@ -439,6 +446,7 @@ function findMatchingToolPart(
   const inputMatches = message.parts.filter(
     (item): item is UIToolMessagePart =>
       item.type === "tool" &&
+      hasCompatibleTurn(item, part) &&
       item.toolName === part.toolName &&
       item.state !== "output-available" &&
       item.state !== "error" &&
@@ -472,6 +480,12 @@ function mergeToolPart(
   }
 
   return merged;
+}
+
+function hasCompatibleTurn(currentPart: UIToolMessagePart, nextPart: UIToolMessagePart): boolean {
+  return nextPart.turn === undefined
+    ? currentPart.turn === undefined
+    : currentPart.turn === nextPart.turn;
 }
 
 function appendAssistantError(messages: UIMessage[], error: UIError): UIMessage[] {
@@ -607,6 +621,10 @@ function isToolCall(value: unknown): value is {
   );
 }
 
+function eventTurn(event: Record<string, unknown>): number | undefined {
+  return typeof event.turn === "number" && Number.isFinite(event.turn) ? event.turn : undefined;
+}
+
 function textFromAssistantContent(content: unknown[]): string {
   return content
     .flatMap((item) =>
@@ -693,8 +711,8 @@ function isJsonObject(value: unknown): value is Record<string, JsonValue | undef
   return isRecord(value) && !Array.isArray(value);
 }
 
-function toolPartId(toolCallId: string): string {
-  return `tool_${toolCallId}`;
+function toolPartId(toolCallId: string, turn?: number): string {
+  return turn === undefined ? `tool_${toolCallId}` : `tool_${turn}_${toolCallId}`;
 }
 
 function findLastIndex<T>(items: T[], predicate: (item: T) => boolean): number {

--- a/packages/react/test/ui-messages.test.ts
+++ b/packages/react/test/ui-messages.test.ts
@@ -1,0 +1,312 @@
+import { AssistantContent, Message } from "@anvia/core/completion";
+import { coreMessagesToUIMessages, type UIMessage, type UIMessagePart } from "@anvia/core/ui";
+import { describe, expect, it } from "vitest";
+
+import { applyAnviaStreamEvent } from "../src/ui-messages";
+
+type UIToolPart = Extract<UIMessagePart, { type: "tool" }>;
+
+describe("@anvia/react UI message reducer", () => {
+  it("keeps reused provider tool ids isolated across turns", () => {
+    let messages: UIMessage[] = [];
+    const events = [
+      { type: "reasoning_delta", turn: 1, delta: "I need to search first." },
+      {
+        type: "tool_call",
+        turn: 1,
+        toolCall: AssistantContent.toolCall("call_0", "webSearch", {
+          query: "AAPL stock price market analysis 2025",
+        }),
+      },
+      {
+        type: "tool_result",
+        turn: 1,
+        toolName: "webSearch",
+        internalCallId: "internal_search_1",
+        toolCallId: "call_0",
+        args: '{"query":"AAPL stock price market analysis 2025"}',
+        result: "search results...",
+        structuredResult: {
+          query: "AAPL stock price market analysis 2025",
+          results: [],
+        },
+      },
+      { type: "reasoning_delta", turn: 2, delta: "Now I need to create a folder." },
+      {
+        type: "tool_call",
+        turn: 2,
+        toolCall: AssistantContent.toolCall("call_0", "exec_command", {
+          cmd: "mkdir -p report",
+        }),
+      },
+      {
+        type: "tool_result",
+        turn: 2,
+        toolName: "exec_command",
+        internalCallId: "internal_exec_1",
+        toolCallId: "call_0",
+        args: '{"cmd":"mkdir -p report"}',
+        result: "",
+        structuredResult: { stdout: "", stderr: "", exitCode: 0 },
+      },
+    ];
+
+    for (const [index, event] of events.entries()) {
+      messages = applyEvent(messages, event);
+      if (index === 2) {
+        expect(toolParts(messages)).toMatchObject([
+          {
+            id: "tool_1_call_0",
+            toolName: "webSearch",
+            toolCallId: "call_0",
+            turn: 1,
+            state: "output-available",
+            input: { query: "AAPL stock price market analysis 2025" },
+            output: { query: "AAPL stock price market analysis 2025", results: [] },
+          },
+        ]);
+      }
+    }
+
+    expect(partSummary(messages)).toEqual([
+      { type: "reasoning", text: "I need to search first." },
+      {
+        type: "tool",
+        id: "tool_1_call_0",
+        toolName: "webSearch",
+        toolCallId: "call_0",
+        callId: "call_0",
+        turn: 1,
+        state: "output-available",
+        input: { query: "AAPL stock price market analysis 2025" },
+        output: { query: "AAPL stock price market analysis 2025", results: [] },
+      },
+      { type: "reasoning", text: "Now I need to create a folder." },
+      {
+        type: "tool",
+        id: "tool_2_call_0",
+        toolName: "exec_command",
+        toolCallId: "call_0",
+        callId: "call_0",
+        turn: 2,
+        state: "output-available",
+        input: { cmd: "mkdir -p report" },
+        output: { stdout: "", stderr: "", exitCode: 0 },
+      },
+    ]);
+  });
+
+  it("uses same-turn input fallback for internal-only results with reused ids", () => {
+    const messages = reduceEvents([
+      { type: "reasoning_delta", turn: 1, delta: "I need to search first." },
+      {
+        type: "tool_call",
+        turn: 1,
+        toolCall: AssistantContent.toolCall("0", "webSearch", {
+          query: "AAPL stock price market analysis 2025",
+        }),
+      },
+      {
+        type: "tool_result",
+        turn: 1,
+        toolName: "webSearch",
+        internalCallId: "internal_search_1",
+        args: '{"query":"AAPL stock price market analysis 2025"}',
+        result: "search results...",
+        structuredResult: {
+          query: "AAPL stock price market analysis 2025",
+          results: [],
+        },
+      },
+      { type: "reasoning_delta", turn: 2, delta: "Now I need to create a folder." },
+      {
+        type: "tool_call",
+        turn: 2,
+        toolCall: AssistantContent.toolCall("0", "exec_command", {
+          cmd: "mkdir -p report",
+        }),
+      },
+      {
+        type: "tool_result",
+        turn: 2,
+        toolName: "exec_command",
+        internalCallId: "internal_exec_1",
+        args: '{"cmd":"mkdir -p report"}',
+        result: "",
+        structuredResult: { stdout: "", stderr: "", exitCode: 0 },
+      },
+    ]);
+
+    expect(toolParts(messages)).toMatchObject([
+      {
+        id: "tool_1_0",
+        toolName: "webSearch",
+        toolCallId: "0",
+        turn: 1,
+        state: "output-available",
+        input: { query: "AAPL stock price market analysis 2025" },
+        output: { query: "AAPL stock price market analysis 2025", results: [] },
+      },
+      {
+        id: "tool_2_0",
+        toolName: "exec_command",
+        toolCallId: "0",
+        turn: 2,
+        state: "output-available",
+        input: { cmd: "mkdir -p report" },
+        output: { stdout: "", stderr: "", exitCode: 0 },
+      },
+    ]);
+  });
+
+  it("does not match same toolCallId across different incoming turns", () => {
+    const messages = reduceEvents([
+      {
+        type: "tool_call",
+        turn: 1,
+        toolCall: AssistantContent.toolCall("call_0", "webSearch", {
+          query: "AAPL stock price market analysis 2025",
+        }),
+      },
+      {
+        type: "tool_call",
+        turn: 2,
+        toolCall: AssistantContent.toolCall("call_0", "exec_command", {
+          cmd: "mkdir -p report",
+        }),
+      },
+    ]);
+
+    expect(toolParts(messages)).toMatchObject([
+      { id: "tool_1_call_0", toolName: "webSearch", toolCallId: "call_0", turn: 1 },
+      { id: "tool_2_call_0", toolName: "exec_command", toolCallId: "call_0", turn: 2 },
+    ]);
+  });
+
+  it("does not match unturned incoming parts against turned existing parts", () => {
+    const messages = reduceEvents([
+      {
+        type: "tool_call",
+        turn: 1,
+        toolCall: AssistantContent.toolCall("call_0", "webSearch", {
+          query: "AAPL stock price market analysis 2025",
+        }),
+      },
+      {
+        type: "tool_result",
+        toolName: "webSearch",
+        internalCallId: "internal_search_1",
+        toolCallId: "call_0",
+        args: '{"query":"AAPL stock price market analysis 2025"}',
+        result: "search results...",
+      },
+    ]);
+
+    expect(toolParts(messages)).toMatchObject([
+      {
+        id: "tool_1_call_0",
+        toolName: "webSearch",
+        toolCallId: "call_0",
+        turn: 1,
+        state: "input-available",
+      },
+      {
+        id: "tool_call_0",
+        toolName: "webSearch",
+        toolCallId: "call_0",
+        state: "output-available",
+        output: "search results...",
+      },
+    ]);
+    expect(turnOf(toolParts(messages)[1])).toBeUndefined();
+  });
+
+  it("keeps legacy no-turn matching among unturned parts", () => {
+    const messages = reduceEvents([
+      {
+        type: "tool_call",
+        toolCall: AssistantContent.toolCall("call_0", "webSearch", {
+          query: "AAPL stock price market analysis 2025",
+        }),
+      },
+      {
+        type: "tool_result",
+        toolName: "webSearch",
+        internalCallId: "internal_search_1",
+        toolCallId: "call_0",
+        args: '{"query":"AAPL stock price market analysis 2025"}',
+        result: "search results...",
+      },
+    ]);
+
+    expect(toolParts(messages)).toMatchObject([
+      {
+        id: "tool_call_0",
+        toolName: "webSearch",
+        toolCallId: "call_0",
+        state: "output-available",
+        input: { query: "AAPL stock price market analysis 2025" },
+        output: "search results...",
+      },
+    ]);
+    expect(turnOf(toolParts(messages)[0])).toBeUndefined();
+  });
+
+  it("does not add turn metadata while replaying persisted core messages", () => {
+    const messages = coreMessagesToUIMessages([
+      Message.assistant([
+        AssistantContent.toolCall("call_0", "webSearch", {
+          query: "AAPL stock price market analysis 2025",
+        }),
+      ]),
+      Message.toolResult("call_0", "search results...", { toolName: "webSearch" }),
+    ]);
+
+    expect(toolParts(messages)).toHaveLength(1);
+    expect(turnOf(toolParts(messages)[0])).toBeUndefined();
+  });
+});
+
+function applyEvent(messages: UIMessage[], event: unknown): UIMessage[] {
+  return applyAnviaStreamEvent(messages, event) ?? messages;
+}
+
+function reduceEvents(events: unknown[]): UIMessage[] {
+  return events.reduce<UIMessage[]>((messages, event) => applyEvent(messages, event), []);
+}
+
+function toolParts(messages: UIMessage[]): UIToolPart[] {
+  return messages.flatMap((message) =>
+    message.parts.filter((part): part is UIToolPart => part.type === "tool"),
+  );
+}
+
+function partSummary(messages: UIMessage[]): unknown[] {
+  return messages.flatMap((message) =>
+    message.parts.flatMap((part): unknown[] => {
+      if (part.type === "reasoning") {
+        return [{ type: "reasoning", text: part.text }];
+      }
+      if (part.type === "tool") {
+        return [
+          {
+            id: part.id,
+            type: "tool",
+            toolName: part.toolName,
+            toolCallId: part.toolCallId,
+            ...(part.callId === undefined ? {} : { callId: part.callId }),
+            ...(turnOf(part) === undefined ? {} : { turn: turnOf(part) }),
+            state: part.state,
+            ...(part.input === undefined ? {} : { input: part.input }),
+            ...(part.output === undefined ? {} : { output: part.output }),
+          },
+        ];
+      }
+      return [];
+    }),
+  );
+}
+
+function turnOf(part: UIToolPart | undefined): unknown {
+  return part === undefined ? undefined : (part as Record<string, unknown>).turn;
+}


### PR DESCRIPTION
## Summary
- Add optional turn metadata to UI tool parts for live reducer state.
- Scope @anvia/react tool part ids and matching by turn so reused provider ids across turns do not overwrite earlier tools.
- Keep strict mixed behavior: unturned incoming tool events only match unturned existing parts, while persisted core replay remains unturned.

## Intended behavior
A single streamed assistant run can contain multiple turns that reuse provider tool ids such as call_0 or 0. The reducer should preserve each turn's tool part independently, including internal-only tool_result matching by same-turn input fallback.

## Verification
- Confirmed the new reducer tests failed before the fix on @anvia/react@0.8.3 behavior.
- pnpm --filter @anvia/react test -- test/ui-messages.test.ts
- pnpm --filter @anvia/react test -- test/transport.test.ts
- pnpm --filter @anvia/react typecheck
- pnpm --filter @anvia/core typecheck
- pnpm exec biome check packages/react/src/ui-messages.ts packages/react/test/ui-messages.test.ts packages/core/src/ui/types.ts .changeset/calm-tools-turn.md

## Notes
- No generated files changed.
- No screenshots were taken because this is reducer/type behavior covered by tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool results and calls now match more reliably during live streaming, especially when the same tool call ID appears in different turns.
  * Existing behavior for older messages without turn information remains supported.
* **New Features**
  * Tool-related message parts can now carry turn information, improving how streaming updates are associated and displayed.
* **Tests**
  * Added coverage for turn-aware tool matching, legacy matching behavior, and replaying stored messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->