### PR TITLE
Fix Composer.Input Tiptap lifecycle handling

### DIFF
--- a/.changeset/calm-editors-wait.md
+++ b/.changeset/calm-editors-wait.md
@@ -1,0 +1,5 @@
+---
+"@anvia/react-ui": patch
+---
+
+Make `Composer.Input` lifecycle-safe when trigger changes recreate its Tiptap editor.

--- a/packages/react-ui/src/chat/composer.tsx
+++ b/packages/react-ui/src/chat/composer.tsx
@@ -463,6 +463,7 @@ const ComposerInput = forwardRef<HTMLDivElement, ComposerInputProps>(function Co
           "data-anvia-composer-editor": "",
           role: "textbox",
         },
+        handleKeyDown: (_view, event) => submitComposerFromEditorKeyDown(event, composerRef),
       },
       onUpdate: ({ editor: updatedEditor }) => {
         if (!editorReadyRef.current) {
@@ -515,21 +516,6 @@ const ComposerInput = forwardRef<HTMLDivElement, ComposerInputProps>(function Co
     }
     editor.setEditable(!composerDisabled, false);
   }, [composerDisabled, editor]);
-
-  useEffect(() => {
-    if (editor === null) {
-      return;
-    }
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (submitComposerFromEditorKeyDown(event, composerRef)) {
-        event.stopPropagation();
-      }
-    };
-    editor.view.dom.addEventListener("keydown", handleKeyDown, true);
-    return () => {
-      editor.view.dom.removeEventListener("keydown", handleKeyDown, true);
-    };
-  }, [editor]);
 
   useEffect(() => {
     if (editor === null) {
@@ -822,7 +808,7 @@ function composerSuggestion(
       range: { from: number; to: number };
       props: ComposerEntityAttrs;
     }) => {
-      const nodeAfter = editor.view.state.selection.$to.nodeAfter;
+      const nodeAfter = editor.state.selection.$to.nodeAfter;
       const overrideSpace = nodeAfter?.text?.startsWith(" ");
       const insertRange = {
         from: range.from,
@@ -842,7 +828,7 @@ function composerSuggestion(
           },
         ])
         .run();
-      editor.view.dom.ownerDocument.defaultView?.getSelection()?.collapseToEnd();
+      composerEditorOwnerDocument(editor)?.defaultView?.getSelection()?.collapseToEnd();
       composerRef.current.setActiveTrigger(undefined);
     },
     render: () => ({
@@ -880,6 +866,14 @@ function resolveTriggerItems(
     entities: composer.entities,
     signal,
   });
+}
+
+function composerEditorOwnerDocument(editor: Editor): Document | undefined {
+  const element = editor.options.element;
+  if (element === null || typeof element === "function") {
+    return undefined;
+  }
+  return "mount" in element ? element.mount.ownerDocument : element.ownerDocument;
 }
 
 function updateComposerTriggerState(

--- a/packages/react-ui/test/chat.test.tsx
+++ b/packages/react-ui/test/chat.test.tsx
@@ -8,7 +8,7 @@ import {
 } from "@anvia/react";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { Editor } from "@tiptap/core";
-import { useState } from "react";
+import { StrictMode, useEffect, useMemo, useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type {
@@ -861,6 +861,178 @@ describe("Chat primitives", () => {
     await waitFor(() => {
       expect(screen.queryByTestId("trigger-menu")).toBeNull();
     });
+  });
+
+  it("handles trigger recreation and conditional remounts safely in Strict Mode", async () => {
+    const sendMessage = vi.fn(async () => {});
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const addEventListener = vi.spyOn(HTMLElement.prototype, "addEventListener");
+    const removeEventListener = vi.spyOn(HTMLElement.prototype, "removeEventListener");
+    const documentsLoaded = createDeferred<Array<{ id: string; title: string }>>();
+
+    function TriggerComposer({
+      documents,
+      visible = true,
+    }: {
+      documents: Array<{ id: string; title: string }>;
+      visible?: boolean;
+    }) {
+      const triggers = useMemo<ComposerTriggerDefinition[]>(
+        () => [
+          {
+            id: "document",
+            char: "@",
+            minQueryLength: 0,
+            allowSpaces: true,
+            items: ({ query }) =>
+              documents
+                .filter((document) => document.title.toLowerCase().includes(query.toLowerCase()))
+                .map((document) => ({
+                  id: document.id,
+                  label: document.title,
+                })),
+          },
+        ],
+        [documents],
+      );
+
+      return (
+        <ChatProvider controller={createChatController({ sendMessage })}>
+          {visible ? (
+            <Composer.Root defaultInput="hello" triggers={triggers}>
+              <Composer.Input />
+              <Composer.TriggerMenu />
+            </Composer.Root>
+          ) : null}
+        </ChatProvider>
+      );
+    }
+
+    function AsyncTriggerComposer() {
+      const [documents, setDocuments] = useState<Array<{ id: string; title: string }>>([]);
+
+      useEffect(() => {
+        let active = true;
+        void documentsLoaded.promise.then((loadedDocuments) => {
+          if (active) {
+            setDocuments(loadedDocuments);
+          }
+        });
+        return () => {
+          active = false;
+        };
+      }, []);
+
+      return <TriggerComposer documents={documents} />;
+    }
+
+    const emptyDocuments: Array<{ id: string; title: string }> = [];
+    const asyncRender = render(
+      <StrictMode>
+        <AsyncTriggerComposer />
+      </StrictMode>,
+    );
+
+    await act(async () => {
+      documentsLoaded.resolve([{ id: "document-1", title: "Example document" }]);
+      await documentsLoaded.promise;
+    });
+
+    fireEvent.keyDown(composerEditor(), { key: "Enter" });
+    await waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+    });
+    asyncRender.unmount();
+
+    const strictRender = render(
+      <StrictMode>
+        <TriggerComposer documents={emptyDocuments} />
+      </StrictMode>,
+    );
+
+    for (let revision = 2; revision <= 4; revision += 1) {
+      strictRender.rerender(
+        <StrictMode>
+          <TriggerComposer
+            documents={[{ id: `document-${revision}`, title: `Document ${revision}` }]}
+          />
+        </StrictMode>,
+      );
+    }
+
+    strictRender.rerender(
+      <StrictMode>
+        <TriggerComposer documents={emptyDocuments} visible={false} />
+      </StrictMode>,
+    );
+    strictRender.rerender(
+      <StrictMode>
+        <TriggerComposer documents={emptyDocuments} />
+      </StrictMode>,
+    );
+    strictRender.unmount();
+
+    const immediateUnmount = render(
+      <StrictMode>
+        <TriggerComposer documents={emptyDocuments} />
+      </StrictMode>,
+    );
+    immediateUnmount.unmount();
+
+    const nonStrictRender = render(<TriggerComposer documents={emptyDocuments} />);
+    nonStrictRender.rerender(
+      <TriggerComposer documents={[{ id: "document-5", title: "Document 5" }]} />,
+    );
+    nonStrictRender.unmount();
+
+    const composerEditorElements = new Set(
+      addEventListener.mock.calls.flatMap(([type], index) => {
+        const element = addEventListener.mock.contexts[index] as HTMLElement;
+        return type === "keydown" && element.hasAttribute("data-anvia-composer-editor")
+          ? [element]
+          : [];
+      }),
+    );
+    const composerEditorListenerCalls = (
+      spy: typeof addEventListener | typeof removeEventListener,
+    ) =>
+      spy.mock.calls.filter(
+        ([type], index) =>
+          type === "keydown" && composerEditorElements.has(spy.mock.contexts[index] as HTMLElement),
+      );
+
+    await waitFor(() => {
+      expect(composerEditorListenerCalls(removeEventListener)).toHaveLength(
+        composerEditorListenerCalls(addEventListener).length,
+      );
+    });
+
+    expect(
+      consoleError.mock.calls.some((args) =>
+        args.some((argument) => String(argument).includes("[tiptap error]")),
+      ),
+    ).toBe(false);
+    expect(composerEditorListenerCalls(addEventListener).length).toBeGreaterThan(0);
+    expect(
+      addEventListener.mock.calls.filter(
+        ([type, , options], index) =>
+          type === "keydown" &&
+          options === true &&
+          (addEventListener.mock.contexts[index] as HTMLElement).hasAttribute(
+            "data-anvia-composer-editor",
+          ),
+      ),
+    ).toHaveLength(0);
+    expect(
+      removeEventListener.mock.calls.filter(
+        ([type, , options], index) =>
+          type === "keydown" &&
+          options === true &&
+          (removeEventListener.mock.contexts[index] as HTMLElement).hasAttribute(
+            "data-anvia-composer-editor",
+          ),
+      ),
+    ).toHaveLength(0);
   });
 
   it("keeps disabled trigger items inert and selects enabled items with the mouse", async () => {


### PR DESCRIPTION
## Summary

- route `Composer.Input` Enter handling through ProseMirror's lifecycle-managed `handleKeyDown` hook
- remove unsafe `editor.view` and `editor.view.dom` access from the composer implementation
- add regression coverage for asynchronous trigger updates, rapid editor recreation, Strict Mode teardown, immediate unmount, conditional remount, normal-mode operation, and balanced listener cleanup
- add a patch changeset for `@anvia/react-ui`

## Root cause

`Composer.Input` rebuilds its extensions when the `triggers` array changes and passes the extension array as a `useEditor` dependency. Tiptap consequently destroys and recreates the editor. During Strict Mode lifecycle churn, Anvia's effect cleanup could retain the editor object after its ProseMirror view had already been destroyed and would read `editor.view.dom` again, causing Tiptap's view getter to throw.

The fix delegates keydown registration and teardown to ProseMirror. Trigger changes may still recreate the editor, but recreation is now safe. Stable trigger references remain a performance optimization rather than a correctness requirement.

## Verification

- `pnpm --filter @anvia/react-ui typecheck`
- `pnpm check`
- `pnpm --filter @anvia/react-ui test` — 65 tests passed
- `pnpm --filter @anvia/react-ui build`
- `git diff --check`

No visual verification was run because this is a lifecycle-only behavior fix with no intended UI changes. No generated files were changed.
