### PR TITLE
Align quoted Composer entity ranges and document persistence

### DIFF
--- a/.changeset/align-quoted-composer-entities.md
+++ b/.changeset/align-quoted-composer-entities.md
@@ -1,0 +1,5 @@
+---
+"@anvia/react-ui": patch
+---
+
+Keep Composer entity ranges aligned when default submission prefixes message text with a quote.

--- a/apps/www/src/content/docs/react-ui/composer-triggers.mdx
+++ b/apps/www/src/content/docs/react-ui/composer-triggers.mdx
@@ -125,6 +125,12 @@ The item callback receives:
 | `entities` | Current selected entities in the composer. |
 | `signal` | Abort signal for cancelling async item loading. |
 
+Changing the `triggers` array rebuilds the Tiptap extension set and editor because trigger
+characters and suggestion plugins are extension configuration. Keeping definitions memoized can
+reduce editor churn when parent components rerender, especially with async item sources, but it is
+an optimization rather than a correctness requirement. Editor recreation, rapid trigger updates,
+and Strict Mode mount cycles are supported.
+
 ## Trigger options
 
 | Option | Use |
@@ -188,6 +194,15 @@ Selected entities are submitted with default composer metadata:
   }
 }
 ```
+
+Entity ranges use JavaScript UTF-16 string offsets: `text.slice(range.from, range.to)` equals the
+entity's `text`. This is the same indexing used by normal JavaScript strings, including text that
+contains emoji or other surrogate pairs. When default submission prefixes the prompt with a
+selected quote, Anvia shifts entity ranges by the exact generated prefix length so they stay
+aligned with the submitted text.
+
+The metadata is strict JSON and survives the supported UI message to core message to JSON storage
+round trip. Applications do not need to reattach it after loading a conversation.
 
 With a custom submit handler, read entities from the submit args and send them wherever your route
 expects them.

--- a/apps/www/src/content/docs/react-ui/messages.mdx
+++ b/apps/www/src/content/docs/react-ui/messages.mdx
@@ -106,6 +106,49 @@ Use `Message.Markdown` when assistant text should render GitHub-flavored Markdow
 
 <CodeVariants id="messages-markdown" variants={markdownVariants} />
 
+### Composer entities
+
+When a message contains valid `metadata.composer.entities`, `Message.Markdown` renders each entity
+in an eligible prose position with headless semantic markup:
+
+```html
+<span
+  data-anvia-message-entity
+  data-entity-id="document-1"
+  data-trigger-id="documents"
+>
+  @Guide.pdf
+</span>
+```
+
+Style the attributes from application CSS without rewriting mentions into Markdown links:
+
+```css
+[data-anvia-message-entity][data-trigger-id="documents"] {
+  color: var(--document-mention-color);
+  font-weight: 600;
+}
+```
+
+Use `renderEntity` to replace the complete output, or render `Message.Entity` directly:
+
+```tsx
+<Message.Markdown
+  renderEntity={(entity) => <DocumentMention entity={entity} />}
+/>
+```
+
+```tsx
+<Message.Entity entity={entity} className="document-mention" />
+```
+
+Ranges must contain integer UTF-16 offsets, stay inside the final message text, match
+`entity.text`, and not overlap. Invalid, stale, overlapping, or out-of-bounds entries fall back to
+ordinary text. Entities render in prose, including emphasis and link labels; ranges inside inline
+code, fenced code, or link destinations remain literal. Regular Markdown links, consumer remark
+plugins, and `components.span` overrides continue to work. Entity `data` is never serialized into
+the DOM.
+
 ### Opt-in streaming animation
 
 `useChat(...)` continues to own the real message state. Enable display smoothing only on the latest

--- a/apps/www/src/content/docs/react-ui/persistence.mdx
+++ b/apps/www/src/content/docs/react-ui/persistence.mdx
@@ -65,6 +65,22 @@ export function LocalChat() {
 A production route usually receives a thread id, authenticates the user, and stores messages or
 runtime events after the stream completes.
 
+`UIMessage.metadata` is preserved by the supported conversion path, including Composer entities:
+
+```ts
+import { coreMessagesToUIMessages, uiMessagesToCoreMessages } from "@anvia/core/ui";
+
+const coreMessages = uiMessagesToCoreMessages(uiMessages);
+await conversationStore.save(JSON.parse(JSON.stringify(coreMessages)));
+
+const restored = coreMessagesToUIMessages(await conversationStore.load());
+```
+
+Anvia's SQLite, Postgres, Prisma, and Drizzle memory adapters store complete core messages, and
+Studio persists message metadata in its normalized SQLite tables. Provider adapters omit this UI
+metadata from model requests. Consumers no longer need to rewrite mentions into fake links or
+reattach Composer metadata after rehydration.
+
 For memory-backed chats, load the saved core messages on the server with `session.messages()` and
 return them from your API as Anvia `Message[]`. The React page converts that payload with
 `initialMessagesFromMemory(...)` before passing it to `useChat`.

--- a/apps/www/src/content/docs/react-ui/reference.md
+++ b/apps/www/src/content/docs/react-ui/reference.md
@@ -18,6 +18,7 @@ import {
   Composer,
   type ComposerEntity,
   type ComposerEntityData,
+  type ComposerMessageMetadata,
   type ComposerTriggerDefinition,
   type ComposerTriggerItem,
   type ComposerTriggerItemsArgs,
@@ -196,11 +197,18 @@ type ComposerEntity = {
   range: { from: number; to: number };
   data?: ComposerEntityData;
 };
+
+type ComposerMessageMetadata = {
+  composer: { entities: ComposerEntity[] };
+};
 ```
 
 Use `entities`, `defaultEntities`, and `onEntitiesChange` on `Composer.Root` when selected entities
 need to be controlled by application state. For a full guide, see
 [Composer triggers](/docs/react-ui/composer-triggers).
+
+Entity ranges use JavaScript UTF-16 offsets. Default quote submission shifts them to match the
+prefixed message text.
 
 ## Message
 
@@ -214,7 +222,8 @@ provider supplied by that list.
 | `Message.Parts` | `div` | `filter`, child function | Renders message parts. |
 | `Message.Part` | `div` | child function | Provides one `UIMessagePart`. |
 | `Message.Text` | `span` | element props | Renders text part as plain text. |
-| `Message.Markdown` | `div` | `components`, `remarkPlugins` | Renders text with GitHub-flavored Markdown. |
+| `Message.Markdown` | `div` | `components`, `remarkPlugins`, `renderEntity` | Renders text with GitHub-flavored Markdown and validated Composer entities. |
+| `Message.Entity` | `span` | `entity`, span props | Renders headless semantic entity markup. |
 | `Message.CodeBlock` | `pre` | `code`, `language` | Markdown code block helper. |
 | `Message.Reasoning` | `details` | element props | Renders reasoning parts. |
 | `Message.Tool` | `div` | `renderWhen` | Renders tool parts. |
@@ -227,6 +236,16 @@ provider supplied by that list.
 
 Tool helpers: `Message.ToolName`, `Message.ToolStatus`, `Message.ToolInput`,
 `Message.ToolOutput`, and `Message.ToolError`.
+
+```ts
+type MessageEntityProps = React.HTMLAttributes<HTMLSpanElement> & {
+  entity: ComposerEntity;
+};
+```
+
+`Message.Entity` emits `data-anvia-message-entity`, `data-entity-id`, and `data-trigger-id` and uses
+`entity.text` as its default children. `Message.Markdown` reads entities from
+`message.metadata.composer.entities`; malformed ranges remain ordinary text.
 
 Child signatures:
 

--- a/packages/react-ui/src/chat/composer.tsx
+++ b/packages/react-ui/src/chat/composer.tsx
@@ -47,6 +47,7 @@ import {
   useChatContext,
   useComposer,
 } from "../contexts";
+import { shiftComposerEntityRanges } from "../entities";
 import { composeRefs, type PrimitiveProps, renderPrimitive } from "../primitives";
 
 type ComposerRootProps = PrimitiveProps<"form"> & {
@@ -246,10 +247,16 @@ const ComposerRoot = forwardRef<HTMLFormElement, ComposerRootProps>(function Com
     }
 
     const submittedAttachments = [...attachments];
-    const submittedEntities = [...entities];
     const submittedQuote = quote === undefined ? undefined : { ...quote };
-    const submittedText =
-      submittedQuote === undefined ? prompt : promptWithQuote(prompt, submittedQuote);
+    const formattedPrompt =
+      submittedQuote === undefined
+        ? { text: prompt, prefixLength: 0 }
+        : promptWithQuote(prompt, submittedQuote);
+    const submittedEntities = shiftComposerEntityRanges(
+      [...entities],
+      formattedPrompt.prefixLength,
+    );
+    const submittedText = formattedPrompt.text;
     const metadata = composerSubmitMetadata(submittedQuote, submittedEntities);
     const payload: Parameters<typeof chat.sendMessage>[0] =
       submittedAttachments.length === 0
@@ -1189,15 +1196,19 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
 }
 
-function promptWithQuote(prompt: string, quote: ComposerQuote): string {
+function promptWithQuote(
+  prompt: string,
+  quote: ComposerQuote,
+): { text: string; prefixLength: number } {
   const quotedText = quote.text
     .split(/\r?\n/)
     .map((line) => `> ${line}`)
     .join("\n");
   if (prompt.trim().length === 0) {
-    return quotedText;
+    return { text: quotedText, prefixLength: 0 };
   }
-  return `${quotedText}\n\n${prompt}`;
+  const prefix = `${quotedText}\n\n`;
+  return { text: `${prefix}${prompt}`, prefixLength: prefix.length };
 }
 
 function normalizeQuote(quote: ComposerQuote | undefined): ComposerQuote | undefined {

--- a/packages/react-ui/test/chat.test.tsx
+++ b/packages/react-ui/test/chat.test.tsx
@@ -282,7 +282,7 @@ describe("Chat primitives", () => {
         <Composer.Root
           defaultAttachments={[attachment]}
           defaultEntities={[entity]}
-          defaultInput="Hello"
+          defaultInput="@Ada says Hello"
           defaultQuote={quote}
         >
           <Composer.TextareaInput />
@@ -305,11 +305,13 @@ describe("Chat primitives", () => {
     });
 
     expect(payloadWhilePending).toEqual({
-      text: "> First line\n> Second line\n\nHello",
+      text: "> First line\n> Second line\n\n@Ada says Hello",
       attachments: [attachment],
       metadata: {
         quote,
-        composer: { entities: [entity] },
+        composer: {
+          entities: [{ ...entity, range: { from: 28, to: 32 } }],
+        },
       },
     });
     expect(stateWhilePending).toBe(


### PR DESCRIPTION
Stack 4 of 4. Depends on #249.

## Summary

- return the actual quote prefix length from default Composer formatting
- shift submitted entity ranges through the shared range helper
- document core metadata factories, validation, conversion, and tool-message semantics
- document Composer entity persistence, UTF-16 ranges, semantic rendering, and customization
- explain that stable trigger references reduce Tiptap editor churn but are not required for correctness

## Verification

- quote-plus-entity regression test
- React UI typecheck and 82 tests
- docs reference coverage with zero missing exports
- 521-page Astro and Pagefind production build
- complete-stack lint, package builds, package typechecks, and package tests

No generated docs or build artifacts are committed. No visual screenshot was needed because the UI change is headless markup with no package styling.