### PR TITLE
Add opt-in streamed text animation

### DIFF
--- a/.changeset/smooth-stream-display.md
+++ b/.changeset/smooth-stream-display.md
@@ -1,0 +1,6 @@
+---
+"@anvia/react": patch
+"@anvia/react-ui": patch
+---
+
+Add opt-in, reduced-motion-aware display smoothing for streamed text and Markdown without changing chat state or transport behavior.

--- a/apps/www/src/content/docs/packages/react-ui/reference.md
+++ b/apps/www/src/content/docs/packages/react-ui/reference.md
@@ -157,6 +157,23 @@ const ThreadListItem: {
 };
 ```
 
+## Streamed text animation
+
+`Message.Text` and `Message.Markdown` accept these optional display props:
+
+```ts
+type MessageStreamAnimationProps = {
+  animate?: boolean;
+  animationMode?: "none" | "smooth" | "fadeIn";
+  isStreaming?: boolean;
+  smoothingPreset?: "realtime" | "balanced" | "silky";
+  reducedMotion?: boolean;
+};
+```
+
+Animation is disabled by default. When enabled, these renderers pass their existing text through
+`useSmoothStreamText`; the underlying `useChat` controller and `UIMessage[]` remain unchanged.
+
 ## Providers
 
 ```ts

--- a/apps/www/src/content/docs/packages/react/reference.md
+++ b/apps/www/src/content/docs/packages/react/reference.md
@@ -423,6 +423,39 @@ Passing `resume: { key }` stores the active `streamId`, last event cursor, and c
 continues tailing live events until `stream_end`. Custom `createRequest` callbacks receive
 `args.resume` and should forward it when using resumable server routes.
 
+## useSmoothStreamText
+
+```ts
+type StreamAnimationMode = "none" | "smooth" | "fadeIn";
+type StreamSmoothingPreset = "realtime" | "balanced" | "silky";
+
+type UseSmoothStreamTextOptions = {
+  enabled?: boolean;
+  mode?: StreamAnimationMode;
+  isStreaming?: boolean;
+  preset?: StreamSmoothingPreset;
+  reducedMotion?: boolean;
+  largeAppendChars?: number;
+};
+
+type UseSmoothStreamTextResult = {
+  text: string;
+  isAnimating: boolean;
+  flush(): void;
+  reset(nextText?: string): void;
+};
+
+function useSmoothStreamText(
+  content: string,
+  options?: UseSmoothStreamTextOptions,
+): UseSmoothStreamTextResult;
+```
+
+Purpose: progressively reveal append-only display text with `requestAnimationFrame`. It does not
+consume transport events, update `UIMessage[]`, or replace `useChat`. Replacement text, large
+appends over the default 500-character threshold, disabled animation, stopped streaming, and
+reduced motion synchronize immediately.
+
 ## useCompletion
 
 ```ts

--- a/apps/www/src/content/docs/react-ui/messages.mdx
+++ b/apps/www/src/content/docs/react-ui/messages.mdx
@@ -106,6 +106,35 @@ Use `Message.Markdown` when assistant text should render GitHub-flavored Markdow
 
 <CodeVariants id="messages-markdown" variants={markdownVariants} />
 
+### Opt-in streaming animation
+
+`useChat(...)` continues to own the real message state. Enable display smoothing only on the latest
+assistant message while its response is streaming:
+
+```tsx
+<Thread.Messages>
+  {(message) => (
+    <Message.Root>
+      <Message.Content>
+        <Message.Markdown
+          animate
+          isStreaming={
+            chat.status === "streaming" &&
+            message.role === "assistant" &&
+            chat.messages.at(-1)?.id === message.id
+          }
+          animationMode="smooth"
+          smoothingPreset="balanced"
+        />
+      </Message.Content>
+    </Message.Root>
+  )}
+</Thread.Messages>
+```
+
+Use `animationMode="fadeIn"` to combine the same progressive reveal with the optional stylesheet's
+entry fade. Reduced-motion preferences and non-streaming content display immediately.
+
 ## Filtering parts
 
 `Message.Parts` accepts `filter` when a surface should hide reasoning, show only pending tools, or

--- a/packages/react-ui/README.md
+++ b/packages/react-ui/README.md
@@ -59,3 +59,19 @@ wrappers are useful for layout.
 support inline `@`, `/`, `$`, or other entity chips; selected entities are submitted under
 `metadata.composer.entities`. Use `Composer.TextareaInput` when you need the previous native
 textarea behavior.
+
+Streaming text animation is opt-in and display-only. Keep `useChat` as the owner of transport and
+`UIMessage[]` state, then enable smoothing on the latest streaming assistant message:
+
+```tsx
+<Message.Markdown
+  animate
+  isStreaming={
+    chat.status === "streaming" &&
+    message.role === "assistant" &&
+    chat.messages.at(-1)?.id === message.id
+  }
+  animationMode="smooth"
+  smoothingPreset="balanced"
+/>
+```

--- a/packages/react-ui/src/message/parts.tsx
+++ b/packages/react-ui/src/message/parts.tsx
@@ -1,4 +1,10 @@
-import type { UIAttachment, UIMessagePart } from "@anvia/react";
+import {
+  type StreamAnimationMode,
+  type StreamSmoothingPreset,
+  type UIAttachment,
+  type UIMessagePart,
+  useSmoothStreamText,
+} from "@anvia/react";
 import { type ComponentPropsWithoutRef, forwardRef, type ReactNode } from "react";
 import ReactMarkdown, {
   type Components,
@@ -24,6 +30,14 @@ type MessageToolChildren = ReactNode | ((part: MessageToolPart) => ReactNode);
 export type MessageToolRenderWhen = "always" | "pending" | "settled";
 export type MessageAttachmentPart = Extract<UIMessagePart, { type: "attachment" }>;
 type MessageAttachmentChildren = ReactNode | ((attachment: UIAttachment) => ReactNode);
+
+type MessageStreamAnimationProps = {
+  animate?: boolean;
+  animationMode?: StreamAnimationMode;
+  isStreaming?: boolean;
+  smoothingPreset?: StreamSmoothingPreset;
+  reducedMotion?: boolean;
+};
 
 type MessagePartsProps = Omit<PrimitiveProps<"div">, "children"> & {
   children?: MessagePartChildren;
@@ -76,33 +90,71 @@ const MessagePart = forwardRef<HTMLDivElement, MessagePartProps>(function Messag
   );
 });
 
-const MessageText = forwardRef<HTMLSpanElement, PrimitiveProps<"span">>(
-  function MessageText(props, ref) {
-    const { part } = useMessagePart();
-    if (part.type !== "text") {
-      return null;
-    }
+type MessageTextProps = PrimitiveProps<"span"> & MessageStreamAnimationProps;
+
+const MessageText = forwardRef<HTMLSpanElement, MessageTextProps>(function MessageText(props, ref) {
+  const { part } = useMessagePart();
+  if (part.type !== "text") {
+    return null;
+  }
+
+  return <MessageTextContent {...props} content={part.text} ref={ref} />;
+});
+
+type MessageTextContentProps = MessageTextProps & {
+  content: string;
+};
+
+const MessageTextContent = forwardRef<HTMLSpanElement, MessageTextContentProps>(
+  function MessageTextContent(
+    {
+      animate = false,
+      animationMode = "smooth",
+      isStreaming,
+      smoothingPreset,
+      reducedMotion,
+      content,
+      ...props
+    },
+    ref,
+  ) {
+    const animationEnabled = animate && props.children === undefined;
+    const smooth = useSmoothStreamText(content, {
+      enabled: animationEnabled,
+      mode: animationMode,
+      ...(isStreaming === undefined ? {} : { isStreaming }),
+      ...(smoothingPreset === undefined ? {} : { preset: smoothingPreset }),
+      ...(reducedMotion === undefined ? {} : { reducedMotion }),
+    });
+    const animationActive =
+      animationEnabled &&
+      animationMode !== "none" &&
+      isStreaming !== false &&
+      reducedMotion !== true;
 
     return renderPrimitive(
       "span",
       {
         ...props,
-        children: props.children ?? part.text,
+        children: props.children ?? (animationEnabled ? smooth.text : content),
         "data-anvia-text": "",
+        "data-anvia-stream-animation": animationEnabled ? animationMode : undefined,
+        "data-streaming": animationActive ? "" : undefined,
       } as PrimitiveProps<"span">,
       ref,
     );
   },
 );
 
-type MessageMarkdownProps = Omit<PrimitiveProps<"div">, "children"> & {
-  children?: string;
-  components?: Components;
-  remarkPlugins?: ReactMarkdownOptions["remarkPlugins"];
-};
+type MessageMarkdownProps = Omit<PrimitiveProps<"div">, "children"> &
+  MessageStreamAnimationProps & {
+    children?: string;
+    components?: Components;
+    remarkPlugins?: ReactMarkdownOptions["remarkPlugins"];
+  };
 
 const MessageMarkdown = forwardRef<HTMLDivElement, MessageMarkdownProps>(function MessageMarkdown(
-  { children, components, remarkPlugins, ...props },
+  { children, ...props },
   ref,
 ) {
   const { message } = useMessage();
@@ -118,23 +170,58 @@ const MessageMarkdown = forwardRef<HTMLDivElement, MessageMarkdownProps>(functio
       ? part.text
       : message.parts.flatMap((item) => (item.type === "text" ? [item.text] : [])).join("\n\n"));
 
-  return renderPrimitive(
-    "div",
-    {
-      ...props,
-      children: (
-        <ReactMarkdown
-          components={{ code: defaultCodeComponent, pre: defaultPreComponent, ...components }}
-          remarkPlugins={remarkPlugins ?? [remarkGfm]}
-        >
-          {markdown}
-        </ReactMarkdown>
-      ),
-      "data-anvia-markdown": "",
-    } as PrimitiveProps<"div">,
-    ref,
-  );
+  return <MessageMarkdownContent {...props} markdown={markdown} ref={ref} />;
 });
+
+type MessageMarkdownContentProps = Omit<MessageMarkdownProps, "children"> & {
+  markdown: string;
+};
+
+const MessageMarkdownContent = forwardRef<HTMLDivElement, MessageMarkdownContentProps>(
+  function MessageMarkdownContent(
+    {
+      animate = false,
+      animationMode = "smooth",
+      isStreaming,
+      smoothingPreset,
+      reducedMotion,
+      components,
+      remarkPlugins,
+      markdown,
+      ...props
+    },
+    ref,
+  ) {
+    const smooth = useSmoothStreamText(markdown, {
+      enabled: animate,
+      mode: animationMode,
+      ...(isStreaming === undefined ? {} : { isStreaming }),
+      ...(smoothingPreset === undefined ? {} : { preset: smoothingPreset }),
+      ...(reducedMotion === undefined ? {} : { reducedMotion }),
+    });
+    const animationActive =
+      animate && animationMode !== "none" && isStreaming !== false && reducedMotion !== true;
+
+    return renderPrimitive(
+      "div",
+      {
+        ...props,
+        children: (
+          <ReactMarkdown
+            components={{ code: defaultCodeComponent, pre: defaultPreComponent, ...components }}
+            remarkPlugins={remarkPlugins ?? [remarkGfm]}
+          >
+            {animate ? smooth.text : markdown}
+          </ReactMarkdown>
+        ),
+        "data-anvia-markdown": "",
+        "data-anvia-stream-animation": animate ? animationMode : undefined,
+        "data-streaming": animationActive ? "" : undefined,
+      } as PrimitiveProps<"div">,
+      ref,
+    );
+  },
+);
 
 type MessageCodeBlockProps = Omit<PrimitiveProps<"pre">, "children"> & {
   children?: ReactNode;

--- a/packages/react-ui/src/styles.css
+++ b/packages/react-ui/src/styles.css
@@ -87,3 +87,23 @@
 [data-state="disabled"] {
   opacity: 0.55;
 }
+
+@keyframes anvia-stream-fade-in {
+  from {
+    opacity: 0.35;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+[data-anvia-stream-animation="fadeIn"][data-streaming] {
+  animation: anvia-stream-fade-in 180ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-anvia-stream-animation="fadeIn"][data-streaming] {
+    animation: none;
+  }
+}

--- a/packages/react-ui/test/message.test.tsx
+++ b/packages/react-ui/test/message.test.tsx
@@ -1,5 +1,6 @@
 import type { UIMessage } from "@anvia/react";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ComponentProps, ReactElement } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ChatProvider, Message, Thread } from "../src";
@@ -9,6 +10,8 @@ const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
   if (originalClipboardDescriptor === undefined) {
     Reflect.deleteProperty(navigator, "clipboard");
   } else {
@@ -72,6 +75,54 @@ describe("Message primitives", () => {
     expect(screen.getByText("photo.png")).toBeTruthy();
     expect(screen.getByText(/"count": 2/)).toBeTruthy();
     expect(screen.getByText("Nope")).toBeTruthy();
+  });
+
+  it("keeps Message.Text rendering immediate by default", () => {
+    const raf = installAnimationFrame();
+    const { container, rerender } = render(textView("Hello"));
+
+    rerender(textView("Hello world"));
+
+    const text = container.querySelector("[data-anvia-text]");
+    expect(text?.textContent).toBe("Hello world");
+    expect(text?.hasAttribute("data-anvia-stream-animation")).toBe(false);
+    expect(raf.request).not.toHaveBeenCalled();
+  });
+
+  it("uses smoothed text when Message.Text animation is enabled", () => {
+    const raf = installAnimationFrame();
+    const props = { animate: true, isStreaming: true, reducedMotion: false };
+    const { container, rerender } = render(textView("Hello", props));
+
+    rerender(textView("Hello world", props));
+
+    const text = container.querySelector("[data-anvia-text]");
+    expect(text?.textContent).toBe("Hello");
+    expect(text?.getAttribute("data-anvia-stream-animation")).toBe("smooth");
+
+    actAnimationFrame(raf);
+
+    expect(text?.textContent).not.toBe("Hello world");
+    expect(text?.textContent?.startsWith("Hello")).toBe(true);
+
+    drainAnimationFrames(raf);
+    expect(text?.textContent).toBe("Hello world");
+  });
+
+  it("preserves custom Message.Text children when animation is enabled", () => {
+    const raf = installAnimationFrame();
+    const props = {
+      animate: true,
+      children: "Custom content",
+      isStreaming: true,
+      reducedMotion: false,
+    };
+    const { container, rerender } = render(textView("Hello", props));
+
+    rerender(textView("Hello world", props));
+
+    expect(container.querySelector("[data-anvia-text]")?.textContent).toBe("Custom content");
+    expect(raf.request).not.toHaveBeenCalled();
   });
 
   it("supports custom tool rendering with input and output in one component", () => {
@@ -269,6 +320,57 @@ describe("Message primitives", () => {
     expect(screen.getAllByTestId("custom-code")).toHaveLength(2);
   });
 
+  it("keeps Message.Markdown rendering immediate by default", () => {
+    const raf = installAnimationFrame();
+    const { container, rerender } = render(markdownView("Hello"));
+
+    rerender(markdownView("Hello **world**"));
+
+    const markdown = container.querySelector("[data-anvia-markdown]");
+    expect(markdown?.textContent).toBe("Hello world");
+    expect(markdown?.querySelector("strong")?.textContent).toBe("world");
+    expect(markdown?.hasAttribute("data-anvia-stream-animation")).toBe(false);
+    expect(raf.request).not.toHaveBeenCalled();
+  });
+
+  it("uses smoothed markdown text and fade-in attributes when enabled", () => {
+    const raf = installAnimationFrame();
+    const props = {
+      animate: true,
+      animationMode: "fadeIn" as const,
+      isStreaming: true,
+      reducedMotion: false,
+    };
+    const { container, rerender } = render(markdownView("Hello", props));
+
+    rerender(markdownView("Hello **world**", props));
+
+    const markdown = container.querySelector("[data-anvia-markdown]");
+    expect(markdown?.textContent).toBe("Hello");
+    expect(markdown?.getAttribute("data-anvia-stream-animation")).toBe("fadeIn");
+    expect(markdown?.hasAttribute("data-streaming")).toBe(true);
+
+    actAnimationFrame(raf);
+    expect(markdown?.textContent).not.toBe("Hello world");
+
+    drainAnimationFrames(raf);
+    expect(markdown?.textContent).toBe("Hello world");
+    expect(markdown?.querySelector("strong")?.textContent).toBe("world");
+  });
+
+  it("preserves code block behavior after animated markdown completes", () => {
+    const raf = installAnimationFrame();
+    const props = { animate: true, isStreaming: true, reducedMotion: false };
+    const { container, rerender } = render(markdownView("Code:\n\n", props));
+
+    rerender(markdownView("Code:\n\n```ts\nconst ok = true;\n```", props));
+    drainAnimationFrames(raf);
+
+    expect(container.querySelectorAll("[data-anvia-code-block]")).toHaveLength(1);
+    expect(container.querySelector("[data-anvia-code-block] pre")).toBeNull();
+    expect(screen.getByText("const ok = true;")).toBeTruthy();
+  });
+
   it("renders default markdown code blocks without nested pre elements", () => {
     const messages = [textMessage("assistant_1", "assistant", "```ts\nconst ok = true;\n```")];
 
@@ -423,3 +525,88 @@ describe("Message primitives", () => {
     expect(regenerate).toHaveBeenCalledTimes(1);
   });
 });
+
+type AnimationFrameHarness = ReturnType<typeof installAnimationFrame>;
+
+function textView(text: string, props: ComponentProps<typeof Message.Text> = {}): ReactElement {
+  return (
+    <ChatProvider
+      controller={createChatController({ messages: [textMessage("msg_1", "assistant", text)] })}
+    >
+      <Thread.Root>
+        <Thread.Messages>
+          <Message.Root>
+            <Message.Content>
+              <Message.Parts>
+                <Message.Part>
+                  <Message.Text {...props} />
+                </Message.Part>
+              </Message.Parts>
+            </Message.Content>
+          </Message.Root>
+        </Thread.Messages>
+      </Thread.Root>
+    </ChatProvider>
+  );
+}
+
+function markdownView(
+  markdown: string,
+  props: ComponentProps<typeof Message.Markdown> = {},
+): ReactElement {
+  return (
+    <ChatProvider
+      controller={createChatController({
+        messages: [textMessage("msg_1", "assistant", markdown)],
+      })}
+    >
+      <Thread.Root>
+        <Thread.Messages>
+          <Message.Root>
+            <Message.Markdown {...props} />
+          </Message.Root>
+        </Thread.Messages>
+      </Thread.Root>
+    </ChatProvider>
+  );
+}
+
+function installAnimationFrame() {
+  let nextId = 0;
+  const callbacks = new Map<number, FrameRequestCallback>();
+  const request = vi.fn((callback: FrameRequestCallback) => {
+    const id = ++nextId;
+    callbacks.set(id, callback);
+    return id;
+  });
+  const cancel = vi.fn((id: number) => {
+    callbacks.delete(id);
+  });
+
+  vi.stubGlobal("requestAnimationFrame", request);
+  vi.stubGlobal("cancelAnimationFrame", cancel);
+
+  return {
+    cancel,
+    pending: () => callbacks.size,
+    request,
+    step() {
+      const pending = [...callbacks.values()];
+      callbacks.clear();
+      for (const callback of pending) {
+        callback(0);
+      }
+    },
+  };
+}
+
+function actAnimationFrame(raf: AnimationFrameHarness): void {
+  act(() => raf.step());
+}
+
+function drainAnimationFrames(raf: AnimationFrameHarness): void {
+  for (let frame = 0; frame < 100 && raf.pending() > 0; frame += 1) {
+    actAnimationFrame(raf);
+  }
+  expect(raf.pending()).toBe(0);
+}

--- a/packages/react-ui/vitest.config.ts
+++ b/packages/react-ui/vitest.config.ts
@@ -3,6 +3,11 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   resolve: {
     alias: {
+      "@anvia/core/completion": new URL("../core/src/completion/index.ts", import.meta.url)
+        .pathname,
+      "@anvia/core/request": new URL("../core/src/request/index.ts", import.meta.url).pathname,
+      "@anvia/core/ui": new URL("../core/src/ui/index.ts", import.meta.url).pathname,
+      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
       "@anvia/react": new URL("../react/src/index.ts", import.meta.url).pathname,
     },
   },

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -44,6 +44,7 @@ export function Chat() {
 - `createChatTransport(options)` creates the default fetch-backed chat transport.
 - `useChat(options)` manages `UIMessage[]` chat state from any `EventTransport`, including optional human-input approval/question state and opt-in stream resume.
 - `useCompletion(options)` appends completion turns into `UIMessage[]` state and exposes derived `completion` text.
+- `useSmoothStreamText(content, options)` smooths an append-only string for display without changing stream events or message state.
 
 Default hook requests use one shared wire shape:
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -54,3 +54,10 @@ export type {
   UseCompletionStatus,
 } from "./use-completion";
 export { useCompletion } from "./use-completion";
+export type {
+  StreamAnimationMode,
+  StreamSmoothingPreset,
+  UseSmoothStreamTextOptions,
+  UseSmoothStreamTextResult,
+} from "./use-smooth-stream-text";
+export { useSmoothStreamText } from "./use-smooth-stream-text";

--- a/packages/react/src/use-smooth-stream-text.ts
+++ b/packages/react/src/use-smooth-stream-text.ts
@@ -159,8 +159,7 @@ export function useSmoothStreamText(
       return;
     }
 
-    const appendedLength = [...content.slice(previousTarget.length)].length;
-    if (appendedLength > largeAppendChars) {
+    if (exceedsCharacterLimit(content.slice(previousTarget.length), largeAppendChars)) {
       syncToTarget();
       return;
     }
@@ -224,4 +223,15 @@ function useSystemReducedMotion(override: boolean | undefined, observe: boolean)
   }, [observe, override]);
 
   return reducedMotion;
+}
+
+function exceedsCharacterLimit(value: string, limit: number): boolean {
+  let count = 0;
+  for (const _character of value) {
+    count += 1;
+    if (count > limit) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/packages/react/src/use-smooth-stream-text.ts
+++ b/packages/react/src/use-smooth-stream-text.ts
@@ -1,0 +1,227 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+
+export type StreamAnimationMode = "none" | "smooth" | "fadeIn";
+
+export type StreamSmoothingPreset = "realtime" | "balanced" | "silky";
+
+export type UseSmoothStreamTextOptions = {
+  enabled?: boolean;
+  mode?: StreamAnimationMode;
+  isStreaming?: boolean;
+  preset?: StreamSmoothingPreset;
+  reducedMotion?: boolean;
+  largeAppendChars?: number;
+};
+
+export type UseSmoothStreamTextResult = {
+  text: string;
+  isAnimating: boolean;
+  flush(): void;
+  reset(nextText?: string): void;
+};
+
+type SmoothingConfig = {
+  fraction: number;
+  maxChars: number;
+};
+
+const DEFAULT_LARGE_APPEND_CHARS = 500;
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
+const smoothingConfigs: Record<StreamSmoothingPreset, SmoothingConfig> = {
+  realtime: { fraction: 0.5, maxChars: 24 },
+  balanced: { fraction: 0.25, maxChars: 12 },
+  silky: { fraction: 0.125, maxChars: 6 },
+};
+
+export function useSmoothStreamText(
+  content: string,
+  options: UseSmoothStreamTextOptions = {},
+): UseSmoothStreamTextResult {
+  const enabled = options.enabled ?? true;
+  const mode = options.mode ?? "smooth";
+  const preset = options.preset ?? "balanced";
+  const largeAppendChars = options.largeAppendChars ?? DEFAULT_LARGE_APPEND_CHARS;
+  const observeReducedMotion = enabled && mode !== "none" && options.isStreaming !== false;
+  const systemReducedMotion = useSystemReducedMotion(options.reducedMotion, observeReducedMotion);
+  const reducedMotion = options.reducedMotion ?? systemReducedMotion;
+  const shouldAnimate =
+    enabled && mode !== "none" && options.isStreaming !== false && !reducedMotion;
+
+  const [text, setText] = useState(content);
+  const [isAnimating, setIsAnimating] = useState(false);
+  const targetRef = useRef(content);
+  const targetCharactersRef = useRef([...content]);
+  const displayedLengthRef = useRef(targetCharactersRef.current.length);
+  const frameRef = useRef<number | undefined>(undefined);
+  const mountedRef = useRef(true);
+  const shouldAnimateRef = useRef(shouldAnimate);
+  const presetRef = useRef(preset);
+
+  shouldAnimateRef.current = shouldAnimate;
+  presetRef.current = preset;
+
+  const cancelFrame = useCallback(() => {
+    const frame = frameRef.current;
+    frameRef.current = undefined;
+    if (
+      frame !== undefined &&
+      typeof window !== "undefined" &&
+      typeof window.cancelAnimationFrame === "function"
+    ) {
+      window.cancelAnimationFrame(frame);
+    }
+  }, []);
+
+  const syncToTarget = useCallback(() => {
+    cancelFrame();
+    displayedLengthRef.current = targetCharactersRef.current.length;
+    setText(targetRef.current);
+    setIsAnimating(false);
+  }, [cancelFrame]);
+
+  const scheduleFrame = useCallback(
+    function scheduleFrame() {
+      if (frameRef.current !== undefined || !mountedRef.current) {
+        return;
+      }
+      if (!shouldAnimateRef.current) {
+        syncToTarget();
+        return;
+      }
+      if (typeof window === "undefined" || typeof window.requestAnimationFrame !== "function") {
+        syncToTarget();
+        return;
+      }
+
+      setIsAnimating(true);
+      frameRef.current = window.requestAnimationFrame(() => {
+        frameRef.current = undefined;
+        if (!mountedRef.current) {
+          return;
+        }
+        if (!shouldAnimateRef.current) {
+          syncToTarget();
+          return;
+        }
+
+        const targetCharacters = targetCharactersRef.current;
+        const remaining = targetCharacters.length - displayedLengthRef.current;
+        if (remaining <= 0) {
+          setIsAnimating(false);
+          return;
+        }
+
+        const config = smoothingConfigs[presetRef.current];
+        const revealCount = Math.min(
+          config.maxChars,
+          Math.max(1, Math.ceil(remaining * config.fraction)),
+        );
+        const nextLength = Math.min(
+          targetCharacters.length,
+          displayedLengthRef.current + revealCount,
+        );
+
+        displayedLengthRef.current = nextLength;
+        setText(targetCharacters.slice(0, nextLength).join(""));
+
+        if (nextLength < targetCharacters.length) {
+          scheduleFrame();
+        } else {
+          setIsAnimating(false);
+        }
+      });
+    },
+    [syncToTarget],
+  );
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      cancelFrame();
+    };
+  }, [cancelFrame]);
+
+  useIsomorphicLayoutEffect(() => {
+    const previousTarget = targetRef.current;
+    const targetCharacters = [...content];
+    targetRef.current = content;
+    targetCharactersRef.current = targetCharacters;
+
+    if (!shouldAnimate) {
+      syncToTarget();
+      return;
+    }
+
+    if (!content.startsWith(previousTarget)) {
+      syncToTarget();
+      return;
+    }
+
+    const appendedLength = [...content.slice(previousTarget.length)].length;
+    if (appendedLength > largeAppendChars) {
+      syncToTarget();
+      return;
+    }
+
+    if (displayedLengthRef.current < targetCharacters.length) {
+      scheduleFrame();
+    }
+  }, [content, largeAppendChars, scheduleFrame, shouldAnimate, syncToTarget]);
+
+  const flush = useCallback(() => {
+    syncToTarget();
+  }, [syncToTarget]);
+
+  const reset = useCallback(
+    (nextText = "") => {
+      cancelFrame();
+      const nextCharacters = [...nextText];
+      targetRef.current = nextText;
+      targetCharactersRef.current = nextCharacters;
+      displayedLengthRef.current = nextCharacters.length;
+      setText(nextText);
+      setIsAnimating(false);
+    },
+    [cancelFrame],
+  );
+
+  return { text, isAnimating, flush, reset };
+}
+
+function useSystemReducedMotion(override: boolean | undefined, observe: boolean): boolean {
+  const [reducedMotion, setReducedMotion] = useState(false);
+
+  useEffect(() => {
+    if (
+      !observe ||
+      override !== undefined ||
+      typeof window === "undefined" ||
+      typeof window.matchMedia !== "function"
+    ) {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
+    const update = () => {
+      setReducedMotion(mediaQuery.matches);
+    };
+
+    update();
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", update);
+    } else {
+      mediaQuery.addListener(update);
+    }
+    return () => {
+      if (typeof mediaQuery.removeEventListener === "function") {
+        mediaQuery.removeEventListener("change", update);
+      } else {
+        mediaQuery.removeListener(update);
+      }
+    };
+  }, [observe, override]);
+
+  return reducedMotion;
+}

--- a/packages/react/test/use-smooth-stream-text.test.ts
+++ b/packages/react/test/use-smooth-stream-text.test.ts
@@ -137,6 +137,20 @@ describe("@anvia/react useSmoothStreamText", () => {
     expect(raf.request).not.toHaveBeenCalled();
   });
 
+  it("counts Unicode code points for the large append threshold", () => {
+    const raf = installAnimationFrame();
+    const { result, rerender } = renderHook(
+      ({ content }) => useSmoothStreamText(content, { largeAppendChars: 1, reducedMotion: false }),
+      { initialProps: { content: "A" } },
+    );
+
+    rerender({ content: "A🙂" });
+
+    expect(result.current.text).toBe("A");
+    expect(result.current.isAnimating).toBe(true);
+    expect(raf.request).toHaveBeenCalledTimes(1);
+  });
+
   it("synchronizes appends larger than the default 500-character threshold", () => {
     const raf = installAnimationFrame();
     const { result, rerender } = renderHook(

--- a/packages/react/test/use-smooth-stream-text.test.ts
+++ b/packages/react/test/use-smooth-stream-text.test.ts
@@ -1,0 +1,282 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { StreamSmoothingPreset } from "../src";
+import { useSmoothStreamText } from "../src";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("@anvia/react useSmoothStreamText", () => {
+  it("returns full content when disabled", () => {
+    const raf = installAnimationFrame();
+    const { result, rerender } = renderHook(
+      ({ content }) => useSmoothStreamText(content, { enabled: false }),
+      { initialProps: { content: "Hello" } },
+    );
+
+    rerender({ content: "Hello world" });
+
+    expect(result.current.text).toBe("Hello world");
+    expect(result.current.isAnimating).toBe(false);
+    expect(raf.request).not.toHaveBeenCalled();
+  });
+
+  it("returns full content in none mode", () => {
+    const raf = installAnimationFrame();
+    const { result, rerender } = renderHook(
+      ({ content }) => useSmoothStreamText(content, { mode: "none" }),
+      { initialProps: { content: "Hello" } },
+    );
+
+    rerender({ content: "Hello world" });
+
+    expect(result.current.text).toBe("Hello world");
+    expect(result.current.isAnimating).toBe(false);
+    expect(raf.request).not.toHaveBeenCalled();
+  });
+
+  it("progressively reveals appended Unicode characters while streaming", () => {
+    const raf = installAnimationFrame();
+    const { result, rerender } = renderHook(
+      ({ content }) => useSmoothStreamText(content, { reducedMotion: false }),
+      { initialProps: { content: "A" } },
+    );
+
+    rerender({ content: "A🙂🙃😉😊" });
+
+    expect(result.current.text).toBe("A");
+    expect(result.current.isAnimating).toBe(true);
+
+    act(() => raf.step());
+
+    expect(result.current.text).toBe("A🙂");
+    expect(result.current.isAnimating).toBe(true);
+
+    drainAnimationFrames(raf);
+
+    expect(result.current.text).toBe("A🙂🙃😉😊");
+    expect(result.current.isAnimating).toBe(false);
+  });
+
+  it.each([
+    ["realtime", 20],
+    ["balanced", 10],
+    ["silky", 5],
+  ] as const)("uses adaptive %s preset pacing", (preset, expectedLength) => {
+    const raf = installAnimationFrame();
+    const content = "x".repeat(40);
+    const { result, rerender } = renderHook(
+      ({ value, smoothingPreset }: { value: string; smoothingPreset: StreamSmoothingPreset }) =>
+        useSmoothStreamText(value, { preset: smoothingPreset, reducedMotion: false }),
+      { initialProps: { value: "", smoothingPreset: preset } },
+    );
+
+    rerender({ value: content, smoothingPreset: preset });
+    act(() => raf.step());
+
+    expect(result.current.text).toBe("x".repeat(expectedLength));
+  });
+
+  it("flushes queued text immediately", () => {
+    const raf = installAnimationFrame();
+    const { result, rerender } = renderHook(
+      ({ content }) => useSmoothStreamText(content, { reducedMotion: false }),
+      { initialProps: { content: "A" } },
+    );
+
+    rerender({ content: "ABCDE" });
+    expect(result.current.isAnimating).toBe(true);
+
+    act(() => result.current.flush());
+
+    expect(result.current.text).toBe("ABCDE");
+    expect(result.current.isAnimating).toBe(false);
+    expect(raf.cancel).toHaveBeenCalled();
+  });
+
+  it("resets its internal target and displayed text", () => {
+    installAnimationFrame();
+    const { result } = renderHook(() => useSmoothStreamText("Original", { reducedMotion: false }));
+
+    act(() => result.current.reset("Replacement"));
+    expect(result.current.text).toBe("Replacement");
+    expect(result.current.isAnimating).toBe(false);
+
+    act(() => result.current.reset());
+    expect(result.current.text).toBe("");
+  });
+
+  it("synchronizes replacement text immediately", () => {
+    const raf = installAnimationFrame();
+    const { result, rerender } = renderHook(
+      ({ content }) => useSmoothStreamText(content, { reducedMotion: false }),
+      { initialProps: { content: "Hello" } },
+    );
+
+    rerender({ content: "Goodbye" });
+
+    expect(result.current.text).toBe("Goodbye");
+    expect(result.current.isAnimating).toBe(false);
+    expect(raf.request).not.toHaveBeenCalled();
+  });
+
+  it("synchronizes appends larger than the configured threshold", () => {
+    const raf = installAnimationFrame();
+    const { result, rerender } = renderHook(
+      ({ content }) => useSmoothStreamText(content, { largeAppendChars: 2, reducedMotion: false }),
+      { initialProps: { content: "A" } },
+    );
+
+    rerender({ content: "ABCDE" });
+
+    expect(result.current.text).toBe("ABCDE");
+    expect(result.current.isAnimating).toBe(false);
+    expect(raf.request).not.toHaveBeenCalled();
+  });
+
+  it("synchronizes appends larger than the default 500-character threshold", () => {
+    const raf = installAnimationFrame();
+    const { result, rerender } = renderHook(
+      ({ content }) => useSmoothStreamText(content, { reducedMotion: false }),
+      { initialProps: { content: "A" } },
+    );
+
+    rerender({ content: `A${"x".repeat(501)}` });
+
+    expect(result.current.text).toBe(`A${"x".repeat(501)}`);
+    expect(result.current.isAnimating).toBe(false);
+    expect(raf.request).not.toHaveBeenCalled();
+  });
+
+  it("synchronizes immediately when streaming stops", () => {
+    const raf = installAnimationFrame();
+    const { result, rerender } = renderHook(
+      ({ content, isStreaming }) =>
+        useSmoothStreamText(content, { isStreaming, reducedMotion: false }),
+      { initialProps: { content: "A", isStreaming: true } },
+    );
+
+    rerender({ content: "ABCDE", isStreaming: true });
+    expect(result.current.text).toBe("A");
+
+    rerender({ content: "ABCDE", isStreaming: false });
+
+    expect(result.current.text).toBe("ABCDE");
+    expect(result.current.isAnimating).toBe(false);
+    expect(raf.cancel).toHaveBeenCalled();
+  });
+
+  it("follows the system reduced motion preference by default", () => {
+    const raf = installAnimationFrame();
+    installMatchMedia(true);
+    const { result, rerender } = renderHook(({ content }) => useSmoothStreamText(content), {
+      initialProps: { content: "A" },
+    });
+
+    rerender({ content: "ABCDE" });
+
+    expect(result.current.text).toBe("ABCDE");
+    expect(result.current.isAnimating).toBe(false);
+    expect(raf.request).not.toHaveBeenCalled();
+  });
+
+  it("lets an explicit reduced motion value override the system preference", () => {
+    const raf = installAnimationFrame();
+    installMatchMedia(true);
+    const { result, rerender } = renderHook(
+      ({ content }) => useSmoothStreamText(content, { reducedMotion: false }),
+      { initialProps: { content: "A" } },
+    );
+
+    rerender({ content: "ABCDE" });
+
+    expect(result.current.text).toBe("A");
+    expect(result.current.isAnimating).toBe(true);
+    expect(raf.request).toHaveBeenCalledTimes(1);
+  });
+
+  it("synchronizes immediately when requestAnimationFrame is unavailable", () => {
+    installMatchMedia(false);
+    vi.stubGlobal("requestAnimationFrame", undefined);
+    const { result, rerender } = renderHook(
+      ({ content }) => useSmoothStreamText(content, { reducedMotion: false }),
+      { initialProps: { content: "A" } },
+    );
+
+    rerender({ content: "ABCDE" });
+
+    expect(result.current.text).toBe("ABCDE");
+    expect(result.current.isAnimating).toBe(false);
+  });
+
+  it("cancels a scheduled animation frame on unmount", () => {
+    const raf = installAnimationFrame();
+    const { rerender, unmount } = renderHook(
+      ({ content }) => useSmoothStreamText(content, { reducedMotion: false }),
+      { initialProps: { content: "A" } },
+    );
+
+    rerender({ content: "ABCDE" });
+    unmount();
+
+    expect(raf.cancel).toHaveBeenCalledTimes(1);
+  });
+});
+
+type AnimationFrameHarness = ReturnType<typeof installAnimationFrame>;
+
+function installAnimationFrame() {
+  let nextId = 0;
+  const callbacks = new Map<number, FrameRequestCallback>();
+  const request = vi.fn((callback: FrameRequestCallback) => {
+    const id = ++nextId;
+    callbacks.set(id, callback);
+    return id;
+  });
+  const cancel = vi.fn((id: number) => {
+    callbacks.delete(id);
+  });
+
+  vi.stubGlobal("requestAnimationFrame", request);
+  vi.stubGlobal("cancelAnimationFrame", cancel);
+  installMatchMedia(false);
+
+  return {
+    cancel,
+    pending: () => callbacks.size,
+    request,
+    step() {
+      const pending = [...callbacks.values()];
+      callbacks.clear();
+      for (const callback of pending) {
+        callback(0);
+      }
+    },
+  };
+}
+
+function drainAnimationFrames(raf: AnimationFrameHarness): void {
+  for (let frame = 0; frame < 100 && raf.pending() > 0; frame += 1) {
+    act(() => raf.step());
+  }
+  expect(raf.pending()).toBe(0);
+}
+
+function installMatchMedia(matches: boolean): void {
+  const mediaQuery = {
+    matches,
+    media: "(prefers-reduced-motion: reduce)",
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(() => true),
+  } as unknown as MediaQueryList;
+
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn(() => mediaQuery),
+  );
+}

--- a/packages/server/test/streams.test.ts
+++ b/packages/server/test/streams.test.ts
@@ -32,7 +32,40 @@ describe("@anvia/server streams", () => {
 
     expect(response.headers.get("content-type")).toBe("application/x-ndjson; charset=utf-8");
     expect(response.headers.get("cache-control")).toBe("no-cache, no-transform");
+    expect(response.headers.get("connection")).toBe("keep-alive");
+    expect(response.headers.get("x-accel-buffering")).toBe("no");
     expect(await response.text()).toBe('{"type":"one"}\n');
+  });
+
+  it("streams event responses before the upstream iterable completes", async () => {
+    let releaseSecondEvent!: () => void;
+    const secondEventReady = new Promise<void>((resolve) => {
+      releaseSecondEvent = resolve;
+    });
+    const response = createEventStream(
+      (async function* () {
+        yield { type: "one" };
+        await secondEventReady;
+        yield { type: "two" };
+      })(),
+    );
+    if (response.body === null) {
+      throw new Error("Expected event stream response body");
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    const first = await reader.read();
+
+    expect(first.done).toBe(false);
+    expect(decoder.decode(first.value)).toBe('{"type":"one"}\n');
+
+    releaseSecondEvent();
+    const second = await reader.read();
+
+    expect(second.done).toBe(false);
+    expect(decoder.decode(second.value)).toBe('{"type":"two"}\n');
+    expect(await reader.read()).toEqual({ done: true, value: undefined });
   });
 
   it("creates event stream responses with custom response init", async () => {
@@ -282,19 +315,21 @@ describe("@anvia/server streams", () => {
     ]);
   });
 
-  it("creates UI stream responses", async () => {
+  it("creates UI stream responses with text deltas", async () => {
     const response = createUIStreamResponse(
       events([
         {
-          type: "message_start",
-          message: { id: "msg_1", role: "assistant", parts: [] },
+          type: "text_delta",
+          messageId: "msg_1",
+          partId: "part_1",
+          delta: "Hello",
         },
       ]),
     );
 
     expect(response.headers.get("content-type")).toBe("application/x-ndjson; charset=utf-8");
     expect(await response.text()).toBe(
-      '{"type":"message_start","message":{"id":"msg_1","role":"assistant","parts":[]}}\n',
+      '{"type":"text_delta","messageId":"msg_1","partId":"part_1","delta":"Hello"}\n',
     );
   });
 
@@ -362,9 +397,9 @@ describe("@anvia/server streams", () => {
     expect(text).toBe('event: error\ndata: {"type":"error","error":"plain failure"}\n\n');
   });
 
-  it("cancels async iterators", async () => {
+  it.each(["jsonl", "sse"] as const)("cancels %s async iterators", async (format) => {
     let canceled = false;
-    const stream = createJsonlStream({
+    const source = {
       [Symbol.asyncIterator]() {
         return {
           async next() {
@@ -376,7 +411,8 @@ describe("@anvia/server streams", () => {
           },
         };
       },
-    });
+    };
+    const stream = format === "jsonl" ? createJsonlStream(source) : createSseStream(source);
 
     await stream.cancel();
 


### PR DESCRIPTION
## Summary

- add `useSmoothStreamText` to `@anvia/react` as a display-only RAF smoothing hook with Unicode-safe reveal, presets, reduced-motion support, flush/reset controls, and large-append/replacement safeguards
- add opt-in animation props to `Message.Text` and `Message.Markdown`, including optional `fadeIn` styling, while leaving `useChat` and `UIMessage[]` ownership unchanged
- strengthen server transport regression coverage for immediate delivery, anti-buffering headers, iterator cancellation, and `text_delta` responses
- document the package APIs and add patch changesets for `@anvia/react` and `@anvia/react-ui`

## Behavior and boundaries

`useChat` remains responsible for transport, streamed events, real message state, persistence, resume, status, errors, and human input. `useSmoothStreamText` only derives displayed text and never mutates events or messages. Animation remains disabled by default in React UI.

## Verification

- `pnpm --filter @anvia/server typecheck`
- `pnpm --filter @anvia/server test` — 22 tests passed
- `pnpm --filter @anvia/react typecheck`
- `pnpm --filter @anvia/react test` — 96 tests passed
- `pnpm --filter @anvia/react build`
- `pnpm --filter @anvia/react-ui typecheck`
- `pnpm --filter @anvia/react-ui test` — 71 tests passed
- `pnpm --filter @anvia/react-ui build`
- `pnpm --filter www reference-check`
- `pnpm --filter www build` — 521 pages built and 518 indexed
- scoped Biome checks and `git diff --check`

## Visual verification

No screenshot was produced. Animation behavior is covered with deterministic RAF, reduced-motion, DOM, Markdown, and code-block tests.
