### PR TITLE
Fix persisted tool result identity matching

### DIFF
--- a/.changeset/quiet-tools-replay.md
+++ b/.changeset/quiet-tools-replay.md
@@ -1,0 +1,5 @@
+---
+"@anvia/core": patch
+---
+
+Match persisted tool results by unique call ID before reused provider IDs and store tool names on new results.

--- a/packages/core/src/internal/prompt-runtime/tool-execution.ts
+++ b/packages/core/src/internal/prompt-runtime/tool-execution.ts
@@ -232,7 +232,10 @@ export class ToolCallExecutor {
         resultPayload.toolCallId = toolCall.callId;
       }
       onResult?.(resultPayload);
-      return ToolContent.toolResult(toolCall.id, output, toolCall.callId);
+      return ToolContent.toolResult(toolCall.id, output, {
+        callId: toolCall.callId,
+        toolName: toolCall.function.name,
+      });
     });
   }
 

--- a/packages/core/src/ui/messages.ts
+++ b/packages/core/src/ui/messages.ts
@@ -22,6 +22,11 @@ type UIToolPartLocation = {
   partIndex: number;
 };
 
+type UIToolPartLocations = {
+  byToolCallId: Map<string, UIToolPartLocation>;
+  byCallId: Map<string, UIToolPartLocation>;
+};
+
 type UIToolMessagePart = Extract<UIMessagePart, { type: "tool" }>;
 
 export function uiMessagesToCoreMessages(messages: UIMessage[]): CoreMessage[] {
@@ -129,8 +134,10 @@ export function uiMessagesToCoreMessages(messages: UIMessage[]): CoreMessage[] {
 
 export function coreMessagesToUIMessages(messages: CoreMessage[]): UIMessage[] {
   const uiMessages: UIMessage[] = [];
-  const toolNamesByCallKey = toolCallNameLookup(messages);
-  const toolPartsByCallKey = new Map<string, UIToolPartLocation>();
+  const toolPartLocations: UIToolPartLocations = {
+    byToolCallId: new Map(),
+    byCallId: new Map(),
+  };
 
   for (const message of messages) {
     if (message.role === "system") {
@@ -202,7 +209,7 @@ export function coreMessagesToUIMessages(messages: CoreMessage[]): UIMessage[] {
       }
       const messageIndex = uiMessages.length;
       uiMessages.push({ id: message.id ?? createId("msg"), role: "assistant", parts });
-      registerToolPartLocations(parts, messageIndex, toolPartsByCallKey);
+      registerToolPartLocations(parts, messageIndex, toolPartLocations);
       continue;
     }
 
@@ -211,7 +218,7 @@ export function coreMessagesToUIMessages(messages: CoreMessage[]): UIMessage[] {
       const part: UIToolMessagePart = {
         id: toolPartId(content.id),
         type: "tool",
-        toolName: toolNameForResult(content, toolNamesByCallKey),
+        toolName: toolNameForResult(content, uiMessages, toolPartLocations),
         toolCallId: content.id,
         state: "output-available",
         output: toolResultContentToJson(content.content),
@@ -219,7 +226,7 @@ export function coreMessagesToUIMessages(messages: CoreMessage[]): UIMessage[] {
       if (content.callId !== undefined) {
         part.callId = content.callId;
       }
-      if (mergeToolResultPart(uiMessages, toolPartsByCallKey, part)) {
+      if (mergeToolResultPart(uiMessages, toolPartLocations, part)) {
         continue;
       }
       parts.push(part);
@@ -235,32 +242,34 @@ export function coreMessagesToUIMessages(messages: CoreMessage[]): UIMessage[] {
 function registerToolPartLocations(
   parts: UIMessagePart[],
   messageIndex: number,
-  toolPartsByCallKey: Map<string, UIToolPartLocation>,
+  toolPartLocations: UIToolPartLocations,
 ): void {
   for (const [partIndex, part] of parts.entries()) {
     if (part.type !== "tool") {
       continue;
     }
     const location = { messageIndex, partIndex };
-    toolPartsByCallKey.set(part.toolCallId, location);
+    toolPartLocations.byToolCallId.set(part.toolCallId, location);
     if (part.callId !== undefined) {
-      toolPartsByCallKey.set(part.callId, location);
+      toolPartLocations.byCallId.set(part.callId, location);
     }
   }
 }
 
 function mergeToolResultPart(
   uiMessages: UIMessage[],
-  toolPartsByCallKey: Map<string, UIToolPartLocation>,
+  toolPartLocations: UIToolPartLocations,
   resultPart: UIMessagePart,
 ): boolean {
   if (resultPart.type !== "tool") {
     return false;
   }
 
-  const location =
-    toolPartsByCallKey.get(resultPart.toolCallId) ??
-    (resultPart.callId === undefined ? undefined : toolPartsByCallKey.get(resultPart.callId));
+  const location = findToolPartLocation(
+    resultPart.toolCallId,
+    resultPart.callId,
+    toolPartLocations,
+  );
   if (location === undefined) {
     return false;
   }
@@ -279,7 +288,7 @@ function mergeToolResultPart(
   };
   if (currentPart.callId === undefined && resultPart.callId !== undefined) {
     mergedPart.callId = resultPart.callId;
-    toolPartsByCallKey.set(resultPart.callId, location);
+    toolPartLocations.byCallId.set(resultPart.callId, location);
   }
 
   const nextParts = [...message.parts];
@@ -288,37 +297,32 @@ function mergeToolResultPart(
   return true;
 }
 
-function toolCallNameLookup(messages: CoreMessage[]): Map<string, string> {
-  const toolNamesByCallKey = new Map<string, string>();
-
-  for (const message of messages) {
-    if (message.role !== "assistant") {
-      continue;
-    }
-    for (const content of message.content) {
-      if (content.type !== "tool_call") {
-        continue;
-      }
-      toolNamesByCallKey.set(content.id, content.function.name);
-      if (content.callId !== undefined) {
-        toolNamesByCallKey.set(content.callId, content.function.name);
-      }
-    }
-  }
-
-  return toolNamesByCallKey;
+function findToolPartLocation(
+  toolCallId: string,
+  callId: string | undefined,
+  toolPartLocations: UIToolPartLocations,
+): UIToolPartLocation | undefined {
+  return (
+    (callId === undefined ? undefined : toolPartLocations.byCallId.get(callId)) ??
+    toolPartLocations.byToolCallId.get(toolCallId)
+  );
 }
 
 function toolNameForResult(
   content: ToolContentType,
-  toolNamesByCallKey: Map<string, string>,
+  uiMessages: UIMessage[],
+  toolPartLocations: UIToolPartLocations,
 ): string {
-  return (
-    content.toolName ??
-    toolNamesByCallKey.get(content.id) ??
-    (content.callId === undefined ? undefined : toolNamesByCallKey.get(content.callId)) ??
-    "tool"
-  );
+  if (content.toolName !== undefined) {
+    return content.toolName;
+  }
+
+  const location = findToolPartLocation(content.id, content.callId, toolPartLocations);
+  const part =
+    location === undefined
+      ? undefined
+      : uiMessages[location.messageIndex]?.parts[location.partIndex];
+  return part?.type === "tool" ? part.toolName : "tool";
 }
 
 export function isUIMessage(value: unknown): value is UIMessage {

--- a/packages/core/test/mcp.test.ts
+++ b/packages/core/test/mcp.test.ts
@@ -316,6 +316,7 @@ describe("MCP tools", () => {
         {
           type: "tool_result",
           id: "call_1",
+          toolName: "mcp_add",
           content: [{ type: "text", text: "7" }],
         },
       ]),
@@ -345,6 +346,7 @@ describe("MCP tools", () => {
         {
           type: "tool_result",
           id: "call_1",
+          toolName: "mcp_add",
           content: [{ type: "text", text: "mcp:7" }],
         },
       ]),

--- a/packages/core/test/prompt-request.test.ts
+++ b/packages/core/test/prompt-request.test.ts
@@ -147,6 +147,7 @@ describe("PromptRequest", () => {
           type: "tool_result",
           id: "call_1",
           callId: "fc_1",
+          toolName: "add",
           content: [{ type: "text", text: "7" }],
         },
       ]),
@@ -203,6 +204,7 @@ describe("PromptRequest", () => {
           type: "tool_result",
           id: "call_1",
           callId: "fc_1",
+          toolName: "add",
           content: [{ type: "text", text: "stored:7" }],
         },
       ]),
@@ -241,6 +243,7 @@ describe("PromptRequest", () => {
           type: "tool_result",
           id: "call_1",
           callId: "fc_1",
+          toolName: "computer_screenshot",
           content: structuredContent,
         },
       ]),
@@ -285,6 +288,7 @@ describe("PromptRequest", () => {
         {
           type: "tool_result",
           id: "call_1",
+          toolName: "computer_screenshot",
           content: [{ type: "text", text: "stored:screenshot" }],
         },
       ]),
@@ -330,6 +334,7 @@ describe("PromptRequest", () => {
         {
           type: "tool_result",
           id: "call_1",
+          toolName: "add",
           content: [{ type: "text", text: "7:agent:request" }],
         },
       ]),
@@ -477,6 +482,7 @@ describe("PromptRequest", () => {
         {
           type: "tool_result",
           id: "call_1",
+          toolName: "add",
           content: [{ type: "text", text: "stored:7" }],
         },
       ]),
@@ -524,6 +530,7 @@ describe("PromptRequest", () => {
         {
           type: "tool_result",
           id: "call_1",
+          toolName: "add",
           content: [{ type: "text", text: "7:agent:request:legacy" }],
         },
       ]),
@@ -549,6 +556,7 @@ describe("PromptRequest", () => {
         {
           type: "tool_result",
           id: "call_1",
+          toolName: "add",
           content: [{ type: "text", text: "7" }],
         },
       ]),
@@ -574,6 +582,7 @@ describe("PromptRequest", () => {
         {
           type: "tool_result",
           id: "call_1",
+          toolName: "add",
           content: [{ type: "text", text: "not needed" }],
         },
       ]),
@@ -708,6 +717,7 @@ describe("PromptRequest", () => {
         {
           type: "tool_result",
           id: "call_1",
+          toolName: "guarded",
           content: [{ type: "text", text: "Rejected by hook." }],
         },
       ]),
@@ -749,6 +759,7 @@ describe("PromptRequest", () => {
         {
           type: "tool_result",
           id: "call_1",
+          toolName: "guarded",
           content: [{ type: "text", text: "approved result" }],
         },
       ]),
@@ -790,6 +801,7 @@ describe("PromptRequest", () => {
         {
           type: "tool_result",
           id: "call_1",
+          toolName: "guarded",
           content: [{ type: "text", text: "Rejected by policy." }],
         },
       ]),
@@ -842,6 +854,7 @@ describe("PromptRequest", () => {
         {
           type: "tool_result",
           id: "call_1",
+          toolName: "guarded",
           content: [{ type: "text", text: "approved 250" }],
         },
       ]),
@@ -931,6 +944,7 @@ describe("PromptRequest", () => {
         {
           type: "tool_result",
           id: "call_1",
+          toolName: "guarded",
           content: [{ type: "text", text: "Rejected by policy." }],
         },
       ]),
@@ -1112,6 +1126,7 @@ describe("PromptRequest", () => {
         {
           type: "tool_result",
           id: "call_1",
+          toolName: "fail",
           content: [{ type: "text", text: "ToolCallError: tool failed" }],
         },
       ]),
@@ -1152,6 +1167,7 @@ describe("PromptRequest", () => {
         {
           type: "tool_result",
           id: "call_1",
+          toolName: "add",
           content: [{ type: "text", text: "7" }],
         },
       ]),

--- a/packages/core/test/skills.test.ts
+++ b/packages/core/test/skills.test.ts
@@ -312,6 +312,7 @@ describe("skills", () => {
         {
           type: "tool_result",
           id: "call_1",
+          toolName: "get_skill_instructions",
           content: [{ type: "text", text: "# Review\nUse direct feedback." }],
         },
       ]),
@@ -360,6 +361,7 @@ describe("skills", () => {
         {
           type: "tool_result",
           id: "call_1",
+          toolName: "get_skill_instructions",
           content: [{ type: "text", text: "# Review\nUse direct feedback." }],
         },
       ]),

--- a/packages/core/test/streaming.test.ts
+++ b/packages/core/test/streaming.test.ts
@@ -268,6 +268,7 @@ describe("PromptRequest streaming", () => {
         {
           type: "tool_result",
           id: "call_1",
+          toolName: "slow_add",
           content: [{ type: "text", text: "7" }],
         },
       ]),
@@ -424,6 +425,7 @@ describe("PromptRequest streaming", () => {
         {
           type: "tool_result",
           id: "call_1",
+          toolName: "add",
           content: [{ type: "text", text: "stored:7" }],
         },
       ]),
@@ -472,6 +474,7 @@ describe("PromptRequest streaming", () => {
         {
           type: "tool_result",
           id: "call_1",
+          toolName: "computer_screenshot",
           content: structuredContent,
         },
       ]),
@@ -576,11 +579,13 @@ describe("PromptRequest streaming", () => {
         {
           type: "tool_result",
           id: "call_slow",
+          toolName: "slow_tool",
           content: [{ type: "text", text: "slow" }],
         },
         {
           type: "tool_result",
           id: "call_fast",
+          toolName: "fast_tool",
           content: [{ type: "text", text: "fast" }],
         },
       ]),
@@ -885,6 +890,7 @@ describe("PromptRequest streaming", () => {
           type: "tool_result",
           id: "tool_0",
           callId: "call_1",
+          toolName: "add",
           content: [{ type: "text", text: "7" }],
         },
       ]),

--- a/packages/core/test/ui-stream.test.ts
+++ b/packages/core/test/ui-stream.test.ts
@@ -229,6 +229,142 @@ describe("UI message adapters", () => {
     });
   });
 
+  it("keeps persisted tools isolated when provider ids are reused across turns", () => {
+    const messages = coreMessagesToUIMessages([
+      Message.user("Run the workflow"),
+      Message.assistant([
+        AssistantContent.toolCall("tool_0", "webSearch", { query: "Anvia" }, "call_search"),
+      ]),
+      Message.toolResult("tool_0", "search-result", { callId: "call_search" }),
+      Message.assistant([
+        AssistantContent.toolCall(
+          "tool_0",
+          "exec_command",
+          { command: "mkdir", args: ["demo"] },
+          "call_exec",
+        ),
+      ]),
+      Message.toolResult("tool_0", "command-result", { callId: "call_exec" }),
+      Message.assistant([
+        AssistantContent.toolCall("tool_0", "write_file", { path: "demo/file.txt" }, "call_write"),
+      ]),
+      Message.toolResult("tool_0", "Wrote demo/file.txt", { callId: "call_write" }),
+    ]);
+
+    const toolParts = messages.flatMap((message) =>
+      message.parts.filter((part) => part.type === "tool"),
+    );
+
+    expect(toolParts).toHaveLength(3);
+    expect(toolParts).toMatchObject([
+      {
+        toolName: "webSearch",
+        toolCallId: "tool_0",
+        callId: "call_search",
+        state: "output-available",
+        input: { query: "Anvia" },
+        output: "search-result",
+      },
+      {
+        toolName: "exec_command",
+        toolCallId: "tool_0",
+        callId: "call_exec",
+        state: "output-available",
+        input: { command: "mkdir", args: ["demo"] },
+        output: "command-result",
+      },
+      {
+        toolName: "write_file",
+        toolCallId: "tool_0",
+        callId: "call_write",
+        state: "output-available",
+        input: { path: "demo/file.txt" },
+        output: "Wrote demo/file.txt",
+      },
+    ]);
+  });
+
+  it("matches reused provider ids to the nearest preceding call without callId metadata", () => {
+    const messages = coreMessagesToUIMessages([
+      Message.assistant([AssistantContent.toolCall("tool_0", "webSearch", { query: "Anvia" })]),
+      Message.toolResult("tool_0", "search-result"),
+      Message.assistant([
+        AssistantContent.toolCall("tool_0", "exec_command", { command: "mkdir" }),
+      ]),
+      Message.toolResult("tool_0", "command-result"),
+    ]);
+
+    const toolParts = messages.flatMap((message) =>
+      message.parts.filter((part) => part.type === "tool"),
+    );
+
+    expect(toolParts).toMatchObject([
+      {
+        toolName: "webSearch",
+        state: "output-available",
+        input: { query: "Anvia" },
+        output: "search-result",
+      },
+      {
+        toolName: "exec_command",
+        state: "output-available",
+        input: { command: "mkdir" },
+        output: "command-result",
+      },
+    ]);
+  });
+
+  it("prefers callId when reused provider ids have multiple pending results", () => {
+    const messages = coreMessagesToUIMessages([
+      Message.assistant([
+        AssistantContent.toolCall("tool_0", "webSearch", { query: "Anvia" }, "call_search"),
+      ]),
+      Message.assistant([
+        AssistantContent.toolCall("tool_0", "exec_command", { command: "mkdir" }, "call_exec"),
+      ]),
+      Message.toolResult("tool_0", "search-result", { callId: "call_search" }),
+      Message.toolResult("tool_0", "command-result", { callId: "call_exec" }),
+    ]);
+
+    const toolParts = messages.flatMap((message) =>
+      message.parts.filter((part) => part.type === "tool"),
+    );
+
+    expect(toolParts).toMatchObject([
+      {
+        toolName: "webSearch",
+        callId: "call_search",
+        state: "output-available",
+        output: "search-result",
+      },
+      {
+        toolName: "exec_command",
+        callId: "call_exec",
+        state: "output-available",
+        output: "command-result",
+      },
+    ]);
+  });
+
+  it("uses an explicit persisted result toolName before identity lookup", () => {
+    const messages = coreMessagesToUIMessages([
+      Message.assistant([AssistantContent.toolCall("tool_0", "legacy_name", {}, "call_1")]),
+      Message.toolResult("tool_0", "done", {
+        callId: "call_1",
+        toolName: "stored_name",
+      }),
+    ]);
+
+    expect(messages[0]?.parts[0]).toMatchObject({
+      type: "tool",
+      toolName: "stored_name",
+      toolCallId: "tool_0",
+      callId: "call_1",
+      state: "output-available",
+      output: "done",
+    });
+  });
+
   it("merges persisted tool results by provider callId", () => {
     const messages = coreMessagesToUIMessages([
       Message.assistant([


### PR DESCRIPTION
## Summary

- match persisted tool results by unique `callId` before reusable provider tool IDs
- process tool-call registrations sequentially so historical results without `callId` use the nearest preceding call
- persist `toolName` on newly executed tool results while preserving old records without it
- retain explicit persisted result names and leave React turn-scoped live matching unchanged

## Confirmed regression

Before the implementation change, the focused transcript test preserved three tool parts but renamed earlier `webSearch` and `exec_command` calls to the final `write_file` registered as `tool_0`. A delayed-result test also showed provider-ID-first matching leaving the intended call incomplete.

## Compatibility

Historical records resolve names and locations sequentially using `callId` first, then the nearest preceding provider ID, then the existing generic fallback. Newly executed results now carry `toolName`. Persisted messages do not require `turn` metadata.

## Verification

- `pnpm --filter @anvia/core test` (298 tests)
- `pnpm --filter @anvia/react test` (61 tests)
- Core memory tests (10 tests)
- memory adapter tests (55 tests)
- agent runtime and streaming tests (66 tests)
- Core and React typechecks and builds
- scoped Biome check and `git diff --check`
- `pnpm --filter www reference-check`

No visual changes; screenshots are not applicable. No generated files are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of persisted tool results when provider tool IDs are reused across turns.
  * Tool results are matched using unique call IDs when available, reducing incorrect associations.
  * Preserved tool names on newly created and persisted tool results for more reliable UI rendering.
  * Improved support for tool results with missing call metadata and multiple pending calls.

* **Tests**
  * Added coverage for reused provider IDs, call ID matching, persisted tool names, and streaming tool results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->