### PR TITLE
test: harden recent package regressions

### DIFF
--- a/packages/core/test/stream-accumulator.test.ts
+++ b/packages/core/test/stream-accumulator.test.ts
@@ -332,4 +332,145 @@ describe("CompletionStreamAccumulator", () => {
       AssistantContent.toolCall("tool_1", "lookup", { query: "x" }),
     ]);
   });
+
+  it.each([
+    ["null", null],
+    ["blank string", "  "],
+    ["empty array", []],
+    ["empty object", {}],
+  ])("uses streamed arguments when final tool arguments are %s", (_label, finalArguments) => {
+    const accumulator = new CompletionStreamAccumulator();
+    accumulator.accept({
+      type: "tool_call_delta",
+      id: "tool_1",
+      callId: "call_1",
+      name: "lookup",
+      signature: "signed",
+      argumentsDelta: '{"query":"anvia"}',
+    });
+    accumulator.accept({
+      type: "final",
+      response: {
+        choice: [AssistantContent.toolCall("tool_1", "lookup", finalArguments, "call_1")],
+        usage: Usage.empty(),
+        rawResponse: {},
+      },
+    });
+
+    expect(accumulator.response().choice).toEqual([
+      {
+        type: "tool_call",
+        id: "tool_1",
+        callId: "call_1",
+        signature: "signed",
+        function: { name: "lookup", arguments: { query: "anvia" } },
+      },
+    ]);
+  });
+
+  it.each([
+    ["false", false],
+    ["zero", 0],
+  ])("keeps meaningful scalar final tool arguments for %s", (_label, finalArguments) => {
+    const accumulator = new CompletionStreamAccumulator();
+    accumulator.accept({
+      type: "tool_call_delta",
+      id: "tool_1",
+      name: "lookup",
+      argumentsDelta: '{"query":"anvia"}',
+    });
+    accumulator.accept({
+      type: "final",
+      response: {
+        choice: [AssistantContent.toolCall("tool_1", "lookup", finalArguments)],
+        usage: Usage.empty(),
+        rawResponse: {},
+      },
+    });
+
+    expect(accumulator.response().choice).toEqual([
+      AssistantContent.toolCall("tool_1", "lookup", finalArguments),
+    ]);
+  });
+
+  it("preserves invalid partial JSON and streamed tool metadata", () => {
+    const accumulator = new CompletionStreamAccumulator();
+    accumulator.accept({
+      type: "tool_call_delta",
+      id: "tool_1",
+      callId: "call_1",
+      name: "lookup",
+      signature: "signature_1",
+      argumentsDelta: '{"query":',
+    });
+
+    expect(accumulator.response().choice).toEqual([
+      {
+        type: "tool_call",
+        id: "tool_1",
+        callId: "call_1",
+        signature: "signature_1",
+        function: { name: "lookup", arguments: '{"query":' },
+      },
+    ]);
+  });
+
+  it("preserves structured reasoning segments in their streamed order", () => {
+    const accumulator = new CompletionStreamAccumulator();
+    accumulator.accept({
+      type: "reasoning_delta",
+      id: "reasoning_1",
+      contentType: "text",
+      delta: "analysis",
+      signature: "signature_1",
+    });
+    accumulator.accept({
+      type: "reasoning_delta",
+      id: "reasoning_1",
+      contentType: "summary",
+      delta: "summary",
+    });
+    accumulator.accept({
+      type: "reasoning_delta",
+      id: "reasoning_1",
+      contentType: "encrypted",
+      delta: "ciphertext",
+    });
+    accumulator.accept({
+      type: "reasoning_delta",
+      id: "reasoning_1",
+      contentType: "redacted",
+      delta: "redacted-data",
+    });
+
+    expect(accumulator.response().choice).toEqual([
+      {
+        type: "reasoning",
+        id: "reasoning_1",
+        text: "analysissummary",
+        content: [
+          { type: "text", text: "analysis", signature: "signature_1" },
+          { type: "summary", text: "summary" },
+          { type: "encrypted", data: "ciphertext" },
+          { type: "redacted", data: "redacted-data" },
+        ],
+      },
+    ]);
+  });
+
+  it("uses a streamed message id only when the final response omits one", () => {
+    const accumulator = new CompletionStreamAccumulator();
+    accumulator.accept({ type: "message_id", id: "stream_message" });
+    accumulator.accept({ type: "text_delta", delta: "answer" });
+    accumulator.accept({
+      type: "final",
+      response: {
+        choice: [AssistantContent.text("answer")],
+        usage: Usage.empty(),
+        rawResponse: {},
+      },
+    });
+
+    expect(accumulator.response()).toMatchObject({ messageId: "stream_message" });
+  });
 });

--- a/packages/memory-drizzle/test/store.test.ts
+++ b/packages/memory-drizzle/test/store.test.ts
@@ -19,6 +19,94 @@ const assistantMessage: Message = {
   content: [{ type: "text", text: "stored" }],
 };
 
+const richMessages: Message[] = [
+  { role: "system", content: "System instructions" },
+  {
+    role: "user",
+    content: [
+      { type: "text", text: "Inspect these", signature: "user-signature" },
+      {
+        type: "image",
+        source: { type: "url", url: "https://example.test/image.png" },
+        detail: "high",
+      },
+      {
+        type: "image",
+        source: { type: "base64", data: "aW1hZ2U=", mediaType: "image/png" },
+        detail: "low",
+      },
+      {
+        type: "document",
+        source: {
+          type: "url",
+          url: "https://example.test/report.pdf",
+          mediaType: "application/pdf",
+          filename: "report.pdf",
+        },
+      },
+      {
+        type: "document",
+        source: {
+          type: "base64",
+          data: "cmVwb3J0",
+          mediaType: "application/pdf",
+          filename: "inline.pdf",
+        },
+      },
+      {
+        type: "document",
+        source: { type: "text", text: "inline document", mediaType: "text/plain" },
+      },
+    ],
+  },
+  {
+    role: "assistant",
+    id: "assistant-1",
+    content: [
+      { type: "text", text: "Working", signature: "assistant-signature" },
+      {
+        type: "reasoning",
+        id: "reasoning-1",
+        text: "analysis summary",
+        content: [
+          { type: "text", text: "analysis", signature: "reasoning-signature" },
+          { type: "summary", text: " summary" },
+          { type: "encrypted", data: "ciphertext" },
+          { type: "redacted", data: "redacted-data" },
+        ],
+      },
+      {
+        type: "tool_call",
+        id: "tool-1",
+        callId: "call-1",
+        function: { name: "lookup", arguments: { query: "Anvia", limit: 3 } },
+        signature: "tool-signature",
+        additionalParams: { provider: "test" },
+      },
+      {
+        type: "image",
+        source: { type: "base64", data: "b3V0cHV0", mediaType: "image/png" },
+        detail: "auto",
+      },
+    ],
+  },
+  {
+    role: "tool",
+    content: [
+      {
+        type: "tool_result",
+        id: "tool-1",
+        callId: "call-1",
+        toolName: "lookup",
+        content: [
+          { type: "text", text: "result" },
+          { type: "image", data: "cmVzdWx0", mediaType: "image/png" },
+        ],
+      },
+    ],
+  },
+];
+
 describe("Drizzle memory public API", () => {
   it("exports schema tables users can include in their Drizzle schema", () => {
     expect(agentMemorySessions).toBe(drizzleMemorySchema.agentMemorySessions);
@@ -50,6 +138,15 @@ describe("Drizzle memory public API", () => {
 
     await store.clear(context);
     expect(await store.load(context)).toEqual([]);
+  });
+
+  it("round-trips every supported message content shape", async () => {
+    const store = createDrizzleMemoryStore(new FakeDrizzleDb());
+    const context = { sessionId: "rich-thread", userId: "user-1" };
+
+    await store.append({ context, runId: "run-rich", turn: 0, messages: richMessages });
+
+    await expect(store.load(context)).resolves.toEqual(richMessages);
   });
 
   it("does not open a transaction for empty appends", async () => {
@@ -99,6 +196,33 @@ describe("Drizzle memory public API", () => {
 
     expect(ignoringDb.events).toEqual([]);
     expect(ignoringDb.errors).toEqual([]);
+  });
+
+  it("serializes JSON and non-JSON failed-run diagnostics", async () => {
+    const db = new FakeDrizzleDb();
+    const store = createDrizzleMemoryStore(db);
+
+    await store.recordError({
+      context: { sessionId: "thread-json" },
+      runId: "run-json",
+      error: { code: 409, retryable: false },
+      messages: richMessages,
+    });
+    await store.recordError({
+      context: { sessionId: "thread-bigint" },
+      runId: "run-bigint",
+      error: 42n,
+      messages: [],
+    });
+
+    expect(db.errors.map(({ runId, error, messages }) => ({ runId, error, messages }))).toEqual([
+      {
+        runId: "run-json",
+        error: { code: 409, retryable: false },
+        messages: richMessages,
+      },
+      { runId: "run-bigint", error: { message: "42" }, messages: [] },
+    ]);
   });
 
   it("requires db.execute for advisory locking but supports lock none without it", async () => {
@@ -179,6 +303,15 @@ describe("Drizzle memory public API", () => {
         { metadataKeys: ["tenant.id"] },
       ),
     ).toBe(JSON.stringify(["thread-1", "user-1", "tenant-1"]));
+  });
+
+  it("keeps falsey metadata values and normalizes missing scope paths to null", () => {
+    expect(
+      createDrizzleMemoryScopeKey(
+        { sessionId: "thread-1", metadata: { count: 0, enabled: false } },
+        { metadataKeys: ["count", "enabled", "missing.value"] },
+      ),
+    ).toBe(JSON.stringify(["thread-1", null, 0, false, null]));
   });
 
   it("can omit user ids from generated scope keys", () => {

--- a/packages/memory-postgres/test/store.test.ts
+++ b/packages/memory-postgres/test/store.test.ts
@@ -21,6 +21,94 @@ const assistantMessage: Message = {
   content: [{ type: "text", text: "stored" }],
 };
 
+const richMessages: Message[] = [
+  { role: "system", content: "System instructions" },
+  {
+    role: "user",
+    content: [
+      { type: "text", text: "Inspect these", signature: "user-signature" },
+      {
+        type: "image",
+        source: { type: "url", url: "https://example.test/image.png" },
+        detail: "high",
+      },
+      {
+        type: "image",
+        source: { type: "base64", data: "aW1hZ2U=", mediaType: "image/png" },
+        detail: "low",
+      },
+      {
+        type: "document",
+        source: {
+          type: "url",
+          url: "https://example.test/report.pdf",
+          mediaType: "application/pdf",
+          filename: "report.pdf",
+        },
+      },
+      {
+        type: "document",
+        source: {
+          type: "base64",
+          data: "cmVwb3J0",
+          mediaType: "application/pdf",
+          filename: "inline.pdf",
+        },
+      },
+      {
+        type: "document",
+        source: { type: "text", text: "inline document", mediaType: "text/plain" },
+      },
+    ],
+  },
+  {
+    role: "assistant",
+    id: "assistant-1",
+    content: [
+      { type: "text", text: "Working", signature: "assistant-signature" },
+      {
+        type: "reasoning",
+        id: "reasoning-1",
+        text: "analysis summary",
+        content: [
+          { type: "text", text: "analysis", signature: "reasoning-signature" },
+          { type: "summary", text: " summary" },
+          { type: "encrypted", data: "ciphertext" },
+          { type: "redacted", data: "redacted-data" },
+        ],
+      },
+      {
+        type: "tool_call",
+        id: "tool-1",
+        callId: "call-1",
+        function: { name: "lookup", arguments: { query: "Anvia", limit: 3 } },
+        signature: "tool-signature",
+        additionalParams: { provider: "test" },
+      },
+      {
+        type: "image",
+        source: { type: "base64", data: "b3V0cHV0", mediaType: "image/png" },
+        detail: "auto",
+      },
+    ],
+  },
+  {
+    role: "tool",
+    content: [
+      {
+        type: "tool_result",
+        id: "tool-1",
+        callId: "call-1",
+        toolName: "lookup",
+        content: [
+          { type: "text", text: "result" },
+          { type: "image", data: "cmVzdWx0", mediaType: "image/png" },
+        ],
+      },
+    ],
+  },
+];
+
 type FakePgCall = {
   text: string;
   values: readonly unknown[];
@@ -205,6 +293,16 @@ describe("PostgresMemoryStore", () => {
     expect(client.queries.filter((query) => query === "COMMIT")).toHaveLength(2);
   });
 
+  it("round-trips every supported message content shape", async () => {
+    const client = new FakePgClient();
+    const store = await createPostgresMemoryStore({ client, createIfMissing: false });
+    const context = { sessionId: "rich-thread", userId: "user-1" };
+
+    await store.append({ context, runId: "run-rich", turn: 0, messages: richMessages });
+
+    await expect(store.load(context)).resolves.toEqual(richMessages);
+  });
+
   it("does not open a transaction for empty appends", async () => {
     const client = new FakePgClient();
     const store = await createPostgresMemoryStore({ client, createIfMissing: false });
@@ -300,6 +398,35 @@ describe("PostgresMemoryStore", () => {
     expect(ignoringClient.errors).toEqual([]);
   });
 
+  it("serializes JSON and non-JSON failed-run diagnostics", async () => {
+    const client = new FakePgClient();
+    const store = await createPostgresMemoryStore({ client, createIfMissing: false });
+
+    await store.recordError({
+      context: { sessionId: "thread-json" },
+      runId: "run-json",
+      error: { code: 409, retryable: false },
+      messages: richMessages,
+    });
+    await store.recordError({
+      context: { sessionId: "thread-bigint" },
+      runId: "run-bigint",
+      error: 42n,
+      messages: [],
+    });
+
+    expect(client.errors.map(({ runId, error, messages }) => ({ runId, error, messages }))).toEqual(
+      [
+        {
+          runId: "run-json",
+          error: { code: 409, retryable: false },
+          messages: richMessages,
+        },
+        { runId: "run-bigint", error: { message: "42" }, messages: [] },
+      ],
+    );
+  });
+
   it("can disable advisory locking", async () => {
     const client = new FakePgClient();
     const store = await createPostgresMemoryStore({
@@ -383,6 +510,15 @@ describe("PostgresMemoryStore", () => {
         { metadataKeys: ["tenant.id"] },
       ),
     ).toBe(JSON.stringify(["thread-1", "user-1", "tenant-1"]));
+  });
+
+  it("keeps falsey metadata values and normalizes missing scope paths to null", () => {
+    expect(
+      createPostgresMemoryScopeKey(
+        { sessionId: "thread-1", metadata: { count: 0, enabled: false } },
+        { metadataKeys: ["count", "enabled", "missing.value"] },
+      ),
+    ).toBe(JSON.stringify(["thread-1", null, 0, false, null]));
   });
 
   it("can omit user ids from generated scope keys", () => {

--- a/packages/memory-prisma/test/cli.test.ts
+++ b/packages/memory-prisma/test/cli.test.ts
@@ -18,6 +18,52 @@ afterEach(async () => {
 });
 
 describe("memory-prisma init CLI", () => {
+  it.each([
+    { argv: [] },
+    { argv: ["init", "--help"] },
+    { argv: ["init", "-h"] },
+  ])("prints help without writing files for arguments $argv", async ({ argv }) => {
+    const cwd = createPrismaProject();
+    const events: Event[] = [];
+
+    const code = await runCli(argv, cwd, io(events));
+
+    expect(code).toBe(0);
+    expect(messages(events)).toContain("Usage: anvia-memory-prisma init [options]");
+    expect(existsSync(join(cwd, "prisma/models/anvia-memory.prisma"))).toBe(false);
+  });
+
+  it.each([
+    [["unknown"], "Unknown command: unknown"],
+    [["init", "--unknown"], "Unknown option: --unknown"],
+    [["init", "--schema"], "--schema requires a path"],
+    [["init", "--schema", "--write"], "--schema requires a path"],
+  ])("rejects invalid arguments %#", async (argv, expectedMessage) => {
+    const cwd = createPrismaProject();
+    const events: Event[] = [];
+
+    const code = await runCli(argv, cwd, io(events));
+
+    expect(code).toBe(1);
+    expect(messages(events)).toContain(expectedMessage);
+    expect(messages(events)).toContain("Usage: anvia-memory-prisma init [options]");
+  });
+
+  it("reports a missing explicit schema without writing files", async () => {
+    const cwd = createPrismaProject();
+    const events: Event[] = [];
+
+    const code = await runCli(
+      ["init", "--schema", "missing/schema.prisma", "--write"],
+      cwd,
+      io(events),
+    );
+
+    expect(code).toBe(1);
+    expect(messages(events)).toContain("Prisma schema not found at missing/schema.prisma");
+    expect(existsSync(join(cwd, "missing/models/anvia-memory.prisma"))).toBe(false);
+  });
+
   it("prints a dry-run plan without writing files", async () => {
     const cwd = createPrismaProject();
     const events: Event[] = [];
@@ -53,6 +99,25 @@ describe("memory-prisma init CLI", () => {
 
     expect(code).toBe(1);
     expect(messages(events)).toContain("already exists");
+  });
+
+  it("force-replaces an existing generated schema file", async () => {
+    const cwd = createPrismaProject();
+    const generatedPath = join(cwd, "prisma/models/anvia-memory.prisma");
+    await runCli(["init", "--write"], cwd, io([]));
+    writeFileSync(
+      generatedPath,
+      `${readFileSync(generatedPath, "utf8")}\n// local generated edit\n`,
+    );
+    const events: Event[] = [];
+
+    const code = await runCli(["init", "--write", "--force"], cwd, io(events));
+
+    expect(code).toBe(0);
+    const generated = readFileSync(generatedPath, "utf8");
+    expect(generated).not.toContain("// local generated edit");
+    expect(count(generated, "model AgentMemorySession")).toBe(1);
+    expect(messages(events)).toContain("Updated prisma/models/anvia-memory.prisma");
   });
 
   it("does not force-overwrite user-owned files", async () => {

--- a/packages/memory-prisma/test/store.test.ts
+++ b/packages/memory-prisma/test/store.test.ts
@@ -65,6 +65,94 @@ type CreateErrorArgs = {
   data: ErrorRow;
 };
 
+const richMessages: MessageType[] = [
+  { role: "system", content: "System instructions" },
+  {
+    role: "user",
+    content: [
+      { type: "text", text: "Inspect these", signature: "user-signature" },
+      {
+        type: "image",
+        source: { type: "url", url: "https://example.test/image.png" },
+        detail: "high",
+      },
+      {
+        type: "image",
+        source: { type: "base64", data: "aW1hZ2U=", mediaType: "image/png" },
+        detail: "low",
+      },
+      {
+        type: "document",
+        source: {
+          type: "url",
+          url: "https://example.test/report.pdf",
+          mediaType: "application/pdf",
+          filename: "report.pdf",
+        },
+      },
+      {
+        type: "document",
+        source: {
+          type: "base64",
+          data: "cmVwb3J0",
+          mediaType: "application/pdf",
+          filename: "inline.pdf",
+        },
+      },
+      {
+        type: "document",
+        source: { type: "text", text: "inline document", mediaType: "text/plain" },
+      },
+    ],
+  },
+  {
+    role: "assistant",
+    id: "assistant-1",
+    content: [
+      { type: "text", text: "Working", signature: "assistant-signature" },
+      {
+        type: "reasoning",
+        id: "reasoning-1",
+        text: "analysis summary",
+        content: [
+          { type: "text", text: "analysis", signature: "reasoning-signature" },
+          { type: "summary", text: " summary" },
+          { type: "encrypted", data: "ciphertext" },
+          { type: "redacted", data: "redacted-data" },
+        ],
+      },
+      {
+        type: "tool_call",
+        id: "tool-1",
+        callId: "call-1",
+        function: { name: "lookup", arguments: { query: "Anvia", limit: 3 } },
+        signature: "tool-signature",
+        additionalParams: { provider: "test" },
+      },
+      {
+        type: "image",
+        source: { type: "base64", data: "b3V0cHV0", mediaType: "image/png" },
+        detail: "auto",
+      },
+    ],
+  },
+  {
+    role: "tool",
+    content: [
+      {
+        type: "tool_result",
+        id: "tool-1",
+        callId: "call-1",
+        toolName: "lookup",
+        content: [
+          { type: "text", text: "result" },
+          { type: "image", data: "cmVzdWx0", mediaType: "image/png" },
+        ],
+      },
+    ],
+  },
+];
+
 class FakePrisma {
   readonly sessions = new Map<string, SessionRow>();
   readonly messages: MessageRow[] = [];
@@ -202,6 +290,16 @@ describe("PrismaMemoryStore", () => {
     ]);
   });
 
+  it("round-trips every supported message content shape", async () => {
+    const prisma = new FakePrisma();
+    const store = createPrismaMemoryStore(prisma.client);
+    const context = { sessionId: "rich-thread", userId: "user-1" };
+
+    await store.append({ context, runId: "run-rich", turn: 0, messages: richMessages });
+
+    await expect(store.load(context)).resolves.toEqual(richMessages);
+  });
+
   it("does not open a transaction for empty appends", async () => {
     const prisma = new FakePrisma();
     const store = createPrismaMemoryStore(prisma.client);
@@ -261,6 +359,35 @@ describe("PrismaMemoryStore", () => {
       error: { name: "Error", message: "boom" },
       messages: [Message.user("hi")],
     });
+  });
+
+  it("serializes JSON and non-JSON failed-run diagnostics", async () => {
+    const prisma = new FakePrisma();
+    const store = createPrismaMemoryStore(prisma.client);
+
+    await store.recordError({
+      context: { sessionId: "thread-json" },
+      runId: "run-json",
+      error: { code: 409, retryable: false },
+      messages: richMessages,
+    });
+    await store.recordError({
+      context: { sessionId: "thread-bigint" },
+      runId: "run-bigint",
+      error: 42n,
+      messages: [],
+    });
+
+    expect(prisma.errors.map(({ runId, error, messages }) => ({ runId, error, messages }))).toEqual(
+      [
+        {
+          runId: "run-json",
+          error: { code: 409, retryable: false },
+          messages: richMessages,
+        },
+        { runId: "run-bigint", error: { message: "42" }, messages: [] },
+      ],
+    );
   });
 
   it("can ignore failed-run errors", async () => {
@@ -394,6 +521,15 @@ describe("PrismaMemoryStore", () => {
         { metadataKeys: ["tenant.id"] },
       ),
     ).toBe(JSON.stringify(["thread_123", "user_456", "tenant_789"]));
+  });
+
+  it("keeps falsey metadata values and normalizes missing scope paths to null", () => {
+    expect(
+      createPrismaMemoryScopeKey(
+        { sessionId: "thread_123", metadata: { count: 0, enabled: false } },
+        { metadataKeys: ["count", "enabled", "missing.value"] },
+      ),
+    ).toBe(JSON.stringify(["thread_123", null, 0, false, null]));
   });
 
   it("can omit user ids from generated scope keys", () => {

--- a/packages/memory-sqlite/test/store.test.ts
+++ b/packages/memory-sqlite/test/store.test.ts
@@ -16,6 +16,94 @@ const assistantMessage: Message = {
   content: [{ type: "text", text: "stored" }],
 };
 
+const richMessages: Message[] = [
+  { role: "system", content: "System instructions" },
+  {
+    role: "user",
+    content: [
+      { type: "text", text: "Inspect these", signature: "user-signature" },
+      {
+        type: "image",
+        source: { type: "url", url: "https://example.test/image.png" },
+        detail: "high",
+      },
+      {
+        type: "image",
+        source: { type: "base64", data: "aW1hZ2U=", mediaType: "image/png" },
+        detail: "low",
+      },
+      {
+        type: "document",
+        source: {
+          type: "url",
+          url: "https://example.test/report.pdf",
+          mediaType: "application/pdf",
+          filename: "report.pdf",
+        },
+      },
+      {
+        type: "document",
+        source: {
+          type: "base64",
+          data: "cmVwb3J0",
+          mediaType: "application/pdf",
+          filename: "inline.pdf",
+        },
+      },
+      {
+        type: "document",
+        source: { type: "text", text: "inline document", mediaType: "text/plain" },
+      },
+    ],
+  },
+  {
+    role: "assistant",
+    id: "assistant-1",
+    content: [
+      { type: "text", text: "Working", signature: "assistant-signature" },
+      {
+        type: "reasoning",
+        id: "reasoning-1",
+        text: "analysis summary",
+        content: [
+          { type: "text", text: "analysis", signature: "reasoning-signature" },
+          { type: "summary", text: " summary" },
+          { type: "encrypted", data: "ciphertext" },
+          { type: "redacted", data: "redacted-data" },
+        ],
+      },
+      {
+        type: "tool_call",
+        id: "tool-1",
+        callId: "call-1",
+        function: { name: "lookup", arguments: { query: "Anvia", limit: 3 } },
+        signature: "tool-signature",
+        additionalParams: { provider: "test" },
+      },
+      {
+        type: "image",
+        source: { type: "base64", data: "b3V0cHV0", mediaType: "image/png" },
+        detail: "auto",
+      },
+    ],
+  },
+  {
+    role: "tool",
+    content: [
+      {
+        type: "tool_result",
+        id: "tool-1",
+        callId: "call-1",
+        toolName: "lookup",
+        content: [
+          { type: "text", text: "result" },
+          { type: "image", data: "cmVzdWx0", mediaType: "image/png" },
+        ],
+      },
+    ],
+  },
+];
+
 const tempDirs: string[] = [];
 
 afterEach(async () => {
@@ -53,6 +141,15 @@ describe("SqliteMemoryStore", () => {
     expect(await store.load(context)).toEqual([]);
   });
 
+  it("round-trips every supported message content shape", async () => {
+    const store = createSqliteMemoryStore();
+    const context = { sessionId: "rich-thread", userId: "user-1" };
+
+    await store.append({ context, runId: "run-rich", turn: 0, messages: richMessages });
+
+    await expect(store.load(context)).resolves.toEqual(richMessages);
+  });
+
   it("persists messages when reopened from the same file path", async () => {
     const path = sqlitePath();
     const context = { sessionId: "thread-1", userId: "user-1" };
@@ -78,6 +175,41 @@ describe("SqliteMemoryStore", () => {
         messages: [userMessage],
       }),
     ).resolves.toBeUndefined();
+  });
+
+  it("serializes JSON and non-JSON failed-run diagnostics", async () => {
+    const store = createSqliteMemoryStore();
+
+    await store.recordError({
+      context: { sessionId: "thread-json" },
+      runId: "run-json",
+      error: { code: 409, retryable: false },
+      messages: richMessages,
+    });
+    await store.recordError({
+      context: { sessionId: "thread-bigint" },
+      runId: "run-bigint",
+      error: 42n,
+      messages: [],
+    });
+
+    const rows = sqliteDatabase(store)
+      .prepare("SELECT run_id, error_json, messages_json FROM anvia_memory_errors ORDER BY rowid")
+      .all() as Array<{ run_id: string; error_json: string; messages_json: string }>;
+    expect(
+      rows.map((row) => ({
+        runId: row.run_id,
+        error: JSON.parse(row.error_json) as unknown,
+        messages: JSON.parse(row.messages_json) as unknown,
+      })),
+    ).toEqual([
+      {
+        runId: "run-json",
+        error: { code: 409, retryable: false },
+        messages: richMessages,
+      },
+      { runId: "run-bigint", error: { message: "42" }, messages: [] },
+    ]);
   });
 
   it("does not create sessions when failed-run diagnostics are ignored", async () => {
@@ -172,6 +304,15 @@ describe("SqliteMemoryStore", () => {
         { metadataKeys: ["tenant.id"] },
       ),
     ).toBe(JSON.stringify(["thread-1", "user-1", "tenant-1"]));
+  });
+
+  it("keeps falsey metadata values and normalizes missing scope paths to null", () => {
+    expect(
+      createSqliteMemoryScopeKey(
+        { sessionId: "thread-1", metadata: { count: 0, enabled: false } },
+        { metadataKeys: ["count", "enabled", "missing.value"] },
+      ),
+    ).toBe(JSON.stringify(["thread-1", null, 0, false, null]));
   });
 
   it("can omit user ids from generated scope keys", () => {

--- a/packages/react-ui/test/chat.test.tsx
+++ b/packages/react-ui/test/chat.test.tsx
@@ -7,10 +7,16 @@ import {
   useChat,
 } from "@anvia/react";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { Editor } from "@tiptap/core";
 import { useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { ComposerEntity, ComposerSubmitMessage, ComposerTriggerDefinition } from "../src";
+import type {
+  ComposerEntity,
+  ComposerSubmitMessage,
+  ComposerTriggerDefinition,
+  ComposerTriggerItemsArgs,
+} from "../src";
 import { ChatProvider, Composer, Thread, useComposer } from "../src";
 import { createChatController, textMessage } from "./helpers";
 
@@ -21,6 +27,14 @@ afterEach(() => {
 
 function composerEditor(): HTMLElement {
   return screen.getByLabelText("Message");
+}
+
+function composerTiptapEditor(): Editor {
+  const editor = (composerEditor() as HTMLElement & { editor?: Editor }).editor;
+  if (editor === undefined) {
+    throw new Error("Expected TipTap editor instance");
+  }
+  return editor;
 }
 
 function ComposerInputSetter({ children, value }: { children: string; value: string }) {
@@ -718,6 +732,178 @@ describe("Chat primitives", () => {
           },
         },
       });
+    });
+  });
+
+  it("filters and selects trigger entities through the TipTap editor", async () => {
+    const sendMessage = vi.fn(async () => {});
+    const trigger: ComposerTriggerDefinition = {
+      id: "people",
+      char: "@",
+      items: [
+        { id: "user_ada", label: "Ada", data: { kind: "user" } },
+        { id: "user_grace", label: "Grace", text: "@grace-hopper" },
+        { id: "user_lin", label: "Lin" },
+      ],
+    };
+
+    render(
+      <ChatProvider controller={createChatController({ sendMessage })}>
+        <Composer.Root triggers={[trigger]}>
+          <Composer.Input />
+          <Composer.TriggerMenu />
+          <ComposerStateSnapshot />
+          <Composer.Submit />
+        </Composer.Root>
+      </ChatProvider>,
+    );
+
+    act(() => {
+      composerTiptapEditor().commands.insertContent("@a");
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Ada")).toBeTruthy();
+      expect(screen.getByText("Grace")).toBeTruthy();
+    });
+    expect(screen.queryByText("Lin")).toBeNull();
+    expect(screen.getByText("Ada").getAttribute("data-selected")).toBe("");
+
+    fireEvent.keyDown(composerEditor(), { key: "ArrowDown" });
+    expect(screen.getByText("Grace").getAttribute("data-selected")).toBe("");
+    const selection = window.getSelection();
+    if (selection !== null) {
+      vi.spyOn(selection, "collapseToEnd").mockImplementation(() => {});
+    }
+    fireEvent.keyDown(composerEditor(), { key: "Enter" });
+
+    await waitFor(() => {
+      expect(composerEditor().textContent).toBe("@grace-hopper ");
+    });
+    expect(screen.getByTestId("composer-state").textContent).toBe(
+      JSON.stringify({
+        input: "@grace-hopper ",
+        attachmentIds: [],
+        entityIds: ["user_grace"],
+      }),
+    );
+
+    fireEvent.click(screen.getByText("Send"));
+    await waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledWith({
+        text: "@grace-hopper ",
+        metadata: {
+          composer: {
+            entities: [
+              {
+                id: "user_grace",
+                triggerId: "people",
+                trigger: "@",
+                label: "Grace",
+                text: "@grace-hopper",
+                range: { from: 0, to: 13 },
+              },
+            ],
+          },
+        },
+      });
+    });
+  });
+
+  it("resolves async trigger items with editor context and supports escape", async () => {
+    const itemsCompletion =
+      createDeferred<Array<{ id: string; label: string; data: { kind: string } }>>();
+    const items = vi.fn((_args: ComposerTriggerItemsArgs) => itemsCompletion.promise);
+    const trigger: ComposerTriggerDefinition = {
+      id: "projects",
+      char: "#",
+      minQueryLength: 2,
+      items,
+    };
+
+    render(
+      <ChatProvider controller={createChatController()}>
+        <Composer.Root defaultInput="Review " triggers={[trigger]}>
+          <Composer.Input />
+          <Composer.TriggerMenu data-testid="trigger-menu" />
+        </Composer.Root>
+      </ChatProvider>,
+    );
+
+    act(() => {
+      composerTiptapEditor().commands.focus("end");
+      composerTiptapEditor().commands.insertContent("#an");
+    });
+
+    await waitFor(() => {
+      expect(items).toHaveBeenCalledTimes(1);
+    });
+    expect(items.mock.calls[0]?.[0]).toMatchObject({
+      trigger,
+      query: "an",
+      input: "Review ",
+      entities: [],
+      signal: expect.any(AbortSignal),
+    });
+    expect(screen.getByTestId("trigger-menu").getAttribute("data-loading")).toBe("");
+
+    await act(async () => {
+      itemsCompletion.resolve([{ id: "project_anvia", label: "Anvia", data: { kind: "project" } }]);
+      await itemsCompletion.promise;
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Anvia")).toBeTruthy();
+      expect(screen.getByTestId("trigger-menu").getAttribute("data-loading")).toBeNull();
+    });
+
+    fireEvent.keyDown(composerEditor(), { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByTestId("trigger-menu")).toBeNull();
+    });
+  });
+
+  it("keeps disabled trigger items inert and selects enabled items with the mouse", async () => {
+    const trigger: ComposerTriggerDefinition = {
+      id: "people",
+      char: "@",
+      items: [
+        { id: "blocked", label: "Blocked", disabled: true },
+        { id: "user_ada", label: "Ada" },
+      ],
+    };
+
+    render(
+      <ChatProvider controller={createChatController()}>
+        <Composer.Root triggers={[trigger]}>
+          <Composer.Input />
+          <Composer.TriggerMenu />
+        </Composer.Root>
+      </ChatProvider>,
+    );
+
+    act(() => {
+      composerTiptapEditor().commands.insertContent("@");
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Blocked")).toBeTruthy();
+      expect(screen.getByText("Ada")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText("Blocked"));
+    expect(composerEditor().textContent).toBe("@");
+    expect(screen.getByText("Blocked").getAttribute("data-disabled")).toBe("");
+
+    fireEvent.mouseEnter(screen.getByText("Ada"));
+    expect(screen.getByText("Ada").getAttribute("data-selected")).toBe("");
+    const selection = window.getSelection();
+    if (selection !== null) {
+      vi.spyOn(selection, "collapseToEnd").mockImplementation(() => {});
+    }
+    fireEvent.click(screen.getByText("Ada"));
+
+    await waitFor(() => {
+      expect(composerEditor().textContent).toBe("@Ada ");
     });
   });
 

--- a/packages/react/test/resume.test.ts
+++ b/packages/react/test/resume.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearChatResumeState,
+  isResumableStreamEnvelope,
+  loadChatResumeState,
+  saveChatResumeState,
+} from "../src/resume";
+import type { ChatResumeOptions, ChatResumeState } from "../src/types";
+
+const state: ChatResumeState = {
+  version: 1,
+  streamId: "stream_1",
+  lastEventId: 3,
+  messages: [
+    {
+      id: "user_1",
+      role: "user",
+      parts: [{ id: "part_1", type: "text", text: "hello" }],
+    },
+  ],
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+});
+
+describe("chat resume state", () => {
+  it("round-trips session, local, and custom storage state", () => {
+    const customStorage = createStorage();
+    const options: ChatResumeOptions[] = [
+      { key: "session" },
+      { key: "local", storage: "localStorage" },
+      { key: "custom", storage: customStorage },
+    ];
+
+    for (const option of options) {
+      saveChatResumeState(option, state);
+      expect(loadChatResumeState(option)).toEqual(state);
+      clearChatResumeState(option);
+      expect(loadChatResumeState(option)).toBeUndefined();
+    }
+  });
+
+  it.each([
+    ["invalid JSON", "{"],
+    ["unsupported version", JSON.stringify({ ...state, version: 2 })],
+    ["negative cursor", JSON.stringify({ ...state, lastEventId: -1 })],
+    ["non-numeric cursor", JSON.stringify({ ...state, lastEventId: "3" })],
+    ["missing stream id", JSON.stringify({ ...state, streamId: undefined })],
+    ["malformed messages", JSON.stringify({ ...state, messages: [{ role: "user" }] })],
+  ])("ignores %s", (_label, raw) => {
+    const storage = createStorage({ "anvia:chat-resume:thread": raw });
+
+    expect(loadChatResumeState({ key: "thread", storage })).toBeUndefined();
+  });
+
+  it("treats storage as optional when the browser or storage access is unavailable", () => {
+    const throwingStorage = createStorage();
+    vi.spyOn(throwingStorage, "getItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    vi.spyOn(throwingStorage, "setItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    vi.spyOn(throwingStorage, "removeItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+
+    expect(loadChatResumeState({ key: "thread", storage: throwingStorage })).toBeUndefined();
+    expect(() =>
+      saveChatResumeState({ key: "thread", storage: throwingStorage }, state),
+    ).not.toThrow();
+    expect(() => clearChatResumeState({ key: "thread", storage: throwingStorage })).not.toThrow();
+    expect(loadChatResumeState(undefined)).toBeUndefined();
+
+    vi.stubGlobal("window", undefined);
+    expect(loadChatResumeState({ key: "thread" })).toBeUndefined();
+  });
+
+  it.each([
+    [{ type: "stream_start", streamId: "stream_1", eventId: 0 }, true],
+    [{ type: "stream_event", streamId: "stream_1", eventId: 1, event: { type: "delta" } }, true],
+    [{ type: "stream_end", streamId: "stream_1", eventId: 1, status: "completed" }, true],
+    [{ type: "stream_start", streamId: "stream_1", eventId: 1 }, false],
+    [{ type: "stream_event", streamId: "stream_1", eventId: "1", event: {} }, false],
+    [{ type: "stream_end", streamId: "stream_1", eventId: 1 }, false],
+    [null, false],
+  ])("recognizes resumable envelope shape %#", (value, expected) => {
+    expect(isResumableStreamEnvelope(value)).toBe(expected);
+  });
+});
+
+function createStorage(initial: Record<string, string> = {}): Storage {
+  const values = new Map(Object.entries(initial));
+  return {
+    get length() {
+      return values.size;
+    },
+    clear: vi.fn(() => values.clear()),
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    key: vi.fn((index: number) => [...values.keys()][index] ?? null),
+    removeItem: vi.fn((key: string) => {
+      values.delete(key);
+    }),
+    setItem: vi.fn((key: string, value: string) => {
+      values.set(key, value);
+    }),
+  };
+}

--- a/packages/react/test/transport.test.ts
+++ b/packages/react/test/transport.test.ts
@@ -442,6 +442,102 @@ describe("@anvia/react useChat", () => {
     expect(window.sessionStorage.getItem("anvia:chat-resume:thread_1")).toBeNull();
   });
 
+  it("waits for an explicit resume when auto resume is disabled", async () => {
+    window.sessionStorage.setItem(
+      "anvia:chat-resume:thread_1",
+      JSON.stringify({
+        version: 1,
+        streamId: "run_1",
+        lastEventId: 4,
+        messages: [
+          {
+            id: "user_1",
+            role: "user",
+            parts: [{ id: "part_1", type: "text", text: "hello" }],
+          },
+        ],
+      }),
+    );
+    const streamCompletion = deferred();
+    const send = vi.fn(async function* (request: UIStreamRequest) {
+      yield { type: "stream_start", streamId: "run_1", eventId: 0 } as const;
+      await streamCompletion.promise;
+      yield { type: "stream_end", streamId: "run_1", eventId: 4, status: "completed" } as const;
+      expect(request).toMatchObject({ resume: { streamId: "run_1", after: 4 } });
+    });
+    const transport: EventTransport<UIStreamRequest, ResumableStreamEnvelope<UIStreamEvent>> = {
+      send,
+    };
+    const { result } = renderHook(() =>
+      useChat({ transport, resume: { key: "thread_1", auto: false } }),
+    );
+
+    await act(async () => Promise.resolve());
+    expect(send).not.toHaveBeenCalled();
+
+    let resumePromise!: Promise<void>;
+    act(() => {
+      resumePromise = result.current.resume();
+    });
+    await vi.waitFor(() => {
+      expect(result.current.isResuming).toBe(true);
+      expect(result.current.streamId).toBe("run_1");
+    });
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(result.current.messages).toMatchObject([
+      { id: "user_1", role: "user", parts: [{ type: "text", text: "hello" }] },
+    ]);
+
+    await act(async () => {
+      streamCompletion.resolve();
+      await resumePromise;
+    });
+
+    expect(result.current.isResuming).toBe(false);
+    expect(result.current.streamId).toBeUndefined();
+    expect(window.sessionStorage.getItem("anvia:chat-resume:thread_1")).toBeNull();
+  });
+
+  it("clears an active resume cursor when a resumable chat is stopped", async () => {
+    const streamStarted = deferred();
+    const transport: EventTransport<
+      UIStreamRequest,
+      UIStreamEvent | ResumableStreamEnvelope<UIStreamEvent>
+    > = {
+      send: async function* (_request, options) {
+        yield { type: "stream_start", streamId: "run_1", eventId: 0 };
+        yield {
+          type: "stream_event",
+          streamId: "run_1",
+          eventId: 1,
+          event: {
+            type: "message_start",
+            message: { id: "assistant_1", role: "assistant", parts: [] },
+          },
+        };
+        streamStarted.resolve();
+        await new Promise<void>((resolve) => {
+          options?.signal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+      },
+    };
+    const { result } = renderHook(() => useChat({ transport, resume: { key: "thread_1" } }));
+
+    act(() => {
+      void result.current.send("hello");
+    });
+    await streamStarted.promise;
+    await vi.waitFor(() => {
+      expect(window.sessionStorage.getItem("anvia:chat-resume:thread_1")).not.toBeNull();
+    });
+
+    act(() => result.current.stop());
+
+    expect(result.current.status).toBe("idle");
+    expect(result.current.streamId).toBeUndefined();
+    expect(window.sessionStorage.getItem("anvia:chat-resume:thread_1")).toBeNull();
+  });
+
   it("ignores resume storage failures", async () => {
     const storage: Storage = {
       length: 0,
@@ -1602,4 +1698,12 @@ function streamFrom(text: string): ReadableStream<Uint8Array> {
       controller.close();
     },
   });
+}
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
 }

--- a/packages/react/test/ui-messages.test.ts
+++ b/packages/react/test/ui-messages.test.ts
@@ -252,6 +252,35 @@ describe("@anvia/react UI message reducer", () => {
     expect(turnOf(toolParts(messages)[0])).toBeUndefined();
   });
 
+  it("does not guess when same-turn input fallback is ambiguous", () => {
+    const messages = reduceEvents([
+      {
+        type: "tool_call",
+        turn: 1,
+        toolCall: AssistantContent.toolCall("tool_a", "lookup", { query: "Anvia" }),
+      },
+      {
+        type: "tool_call",
+        turn: 1,
+        toolCall: AssistantContent.toolCall("tool_b", "lookup", { query: "Anvia" }),
+      },
+      {
+        type: "tool_result",
+        turn: 1,
+        toolName: "lookup",
+        internalCallId: "internal_result",
+        args: '{"query":"Anvia"}',
+        result: "result",
+      },
+    ]);
+
+    expect(toolParts(messages)).toMatchObject([
+      { toolCallId: "tool_a", state: "input-available", input: { query: "Anvia" } },
+      { toolCallId: "tool_b", state: "input-available", input: { query: "Anvia" } },
+      { toolCallId: "internal_result", state: "output-available", output: "result" },
+    ]);
+  });
+
   it("does not add turn metadata while replaying persisted core messages", () => {
     const messages = coreMessagesToUIMessages([
       Message.assistant([
@@ -264,6 +293,100 @@ describe("@anvia/react UI message reducer", () => {
 
     expect(toolParts(messages)).toHaveLength(1);
     expect(turnOf(toolParts(messages)[0])).toBeUndefined();
+  });
+
+  it("matches live and persisted ordering when provider tool ids repeat across turns", () => {
+    const live = reduceEvents([
+      { type: "text_delta", turn: 1, delta: "Searching first." },
+      {
+        type: "tool_call",
+        turn: 1,
+        toolCall: AssistantContent.toolCall(
+          "tool_0",
+          "webSearch",
+          { query: "Anvia" },
+          "call_search",
+        ),
+      },
+      {
+        type: "tool_result",
+        turn: 1,
+        toolName: "webSearch",
+        toolCallId: "call_search",
+        internalCallId: "internal_search",
+        args: '{"query":"Anvia"}',
+        result: "search-result",
+      },
+      { type: "text_delta", turn: 2, delta: "Writing next." },
+      {
+        type: "tool_call",
+        turn: 2,
+        toolCall: AssistantContent.toolCall(
+          "tool_0",
+          "write_file",
+          { path: "report.md" },
+          "call_write",
+        ),
+      },
+      {
+        type: "tool_result",
+        turn: 2,
+        toolName: "write_file",
+        toolCallId: "call_write",
+        internalCallId: "internal_write",
+        args: '{"path":"report.md"}',
+        result: "written",
+      },
+      { type: "text_delta", turn: 2, delta: "Done." },
+    ]);
+    const persisted = coreMessagesToUIMessages([
+      Message.assistant([
+        AssistantContent.text("Searching first."),
+        AssistantContent.toolCall("tool_0", "webSearch", { query: "Anvia" }, "call_search"),
+      ]),
+      Message.toolResult("tool_0", "search-result", {
+        callId: "call_search",
+        toolName: "webSearch",
+      }),
+      Message.assistant([
+        AssistantContent.text("Writing next."),
+        AssistantContent.toolCall("tool_0", "write_file", { path: "report.md" }, "call_write"),
+      ]),
+      Message.toolResult("tool_0", "written", {
+        callId: "call_write",
+        toolName: "write_file",
+      }),
+      Message.assistant("Done."),
+    ]);
+
+    expect(semanticPartSummary(live)).toEqual(semanticPartSummary(persisted));
+    expect(partSummary(live)).toEqual([
+      { type: "text", text: "Searching first." },
+      {
+        type: "tool",
+        id: "tool_1_tool_0",
+        toolName: "webSearch",
+        toolCallId: "tool_0",
+        callId: "call_search",
+        turn: 1,
+        state: "output-available",
+        input: { query: "Anvia" },
+        output: "search-result",
+      },
+      { type: "text", text: "Writing next." },
+      {
+        type: "tool",
+        id: "tool_2_tool_0",
+        toolName: "write_file",
+        toolCallId: "tool_0",
+        callId: "call_write",
+        turn: 2,
+        state: "output-available",
+        input: { path: "report.md" },
+        output: "written",
+      },
+      { type: "text", text: "Done." },
+    ]);
   });
 });
 
@@ -284,6 +407,9 @@ function toolParts(messages: UIMessage[]): UIToolPart[] {
 function partSummary(messages: UIMessage[]): unknown[] {
   return messages.flatMap((message) =>
     message.parts.flatMap((part): unknown[] => {
+      if (part.type === "text") {
+        return [{ type: "text", text: part.text }];
+      }
       if (part.type === "reasoning") {
         return [{ type: "reasoning", text: part.text }];
       }
@@ -303,6 +429,30 @@ function partSummary(messages: UIMessage[]): unknown[] {
         ];
       }
       return [];
+    }),
+  );
+}
+
+function semanticPartSummary(messages: UIMessage[]): unknown[] {
+  return messages.flatMap((message) =>
+    message.parts.flatMap((part): unknown[] => {
+      if (part.type === "text") {
+        return [{ type: "text", text: part.text }];
+      }
+      if (part.type !== "tool") {
+        return [];
+      }
+      return [
+        {
+          type: "tool",
+          toolName: part.toolName,
+          toolCallId: part.toolCallId,
+          ...(part.callId === undefined ? {} : { callId: part.callId }),
+          state: part.state,
+          ...(part.input === undefined ? {} : { input: part.input }),
+          ...(part.output === undefined ? {} : { output: part.output }),
+        },
+      ];
     }),
   );
 }

--- a/packages/server/test/streams.test.ts
+++ b/packages/server/test/streams.test.ts
@@ -4,6 +4,7 @@ import {
   createEventStream,
   createJsonlStream,
   createMemoryResumableStreamStore,
+  createResumableStream,
   createSseStream,
   createUIStreamResponse,
   resumeStreamEvents,
@@ -183,6 +184,104 @@ describe("@anvia/server streams", () => {
     });
   });
 
+  it("enforces resumable store lifecycle boundaries", async () => {
+    const store = createMemoryResumableStreamStore<{ type: string }>();
+
+    await expect(store.status({ streamId: "missing" })).resolves.toEqual({
+      status: "missing",
+      lastEventId: 0,
+    });
+    await expect(store.append({ streamId: "missing", event: { type: "one" } })).rejects.toThrow(
+      'Resumable stream "missing" is not open',
+    );
+    await expect(store.close({ streamId: "missing", status: "error" })).resolves.toEqual({
+      status: "error",
+      lastEventId: 0,
+    });
+
+    await store.open({ streamId: "run_1" });
+    await store.append({ streamId: "run_1", event: { type: "one" } });
+    await store.close({ streamId: "run_1", status: "completed" });
+
+    await expect(store.append({ streamId: "run_1", event: { type: "two" } })).rejects.toThrow(
+      'Resumable stream "run_1" is already completed',
+    );
+  });
+
+  it("honors resume cursors for stored events and concurrent subscribers", async () => {
+    const store = createMemoryResumableStreamStore<{ type: string }>();
+    await store.open({ streamId: "run_1" });
+    await store.append({ streamId: "run_1", event: { type: "one" } });
+
+    const first = store.subscribe({ streamId: "run_1", after: 1 })[Symbol.asyncIterator]();
+    const second = store.subscribe({ streamId: "run_1", after: 0 })[Symbol.asyncIterator]();
+    await expect(nextValue(second)).resolves.toMatchObject({
+      streamId: "run_1",
+      eventId: 1,
+      event: { type: "one" },
+    });
+
+    const firstLive = nextValue(first);
+    const secondLive = nextValue(second);
+    await store.append({ streamId: "run_1", event: { type: "two" } });
+
+    const expected = {
+      streamId: "run_1",
+      eventId: 2,
+      event: { type: "two" },
+    };
+    await expect(firstLive).resolves.toMatchObject(expected);
+    await expect(secondLive).resolves.toMatchObject(expected);
+
+    await first.return?.();
+    const secondEnd = second.next();
+    await store.close({ streamId: "run_1", status: "completed" });
+    await expect(secondEnd).resolves.toEqual({ value: undefined, done: true });
+  });
+
+  it("reopening a stream resets records and closes existing subscribers", async () => {
+    const store = createMemoryResumableStreamStore<{ type: string }>();
+    await store.open({ streamId: "run_1" });
+    await store.append({ streamId: "run_1", event: { type: "old" } });
+    const oldSubscriber = store.subscribe({ streamId: "run_1", after: 1 })[Symbol.asyncIterator]();
+    const oldNext = oldSubscriber.next();
+
+    await store.open({ streamId: "run_1" });
+    await expect(oldNext).resolves.toEqual({ value: undefined, done: true });
+    await expect(store.status({ streamId: "run_1" })).resolves.toEqual({
+      status: "running",
+      lastEventId: 0,
+    });
+
+    await expect(
+      store.append({ streamId: "run_1", event: { type: "new" } }),
+    ).resolves.toMatchObject({ eventId: 1, event: { type: "new" } });
+  });
+
+  it("drains a resumable source only once for multiple consumers", async () => {
+    const store = createMemoryResumableStreamStore<{ type: string }>();
+    let sourceStarts = 0;
+    const stream = createResumableStream(
+      (async function* () {
+        sourceStarts += 1;
+        yield { type: "one" };
+        yield { type: "two" };
+      })(),
+      { id: "run_1", store },
+    );
+
+    const [first, second] = await Promise.all([collect(stream), collect(stream)]);
+
+    expect(sourceStarts).toBe(1);
+    expect(first).toEqual(second);
+    expect(first).toEqual([
+      { type: "stream_start", streamId: "run_1", eventId: 0 },
+      { type: "stream_event", streamId: "run_1", eventId: 1, event: { type: "one" } },
+      { type: "stream_event", streamId: "run_1", eventId: 2, event: { type: "two" } },
+      { type: "stream_end", streamId: "run_1", eventId: 2, status: "completed" },
+    ]);
+  });
+
   it("creates UI stream responses", async () => {
     const response = createUIStreamResponse(
       events([
@@ -309,6 +408,14 @@ async function nextValue<T>(iterator: AsyncIterator<T>): Promise<T> {
     throw new Error("Expected iterator value");
   }
   return next.value;
+}
+
+async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const values: T[] = [];
+  for await (const value of iterable) {
+    values.push(value);
+  }
+  return values;
 }
 
 async function waitFor(predicate: () => Promise<boolean>): Promise<void> {


### PR DESCRIPTION
## Summary

- Add behavior-first regression coverage for the July 8-10 package changes without modifying runtime code.
- Exercise real TipTap composer triggers, resumable chat and server stream lifecycles, tool ordering and replay identity, and all four durable memory adapters.
- Extend Prisma memory CLI coverage for argument validation, dry runs, missing schemas, and forced replacement.

## Intent and assumptions

- Preserve the current working runtime behavior; this PR changes tests only.
- Keep database tests deterministic: real temporary SQLite, existing fake Postgres, Drizzle, and Prisma clients, and no network services.
- No public APIs, dependencies, generated files, or changesets are modified.

## Verification

- pnpm check
- Typecheck passed for @anvia/core, @anvia/react, @anvia/react-ui, @anvia/server, and all four @anvia/memory-* packages.
- 547 tests passed across the eight affected packages.
- Builds passed for all eight affected packages, with @anvia/core built first.
- Server coverage passed: 94.76% statements and 92.07% branches.

## Coverage diagnostics

- React UI improved to 85.07% statements and 74.55% branches; its existing 80% global branch threshold remains unmet.
- React improved to 85.68% statements and 81.51% branches; its existing 85% global branch threshold remains unmet.
- These two coverage commands were already below their configured branch thresholds before this PR; thresholds were not changed.

## UI verification

- No screenshots required because this PR has no production UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when resuming interrupted chats and managing resumable streams.
  - Preserved streamed tool-call details, reasoning content, message identifiers, and message ordering more consistently.
  - Improved persistence of rich messages, diagnostics, and scope metadata across supported memory backends.
  - Enhanced chat trigger menus, including filtering, async loading, keyboard dismissal, and disabled-item behavior.
  - Prevented ambiguous tool results from being incorrectly matched to tool calls.

- **Tests**
  - Added broad coverage for storage, streaming, chat resume, editor interactions, and message rendering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->