### PR TITLE
Persist JSON metadata on core messages

### DIFF
--- a/.changeset/persist-core-message-metadata.md
+++ b/.changeset/persist-core-message-metadata.md
@@ -1,0 +1,8 @@
+---
+"@anvia/core": minor
+"@anvia/react": patch
+"@anvia/otel": patch
+"@anvia/langfuse": patch
+---
+
+Persist strict JSON message metadata across UI and core message conversions while keeping it out of provider requests and model-generation trace inputs.

--- a/apps/www/src/content/docs/packages/core/reference/completion.md
+++ b/apps/www/src/content/docs/packages/core/reference/completion.md
@@ -15,11 +15,15 @@ Import from `@anvia/core` or `@anvia/core/completion`.
 type JsonPrimitive = string | number | boolean | null;
 type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
 type JsonObject = { [key: string]: JsonValue | undefined };
+
+function isJsonValue(value: unknown): value is JsonValue;
 ```
 
 Purpose: provider-safe JSON contracts used by tool arguments, model parameters, schemas, and metadata.
 
-Return behavior: type-only exports.
+Return behavior: `isJsonValue(...)` accepts strict, JSON-serializable values. It rejects non-finite
+numbers, `undefined`, functions, symbols, bigint values, cycles, sparse arrays, accessors, and
+non-plain objects.
 
 Notable errors: none directly.
 
@@ -69,26 +73,51 @@ Notable errors: none directly.
 ## Message
 
 ```ts
-type SystemMessage = { role: "system"; content: string };
-type UserMessage = { role: "user"; content: UserContent[] };
-type AssistantMessage = { role: "assistant"; id?: string; content: AssistantContent[] };
-type ToolMessage = { role: "tool"; content: ToolContent[] };
+type MessageOptions = { metadata?: JsonValue };
+type AssistantMessageOptions = MessageOptions & { id?: string };
+type ToolResultOptions = {
+  callId?: string;
+  toolName?: string;
+};
+type ToolResultMessageOptions = ToolResultOptions & MessageOptions;
+
+type SystemMessage = { role: "system"; content: string; metadata?: JsonValue };
+type UserMessage = { role: "user"; content: UserContent[]; metadata?: JsonValue };
+type AssistantMessage = {
+  role: "assistant";
+  id?: string;
+  content: AssistantContent[];
+  metadata?: JsonValue;
+};
+type ToolMessage = { role: "tool"; content: ToolContent[]; metadata?: JsonValue };
 type Message = SystemMessage | UserMessage | AssistantMessage | ToolMessage;
 
 const Message: {
-  system(content: string): Message;
-  user(content: string | UserContent[]): Message;
-  assistant(content: string | AssistantContent[], id?: string): Message;
-  tool(content: ToolContent | ToolContent[]): Message;
-  toolResult(id: string, output: unknown, options?: { callId?: string | undefined; toolName?: string | undefined }): Message;
+  system(content: string, options?: MessageOptions): Message;
+  user(content: string | UserContent[], options?: MessageOptions): Message;
+  assistant(
+    content: string | AssistantContent[],
+    idOrOptions?: string | AssistantMessageOptions,
+  ): Message;
+  tool(content: ToolContent | ToolContent[], options?: MessageOptions): Message;
+  toolResult(id: string, output: unknown, options?: ToolResultMessageOptions): Message;
 };
 ```
 
 Purpose: normalized chat history and prompt shape.
 
-Return behavior: factory methods return message objects with normalized content arrays. `Message.tool(...)` is the low-level factory for complete tool content. `Message.toolResult(...)` creates the common tool-role message after executing a model-requested tool call, serializing non-string output with JSON and preserving structured `ToolResultContent[]`.
+Return behavior: factory methods return message objects with normalized content arrays and optional
+strict JSON metadata. Existing assistant message ids remain supported as a string second argument;
+use `{ id, metadata }` when both are needed. `Message.tool(...)` is the low-level factory for
+complete tool content. `Message.toolResult(...)` creates the common tool-role message after
+executing a model-requested tool call, serializing non-string output with JSON and preserving
+structured `ToolResultContent[]`.
 
-Notable errors: none directly.
+Provider adapters construct provider-native payloads from message role and content. Message
+metadata is persisted and observable at the run/transcript level, but is not sent to model APIs or
+included in generation input attributes.
+
+Notable errors: factories throw `TypeError` when metadata is not a strict JSON value.
 
 ## UserContent, AssistantContent, and ToolContent
 

--- a/apps/www/src/content/docs/packages/core/reference/ui.md
+++ b/apps/www/src/content/docs/packages/core/reference/ui.md
@@ -91,7 +91,8 @@ function uiMessagesToCoreMessages(messages: UIMessage[]): Message[];
 
 Purpose: convert client-facing UI messages into core completion messages before calling completion or agent APIs.
 
-Return behavior: text, attachment, reasoning, tool call, and tool output parts are mapped into the closest core message representation.
+Return behavior: text, attachment, reasoning, tool call, tool output, and strict JSON message
+metadata are mapped into the closest core message representation.
 
 ## coreMessagesToUIMessages
 
@@ -101,6 +102,17 @@ function coreMessagesToUIMessages(messages: Message[]): UIMessage[];
 
 Purpose: convert existing core message history into the UI message shape used by React hooks.
 
-Return behavior: generated IDs are assigned where the core message format does not already provide one.
+Return behavior: generated IDs are assigned where the core message format does not already provide
+one, and core message metadata is restored onto the `UIMessage`. Metadata-free tool-result messages
+continue to merge into matching assistant tool parts. A metadata-bearing tool message remains a
+standalone UI tool message so its metadata and transcript structure are not lost.
+
+The supported persistence round trip is:
+
+```ts
+const coreMessages = uiMessagesToCoreMessages(uiMessages);
+const stored = JSON.stringify(coreMessages);
+const restored = coreMessagesToUIMessages(JSON.parse(stored));
+```
 
 Server handlers can pass converted core messages directly to completion or agent APIs. `@anvia/react` can consume raw completion streams, raw agent streams, or `UIStreamEvent` records.

--- a/packages/core/src/completion/index.ts
+++ b/packages/core/src/completion/index.ts
@@ -1,4 +1,5 @@
 export * from "./create-completion";
 export * from "./documents";
+export * from "./json";
 export * from "./request";
 export * from "./types";

--- a/packages/core/src/completion/json.ts
+++ b/packages/core/src/completion/json.ts
@@ -1,0 +1,74 @@
+import type { JsonValue } from "./types";
+
+export function isJsonValue(value: unknown): value is JsonValue {
+  return isJsonValueWithAncestors(value, new WeakSet<object>());
+}
+
+function isJsonValueWithAncestors(value: unknown, ancestors: WeakSet<object>): value is JsonValue {
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
+    return true;
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value);
+  }
+  if (typeof value !== "object" || ancestors.has(value)) {
+    return false;
+  }
+
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      if (!hasOnlyDenseArrayProperties(value)) {
+        return false;
+      }
+      for (let index = 0; index < value.length; index += 1) {
+        if (!isJsonValueWithAncestors(value[index], ancestors)) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      return false;
+    }
+    for (const key of Reflect.ownKeys(value)) {
+      if (typeof key !== "string") {
+        return false;
+      }
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (
+        descriptor === undefined ||
+        !descriptor.enumerable ||
+        !("value" in descriptor) ||
+        !isJsonValueWithAncestors(descriptor.value, ancestors)
+      ) {
+        return false;
+      }
+    }
+    return true;
+  } catch {
+    return false;
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+function hasOnlyDenseArrayProperties(value: unknown[]): boolean {
+  const keys = Reflect.ownKeys(value);
+  if (keys.length !== value.length + 1 || keys.at(-1) !== "length") {
+    return false;
+  }
+  for (let index = 0; index < value.length; index += 1) {
+    const key = String(index);
+    if (keys[index] !== key) {
+      return false;
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (descriptor === undefined || !descriptor.enumerable || !("value" in descriptor)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/packages/core/src/completion/types.ts
+++ b/packages/core/src/completion/types.ts
@@ -1,3 +1,5 @@
+import { isJsonValue } from "./json";
+
 export type JsonPrimitive = string | number | boolean | null;
 export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
 export type JsonObject = { [key: string]: JsonValue | undefined };
@@ -108,10 +110,20 @@ export type ToolResult = {
   content: ToolResultContent[];
 };
 
-type ToolResultOptions = {
+export type MessageOptions = {
+  metadata?: JsonValue | undefined;
+};
+
+export type AssistantMessageOptions = MessageOptions & {
+  id?: string | undefined;
+};
+
+export type ToolResultOptions = {
   callId?: string | undefined;
   toolName?: string | undefined;
 };
+
+export type ToolResultMessageOptions = ToolResultOptions & MessageOptions;
 
 export type UserContent = Text | ImageContent | DocumentContent;
 export type AssistantContent = Text | ToolCall | Reasoning | ImageContent;
@@ -120,22 +132,26 @@ export type ToolContent = ToolResult;
 export type SystemMessage = {
   role: "system";
   content: string;
+  metadata?: JsonValue;
 };
 
 export type UserMessage = {
   role: "user";
   content: UserContent[];
+  metadata?: JsonValue;
 };
 
 export type AssistantMessage = {
   role: "assistant";
   id?: string;
   content: AssistantContent[];
+  metadata?: JsonValue;
 };
 
 export type ToolMessage = {
   role: "tool";
   content: ToolContent[];
+  metadata?: JsonValue;
 };
 
 export type Message = SystemMessage | UserMessage | AssistantMessage | ToolMessage;
@@ -341,32 +357,57 @@ export function reasoningDisplayText(reasoning: Reasoning | ReasoningContent[]):
 }
 
 export const Message = {
-  system(content: string): Message {
-    return { role: "system", content };
+  system(content: string, options: MessageOptions = {}): Message {
+    return { role: "system", content, ...messageMetadata(options) };
   },
-  user(content: string | UserContent[]): Message {
+  user(content: string | UserContent[], options: MessageOptions = {}): Message {
     return {
       role: "user",
       content: typeof content === "string" ? [UserContent.text(content)] : content,
+      ...messageMetadata(options),
     };
   },
-  assistant(content: string | AssistantContent[], id?: string): Message {
+  assistant(
+    content: string | AssistantContent[],
+    idOrOptions?: string | AssistantMessageOptions,
+  ): Message {
     const normalized = typeof content === "string" ? [AssistantContent.text(content)] : content;
-    return id === undefined
-      ? { role: "assistant", content: normalized }
-      : { role: "assistant", id, content: normalized };
+    const options = typeof idOrOptions === "string" ? { id: idOrOptions } : (idOrOptions ?? {});
+    return {
+      role: "assistant",
+      ...(options.id === undefined ? {} : { id: options.id }),
+      content: normalized,
+      ...messageMetadata(options),
+    };
   },
-  tool(content: ToolContent | ToolContent[]): Message {
+  tool(content: ToolContent | ToolContent[], options: MessageOptions = {}): Message {
     return {
       role: "tool",
       content: Array.isArray(content) ? content : [content],
+      ...messageMetadata(options),
     };
   },
-  toolResult(id: string, output: unknown, options: ToolResultOptions = {}): Message {
+  toolResult(id: string, output: unknown, options: ToolResultMessageOptions = {}): Message {
     const content = isToolResultContentArray(output) ? output : serializeToolResultOutput(output);
-    return Message.tool(ToolContent.toolResult(id, content, options));
+    return Message.tool(
+      ToolContent.toolResult(id, content, {
+        callId: options.callId,
+        toolName: options.toolName,
+      }),
+      { metadata: options.metadata },
+    );
   },
 };
+
+function messageMetadata(options: MessageOptions): { metadata?: JsonValue } {
+  if (options.metadata === undefined) {
+    return {};
+  }
+  if (!isJsonValue(options.metadata)) {
+    throw new TypeError("Message metadata must be a strict JSON value.");
+  }
+  return { metadata: options.metadata };
+}
 
 export type ToolChoice =
   | "auto"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export { AgentBuilder } from "./agent/builder";
 export type {
   AssistantMessage,
+  AssistantMessageOptions,
   CompletionModel,
   CompletionRequest,
   CompletionResponse,
@@ -16,6 +17,7 @@ export type {
   JsonObject,
   JsonPrimitive,
   JsonValue,
+  MessageOptions,
   SystemMessage,
   Text,
   ToolCall,
@@ -23,6 +25,8 @@ export type {
   ToolMessage,
   ToolResult,
   ToolResultContent,
+  ToolResultMessageOptions,
+  ToolResultOptions,
   UserMessage,
 } from "./completion/index";
 export {
@@ -30,6 +34,7 @@ export {
   createCompletion,
   createCompletionStream,
   createParsedCompletion,
+  isJsonValue,
   Message,
   ToolContent,
   Usage,

--- a/packages/core/src/ui/messages.ts
+++ b/packages/core/src/ui/messages.ts
@@ -1,3 +1,4 @@
+import { isJsonValue } from "../completion/json";
 import {
   AssistantContent,
   type AssistantContent as AssistantContentType,
@@ -37,7 +38,7 @@ export function uiMessagesToCoreMessages(messages: UIMessage[]): CoreMessage[] {
 
     if (message.role === "system") {
       if (text.length > 0) {
-        coreMessages.push(Message.system(text));
+        coreMessages.push(Message.system(text, metadataOptions(message.metadata)));
       }
       continue;
     }
@@ -62,7 +63,7 @@ export function uiMessagesToCoreMessages(messages: UIMessage[]): CoreMessage[] {
         );
       }
       if (content.length > 0) {
-        coreMessages.push(Message.user(content));
+        coreMessages.push(Message.user(content, metadataOptions(message.metadata)));
       }
       continue;
     }
@@ -104,7 +105,12 @@ export function uiMessagesToCoreMessages(messages: UIMessage[]): CoreMessage[] {
         }
       }
       if (content.length > 0) {
-        coreMessages.push(Message.assistant(content, message.id));
+        coreMessages.push(
+          Message.assistant(content, {
+            id: message.id,
+            ...metadataOptions(message.metadata),
+          }),
+        );
       }
       if (toolResults.length > 0) {
         coreMessages.push(Message.tool(toolResults));
@@ -125,7 +131,7 @@ export function uiMessagesToCoreMessages(messages: UIMessage[]): CoreMessage[] {
       );
     }
     if (toolResults.length > 0) {
-      coreMessages.push(Message.tool(toolResults));
+      coreMessages.push(Message.tool(toolResults, metadataOptions(message.metadata)));
     }
   }
 
@@ -145,6 +151,7 @@ export function coreMessagesToUIMessages(messages: CoreMessage[]): UIMessage[] {
         id: createId("msg"),
         role: "system",
         parts: [{ id: createId("part"), type: "text", text: message.content }],
+        ...uiMetadata(message.metadata),
       });
       continue;
     }
@@ -162,7 +169,12 @@ export function coreMessagesToUIMessages(messages: CoreMessage[]): UIMessage[] {
           });
         }
       }
-      uiMessages.push({ id: createId("msg"), role: "user", parts });
+      uiMessages.push({
+        id: createId("msg"),
+        role: "user",
+        parts,
+        ...uiMetadata(message.metadata),
+      });
       continue;
     }
 
@@ -208,7 +220,12 @@ export function coreMessagesToUIMessages(messages: CoreMessage[]): UIMessage[] {
         });
       }
       const messageIndex = uiMessages.length;
-      uiMessages.push({ id: message.id ?? createId("msg"), role: "assistant", parts });
+      uiMessages.push({
+        id: message.id ?? createId("msg"),
+        role: "assistant",
+        parts,
+        ...uiMetadata(message.metadata),
+      });
       registerToolPartLocations(parts, messageIndex, toolPartLocations);
       continue;
     }
@@ -226,17 +243,45 @@ export function coreMessagesToUIMessages(messages: CoreMessage[]): UIMessage[] {
       if (content.callId !== undefined) {
         part.callId = content.callId;
       }
-      if (mergeToolResultPart(uiMessages, toolPartLocations, part)) {
+      if (
+        message.metadata === undefined &&
+        mergeToolResultPart(uiMessages, toolPartLocations, part)
+      ) {
         continue;
       }
       parts.push(part);
     }
     if (parts.length > 0) {
-      uiMessages.push({ id: createId("msg"), role: "tool", parts });
+      uiMessages.push({
+        id: createId("msg"),
+        role: "tool",
+        parts,
+        ...uiMetadata(message.metadata),
+      });
     }
   }
 
   return uiMessages;
+}
+
+function metadataOptions(metadata: UIMessage["metadata"]): { metadata?: JsonValue } {
+  if (metadata === undefined) {
+    return {};
+  }
+  if (!isJsonValue(metadata)) {
+    throw new TypeError("UI message metadata must be a strict JSON value.");
+  }
+  return { metadata };
+}
+
+function uiMetadata(metadata: JsonValue | undefined): { metadata?: JsonValue } {
+  if (metadata === undefined) {
+    return {};
+  }
+  if (!isJsonValue(metadata)) {
+    throw new TypeError("Core message metadata must be a strict JSON value.");
+  }
+  return { metadata };
 }
 
 function registerToolPartLocations(

--- a/packages/core/test/message-content.test.ts
+++ b/packages/core/test/message-content.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import {
   AssistantContent,
+  isJsonValue,
+  type JsonValue,
   Message,
+  type Message as MessageType,
   reasoningDisplayText,
   ToolContent,
   UserContent,
@@ -176,5 +179,79 @@ describe("message attachment content", () => {
       throw new Error("Expected tool result content");
     }
     expect("callId" in toolResult).toBe(false);
+  });
+
+  it("supports old and metadata-aware message factory signatures", () => {
+    const metadata = { composer: { entities: [] } };
+    const messages = [
+      Message.system("system"),
+      Message.system("system", { metadata }),
+      Message.user("user"),
+      Message.user("user", { metadata }),
+      Message.assistant("assistant"),
+      Message.assistant("assistant", "assistant_1"),
+      Message.assistant("assistant", { id: "assistant_1", metadata }),
+      Message.tool(ToolContent.toolResult("tool_1", "done")),
+      Message.tool(ToolContent.toolResult("tool_1", "done"), { metadata }),
+      Message.toolResult("tool_1", "done", {
+        callId: "call_1",
+        toolName: "lookup",
+        metadata,
+      }),
+    ];
+
+    expectTypeOf(messages).toMatchTypeOf<MessageType[]>();
+    expect(messages[6]).toEqual({
+      role: "assistant",
+      id: "assistant_1",
+      content: [{ type: "text", text: "assistant" }],
+      metadata,
+    });
+    expect(messages[9]).toEqual({
+      role: "tool",
+      content: [
+        {
+          type: "tool_result",
+          id: "tool_1",
+          callId: "call_1",
+          toolName: "lookup",
+          content: [{ type: "text", text: "done" }],
+        },
+      ],
+      metadata,
+    });
+  });
+
+  it("validates strict JSON values without accepting lossy structures", () => {
+    const shared = { value: 1 };
+    expect(isJsonValue({ shared, duplicate: shared, list: [null, true, 1, "ok"] })).toBe(true);
+    expect(isJsonValue(Object.assign(Object.create(null), { value: "ok" }))).toBe(true);
+
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    const sparse = new Array(2);
+    sparse[1] = "value";
+    const invalidValues = [
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      undefined,
+      () => {},
+      Symbol("value"),
+      1n,
+      cyclic,
+      sparse,
+      new Date(),
+      { value: undefined },
+    ];
+
+    for (const value of invalidValues) {
+      expect(isJsonValue(value)).toBe(false);
+    }
+  });
+
+  it("rejects invalid runtime metadata at factory boundaries", () => {
+    expect(() => Message.user("hello", { metadata: { score: Number.NaN } as JsonValue })).toThrow(
+      "Message metadata must be a strict JSON value.",
+    );
   });
 });

--- a/packages/core/test/ui-stream.test.ts
+++ b/packages/core/test/ui-stream.test.ts
@@ -54,6 +54,80 @@ class StreamModel implements StreamingCompletionModel {
 }
 
 describe("UI message adapters", () => {
+  it("round-trips strict UI metadata through core messages and JSON persistence", () => {
+    const metadata = {
+      composer: {
+        entities: [
+          {
+            id: "document-1",
+            triggerId: "documents",
+            trigger: "@",
+            label: "Guide.pdf",
+            text: "@Guide.pdf",
+            range: { from: 4, to: 14 },
+            data: { kind: "document", documentId: "document-1" },
+          },
+        ],
+      },
+    };
+    const messages: UIMessage[] = [
+      {
+        id: "user_1",
+        role: "user",
+        parts: [{ id: "part_1", type: "text", text: "See @Guide.pdf" }],
+        metadata,
+      },
+    ];
+
+    const coreMessages = uiMessagesToCoreMessages(messages);
+    expect(coreMessages).toEqual([Message.user("See @Guide.pdf", { metadata })]);
+
+    const persisted = JSON.parse(JSON.stringify(coreMessages)) as typeof coreMessages;
+    expect(coreMessagesToUIMessages(persisted)[0]?.metadata).toEqual(metadata);
+  });
+
+  it("preserves assistant and standalone tool metadata without changing normal tool merging", () => {
+    const assistantMetadata = { source: "assistant" };
+    const toolMetadata = { source: "tool" };
+    const assistantMessage: UIMessage = {
+      id: "assistant_1",
+      role: "assistant",
+      parts: [
+        {
+          id: "tool_1",
+          type: "tool",
+          toolName: "lookup",
+          toolCallId: "tool_1",
+          state: "output-available",
+          input: { query: "Anvia" },
+          output: "done",
+        },
+      ],
+      metadata: assistantMetadata,
+    };
+
+    const assistantCore = uiMessagesToCoreMessages([assistantMessage]);
+    expect(assistantCore[0]?.metadata).toEqual(assistantMetadata);
+    expect(assistantCore[1]?.metadata).toBeUndefined();
+    const assistantRestored = coreMessagesToUIMessages(assistantCore);
+    expect(assistantRestored).toHaveLength(1);
+    expect(assistantRestored[0]?.metadata).toEqual(assistantMetadata);
+
+    const withStandaloneTool = coreMessagesToUIMessages([
+      Message.assistant([AssistantContent.toolCall("tool_1", "lookup", {})]),
+      Message.toolResult("tool_1", "done", { metadata: toolMetadata }),
+    ]);
+    expect(withStandaloneTool).toHaveLength(2);
+    expect(withStandaloneTool[1]).toMatchObject({ role: "tool", metadata: toolMetadata });
+
+    const mergedWithoutMetadata = coreMessagesToUIMessages([
+      Message.assistant([AssistantContent.toolCall("tool_1", "lookup", {})]),
+      Message.toolResult("tool_1", "done"),
+    ]);
+    expect(mergedWithoutMetadata).toHaveLength(1);
+    expect(mergedWithoutMetadata[0]?.parts[0]).toMatchObject({ state: "output-available" });
+  });
+
   it("converts UI messages into core completion messages", () => {
     const messages: UIMessage[] = [
       {

--- a/packages/observability-langfuse/src/helpers.ts
+++ b/packages/observability-langfuse/src/helpers.ts
@@ -1,8 +1,22 @@
+import type { Message } from "@anvia/core/completion";
 import type {
   AgentGenerationEndArgs,
   AgentGenerationStartArgs,
   AgentToolStartArgs,
 } from "@anvia/core/observability";
+
+export function modelInputMessage(message: Message): Message {
+  if (message.metadata === undefined) {
+    return message;
+  }
+  const result: Message = { ...message };
+  delete result.metadata;
+  return result;
+}
+
+export function modelInputMessages(messages: Message[]): Message[] {
+  return messages.map(modelInputMessage);
+}
 
 export function modelParameters(
   request: AgentGenerationStartArgs["request"],

--- a/packages/observability-langfuse/src/tracing.ts
+++ b/packages/observability-langfuse/src/tracing.ts
@@ -1,4 +1,4 @@
-import { textFromAssistantContent } from "@anvia/core/completion";
+import { type Message, textFromAssistantContent } from "@anvia/core/completion";
 import type {
   AgentGenerationEndArgs,
   AgentGenerationErrorArgs,
@@ -41,6 +41,8 @@ import {
   errorMessage,
   generationKey,
   isRecord,
+  modelInputMessage,
+  modelInputMessages,
   modelParameters,
   usageDetails,
   usageDetailsFromRecord,
@@ -444,7 +446,7 @@ class LangfuseRunObserver implements AgentRunObserver {
   startGeneration(args: AgentGenerationStartArgs): AgentGenerationObserver {
     this.closeEarlierTurns(args.turn);
     const turn = this.turnSpan(args.turn);
-    const redactedChatHistory = this.redactInputValue(args.request.chatHistory);
+    const redactedChatHistory = this.redactInputValue(modelInputMessages(args.request.chatHistory));
     const generation = turn.startObservation(
       `model.turn.${args.turn}`,
       {
@@ -666,8 +668,8 @@ class LangfuseToolObserver implements AgentToolObserver {
         `${agentLabel(agentId, agentName)}.model.turn.${childTurn}`,
         {
           input: {
-            prompt: child.prompt,
-            history: child.history,
+            prompt: modelInputMessage(child.prompt as Message),
+            history: modelInputMessages(child.history as Message[]),
           },
           metadata: childMetadata(args, agentId, agentName, childTurn),
         },

--- a/packages/observability-langfuse/test/langfuse.test.ts
+++ b/packages/observability-langfuse/test/langfuse.test.ts
@@ -1,4 +1,9 @@
-import { AssistantContent, type Message, type Usage } from "@anvia/core/completion";
+import {
+  AssistantContent,
+  Message,
+  type Message as MessageType,
+  type Usage,
+} from "@anvia/core/completion";
 import { EvalOutcome, exactMatch, runEvalSuite } from "@anvia/core/evals";
 import type {
   AgentGenerationStartArgs,
@@ -683,6 +688,56 @@ describe("langfuse", () => {
       }),
     );
     expect(root.end).toHaveBeenCalledOnce();
+  });
+
+  it("keeps message metadata on run transcripts but omits it from model inputs", async () => {
+    const root = fakeObservation("root", "trace-1", "obs-root");
+    const turn = fakeObservation("turn", "trace-1", "obs-turn");
+    const generation = fakeObservation("generation", "trace-1", "obs-generation");
+    root.startObservation.mockReturnValueOnce(turn);
+    turn.startObservation.mockReturnValueOnce(generation);
+    mocks.startObservation.mockReturnValueOnce(root);
+    const metadata = { composer: { entities: [{ id: "document-1" }] } };
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const run = (await tracing.startRun({
+      prompt: Message.user("hello", { metadata }),
+      history: [Message.user("earlier", { metadata })],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+    expect(mocks.startObservation).toHaveBeenCalledWith(
+      "agent.run",
+      expect.objectContaining({
+        input: {
+          prompt: expect.objectContaining({ metadata }),
+          history: [expect.objectContaining({ metadata })],
+        },
+      }),
+      { asType: "agent" },
+    );
+
+    await run.startGeneration?.({
+      ...generationStartArgs(),
+      request: {
+        ...generationStartArgs().request,
+        chatHistory: [Message.user("hello", { metadata })],
+      },
+    });
+    const generationInput = turn.startObservation.mock.calls[0]?.[1]?.input as MessageType[];
+    expect(generationInput[0]).not.toHaveProperty("metadata");
+
+    await run.end({
+      output: "done",
+      usage: usage(1, 1),
+      messages: [Message.assistant("done", { metadata })],
+    });
+    expect(root.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          messages: [expect.objectContaining({ metadata })],
+        }),
+      }),
+    );
   });
 
   it("nests streamed child agent observations under the parent tool observation", async () => {
@@ -2447,7 +2502,7 @@ function generationStartArgs(): AgentGenerationStartArgs {
   };
 }
 
-function userMessage(text: string): Message {
+function userMessage(text: string): MessageType {
   return { role: "user", content: [{ type: "text", text }] };
 }
 

--- a/packages/observability-otel/src/helpers.ts
+++ b/packages/observability-otel/src/helpers.ts
@@ -1,4 +1,4 @@
-import { textFromAssistantContent } from "@anvia/core/completion";
+import { type Message, textFromAssistantContent } from "@anvia/core/completion";
 import type {
   AgentGenerationEndArgs,
   AgentGenerationStartArgs,
@@ -67,12 +67,25 @@ export function generationStartAttributes(args: AgentGenerationStartArgs): Attri
   const params = modelParameters(args.request);
   return compactAttributes({
     "anvia.generation.turn": args.turn,
-    "anvia.generation.input": jsonString(args.request.chatHistory),
+    "anvia.generation.input": jsonString(modelInputMessages(args.request.chatHistory)),
     "anvia.generation.model": args.request.model ?? "default",
     "anvia.generation.tool_count": args.request.tools.length,
     "anvia.generation.has_output_schema": args.request.outputSchema !== undefined,
     ...params,
   });
+}
+
+export function modelInputMessage(message: Message): Message {
+  if (message.metadata === undefined) {
+    return message;
+  }
+  const result: Message = { ...message };
+  delete result.metadata;
+  return result;
+}
+
+export function modelInputMessages(messages: Message[]): Message[] {
+  return messages.map(modelInputMessage);
 }
 
 export function generationEndAttributes(args: AgentGenerationEndArgs): Attributes {

--- a/packages/observability-otel/src/tracing.ts
+++ b/packages/observability-otel/src/tracing.ts
@@ -1,3 +1,4 @@
+import type { Message } from "@anvia/core/completion";
 import type {
   AgentGenerationEndArgs,
   AgentGenerationErrorArgs,
@@ -32,6 +33,8 @@ import {
   generationStartAttributes,
   isRecord,
   jsonString,
+  modelInputMessage,
+  modelInputMessages,
   parentContextFromTraceId,
   recordSpanError,
   rootSpanName,
@@ -195,8 +198,8 @@ class OtelToolObserver implements AgentToolObserver {
             "anvia.parent_tool.internal_call_id": args.internalCallId,
             "anvia.parent_tool.call_id": args.toolCallId,
             "anvia.generation.input": jsonString({
-              prompt: child.prompt,
-              history: child.history,
+              prompt: modelInputMessage(child.prompt as Message),
+              history: modelInputMessages(child.history as Message[]),
             }),
           }),
         },

--- a/packages/observability-otel/test/otel.test.ts
+++ b/packages/observability-otel/test/otel.test.ts
@@ -175,6 +175,48 @@ describe("otel", () => {
     expect(root?.ended).toBe(true);
   });
 
+  it("keeps message metadata on run transcripts but omits it from model inputs", async () => {
+    const tracer = new FakeTracer();
+    const tracing = otel.create({ tracer: tracer.tracer });
+    const metadata = { composer: { entities: [{ id: "document-1" }] } };
+    const run = await tracing.startRun({
+      prompt: Message.user("hello", { metadata }),
+      history: [Message.user("earlier", { metadata })],
+      maxTurns: 1,
+    });
+
+    const root = tracer.spans[0];
+    expect(JSON.parse(String(root?.attributes["anvia.run.prompt"]))).toHaveProperty(
+      "metadata",
+      metadata,
+    );
+    expect(JSON.parse(String(root?.attributes["anvia.run.history"]))[0]).toHaveProperty(
+      "metadata",
+      metadata,
+    );
+
+    await run?.startGeneration?.({
+      ...generationStartArgs(),
+      request: {
+        ...generationStartArgs().request,
+        chatHistory: [Message.user("hello", { metadata })],
+      },
+    });
+    expect(
+      JSON.parse(String(tracer.spans[1]?.attributes["anvia.generation.input"]))[0],
+    ).not.toHaveProperty("metadata");
+
+    await run?.end({
+      output: "done",
+      usage: usage(1, 1),
+      messages: [Message.assistant("done", { metadata })],
+    });
+    expect(JSON.parse(String(root?.attributes["anvia.run.messages"]))[0]).toHaveProperty(
+      "metadata",
+      metadata,
+    );
+  });
+
   it("records generation request options and output schema metadata", async () => {
     const tracer = new FakeTracer();
     const tracing = otel.create({ tracer: tracer.tracer });

--- a/packages/provider-anthropic/test/anthropic-completion.test.ts
+++ b/packages/provider-anthropic/test/anthropic-completion.test.ts
@@ -168,7 +168,10 @@ describe("Anthropic Messages mapping", () => {
 
   it("prepends normalized static context before chat history and maps system messages", () => {
     const request: CompletionRequest = {
-      chatHistory: [Message.system("Use context."), Message.user("What is the owner?")],
+      chatHistory: [
+        Message.system("Use context."),
+        Message.user("What is the owner?", { metadata: { composer: { entities: [] } } }),
+      ],
       documents: [{ id: "owner", text: "Mira owns launch checklists." }],
       tools: [],
     };

--- a/packages/provider-gemini/test/completion.test.ts
+++ b/packages/provider-gemini/test/completion.test.ts
@@ -98,7 +98,9 @@ describe("Gemini completion mapping", () => {
       instructions: "Use the support policy.",
       chatHistory: [
         Message.system("System context."),
-        Message.user("What is the order status?"),
+        Message.user("What is the order status?", {
+          metadata: { composer: { entities: [] } },
+        }),
         Message.assistant([AssistantContent.toolCall("call_1", "lookup_order", { id: "A1" })]),
         Message.tool(ToolContent.toolResult("call_1", "shipped")),
       ],

--- a/packages/provider-grok/test/completion.test.ts
+++ b/packages/provider-grok/test/completion.test.ts
@@ -34,7 +34,7 @@ describe("Grok completion models", () => {
     );
 
     await model.completion({
-      chatHistory: [Message.user("hello")],
+      chatHistory: [Message.user("hello", { metadata: { composer: { entities: [] } } })],
       documents: [],
       tools: [],
       additionalParams: {
@@ -97,5 +97,35 @@ describe("Grok completion models", () => {
       stream: true,
       model: "grok-chat-test",
     });
+  });
+
+  it("omits message metadata from Grok Chat requests", async () => {
+    const calls: unknown[] = [];
+    const model = new GrokChatCompletionModel(
+      {
+        chat: {
+          completions: {
+            create: async (params: unknown) => {
+              calls.push(params);
+              return { choices: [{ message: { role: "assistant", content: "ok" } }], usage: {} };
+            },
+          },
+        },
+      } as never,
+      "grok-chat-test",
+    );
+
+    await model.completion({
+      chatHistory: [Message.user("hello", { metadata: { composer: { entities: [] } } })],
+      documents: [],
+      tools: [],
+    });
+
+    expect(calls).toEqual([
+      {
+        model: "grok-chat-test",
+        messages: [{ role: "user", content: "hello" }],
+      },
+    ]);
   });
 });

--- a/packages/provider-mistral/test/completion.test.ts
+++ b/packages/provider-mistral/test/completion.test.ts
@@ -110,7 +110,9 @@ describe("Mistral completion mapping", () => {
       instructions: "Use the support policy.",
       chatHistory: [
         Message.system("System context."),
-        Message.user("What is the order status?"),
+        Message.user("What is the order status?", {
+          metadata: { composer: { entities: [] } },
+        }),
         Message.assistant([AssistantContent.toolCall("call_1", "lookup_order", { id: "A1" })]),
         Message.tool(ToolContent.toolResult("call_1", "shipped")),
       ],

--- a/packages/provider-openai/test/openai-chat-completion.test.ts
+++ b/packages/provider-openai/test/openai-chat-completion.test.ts
@@ -54,7 +54,7 @@ describe("OpenAI chat-completions client path", () => {
 
     expect(model).toBeInstanceOf(OpenAIChatCompletionModel);
     await model.completion({
-      chatHistory: [Message.user("hello")],
+      chatHistory: [Message.user("hello", { metadata: { composer: { entities: [] } } })],
       documents: [],
       tools: [],
     });

--- a/packages/provider-openai/test/openai-responses.test.ts
+++ b/packages/provider-openai/test/openai-responses.test.ts
@@ -35,7 +35,7 @@ describe("OpenAI Responses mapping", () => {
   it("maps internal tools and tool outputs to Responses API params", () => {
     const request: CompletionRequest = {
       chatHistory: [
-        Message.user("What is 2+5?"),
+        Message.user("What is 2+5?", { metadata: { composer: { entities: [] } } }),
         Message.assistant([AssistantContent.toolCall("call_1", "add", { x: 2, y: 5 }, "fc_1")]),
         Message.tool([
           {
@@ -75,6 +75,7 @@ describe("OpenAI Responses mapping", () => {
       call_id: "fc_1",
       output: "7",
     });
+    expect(params.input).toContainEqual({ role: "user", content: "What is 2+5?" });
   });
 
   it("maps multimodal tool outputs to Responses API output content", () => {

--- a/packages/react/test/transport.test.ts
+++ b/packages/react/test/transport.test.ts
@@ -178,8 +178,9 @@ describe("@anvia/react transports", () => {
 
 describe("@anvia/react useChat", () => {
   it("creates initial UI messages from memory messages", () => {
+    const metadata = { composer: { entities: [{ id: "document-1" }] } };
     const memoryMessages = [
-      Message.user("Where is order A-100?"),
+      Message.user("Where is order A-100?", { metadata }),
       Message.assistant([
         AssistantContent.toolCall("call_1", "lookup_order", { orderId: "A-100" }),
       ]),
@@ -190,7 +191,11 @@ describe("@anvia/react useChat", () => {
     const initialMessages = initialMessagesFromMemory(memoryMessages);
 
     expect(initialMessages).toMatchObject([
-      { role: "user", parts: [{ type: "text", text: "Where is order A-100?" }] },
+      {
+        role: "user",
+        parts: [{ type: "text", text: "Where is order A-100?" }],
+        metadata,
+      },
       {
         role: "assistant",
         parts: [
@@ -224,12 +229,14 @@ describe("@anvia/react useChat", () => {
 
   it("sends converted core messages and applies UI stream events", async () => {
     const onEvent = vi.fn();
+    const metadata = { composer: { entities: [{ id: "document-1" }] } };
     const transport: EventTransport<UIStreamRequest, UIStreamEvent> = {
       send: async function* (request) {
         expect(request.messages).toHaveLength(1);
         expect(request.messages[0]).toMatchObject({
           role: "user",
           content: [{ type: "text", text: "hi" }],
+          metadata,
         });
         expect(request.stream).toBe(true);
         yield {
@@ -259,14 +266,19 @@ describe("@anvia/react useChat", () => {
     const { result } = renderHook(() => useChat({ transport, onEvent }));
 
     await act(async () => {
-      await result.current.sendMessage({ text: "hi", id: "user_1" });
+      await result.current.sendMessage({ text: "hi", id: "user_1", metadata });
     });
 
     expect(result.current.status).toBe("idle");
     expect(result.current.error).toBeUndefined();
     expect(result.current.text).toBe("Hello");
     expect(result.current.messages).toMatchObject([
-      { id: "user_1", role: "user", parts: [{ type: "text", text: "hi" }] },
+      {
+        id: "user_1",
+        role: "user",
+        parts: [{ type: "text", text: "hi" }],
+        metadata,
+      },
       {
         id: "assistant_1",
         role: "assistant",


### PR DESCRIPTION
Stack 1 of 4 for first-class Composer entity persistence.

## Summary

- add strict JSON metadata to every core message role and message factory
- preserve UI message metadata through UI-to-core-to-UI conversion and JSON serialization
- keep metadata-bearing tool messages structurally stable during UI rehydration
- keep UI metadata out of OpenAI, Anthropic, Gemini, Mistral, and Grok requests
- keep metadata on run transcripts while omitting it from model-generation trace inputs
- cover old and new factory signatures, React transport hydration, provider mappings, and observability

## Behavior

Message metadata is durable application state, not model input. The canonical validator rejects lossy or non-JSON values including non-finite numbers, sparse arrays, cycles, bigint values, accessors, and non-plain objects.

## Verification

- pnpm check
- pnpm --filter @anvia/core build
- pnpm --filter ./packages/** --filter !@anvia/core build
- pnpm --filter ./packages/** typecheck
- pnpm --filter ./packages/** test
- pnpm --filter www reference-check
- pnpm --filter www build

All commands pass on the complete stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for strict JSON metadata on system, user, assistant, and tool messages.
  * Preserved message metadata when converting between UI and core messages.
  * Exposed JSON validation utilities and message option types.
* **Bug Fixes**
  * Prevented message metadata from being included in provider requests and model-generation trace inputs.
  * Preserved metadata in observability run transcripts while keeping generation inputs clean.
* **Tests**
  * Added coverage for metadata validation, persistence, conversion, provider requests, and observability traces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->