### PR TITLE
Persist message metadata in memory and Studio

### DIFF
--- a/.changeset/persist-message-metadata-stores.md
+++ b/.changeset/persist-message-metadata-stores.md
@@ -1,0 +1,9 @@
+---
+"@anvia/memory-sqlite": patch
+"@anvia/memory-postgres": patch
+"@anvia/memory-prisma": patch
+"@anvia/memory-drizzle": patch
+"@anvia/studio": patch
+---
+
+Preserve strict JSON message metadata in durable memory adapters and Studio's normalized SQLite session storage.

--- a/packages/memory-drizzle/package.json
+++ b/packages/memory-drizzle/package.json
@@ -39,7 +39,7 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": ">=0.12.0 <1.0.0",
+    "@anvia/core": ">=0.13.0 <1.0.0",
     "drizzle-orm": ">=0.45.0 <1.0.0"
   }
 }

--- a/packages/memory-drizzle/src/message.ts
+++ b/packages/memory-drizzle/src/message.ts
@@ -1,4 +1,4 @@
-import type { JsonValue, Message } from "@anvia/core";
+import { isJsonValue, type JsonValue, type Message } from "@anvia/core";
 
 export function parseMemoryMessage(value: unknown): Message {
   if (!isMemoryMessage(value)) {
@@ -9,6 +9,9 @@ export function parseMemoryMessage(value: unknown): Message {
 
 export function isMemoryMessage(value: unknown): value is Message {
   if (!isRecord(value) || typeof value.role !== "string") {
+    return false;
+  }
+  if (value.metadata !== undefined && !isJsonValue(value.metadata)) {
     return false;
   }
 
@@ -39,25 +42,6 @@ export function serializeUnknownError(error: unknown): JsonValue {
   return {
     message: String(error),
   };
-}
-
-function isJsonValue(value: unknown): value is JsonValue {
-  if (
-    value === null ||
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  ) {
-    return Number.isFinite(value) || typeof value !== "number";
-  }
-
-  if (Array.isArray(value)) {
-    return value.every(isJsonValue);
-  }
-
-  return (
-    isRecord(value) && Object.values(value).every((item) => item === undefined || isJsonValue(item))
-  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/memory-drizzle/src/store.ts
+++ b/packages/memory-drizzle/src/store.ts
@@ -112,6 +112,7 @@ export class DrizzleMemoryStore implements MemoryStore {
     if (input.messages.length === 0) {
       return;
     }
+    this.validateInputMessages(input.messages);
 
     const scopeKey = this.scopeKey(input.context);
 
@@ -150,6 +151,7 @@ export class DrizzleMemoryStore implements MemoryStore {
     if (this.options.errors === "ignore") {
       return;
     }
+    this.validateInputMessages(input.messages);
 
     const scopeKey = this.scopeKey(input.context);
 
@@ -220,6 +222,14 @@ export class DrizzleMemoryStore implements MemoryStore {
       return this.options.scope(context);
     }
     return createDrizzleMemoryScopeKey(context, this.options.scope);
+  }
+
+  private validateInputMessages(messages: Message[]): void {
+    if (this.options.validateMessages) {
+      for (const message of messages) {
+        parseMemoryMessage(message);
+      }
+    }
   }
 }
 

--- a/packages/memory-drizzle/test/store.test.ts
+++ b/packages/memory-drizzle/test/store.test.ts
@@ -8,6 +8,7 @@ import {
   createDrizzleMemoryStore,
   drizzleMemorySchema,
 } from "../src/index.js";
+import { isMemoryMessage } from "../src/message.js";
 
 const userMessage: Message = {
   role: "user",
@@ -20,9 +21,10 @@ const assistantMessage: Message = {
 };
 
 const richMessages: Message[] = [
-  { role: "system", content: "System instructions" },
+  { role: "system", content: "System instructions", metadata: { source: "system" } },
   {
     role: "user",
+    metadata: { composer: { entities: [{ id: "document-1" }] } },
     content: [
       { type: "text", text: "Inspect these", signature: "user-signature" },
       {
@@ -62,6 +64,7 @@ const richMessages: Message[] = [
   {
     role: "assistant",
     id: "assistant-1",
+    metadata: { source: "assistant" },
     content: [
       { type: "text", text: "Working", signature: "assistant-signature" },
       {
@@ -92,6 +95,7 @@ const richMessages: Message[] = [
   },
   {
     role: "tool",
+    metadata: { source: "tool" },
     content: [
       {
         type: "tool_result",
@@ -108,6 +112,20 @@ const richMessages: Message[] = [
 ];
 
 describe("Drizzle memory public API", () => {
+  it("uses core strict JSON validation for message metadata", async () => {
+    expect(isMemoryMessage({ ...userMessage, metadata: { score: 1 } })).toBe(true);
+    expect(isMemoryMessage({ ...userMessage, metadata: { score: Number.NaN } })).toBe(false);
+    const store = createDrizzleMemoryStore(new FakeDrizzleDb());
+    await expect(
+      store.append({
+        context: { sessionId: "thread-invalid" },
+        runId: "run-invalid",
+        turn: 0,
+        messages: [{ ...userMessage, metadata: { score: Number.NaN } } as Message],
+      }),
+    ).rejects.toThrow("valid Anvia Message");
+  });
+
   it("exports schema tables users can include in their Drizzle schema", () => {
     expect(agentMemorySessions).toBe(drizzleMemorySchema.agentMemorySessions);
     expect(agentMemoryMessages).toBe(drizzleMemorySchema.agentMemoryMessages);

--- a/packages/memory-postgres/package.json
+++ b/packages/memory-postgres/package.json
@@ -42,6 +42,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": ">=0.12.0 <1.0.0"
+    "@anvia/core": ">=0.13.0 <1.0.0"
   }
 }

--- a/packages/memory-postgres/src/message.ts
+++ b/packages/memory-postgres/src/message.ts
@@ -1,4 +1,4 @@
-import type { JsonValue, Message } from "@anvia/core";
+import { isJsonValue, type JsonValue, type Message } from "@anvia/core";
 
 export function parseMemoryMessage(value: unknown): Message {
   if (!isMemoryMessage(value)) {
@@ -9,6 +9,9 @@ export function parseMemoryMessage(value: unknown): Message {
 
 export function isMemoryMessage(value: unknown): value is Message {
   if (!isRecord(value) || typeof value.role !== "string") {
+    return false;
+  }
+  if (value.metadata !== undefined && !isJsonValue(value.metadata)) {
     return false;
   }
 
@@ -39,25 +42,6 @@ export function serializeUnknownError(error: unknown): JsonValue {
   return {
     message: String(error),
   };
-}
-
-function isJsonValue(value: unknown): value is JsonValue {
-  if (
-    value === null ||
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  ) {
-    return Number.isFinite(value) || typeof value !== "number";
-  }
-
-  if (Array.isArray(value)) {
-    return value.every(isJsonValue);
-  }
-
-  return (
-    isRecord(value) && Object.values(value).every((item) => item === undefined || isJsonValue(item))
-  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/memory-postgres/src/store.ts
+++ b/packages/memory-postgres/src/store.ts
@@ -140,6 +140,7 @@ export class PostgresMemoryStore implements MemoryStore {
     if (input.messages.length === 0) {
       return;
     }
+    this.validateInputMessages(input.messages);
 
     const scopeKey = this.scopeKey(input.context);
 
@@ -172,6 +173,7 @@ export class PostgresMemoryStore implements MemoryStore {
     if (this.options.errors === "ignore") {
       return;
     }
+    this.validateInputMessages(input.messages);
 
     const scopeKey = this.scopeKey(input.context);
 
@@ -281,6 +283,14 @@ export class PostgresMemoryStore implements MemoryStore {
   private messageFromValue(value: unknown): Message {
     const parsed = typeof value === "string" ? (JSON.parse(value) as unknown) : value;
     return this.options.validateMessages ? parseMemoryMessage(parsed) : (parsed as Message);
+  }
+
+  private validateInputMessages(messages: Message[]): void {
+    if (this.options.validateMessages) {
+      for (const message of messages) {
+        parseMemoryMessage(message);
+      }
+    }
   }
 
   private scopeKey(context: MemoryContext): string {

--- a/packages/memory-postgres/test/store.test.ts
+++ b/packages/memory-postgres/test/store.test.ts
@@ -10,6 +10,7 @@ import {
   createPostgresMemoryScopeKey,
   createPostgresMemoryStore,
 } from "../src/index.js";
+import { isMemoryMessage } from "../src/message.js";
 
 const userMessage: Message = {
   role: "user",
@@ -22,9 +23,10 @@ const assistantMessage: Message = {
 };
 
 const richMessages: Message[] = [
-  { role: "system", content: "System instructions" },
+  { role: "system", content: "System instructions", metadata: { source: "system" } },
   {
     role: "user",
+    metadata: { composer: { entities: [{ id: "document-1" }] } },
     content: [
       { type: "text", text: "Inspect these", signature: "user-signature" },
       {
@@ -64,6 +66,7 @@ const richMessages: Message[] = [
   {
     role: "assistant",
     id: "assistant-1",
+    metadata: { source: "assistant" },
     content: [
       { type: "text", text: "Working", signature: "assistant-signature" },
       {
@@ -94,6 +97,7 @@ const richMessages: Message[] = [
   },
   {
     role: "tool",
+    metadata: { source: "tool" },
     content: [
       {
         type: "tool_result",
@@ -265,6 +269,23 @@ class FakePgPool extends FakePgClient {
 }
 
 describe("PostgresMemoryStore", () => {
+  it("uses core strict JSON validation for message metadata", async () => {
+    expect(isMemoryMessage({ ...userMessage, metadata: { score: 1 } })).toBe(true);
+    expect(isMemoryMessage({ ...userMessage, metadata: { score: Number.NaN } })).toBe(false);
+    const store = await createPostgresMemoryStore({
+      client: new FakePgClient(),
+      createIfMissing: false,
+    });
+    await expect(
+      store.append({
+        context: { sessionId: "thread-invalid" },
+        runId: "run-invalid",
+        turn: 0,
+        messages: [{ ...userMessage, metadata: { score: Number.NaN } } as Message],
+      }),
+    ).rejects.toThrow("valid Anvia Message");
+  });
+
   it("appends multiple turns, loads in position order, and clears scoped messages", async () => {
     const client = new FakePgClient();
     const store = await createPostgresMemoryStore({ client, createIfMissing: false });

--- a/packages/memory-prisma/package.json
+++ b/packages/memory-prisma/package.json
@@ -41,7 +41,7 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": ">=0.12.0 <1.0.0",
+    "@anvia/core": ">=0.13.0 <1.0.0",
     "@prisma/client": ">=6.2.0 <8.0.0"
   }
 }

--- a/packages/memory-prisma/src/message.ts
+++ b/packages/memory-prisma/src/message.ts
@@ -1,4 +1,4 @@
-import type { JsonValue, Message } from "@anvia/core";
+import { isJsonValue, type JsonValue, type Message } from "@anvia/core";
 
 export function parseMemoryMessage(value: unknown): Message {
   if (!isMemoryMessage(value)) {
@@ -9,6 +9,9 @@ export function parseMemoryMessage(value: unknown): Message {
 
 export function isMemoryMessage(value: unknown): value is Message {
   if (!isRecord(value)) {
+    return false;
+  }
+  if (value.metadata !== undefined && !isJsonValue(value.metadata)) {
     return false;
   }
 
@@ -227,25 +230,6 @@ function isDocumentContent(value: Record<string, unknown>): boolean {
   }
 
   return false;
-}
-
-function isJsonValue(value: unknown): value is JsonValue {
-  if (
-    value === null ||
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  ) {
-    return Number.isFinite(value) || typeof value !== "number";
-  }
-
-  if (Array.isArray(value)) {
-    return value.every(isJsonValue);
-  }
-
-  return (
-    isRecord(value) && Object.values(value).every((item) => item === undefined || isJsonValue(item))
-  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/memory-prisma/src/store.ts
+++ b/packages/memory-prisma/src/store.ts
@@ -76,6 +76,7 @@ export class PrismaMemoryStore implements MemoryStore {
     if (input.messages.length === 0) {
       return;
     }
+    this.validateInputMessages(input.messages);
 
     await this.delegates.transaction(async (tx) => {
       const session = await upsertSession(tx, input.context, this.scopeKey(input.context));
@@ -109,6 +110,7 @@ export class PrismaMemoryStore implements MemoryStore {
     if (this.options.errors === "ignore") {
       return;
     }
+    this.validateInputMessages(input.messages);
     if (this.delegates.errors === undefined) {
       throw new Error(
         'PrismaMemoryStore recordError requires an errors delegate. Pass errors: "ignore" to disable failed-run storage.',
@@ -137,6 +139,14 @@ export class PrismaMemoryStore implements MemoryStore {
       return this.options.scope(context);
     }
     return createPrismaMemoryScopeKey(context, this.options.scope);
+  }
+
+  private validateInputMessages(messages: Message[]): void {
+    if (this.options.validateMessages) {
+      for (const message of messages) {
+        parseMemoryMessage(message);
+      }
+    }
   }
 }
 

--- a/packages/memory-prisma/test/store.test.ts
+++ b/packages/memory-prisma/test/store.test.ts
@@ -9,6 +9,7 @@ import {
   PrismaMemoryStore,
   type PrismaMemoryTransactionOptions,
 } from "../src/index";
+import { isMemoryMessage } from "../src/message";
 
 type SessionRow = {
   id: string;
@@ -66,9 +67,10 @@ type CreateErrorArgs = {
 };
 
 const richMessages: MessageType[] = [
-  { role: "system", content: "System instructions" },
+  { role: "system", content: "System instructions", metadata: { source: "system" } },
   {
     role: "user",
+    metadata: { composer: { entities: [{ id: "document-1" }] } },
     content: [
       { type: "text", text: "Inspect these", signature: "user-signature" },
       {
@@ -108,6 +110,7 @@ const richMessages: MessageType[] = [
   {
     role: "assistant",
     id: "assistant-1",
+    metadata: { source: "assistant" },
     content: [
       { type: "text", text: "Working", signature: "assistant-signature" },
       {
@@ -138,6 +141,7 @@ const richMessages: MessageType[] = [
   },
   {
     role: "tool",
+    metadata: { source: "tool" },
     content: [
       {
         type: "tool_result",
@@ -250,6 +254,21 @@ class FakePrisma {
 }
 
 describe("PrismaMemoryStore", () => {
+  it("uses core strict JSON validation for message metadata", async () => {
+    const message = Message.user("hello");
+    expect(isMemoryMessage({ ...message, metadata: { score: 1 } })).toBe(true);
+    expect(isMemoryMessage({ ...message, metadata: { score: Number.NaN } })).toBe(false);
+    const store = createPrismaMemoryStore(new FakePrisma().client);
+    await expect(
+      store.append({
+        context: { sessionId: "thread-invalid" },
+        runId: "run-invalid",
+        turn: 0,
+        messages: [{ ...message, metadata: { score: Number.NaN } } as MessageType],
+      }),
+    ).rejects.toThrow("valid Anvia Message");
+  });
+
   it("appends and loads scoped messages in position order", async () => {
     const prisma = new FakePrisma();
     const store = createPrismaMemoryStore(prisma.client, {

--- a/packages/memory-sqlite/package.json
+++ b/packages/memory-sqlite/package.json
@@ -38,6 +38,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": ">=0.12.0 <1.0.0"
+    "@anvia/core": ">=0.13.0 <1.0.0"
   }
 }

--- a/packages/memory-sqlite/src/message.ts
+++ b/packages/memory-sqlite/src/message.ts
@@ -1,4 +1,4 @@
-import type { JsonValue, Message } from "@anvia/core";
+import { isJsonValue, type JsonValue, type Message } from "@anvia/core";
 
 export function parseMemoryMessage(value: unknown): Message {
   if (!isMemoryMessage(value)) {
@@ -9,6 +9,9 @@ export function parseMemoryMessage(value: unknown): Message {
 
 export function isMemoryMessage(value: unknown): value is Message {
   if (!isRecord(value)) {
+    return false;
+  }
+  if (value.metadata !== undefined && !isJsonValue(value.metadata)) {
     return false;
   }
 
@@ -227,25 +230,6 @@ function isDocumentContent(value: Record<string, unknown>): boolean {
   }
 
   return false;
-}
-
-function isJsonValue(value: unknown): value is JsonValue {
-  if (
-    value === null ||
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  ) {
-    return Number.isFinite(value) || typeof value !== "number";
-  }
-
-  if (Array.isArray(value)) {
-    return value.every(isJsonValue);
-  }
-
-  return (
-    isRecord(value) && Object.values(value).every((item) => item === undefined || isJsonValue(item))
-  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/memory-sqlite/src/store.ts
+++ b/packages/memory-sqlite/src/store.ts
@@ -86,6 +86,7 @@ export class SqliteMemoryStore implements MemoryStore {
     if (input.messages.length === 0) {
       return;
     }
+    this.validateInputMessages(input.messages);
 
     const db = this.database();
     const scopeKey = this.scopeKey(input.context);
@@ -156,6 +157,7 @@ export class SqliteMemoryStore implements MemoryStore {
     if (this.options.errors === "ignore") {
       return;
     }
+    this.validateInputMessages(input.messages);
 
     const db = this.database();
     const scopeKey = this.scopeKey(input.context);
@@ -272,6 +274,14 @@ export class SqliteMemoryStore implements MemoryStore {
   private messageFromJson(raw: string): Message {
     const value = JSON.parse(raw) as unknown;
     return this.options.validateMessages ? parseMemoryMessage(value) : (value as Message);
+  }
+
+  private validateInputMessages(messages: Message[]): void {
+    if (this.options.validateMessages) {
+      for (const message of messages) {
+        parseMemoryMessage(message);
+      }
+    }
   }
 
   private scopeKey(context: MemoryContext): string {

--- a/packages/memory-sqlite/test/store.test.ts
+++ b/packages/memory-sqlite/test/store.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import type { Message } from "@anvia/core";
 import { afterEach, describe, expect, it } from "vitest";
 import { createSqliteMemoryScopeKey, createSqliteMemoryStore } from "../src/index.js";
+import { isMemoryMessage } from "../src/message.js";
 
 const userMessage: Message = {
   role: "user",
@@ -17,9 +18,10 @@ const assistantMessage: Message = {
 };
 
 const richMessages: Message[] = [
-  { role: "system", content: "System instructions" },
+  { role: "system", content: "System instructions", metadata: { source: "system" } },
   {
     role: "user",
+    metadata: { composer: { entities: [{ id: "document-1" }] } },
     content: [
       { type: "text", text: "Inspect these", signature: "user-signature" },
       {
@@ -59,6 +61,7 @@ const richMessages: Message[] = [
   {
     role: "assistant",
     id: "assistant-1",
+    metadata: { source: "assistant" },
     content: [
       { type: "text", text: "Working", signature: "assistant-signature" },
       {
@@ -89,6 +92,7 @@ const richMessages: Message[] = [
   },
   {
     role: "tool",
+    metadata: { source: "tool" },
     content: [
       {
         type: "tool_result",
@@ -112,6 +116,20 @@ afterEach(async () => {
 });
 
 describe("SqliteMemoryStore", () => {
+  it("uses core strict JSON validation for message metadata", async () => {
+    expect(isMemoryMessage({ ...userMessage, metadata: { score: 1 } })).toBe(true);
+    expect(isMemoryMessage({ ...userMessage, metadata: { score: Number.NaN } })).toBe(false);
+    const store = createSqliteMemoryStore();
+    await expect(
+      store.append({
+        context: { sessionId: "thread-invalid" },
+        runId: "run-invalid",
+        turn: 0,
+        messages: [{ ...userMessage, metadata: { score: Number.NaN } } as Message],
+      }),
+    ).rejects.toThrow("valid Anvia Message");
+  });
+
   it("appends multiple turns, loads in position order, and clears scoped messages", async () => {
     const store = createSqliteMemoryStore();
     const context = { sessionId: "thread-1", userId: "user-1" };

--- a/packages/tool-studio/package.json
+++ b/packages/tool-studio/package.json
@@ -71,6 +71,6 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "@anvia/core": ">=0.7.1 <1.0.0"
+    "@anvia/core": ">=0.13.0 <1.0.0"
   }
 }

--- a/packages/tool-studio/src/runtime/pipelines.ts
+++ b/packages/tool-studio/src/runtime/pipelines.ts
@@ -28,7 +28,7 @@ import {
 } from "./pipeline-logs";
 import { AsyncEventQueue } from "./runs";
 import { streamStudioJsonl } from "./streams";
-import { isJsonObject, isObject } from "./type-guards";
+import { isJsonObject, isJsonValue, isObject } from "./type-guards";
 
 export function registerPipelineRoutes(
   app: Hono,
@@ -494,22 +494,4 @@ function parsePipelineLogAfter(value: string | undefined): number | undefined | 
     return false;
   }
   return after;
-}
-
-function isJsonValue(value: unknown): value is JsonValue {
-  if (
-    value === null ||
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  ) {
-    return Number.isFinite(value) || typeof value !== "number";
-  }
-  if (Array.isArray(value)) {
-    return value.every(isJsonValue);
-  }
-  if (isObject(value)) {
-    return Object.values(value).every((item) => item === undefined || isJsonValue(item));
-  }
-  return false;
 }

--- a/packages/tool-studio/src/runtime/type-guards.ts
+++ b/packages/tool-studio/src/runtime/type-guards.ts
@@ -1,4 +1,9 @@
-import type { JsonObject, JsonValue, Message } from "@anvia/core/completion";
+import {
+  isJsonValue as isCoreJsonValue,
+  type JsonObject,
+  type JsonValue,
+  type Message,
+} from "@anvia/core/completion";
 import type { AgentTraceOptions } from "../types";
 
 export function isObject(value: unknown): value is Record<string, unknown> {
@@ -6,22 +11,11 @@ export function isObject(value: unknown): value is Record<string, unknown> {
 }
 
 export function isJsonObject(value: unknown): value is JsonObject {
-  return isObject(value) && Object.values(value).every(isJsonValue);
+  return isObject(value) && isCoreJsonValue(value);
 }
 
 export function isJsonValue(value: unknown): value is JsonValue {
-  if (
-    value === null ||
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  ) {
-    return true;
-  }
-  if (Array.isArray(value)) {
-    return value.every(isJsonValue);
-  }
-  return isJsonObject(value);
+  return isCoreJsonValue(value);
 }
 
 export function isMessageInput(value: unknown): value is string | Message {

--- a/packages/tool-studio/src/storage/memory-store.ts
+++ b/packages/tool-studio/src/storage/memory-store.ts
@@ -2,6 +2,7 @@ import type { JsonObject, JsonValue, Message } from "@anvia/core/completion";
 import type { MemoryAppendInput, MemoryContext, MemoryErrorInput } from "@anvia/core/memory";
 import { compact } from "../runtime/compact";
 import { renumberTranscript, transcriptFromMessages } from "../runtime/transcript";
+import { isJsonObject, isJsonValue } from "../runtime/type-guards";
 import type {
   StudioPipelineLogAppendInput,
   StudioPipelineLogEntry,
@@ -327,23 +328,4 @@ function serializeJsonError(error: unknown): JsonValue {
     };
   }
   return isJsonValue(error) ? error : String(error);
-}
-
-function isJsonObject(value: unknown): value is JsonObject {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isJsonValue(value: unknown): value is JsonValue {
-  if (
-    value === null ||
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  ) {
-    return true;
-  }
-  if (Array.isArray(value)) {
-    return value.every(isJsonValue);
-  }
-  return isJsonObject(value) && Object.values(value).every(isJsonValue);
 }

--- a/packages/tool-studio/src/storage/sqlite-store.ts
+++ b/packages/tool-studio/src/storage/sqlite-store.ts
@@ -2,7 +2,7 @@ import { mkdirSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
 import type { DatabaseSync as DatabaseSyncType } from "node:sqlite";
-import type { JsonObject, JsonValue, Message } from "@anvia/core/completion";
+import { isJsonValue, type JsonObject, type JsonValue, type Message } from "@anvia/core/completion";
 import type { MemoryAppendInput, MemoryContext, MemoryErrorInput } from "@anvia/core/memory";
 import { compact } from "../runtime/compact";
 import { renumberTranscript, transcriptFromMessages } from "../runtime/transcript";
@@ -59,6 +59,7 @@ type MessageRow = {
   message_index: number;
   role: Message["role"];
   message_id: string | null;
+  metadata_json: string | null;
   created_at: string;
 };
 
@@ -891,6 +892,7 @@ class SqliteSessionStore
         message_index INTEGER NOT NULL,
         role TEXT NOT NULL,
         message_id TEXT,
+        metadata_json TEXT,
         created_at TEXT NOT NULL,
         PRIMARY KEY(session_id, message_index),
         FOREIGN KEY(session_id) REFERENCES anvia_studio_sessions(id) ON DELETE CASCADE
@@ -985,6 +987,7 @@ class SqliteSessionStore
       CREATE INDEX IF NOT EXISTS anvia_studio_traces_session_started_idx
         ON anvia_studio_traces(session_id, started_at DESC);
     `);
+    ensureMessageMetadataColumn(db);
 
     this.db = db;
     return db;
@@ -1047,7 +1050,7 @@ class SqliteSessionStore
     const db = this.database();
     const messageRows = db
       .prepare(
-        `SELECT session_id, message_index, role, message_id, created_at
+        `SELECT session_id, message_index, role, message_id, metadata_json, created_at
          FROM anvia_studio_session_messages
          WHERE session_id = $sessionId
          ORDER BY message_index ASC`,
@@ -1102,8 +1105,9 @@ class SqliteSessionStore
         message_index,
         role,
         message_id,
+        metadata_json,
         created_at
-      ) VALUES ($sessionId, $messageIndex, $role, $messageId, $createdAt)`,
+      ) VALUES ($sessionId, $messageIndex, $role, $messageId, $metadata, $createdAt)`,
     );
     const insertPart = db.prepare(
       `INSERT INTO anvia_studio_session_message_parts (
@@ -1117,11 +1121,15 @@ class SqliteSessionStore
 
     messages.forEach((message, messageOffset) => {
       const messageIndex = startIndex + messageOffset;
+      if (message.metadata !== undefined && !isJsonValue(message.metadata)) {
+        throw new TypeError("Studio message metadata must be a strict JSON value.");
+      }
       insertMessage.run({
         $sessionId: sessionId,
         $messageIndex: messageIndex,
         $role: message.role,
         $messageId: message.role === "assistant" ? (message.id ?? null) : null,
+        $metadata: message.metadata === undefined ? null : JSON.stringify(message.metadata),
         $createdAt: createdAt,
       });
 
@@ -1230,14 +1238,20 @@ function messageParts(message: Message): StoredMessagePart[] {
 
 function messageFromRows(row: MessageRow, partRows: MessagePartRow[]): Message {
   const parts = partRows.map((partRow) => JSON.parse(partRow.part_json) as unknown);
+  const metadata = parseJsonValue<JsonValue>(row.metadata_json);
+  if (metadata !== undefined && !isJsonValue(metadata)) {
+    throw new TypeError("Stored Studio message metadata is not a strict JSON value.");
+  }
+  const metadataProperties = compact({ metadata });
 
   if (row.role === "system") {
-    return { role: "system", content: systemContentFromParts(parts) };
+    return { role: "system", content: systemContentFromParts(parts), ...metadataProperties };
   }
   if (row.role === "user") {
     return {
       role: "user",
       content: parts as Extract<Message, { role: "user" }>["content"],
+      ...metadataProperties,
     };
   }
   if (row.role === "assistant") {
@@ -1245,12 +1259,14 @@ function messageFromRows(row: MessageRow, partRows: MessagePartRow[]): Message {
       role: "assistant",
       ...compact({ id: row.message_id ?? undefined }),
       content: parts as Extract<Message, { role: "assistant" }>["content"],
+      ...metadataProperties,
     };
   }
   if (row.role === "tool") {
     return {
       role: "tool",
       content: parts as Extract<Message, { role: "tool" }>["content"],
+      ...metadataProperties,
     };
   }
 
@@ -1278,6 +1294,15 @@ function guardAgainstLegacySessionSchema(db: DatabaseSyncType): void {
     throw new Error(
       "Existing Studio SQLite DB uses the legacy messages_json schema. Delete or recreate the Studio SQLite DB to use normalized session messages.",
     );
+  }
+}
+
+function ensureMessageMetadataColumn(db: DatabaseSyncType): void {
+  const columns = db
+    .prepare("PRAGMA table_info('anvia_studio_session_messages')")
+    .all() as TableInfoRow[];
+  if (!columns.some((column) => column.name === "metadata_json")) {
+    db.exec("ALTER TABLE anvia_studio_session_messages ADD COLUMN metadata_json TEXT");
   }
 }
 

--- a/packages/tool-studio/test/runner.test.ts
+++ b/packages/tool-studio/test/runner.test.ts
@@ -3422,20 +3422,58 @@ describe("Anvia studio", () => {
     });
   });
 
+  it("rejects non-JSON message metadata in the SQLite session store", async () => {
+    const store = createSqliteSessionStore({ path: ":memory:" });
+    store.createSession({ id: "session_1", agentId: "support" });
+    const invalidMessage = {
+      ...Message.user("hi"),
+      metadata: { score: Number.NaN },
+    } as CoreMessage;
+
+    expect(() =>
+      store.append({
+        context: { sessionId: "session_1" },
+        runId: "run_1",
+        turn: 1,
+        messages: [invalidMessage],
+      }),
+    ).toThrow("Studio message metadata must be a strict JSON value");
+    await expect(store.load({ sessionId: "session_1" })).resolves.toEqual([]);
+  });
+
   it("persists session messages and parts in normalized SQLite tables", async () => {
     const path = join(studioDbDir ?? tmpdir(), "normalized.sqlite");
     const store = createSqliteSessionStore({ path });
     store.createSession({ id: "session_1", agentId: "support" });
 
     const messages = [
-      Message.system("Use project policy."),
-      Message.user([
-        UserContent.text("hi"),
-        UserContent.imageUrl("https://example.test/image.png", { detail: "high" }),
-        UserContent.documentUrl("https://example.test/file.pdf", "application/pdf", {
-          filename: "file.pdf",
-        }),
-      ]),
+      Message.system("Use project policy.", { metadata: { source: "system" } }),
+      Message.user(
+        [
+          UserContent.text("hi @Guide.pdf"),
+          UserContent.imageUrl("https://example.test/image.png", { detail: "high" }),
+          UserContent.documentUrl("https://example.test/file.pdf", "application/pdf", {
+            filename: "file.pdf",
+          }),
+        ],
+        {
+          metadata: {
+            composer: {
+              entities: [
+                {
+                  id: "document-1",
+                  triggerId: "documents",
+                  trigger: "@",
+                  label: "Guide.pdf",
+                  text: "@Guide.pdf",
+                  range: { from: 3, to: 13 },
+                  data: { kind: "document", documentId: "document-1" },
+                },
+              ],
+            },
+          },
+        },
+      ),
       Message.assistant(
         [
           AssistantContent.text("hello"),
@@ -3443,7 +3481,7 @@ describe("Anvia studio", () => {
           AssistantContent.toolCall("tool_1", "lookup", { query: "x" }, "call_1"),
           AssistantContent.imageBase64("abc123", "image/png"),
         ],
-        "assistant_message_1",
+        { id: "assistant_message_1", metadata: { source: "assistant" } },
       ),
       Message.tool(
         ToolContent.toolResult(
@@ -3454,6 +3492,7 @@ describe("Anvia studio", () => {
           ],
           "call_1",
         ),
+        { metadata: { source: "tool" } },
       ),
     ];
 
@@ -3479,6 +3518,13 @@ describe("Anvia studio", () => {
       .get() as { count: number };
     expect(messageCount.count).toBe(4);
     expect(partCount.count).toBe(9);
+    expect(
+      db
+        .prepare(
+          "SELECT COUNT(*) AS count FROM anvia_studio_session_messages WHERE metadata_json IS NOT NULL",
+        )
+        .get(),
+    ).toEqual({ count: 4 });
     db.close();
 
     const reloaded = createSqliteSessionStore({ path });
@@ -3488,6 +3534,73 @@ describe("Anvia studio", () => {
       messageCount: 4,
       messages,
     });
+  });
+
+  it("migrates normalized SQLite message tables to persist metadata", async () => {
+    const path = join(studioDbDir ?? tmpdir(), "normalized-metadata-migration.sqlite");
+    const db = new DatabaseSync(path);
+    db.exec(`
+      PRAGMA foreign_keys = ON;
+      CREATE TABLE anvia_studio_sessions (
+        id TEXT PRIMARY KEY,
+        agent_id TEXT NOT NULL,
+        title TEXT,
+        metadata_json TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      ) STRICT;
+      CREATE TABLE anvia_studio_session_messages (
+        session_id TEXT NOT NULL,
+        message_index INTEGER NOT NULL,
+        role TEXT NOT NULL,
+        message_id TEXT,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY(session_id, message_index),
+        FOREIGN KEY(session_id) REFERENCES anvia_studio_sessions(id) ON DELETE CASCADE
+      ) STRICT;
+      CREATE TABLE anvia_studio_session_message_parts (
+        session_id TEXT NOT NULL,
+        message_index INTEGER NOT NULL,
+        part_index INTEGER NOT NULL,
+        type TEXT NOT NULL,
+        part_json TEXT NOT NULL,
+        PRIMARY KEY(session_id, message_index, part_index),
+        FOREIGN KEY(session_id, message_index)
+          REFERENCES anvia_studio_session_messages(session_id, message_index)
+          ON DELETE CASCADE
+      ) STRICT;
+      INSERT INTO anvia_studio_sessions
+        (id, agent_id, title, metadata_json, created_at, updated_at)
+      VALUES ('session_1', 'support', NULL, NULL, '2026-01-01', '2026-01-01');
+      INSERT INTO anvia_studio_session_messages
+        (session_id, message_index, role, message_id, created_at)
+      VALUES ('session_1', 0, 'user', NULL, '2026-01-01');
+      INSERT INTO anvia_studio_session_message_parts
+        (session_id, message_index, part_index, type, part_json)
+      VALUES ('session_1', 0, 0, 'text', '{"type":"text","text":"legacy"}');
+    `);
+    db.close();
+
+    const store = createSqliteSessionStore({ path });
+    await expect(store.load({ sessionId: "session_1" })).resolves.toEqual([Message.user("legacy")]);
+    const metadata = { composer: { entities: [{ id: "document-1" }] } };
+    await store.append({
+      context: { sessionId: "session_1" },
+      runId: "run_1",
+      turn: 1,
+      messages: [Message.user("new", { metadata })],
+    });
+    await expect(store.load({ sessionId: "session_1" })).resolves.toEqual([
+      Message.user("legacy"),
+      Message.user("new", { metadata }),
+    ]);
+
+    const migrated = new DatabaseSync(path);
+    const columns = migrated
+      .prepare("PRAGMA table_info('anvia_studio_session_messages')")
+      .all() as Array<{ name: string }>;
+    expect(columns.map((column) => column.name)).toContain("metadata_json");
+    migrated.close();
   });
 
   it("persists session audit logs with monotonic sequence and deletes them with sessions", async () => {


### PR DESCRIPTION
Stack 2 of 4. Depends on #247.

## Summary

- reuse the core strict JSON validator in SQLite, Postgres, Prisma, and Drizzle memory adapters
- validate messages before append and when loading stored rows
- preserve metadata through each adapter existing full-message JSON storage
- add Studio normalized SQLite message metadata storage
- migrate already-normalized Studio databases by adding the nullable metadata_json column
- centralize Studio JSON checks on the core validator

## Migration safety

Existing normalized Studio databases are upgraded in place. Legacy messages_json databases retain the existing explicit unsupported-schema error. Database adapters that already store complete message JSON require no schema changes.

## Verification

- all four memory adapter typechecks and tests
- Studio typecheck, 105 tests, and production build
- migration regression from the previous normalized schema
- complete-stack lint, package builds, package typechecks/tests, reference coverage, and docs build

All commands pass.