### PR TITLE
Render Composer entities in Message.Markdown

### DIFF
--- a/.changeset/render-composer-message-entities.md
+++ b/.changeset/render-composer-message-entities.md
@@ -1,0 +1,5 @@
+---
+"@anvia/react-ui": minor
+---
+
+Render validated Composer entities as headless semantic markup in `Message.Markdown`, with `Message.Entity` and `renderEntity` customization APIs.

--- a/apps/www/src/content/docs/packages/react-ui/reference.md
+++ b/apps/www/src/content/docs/packages/react-ui/reference.md
@@ -93,6 +93,7 @@ const Message: {
   Part: React.ForwardRefExoticComponent<...>;
   Text: React.ForwardRefExoticComponent<...>;
   Markdown: React.ForwardRefExoticComponent<...>;
+  Entity: React.ForwardRefExoticComponent<MessageEntityProps & React.RefAttributes<HTMLSpanElement>>;
   CodeBlock: React.ForwardRefExoticComponent<...>;
   Reasoning: React.ForwardRefExoticComponent<...>;
   Tool: React.ForwardRefExoticComponent<...>;
@@ -173,6 +174,18 @@ type MessageStreamAnimationProps = {
 
 Animation is disabled by default. When enabled, these renderers pass their existing text through
 `useSmoothStreamText`; the underlying `useChat` controller and `UIMessage[]` remain unchanged.
+
+`Message.Markdown` also accepts `renderEntity?: (entity: ComposerEntity) => ReactNode`. Valid
+entities from `message.metadata.composer.entities` render through `Message.Entity` by default.
+
+```ts
+type MessageEntityProps = React.HTMLAttributes<HTMLSpanElement> & {
+  entity: ComposerEntity;
+};
+```
+
+The default span emits `data-anvia-message-entity`, `data-entity-id`, and `data-trigger-id`. It does
+not serialize `entity.data` into the DOM.
 
 ## Providers
 
@@ -341,6 +354,12 @@ type ComposerEntity = {
     to: number;
   };
   data?: ComposerEntityData;
+};
+
+type ComposerMessageMetadata = {
+  composer: {
+    entities: ComposerEntity[];
+  };
 };
 
 type ComposerTriggerState = {

--- a/packages/react-ui/src/chat/index.ts
+++ b/packages/react-ui/src/chat/index.ts
@@ -7,6 +7,7 @@ export type {
   ComposerEntitiesUpdate,
   ComposerEntity,
   ComposerEntityData,
+  ComposerMessageMetadata,
   ComposerQuote,
   ComposerTriggerDefinition,
   ComposerTriggerItem,

--- a/packages/react-ui/src/contexts/composer.tsx
+++ b/packages/react-ui/src/contexts/composer.tsx
@@ -60,6 +60,11 @@ export type ComposerEntity = {
   };
   data?: ComposerEntityData | undefined;
 };
+export type ComposerMessageMetadata = {
+  composer: {
+    entities: ComposerEntity[];
+  };
+};
 export type ComposerTriggerState = {
   trigger: ComposerTriggerDefinition;
   query: string;

--- a/packages/react-ui/src/contexts/index.ts
+++ b/packages/react-ui/src/contexts/index.ts
@@ -13,6 +13,7 @@ export type {
   ComposerEntitiesUpdate,
   ComposerEntity,
   ComposerEntityData,
+  ComposerMessageMetadata,
   ComposerQuote,
   ComposerTriggerDefinition,
   ComposerTriggerItem,

--- a/packages/react-ui/src/entities.ts
+++ b/packages/react-ui/src/entities.ts
@@ -1,0 +1,151 @@
+import type { UIMessagePart } from "@anvia/react";
+import type { ComposerEntity } from "./contexts/composer";
+
+export type MessageTextSegment = {
+  part: Extract<UIMessagePart, { type: "text" }>;
+  from: number;
+  to: number;
+};
+
+export type MessageTextLayout = {
+  text: string;
+  segments: MessageTextSegment[];
+};
+
+export function messageTextLayout(parts: UIMessagePart[]): MessageTextLayout {
+  const textParts = parts.filter(
+    (part): part is Extract<UIMessagePart, { type: "text" }> => part.type === "text",
+  );
+  const segments: MessageTextSegment[] = [];
+  let offset = 0;
+
+  for (const [index, part] of textParts.entries()) {
+    const from = offset;
+    const to = from + part.text.length;
+    segments.push({ part, from, to });
+    offset = to + (index === textParts.length - 1 ? 0 : 2);
+  }
+
+  return {
+    text: textParts.map((part) => part.text).join("\n\n"),
+    segments,
+  };
+}
+
+export function validComposerEntities(text: string, metadata: unknown): ComposerEntity[] {
+  const candidates = composerEntityCandidates(metadata);
+  const individuallyValid = candidates.flatMap((entity, index) =>
+    isValidComposerEntity(entity, text) ? [{ entity, index }] : [],
+  );
+  individuallyValid.sort(
+    (left, right) =>
+      left.entity.range.from - right.entity.range.from ||
+      left.entity.range.to - right.entity.range.to ||
+      left.index - right.index,
+  );
+
+  const overlapping = new Set<number>();
+  let groupStart = 0;
+  let groupEnd = individuallyValid[0]?.entity.range.to ?? 0;
+  let groupHasOverlap = false;
+  for (let index = 1; index <= individuallyValid.length; index += 1) {
+    const current = individuallyValid[index];
+    if (current !== undefined && current.entity.range.from < groupEnd) {
+      groupHasOverlap = true;
+      groupEnd = Math.max(groupEnd, current.entity.range.to);
+      continue;
+    }
+    if (groupHasOverlap) {
+      for (let groupIndex = groupStart; groupIndex < index; groupIndex += 1) {
+        const candidate = individuallyValid[groupIndex];
+        if (candidate !== undefined) {
+          overlapping.add(candidate.index);
+        }
+      }
+    }
+    groupStart = index;
+    groupEnd = current?.entity.range.to ?? 0;
+    groupHasOverlap = false;
+  }
+
+  return individuallyValid
+    .filter((candidate) => !overlapping.has(candidate.index))
+    .map((candidate) => candidate.entity);
+}
+
+export function entitiesForTextSegment(
+  entities: ComposerEntity[],
+  segment: MessageTextSegment,
+): ComposerEntity[] {
+  return entities.flatMap((entity) => {
+    if (entity.range.from < segment.from || entity.range.to > segment.to) {
+      return [];
+    }
+    return [
+      {
+        ...entity,
+        range: {
+          from: entity.range.from - segment.from,
+          to: entity.range.to - segment.from,
+        },
+      },
+    ];
+  });
+}
+
+export function shiftComposerEntityRanges(
+  entities: ComposerEntity[],
+  offset: number,
+): ComposerEntity[] {
+  if (offset === 0) {
+    return entities;
+  }
+  return entities.map((entity) => ({
+    ...entity,
+    range: {
+      from: entity.range.from + offset,
+      to: entity.range.to + offset,
+    },
+  }));
+}
+
+function composerEntityCandidates(metadata: unknown): unknown[] {
+  if (!isRecord(metadata) || !isRecord(metadata.composer)) {
+    return [];
+  }
+  return Array.isArray(metadata.composer.entities) ? metadata.composer.entities : [];
+}
+
+function isValidComposerEntity(value: unknown, text: string): value is ComposerEntity {
+  if (!isRecord(value) || !isRecord(value.range)) {
+    return false;
+  }
+  if (
+    !isNonEmptyString(value.id) ||
+    !isNonEmptyString(value.triggerId) ||
+    !isNonEmptyString(value.trigger) ||
+    !isNonEmptyString(value.label) ||
+    !isNonEmptyString(value.text)
+  ) {
+    return false;
+  }
+  const { from, to } = value.range;
+  return (
+    typeof from === "number" &&
+    typeof to === "number" &&
+    Number.isInteger(from) &&
+    Number.isInteger(to) &&
+    from >= 0 &&
+    to > from &&
+    to <= text.length &&
+    text.slice(from, to) === value.text
+  );
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/react-ui/src/index.ts
+++ b/packages/react-ui/src/index.ts
@@ -24,6 +24,7 @@ export {
 export { Image, useImage } from "./image/index";
 export type {
   MessageAttachmentPart,
+  MessageEntityProps,
   MessagePartsFilter,
   MessageToolPart,
   MessageToolRenderWhen,
@@ -45,6 +46,7 @@ export type {
   ComposerEntitiesUpdate,
   ComposerEntity,
   ComposerEntityData,
+  ComposerMessageMetadata,
   ComposerQuote,
   ComposerTriggerDefinition,
   ComposerTriggerItem,

--- a/packages/react-ui/src/message/entity.tsx
+++ b/packages/react-ui/src/message/entity.tsx
@@ -1,0 +1,25 @@
+import { forwardRef, type HTMLAttributes } from "react";
+import type { ComposerEntity } from "../contexts";
+
+export type MessageEntityProps = HTMLAttributes<HTMLSpanElement> & {
+  entity: ComposerEntity;
+};
+
+const MessageEntity = forwardRef<HTMLSpanElement, MessageEntityProps>(function MessageEntity(
+  { children, entity, ...props },
+  ref,
+) {
+  return (
+    <span
+      {...props}
+      data-anvia-message-entity=""
+      data-entity-id={entity.id}
+      data-trigger-id={entity.triggerId}
+      ref={ref}
+    >
+      {children ?? entity.text}
+    </span>
+  );
+});
+
+export { MessageEntity };

--- a/packages/react-ui/src/message/index.ts
+++ b/packages/react-ui/src/message/index.ts
@@ -1,4 +1,5 @@
 import { MessageActions, MessageCopy, MessageRegenerate } from "./actions";
+import { MessageEntity } from "./entity";
 import {
   MessageAttachment,
   MessageCodeBlock,
@@ -25,6 +26,7 @@ export const Message = {
   Part: MessagePart,
   Text: MessageText,
   Markdown: MessageMarkdown,
+  Entity: MessageEntity,
   CodeBlock: MessageCodeBlock,
   Reasoning: MessageReasoning,
   Tool: MessageTool,
@@ -43,6 +45,7 @@ export const Message = {
 
 export type { MessageContextValue, MessagePartContextValue } from "../contexts";
 export { useChatContext, useMessage, useMessagePart } from "../contexts";
+export type { MessageEntityProps } from "./entity";
 export type {
   MessageAttachmentPart,
   MessagePartsFilter,

--- a/packages/react-ui/src/message/markdown-entities.ts
+++ b/packages/react-ui/src/message/markdown-entities.ts
@@ -1,0 +1,306 @@
+import type { Options as ReactMarkdownOptions } from "react-markdown";
+import type { ComposerEntity } from "../contexts";
+
+type MarkdownPoint = {
+  offset?: number | undefined;
+};
+
+type MarkdownPosition = {
+  start: MarkdownPoint;
+  end: MarkdownPoint;
+};
+
+type MarkdownNode = {
+  type: string;
+  value?: string | undefined;
+  children?: MarkdownNode[] | undefined;
+  position?: MarkdownPosition | undefined;
+  entityIndex?: number | undefined;
+};
+
+const phrasingParentTypes = new Set([
+  "paragraph",
+  "heading",
+  "emphasis",
+  "strong",
+  "delete",
+  "link",
+  "linkReference",
+  "tableCell",
+]);
+const literalNodeTypes = new Set(["code", "inlineCode", "html", "yaml"]);
+
+export function createMessageEntityRemarkPlugin(markdown: string, entities: ComposerEntity[]) {
+  return function messageEntityRemarkPlugin() {
+    return (tree: MarkdownNode): void => {
+      const rendered = new Set<number>();
+      transformNode(tree, markdown, entities, rendered);
+    };
+  };
+}
+
+export function messageEntityRehypeOptions(): ReactMarkdownOptions["remarkRehypeOptions"] {
+  return {
+    handlers: {
+      messageEntity(_state: unknown, node: MarkdownNode) {
+        const entityIndex = node.entityIndex;
+        return {
+          type: "element",
+          tagName: "span",
+          properties: {
+            dataAnviaMessageEntity: "",
+            dataAnviaEntityIndex: entityIndex === undefined ? "" : String(entityIndex),
+          },
+          children: [{ type: "text", value: node.value ?? "" }],
+        };
+      },
+    } as never,
+  };
+}
+
+function transformNode(
+  node: MarkdownNode,
+  markdown: string,
+  entities: ComposerEntity[],
+  rendered: Set<number>,
+): void {
+  if (literalNodeTypes.has(node.type) || node.children === undefined) {
+    return;
+  }
+
+  for (const child of node.children) {
+    transformNode(child, markdown, entities, rendered);
+  }
+  if (!phrasingParentTypes.has(node.type)) {
+    return;
+  }
+
+  for (let entityIndex = entities.length - 1; entityIndex >= 0; entityIndex -= 1) {
+    if (rendered.has(entityIndex)) {
+      continue;
+    }
+    const entity = entities[entityIndex];
+    if (entity !== undefined && replaceEntity(node, markdown, entity, entityIndex)) {
+      rendered.add(entityIndex);
+    }
+  }
+}
+
+function replaceEntity(
+  parent: MarkdownNode,
+  markdown: string,
+  entity: ComposerEntity,
+  entityIndex: number,
+): boolean {
+  const children = parent.children;
+  if (children === undefined) {
+    return false;
+  }
+  const firstIndex = children.findIndex((child) => containsStart(child, entity.range.from));
+  const lastIndex = findLastIndex(children, (child) => containsEnd(child, entity.range.to));
+  if (firstIndex < 0 || lastIndex < firstIndex) {
+    return false;
+  }
+
+  const first = children[firstIndex];
+  const last = children[lastIndex];
+  const firstPosition = offsets(first);
+  const lastPosition = offsets(last);
+  if (
+    first === undefined ||
+    last === undefined ||
+    firstPosition === undefined ||
+    lastPosition === undefined ||
+    entity.range.from < firstPosition.from ||
+    entity.range.to > lastPosition.to
+  ) {
+    return false;
+  }
+
+  if (firstIndex === lastIndex && literalNodeTypes.has(first.type)) {
+    return false;
+  }
+  const before = contentBefore(first, markdown, entity);
+  const after = contentAfter(last, markdown, entity);
+  if (before === undefined || after === undefined) {
+    return false;
+  }
+
+  const replacement: MarkdownNode[] = [];
+  replacement.push(...before);
+  replacement.push({
+    type: "messageEntity",
+    value: entity.text,
+    entityIndex,
+    position: {
+      start: { offset: entity.range.from },
+      end: { offset: entity.range.to },
+    },
+  });
+  replacement.push(...after);
+  children.splice(firstIndex, lastIndex - firstIndex + 1, ...replacement);
+  return true;
+}
+
+function contentBefore(
+  node: MarkdownNode,
+  markdown: string,
+  entity: ComposerEntity,
+): MarkdownNode[] | undefined {
+  const position = offsets(node);
+  if (position === undefined) {
+    return undefined;
+  }
+  if (entity.range.from === position.from) {
+    return [];
+  }
+  if (node.type !== "text" || node.value === undefined) {
+    if (node.children === undefined || literalNodeTypes.has(node.type)) {
+      return undefined;
+    }
+    const childIndex = node.children.findIndex((child) => containsStart(child, entity.range.from));
+    const child = node.children[childIndex];
+    if (child === undefined) {
+      return undefined;
+    }
+    const childContent = contentBefore(child, markdown, entity);
+    return childContent === undefined
+      ? undefined
+      : [...node.children.slice(0, childIndex), ...childContent];
+  }
+  const split = textValueRange(node, markdown, entity);
+  if (split === undefined) {
+    return undefined;
+  }
+  return [
+    {
+      ...node,
+      value: node.value.slice(0, split.from),
+      position: {
+        start: node.position?.start ?? {},
+        end: { offset: entity.range.from },
+      },
+    },
+  ];
+}
+
+function contentAfter(
+  node: MarkdownNode,
+  markdown: string,
+  entity: ComposerEntity,
+): MarkdownNode[] | undefined {
+  const position = offsets(node);
+  if (position === undefined) {
+    return undefined;
+  }
+  if (entity.range.to === position.to) {
+    return [];
+  }
+  if (node.type !== "text" || node.value === undefined) {
+    if (node.children === undefined || literalNodeTypes.has(node.type)) {
+      return undefined;
+    }
+    const childIndex = findLastIndex(node.children, (child) => containsEnd(child, entity.range.to));
+    const child = node.children[childIndex];
+    if (child === undefined) {
+      return undefined;
+    }
+    const childContent = contentAfter(child, markdown, entity);
+    return childContent === undefined
+      ? undefined
+      : [...childContent, ...node.children.slice(childIndex + 1)];
+  }
+  const split = textValueRange(node, markdown, entity);
+  if (split === undefined) {
+    return undefined;
+  }
+  return [
+    {
+      ...node,
+      value: node.value.slice(split.to),
+      position: {
+        start: { offset: entity.range.to },
+        end: node.position?.end ?? {},
+      },
+    },
+  ];
+}
+
+function textValueRange(
+  node: MarkdownNode,
+  markdown: string,
+  entity: ComposerEntity,
+): { from: number; to: number } | undefined {
+  const position = offsets(node);
+  const value = node.value;
+  if (position === undefined || value === undefined) {
+    return undefined;
+  }
+  const raw = markdown.slice(position.from, position.to);
+  const relativeFrom = entity.range.from - position.from;
+  const relativeTo = entity.range.to - position.from;
+  if (raw === value) {
+    return { from: relativeFrom, to: relativeTo };
+  }
+
+  const occurrence = countOccurrences(raw.slice(0, relativeFrom), entity.text);
+  const valueFrom = occurrenceIndex(value, entity.text, occurrence);
+  return valueFrom === undefined
+    ? undefined
+    : { from: valueFrom, to: valueFrom + entity.text.length };
+}
+
+function countOccurrences(value: string, search: string): number {
+  let count = 0;
+  let offset = 0;
+  while (offset <= value.length - search.length) {
+    const index = value.indexOf(search, offset);
+    if (index < 0) {
+      break;
+    }
+    count += 1;
+    offset = index + search.length;
+  }
+  return count;
+}
+
+function occurrenceIndex(value: string, search: string, occurrence: number): number | undefined {
+  let offset = 0;
+  for (let index = 0; index <= occurrence; index += 1) {
+    const found = value.indexOf(search, offset);
+    if (found < 0) {
+      return undefined;
+    }
+    if (index === occurrence) {
+      return found;
+    }
+    offset = found + search.length;
+  }
+  return undefined;
+}
+
+function containsStart(node: MarkdownNode, offset: number): boolean {
+  const position = offsets(node);
+  return position !== undefined && offset >= position.from && offset < position.to;
+}
+
+function containsEnd(node: MarkdownNode, offset: number): boolean {
+  const position = offsets(node);
+  return position !== undefined && offset > position.from && offset <= position.to;
+}
+
+function offsets(node: MarkdownNode | undefined): { from: number; to: number } | undefined {
+  const from = node?.position?.start.offset;
+  const to = node?.position?.end.offset;
+  return typeof from === "number" && typeof to === "number" ? { from, to } : undefined;
+}
+
+function findLastIndex<T>(items: T[], predicate: (item: T) => boolean): number {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const item = items[index];
+    if (item !== undefined && predicate(item)) {
+      return index;
+    }
+  }
+  return -1;
+}

--- a/packages/react-ui/src/message/parts.tsx
+++ b/packages/react-ui/src/message/parts.tsx
@@ -5,7 +5,7 @@ import {
   type UIMessagePart,
   useSmoothStreamText,
 } from "@anvia/react";
-import { type ComponentPropsWithoutRef, forwardRef, type ReactNode } from "react";
+import { type ComponentPropsWithoutRef, createElement, forwardRef, type ReactNode } from "react";
 import ReactMarkdown, {
   type Components,
   type Options as ReactMarkdownOptions,
@@ -13,6 +13,7 @@ import ReactMarkdown, {
 import remarkGfm from "remark-gfm";
 
 import { Attachment } from "../attachment/index";
+import type { ComposerEntity } from "../contexts";
 import {
   InternalAttachmentProvider,
   InternalMessagePartProvider,
@@ -20,8 +21,11 @@ import {
   useMessagePart,
   useOptionalMessagePart,
 } from "../contexts";
+import { entitiesForTextSegment, messageTextLayout, validComposerEntities } from "../entities";
 import { stringifyValue } from "../format";
 import { type PrimitiveProps, renderPrimitive } from "../primitives";
+import { MessageEntity } from "./entity";
+import { createMessageEntityRemarkPlugin, messageEntityRehypeOptions } from "./markdown-entities";
 
 type MessagePartChildren = ReactNode | ((part: UIMessagePart) => ReactNode);
 export type MessagePartsFilter = (part: UIMessagePart) => boolean;
@@ -150,6 +154,7 @@ type MessageMarkdownProps = Omit<PrimitiveProps<"div">, "children"> &
   MessageStreamAnimationProps & {
     children?: string;
     components?: Components;
+    renderEntity?: ((entity: ComposerEntity) => ReactNode) | undefined;
     remarkPlugins?: ReactMarkdownOptions["remarkPlugins"];
   };
 
@@ -164,16 +169,25 @@ const MessageMarkdown = forwardRef<HTMLDivElement, MessageMarkdownProps>(functio
     return null;
   }
 
-  const markdown =
-    children ??
-    (part?.type === "text"
-      ? part.text
-      : message.parts.flatMap((item) => (item.type === "text" ? [item.text] : [])).join("\n\n"));
+  const layout = messageTextLayout(message.parts);
+  const markdown = children ?? (part?.type === "text" ? part.text : layout.text);
+  const expectedMarkdown = part?.type === "text" ? part.text : layout.text;
+  const validEntities =
+    children === undefined || children === expectedMarkdown
+      ? validComposerEntities(layout.text, message.metadata)
+      : [];
+  const segment =
+    part?.type === "text"
+      ? layout.segments.find((candidate) => candidate.part.id === part.id)
+      : undefined;
+  const entities =
+    segment === undefined ? validEntities : entitiesForTextSegment(validEntities, segment);
 
-  return <MessageMarkdownContent {...props} markdown={markdown} ref={ref} />;
+  return <MessageMarkdownContent {...props} entities={entities} markdown={markdown} ref={ref} />;
 });
 
 type MessageMarkdownContentProps = Omit<MessageMarkdownProps, "children"> & {
+  entities: ComposerEntity[];
   markdown: string;
 };
 
@@ -186,7 +200,9 @@ const MessageMarkdownContent = forwardRef<HTMLDivElement, MessageMarkdownContent
       smoothingPreset,
       reducedMotion,
       components,
+      renderEntity,
       remarkPlugins,
+      entities,
       markdown,
       ...props
     },
@@ -201,6 +217,10 @@ const MessageMarkdownContent = forwardRef<HTMLDivElement, MessageMarkdownContent
     });
     const animationActive =
       animate && animationMode !== "none" && isStreaming !== false && reducedMotion !== true;
+    const renderedMarkdown = animate ? smooth.text : markdown;
+    const renderedEntities = validComposerEntities(renderedMarkdown, {
+      composer: { entities },
+    });
 
     return renderPrimitive(
       "div",
@@ -208,10 +228,14 @@ const MessageMarkdownContent = forwardRef<HTMLDivElement, MessageMarkdownContent
         ...props,
         children: (
           <ReactMarkdown
-            components={{ code: defaultCodeComponent, pre: defaultPreComponent, ...components }}
-            remarkPlugins={remarkPlugins ?? [remarkGfm]}
+            components={markdownComponents(components, renderedEntities, renderEntity)}
+            remarkPlugins={[
+              createMessageEntityRemarkPlugin(renderedMarkdown, renderedEntities),
+              ...(remarkPlugins ?? [remarkGfm]),
+            ]}
+            remarkRehypeOptions={messageEntityRehypeOptions()}
           >
-            {animate ? smooth.text : markdown}
+            {renderedMarkdown}
           </ReactMarkdown>
         ),
         "data-anvia-markdown": "",
@@ -222,6 +246,55 @@ const MessageMarkdownContent = forwardRef<HTMLDivElement, MessageMarkdownContent
     );
   },
 );
+
+function markdownComponents(
+  components: Components | undefined,
+  entities: ComposerEntity[],
+  renderEntity: ((entity: ComposerEntity) => ReactNode) | undefined,
+): Components {
+  const consumerSpan = components?.span;
+  return {
+    code: defaultCodeComponent,
+    pre: defaultPreComponent,
+    ...components,
+    span(spanProps) {
+      const internalProps = spanProps as typeof spanProps & {
+        "data-anvia-entity-index"?: string | undefined;
+      };
+      const entityIndexValue = internalProps["data-anvia-entity-index"];
+      const entityIndex =
+        typeof entityIndexValue === "string" && /^\d+$/.test(entityIndexValue)
+          ? Number(entityIndexValue)
+          : undefined;
+      const entity = entityIndex === undefined ? undefined : entities[entityIndex];
+      const consumerProps = { ...internalProps };
+      delete consumerProps["data-anvia-entity-index"];
+
+      if (entity !== undefined) {
+        if (renderEntity !== undefined) {
+          return renderEntity(entity);
+        }
+        const entityProps = {
+          ...consumerProps,
+          "data-anvia-message-entity": "",
+          "data-entity-id": entity.id,
+          "data-trigger-id": entity.triggerId,
+        };
+        if (consumerSpan !== undefined) {
+          return createElement(consumerSpan, entityProps);
+        }
+        const { node: _node, ...elementProps } = entityProps;
+        return <MessageEntity {...elementProps} entity={entity} />;
+      }
+
+      if (consumerSpan !== undefined) {
+        return createElement(consumerSpan, consumerProps);
+      }
+      const { node: _node, ...elementProps } = consumerProps;
+      return <span {...elementProps} />;
+    },
+  };
+}
 
 type MessageCodeBlockProps = Omit<PrimitiveProps<"pre">, "children"> & {
   children?: ReactNode;

--- a/packages/react-ui/src/shared.ts
+++ b/packages/react-ui/src/shared.ts
@@ -12,6 +12,7 @@ export type {
   ComposerEntitiesUpdate,
   ComposerEntity,
   ComposerEntityData,
+  ComposerMessageMetadata,
   ComposerQuote,
   ComposerTriggerDefinition,
   ComposerTriggerItem,

--- a/packages/react-ui/test/exports.test.ts
+++ b/packages/react-ui/test/exports.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, expectTypeOf, it } from "vitest";
 import type {
   ComposerAttachmentInput,
   ComposerAttachmentsUpdate,
+  ComposerEntity,
+  ComposerMessageMetadata,
   ComposerQuote,
   ComposerSubmitMessage,
   ComposerSubmitMessageArgs,
   ImageContextValue,
   MessageAttachmentPart,
+  MessageEntityProps,
   MessageToolPart,
   SelectionToolbarSelection,
   ThreadListController,
@@ -34,6 +37,7 @@ describe("public entrypoints", () => {
     expect(Composer.Root).toBeTypeOf("object");
     expect(Composer.AttachmentInput).toBeTypeOf("object");
     expect(Message.Root).toBeTypeOf("object");
+    expect(Message.Entity).toBeTypeOf("object");
     expect(HumanInput.Approvals).toBeTypeOf("object");
     expect(Completion.Root).toBeTypeOf("object");
     expect(Image.Root).toBeTypeOf("object");
@@ -51,6 +55,10 @@ describe("public entrypoints", () => {
   it("exports public helper types from domain barrels", () => {
     expectTypeOf<MessageToolPart>().toMatchTypeOf<{ type: "tool" }>();
     expectTypeOf<MessageAttachmentPart>().toMatchTypeOf<{ type: "attachment" }>();
+    expectTypeOf<MessageEntityProps>().toMatchTypeOf<{ entity: ComposerEntity }>();
+    expectTypeOf<ComposerMessageMetadata>().toMatchTypeOf<{
+      composer: { entities: ComposerEntity[] };
+    }>();
     expectTypeOf<File>().toMatchTypeOf<ComposerAttachmentInput>();
     expectTypeOf<
       Array<{ id: string; type: "image" | "document" | "file" }>

--- a/packages/react-ui/test/message.test.tsx
+++ b/packages/react-ui/test/message.test.tsx
@@ -1,9 +1,9 @@
 import type { UIMessage } from "@anvia/react";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import type { ComponentProps, ReactElement } from "react";
+import { type ComponentProps, type ReactElement, StrictMode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { ChatProvider, Message, Thread } from "../src";
+import { ChatProvider, type ComposerEntity, Message, Thread } from "../src";
 import { createChatController, textMessage } from "./helpers";
 
 const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
@@ -320,6 +320,263 @@ describe("Message primitives", () => {
     expect(screen.getAllByTestId("custom-code")).toHaveLength(2);
   });
 
+  it("renders valid Composer entities as semantic Markdown markup", () => {
+    const text = "See @Guide.pdf for details.";
+    const entity = composerEntity(text, "@Guide.pdf", "document-1");
+    const { container } = render(<StrictMode>{markdownEntityView(text, [entity])}</StrictMode>);
+
+    const element = container.querySelector("[data-anvia-message-entity]");
+    expect(element?.textContent).toBe("@Guide.pdf");
+    expect(element?.getAttribute("data-entity-id")).toBe("document-1");
+    expect(element?.getAttribute("data-trigger-id")).toBe("documents");
+    expect(element?.hasAttribute("data-anvia-entity-index")).toBe(false);
+    expect(container.querySelectorAll("[data-anvia-message-entity]")).toHaveLength(1);
+  });
+
+  it("renders multiple and adjacent entities without changing normal Markdown links", () => {
+    const text =
+      "See @One.pdf and [the guide](https://example.test/guide), then @Two.pdf@Three.pdf.";
+    const entities = [
+      composerEntity(text, "@One.pdf", "document-1"),
+      composerEntity(text, "@Two.pdf", "document-2"),
+      composerEntity(text, "@Three.pdf", "document-3"),
+    ];
+    const { container } = render(markdownEntityView(text, entities));
+
+    expect(
+      [...container.querySelectorAll("[data-anvia-message-entity]")].map(
+        (element) => element.textContent,
+      ),
+    ).toEqual(["@One.pdf", "@Two.pdf", "@Three.pdf"]);
+    expect(container.querySelector("a")?.getAttribute("href")).toBe("https://example.test/guide");
+    expect(container.querySelector("a")?.textContent).toBe("the guide");
+  });
+
+  it("renders Markdown punctuation inside entity text literally", () => {
+    const entityText = "@Guide[1]*draft*_copy_`v2`.pdf";
+    const text = `Open ${entityText} now.`;
+    const { container } = render(
+      markdownEntityView(text, [composerEntity(text, entityText, "document-1")]),
+    );
+
+    const element = container.querySelector("[data-anvia-message-entity]");
+    expect(element?.textContent).toBe(entityText);
+    expect(element?.querySelector("em, code, a")).toBeNull();
+    expect(container.querySelector("[data-anvia-markdown]")?.textContent).toBe(text);
+  });
+
+  it("keeps escaped and Unicode text aligned with UTF-16 entity offsets", () => {
+    const text = String.raw`Escaped \*literal\* 👋 before @文档.pdf.`;
+    const entity = composerEntity(text, "@文档.pdf", "document-unicode");
+    const { container } = render(markdownEntityView(text, [entity]));
+
+    expect(container.querySelector("[data-anvia-message-entity]")?.textContent).toBe("@文档.pdf");
+    expect(container.querySelector("[data-anvia-markdown]")?.textContent).toBe(
+      "Escaped *literal* 👋 before @文档.pdf.",
+    );
+    expect(() => JSON.stringify(entity.data)).not.toThrow();
+  });
+
+  it("renders entities only in eligible prose positions", () => {
+    const text = [
+      "**@Strong.pdf**",
+      "",
+      "`@Inline.pdf`",
+      "",
+      "```txt",
+      "@Fenced.pdf",
+      "```",
+      "",
+      "[@Label.pdf](https://example.test)",
+      "",
+      "[destination](@Destination.pdf)",
+      "",
+      "# @Heading.pdf",
+      "",
+      "- @List.pdf",
+      "",
+      "> @Quote.pdf",
+      "",
+      "| Document |",
+      "| --- |",
+      "| @Table.pdf |",
+    ].join("\n");
+    const entityTexts = [
+      "@Strong.pdf",
+      "@Inline.pdf",
+      "@Fenced.pdf",
+      "@Label.pdf",
+      "@Destination.pdf",
+      "@Heading.pdf",
+      "@List.pdf",
+      "@Quote.pdf",
+      "@Table.pdf",
+    ];
+    const entities = entityTexts.map((entityText, index) =>
+      composerEntity(text, entityText, `document-${index + 1}`),
+    );
+    const { container } = render(markdownEntityView(text, entities));
+
+    const rendered = [...container.querySelectorAll("[data-anvia-message-entity]")].map(
+      (element) => element.textContent,
+    );
+    expect(rendered).toEqual([
+      "@Strong.pdf",
+      "@Label.pdf",
+      "@Heading.pdf",
+      "@List.pdf",
+      "@Quote.pdf",
+      "@Table.pdf",
+    ]);
+    expect(container.querySelector("strong [data-anvia-message-entity]")).toBeTruthy();
+    expect(container.querySelector("a [data-anvia-message-entity]")?.textContent).toBe(
+      "@Label.pdf",
+    );
+    expect(container.querySelector("code")?.textContent).toBe("@Inline.pdf");
+    expect(container.querySelector('a[href="@Destination.pdf"]')?.textContent).toBe("destination");
+  });
+
+  it("falls back to ordinary text for malformed, stale, and overlapping entities", () => {
+    const text = "@One.pdf @Two.pdf";
+    const overlapping = composerEntity(text, text, "overlap-all", 0);
+    const second = composerEntity(text, "@Two.pdf", "overlap-second");
+    const malformed: ComposerEntity[] = [
+      overlapping,
+      second,
+      { ...composerEntity(text, "@One.pdf", "stale"), text: "@Stale.pdf" },
+      { ...composerEntity(text, "@One.pdf", "out-of-bounds"), range: { from: 0, to: 999 } },
+      { ...composerEntity(text, "@One.pdf", "fractional"), range: { from: 0.5, to: 8 } },
+      { ...composerEntity(text, "@One.pdf", ""), id: "" },
+    ];
+    const { container } = render(markdownEntityView(text, malformed));
+
+    expect(container.querySelector("[data-anvia-message-entity]")).toBeNull();
+    expect(container.querySelector("[data-anvia-markdown]")?.textContent).toBe(text);
+  });
+
+  it("supports renderEntity and components.span overrides", () => {
+    const text = "See @Guide.pdf.";
+    const entity = composerEntity(text, "@Guide.pdf", "document-1");
+    const custom = render(
+      markdownEntityView(text, [entity], {
+        renderEntity(current) {
+          return <mark data-testid="custom-entity">{current.label}</mark>;
+        },
+      }),
+    );
+    expect(screen.getByTestId("custom-entity").textContent).toBe("Guide.pdf");
+    expect(custom.container.querySelector("[data-anvia-message-entity]")).toBeNull();
+    custom.unmount();
+
+    const span = render(
+      markdownEntityView(text, [entity], {
+        components: {
+          span({ node: _node, ...props }) {
+            return <span {...props} data-testid="custom-span" />;
+          },
+        },
+      }),
+    );
+    const element = screen.getByTestId("custom-span");
+    expect(element.getAttribute("data-entity-id")).toBe("document-1");
+    expect(element.textContent).toBe("@Guide.pdf");
+    span.unmount();
+  });
+
+  it("maps message-level entity offsets across multiple text parts", () => {
+    const first = "First paragraph.";
+    const second = "Open @Guide.pdf.";
+    const joined = `${first}\n\n${second}`;
+    const entity = composerEntity(joined, "@Guide.pdf", "document-1");
+    const message: UIMessage = {
+      id: "msg_1",
+      role: "user",
+      parts: [
+        { id: "part_1", type: "text", text: first },
+        { id: "part_2", type: "text", text: second },
+      ],
+      metadata: { composer: { entities: [entity] } },
+    };
+    const { container } = render(
+      <ChatProvider controller={createChatController({ messages: [message] })}>
+        <Thread.Root>
+          <Thread.Messages>
+            <Message.Root>
+              <Message.Markdown />
+            </Message.Root>
+          </Thread.Messages>
+        </Thread.Root>
+      </ChatProvider>,
+    );
+
+    expect(container.querySelectorAll("p")).toHaveLength(2);
+    expect(container.querySelector("[data-anvia-message-entity]")?.textContent).toBe("@Guide.pdf");
+  });
+
+  it("runs the entity transform before consumer remark plugins", () => {
+    const text = "See @Guide.pdf.";
+    const entity = composerEntity(text, "@Guide.pdf", "document-1");
+    const visitedTypes: string[] = [];
+
+    function inspectPlugin() {
+      return (tree: unknown) => collectNodeTypes(tree, visitedTypes);
+    }
+
+    render(markdownEntityView(text, [entity], { remarkPlugins: [inspectPlugin] }));
+    expect(visitedTypes).toContain("messageEntity");
+  });
+
+  it("lets consumer remark plugins reconstruct entity nodes as exact text", () => {
+    const entityText = "@Guide[1]*draft*.pdf";
+    const text = `Open ${entityText}.`;
+
+    function literalizePlugin() {
+      return (tree: unknown) => literalizeEntityNodes(tree);
+    }
+
+    const { container } = render(
+      markdownEntityView(text, [composerEntity(text, entityText, "document-1")], {
+        remarkPlugins: [literalizePlugin],
+      }),
+    );
+    expect(container.querySelector("[data-anvia-message-entity]")).toBeNull();
+    expect(container.querySelector("[data-anvia-markdown]")?.textContent).toBe(text);
+  });
+
+  it("keeps copy and regenerate disabled for standalone tool messages", () => {
+    const toolMessage: UIMessage = {
+      id: "tool_message_1",
+      role: "tool",
+      parts: [
+        {
+          id: "tool_1",
+          type: "tool",
+          toolName: "lookup",
+          toolCallId: "tool_1",
+          state: "output-available",
+          input: { query: "Anvia" },
+          output: "done",
+        },
+      ],
+      metadata: { source: "tool" },
+    };
+    render(
+      <ChatProvider controller={createChatController({ messages: [toolMessage] })}>
+        <Thread.Root>
+          <Thread.Messages>
+            <Message.Root>
+              <Message.Copy />
+              <Message.Regenerate />
+            </Message.Root>
+          </Thread.Messages>
+        </Thread.Root>
+      </ChatProvider>,
+    );
+
+    expect((screen.getByText("Copy") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByText("Regenerate") as HTMLButtonElement).disabled).toBe(true);
+  });
+
   it("keeps Message.Markdown rendering immediate by default", () => {
     const raf = installAnimationFrame();
     const { container, rerender } = render(markdownView("Hello"));
@@ -569,6 +826,76 @@ function markdownView(
       </Thread.Root>
     </ChatProvider>
   );
+}
+
+function markdownEntityView(
+  markdown: string,
+  entities: ComposerEntity[],
+  props: ComponentProps<typeof Message.Markdown> = {},
+): ReactElement {
+  const message = {
+    ...textMessage("msg_1", "user", markdown),
+    metadata: { composer: { entities } },
+  };
+  return (
+    <ChatProvider controller={createChatController({ messages: [message] })}>
+      <Thread.Root>
+        <Thread.Messages>
+          <Message.Root>
+            <Message.Markdown {...props} />
+          </Message.Root>
+        </Thread.Messages>
+      </Thread.Root>
+    </ChatProvider>
+  );
+}
+
+function composerEntity(
+  text: string,
+  entityText: string,
+  id: string,
+  from = text.indexOf(entityText),
+): ComposerEntity {
+  return {
+    id,
+    triggerId: "documents",
+    trigger: "@",
+    label: entityText.slice(1),
+    text: entityText,
+    range: { from, to: from + entityText.length },
+    data: { kind: "document", documentId: id },
+  };
+}
+
+function collectNodeTypes(value: unknown, types: string[]): void {
+  if (typeof value !== "object" || value === null) {
+    return;
+  }
+  if ("type" in value && typeof value.type === "string") {
+    types.push(value.type);
+  }
+  if ("children" in value && Array.isArray(value.children)) {
+    for (const child of value.children) {
+      collectNodeTypes(child, types);
+    }
+  }
+}
+
+function literalizeEntityNodes(value: unknown): void {
+  if (typeof value !== "object" || value === null) {
+    return;
+  }
+  if ("type" in value && value.type === "messageEntity") {
+    value.type = "text";
+    if ("entityIndex" in value) {
+      delete value.entityIndex;
+    }
+  }
+  if ("children" in value && Array.isArray(value.children)) {
+    for (const child of value.children) {
+      literalizeEntityNodes(child);
+    }
+  }
 }
 
 function installAnimationFrame() {


### PR DESCRIPTION
Stack 3 of 4. Depends on #248.

## Summary

- add public ComposerMessageMetadata and MessageEntityProps types
- add the headless Message.Entity span primitive
- render validated metadata.composer.entities from Message.Markdown
- expose renderEntity as a complete-output override
- transform source-position-aware Markdown AST nodes before consumer remark plugins
- preserve normal links, emphasis, code, tables, headings, lists, blockquotes, multiple parts, escapes, Unicode, and punctuation-heavy filenames

## Validation and safety

Ranges use JavaScript UTF-16 offsets. They must be integer, in bounds, non-overlapping, and match entity.text exactly. Malformed entities remain ordinary text. Inline and fenced code plus link destinations remain literal. No raw HTML or rehypeRaw is used, arbitrary entity data is not serialized into the DOM, and components.span overrides continue to work.

## Verification

- React UI typecheck
- 82 React UI tests, including Strict Mode and malformed range coverage
- React UI package build
- public export contract tests
- complete-stack lint, package builds, package typechecks/tests, reference coverage, and docs build

No visual styling is added; markup is intentionally headless.