### PR TITLE
Land Composer entity persistence and rendering on main

### DIFF
--- a/.changeset/align-quoted-composer-entities.md
+++ b/.changeset/align-quoted-composer-entities.md
@@ -1,0 +1,5 @@
+---
+"@anvia/react-ui": patch
+---
+
+Keep Composer entity ranges aligned when default submission prefixes message text with a quote.

--- a/.changeset/persist-message-metadata-stores.md
+++ b/.changeset/persist-message-metadata-stores.md
@@ -1,0 +1,9 @@
+---
+"@anvia/memory-sqlite": patch
+"@anvia/memory-postgres": patch
+"@anvia/memory-prisma": patch
+"@anvia/memory-drizzle": patch
+"@anvia/studio": patch
+---
+
+Preserve strict JSON message metadata in durable memory adapters and Studio's normalized SQLite session storage.

--- a/.changeset/render-composer-message-entities.md
+++ b/.changeset/render-composer-message-entities.md
@@ -1,0 +1,5 @@
+---
+"@anvia/react-ui": minor
+---
+
+Render validated Composer entities as headless semantic markup in `Message.Markdown`, with `Message.Entity` and `renderEntity` customization APIs.

--- a/apps/www/src/content/docs/packages/react-ui/reference.md
+++ b/apps/www/src/content/docs/packages/react-ui/reference.md
@@ -93,6 +93,7 @@ const Message: {
   Part: React.ForwardRefExoticComponent<...>;
   Text: React.ForwardRefExoticComponent<...>;
   Markdown: React.ForwardRefExoticComponent<...>;
+  Entity: React.ForwardRefExoticComponent<MessageEntityProps & React.RefAttributes<HTMLSpanElement>>;
   CodeBlock: React.ForwardRefExoticComponent<...>;
   Reasoning: React.ForwardRefExoticComponent<...>;
   Tool: React.ForwardRefExoticComponent<...>;
@@ -173,6 +174,18 @@ type MessageStreamAnimationProps = {
 
 Animation is disabled by default. When enabled, these renderers pass their existing text through
 `useSmoothStreamText`; the underlying `useChat` controller and `UIMessage[]` remain unchanged.
+
+`Message.Markdown` also accepts `renderEntity?: (entity: ComposerEntity) => ReactNode`. Valid
+entities from `message.metadata.composer.entities` render through `Message.Entity` by default.
+
+```ts
+type MessageEntityProps = React.HTMLAttributes<HTMLSpanElement> & {
+  entity: ComposerEntity;
+};
+```
+
+The default span emits `data-anvia-message-entity`, `data-entity-id`, and `data-trigger-id`. It does
+not serialize `entity.data` into the DOM.
 
 ## Providers
 
@@ -341,6 +354,12 @@ type ComposerEntity = {
     to: number;
   };
   data?: ComposerEntityData;
+};
+
+type ComposerMessageMetadata = {
+  composer: {
+    entities: ComposerEntity[];
+  };
 };
 
 type ComposerTriggerState = {

--- a/apps/www/src/content/docs/react-ui/composer-triggers.mdx
+++ b/apps/www/src/content/docs/react-ui/composer-triggers.mdx
@@ -125,6 +125,12 @@ The item callback receives:
 | `entities` | Current selected entities in the composer. |
 | `signal` | Abort signal for cancelling async item loading. |
 
+Changing the `triggers` array rebuilds the Tiptap extension set and editor because trigger
+characters and suggestion plugins are extension configuration. Keeping definitions memoized can
+reduce editor churn when parent components rerender, especially with async item sources, but it is
+an optimization rather than a correctness requirement. Editor recreation, rapid trigger updates,
+and Strict Mode mount cycles are supported.
+
 ## Trigger options
 
 | Option | Use |
@@ -188,6 +194,15 @@ Selected entities are submitted with default composer metadata:
   }
 }
 ```
+
+Entity ranges use JavaScript UTF-16 string offsets: `text.slice(range.from, range.to)` equals the
+entity's `text`. This is the same indexing used by normal JavaScript strings, including text that
+contains emoji or other surrogate pairs. When default submission prefixes the prompt with a
+selected quote, Anvia shifts entity ranges by the exact generated prefix length so they stay
+aligned with the submitted text.
+
+The metadata is strict JSON and survives the supported UI message to core message to JSON storage
+round trip. Applications do not need to reattach it after loading a conversation.
 
 With a custom submit handler, read entities from the submit args and send them wherever your route
 expects them.

--- a/apps/www/src/content/docs/react-ui/messages.mdx
+++ b/apps/www/src/content/docs/react-ui/messages.mdx
@@ -106,6 +106,49 @@ Use `Message.Markdown` when assistant text should render GitHub-flavored Markdow
 
 <CodeVariants id="messages-markdown" variants={markdownVariants} />
 
+### Composer entities
+
+When a message contains valid `metadata.composer.entities`, `Message.Markdown` renders each entity
+in an eligible prose position with headless semantic markup:
+
+```html
+<span
+  data-anvia-message-entity
+  data-entity-id="document-1"
+  data-trigger-id="documents"
+>
+  @Guide.pdf
+</span>
+```
+
+Style the attributes from application CSS without rewriting mentions into Markdown links:
+
+```css
+[data-anvia-message-entity][data-trigger-id="documents"] {
+  color: var(--document-mention-color);
+  font-weight: 600;
+}
+```
+
+Use `renderEntity` to replace the complete output, or render `Message.Entity` directly:
+
+```tsx
+<Message.Markdown
+  renderEntity={(entity) => <DocumentMention entity={entity} />}
+/>
+```
+
+```tsx
+<Message.Entity entity={entity} className="document-mention" />
+```
+
+Ranges must contain integer UTF-16 offsets, stay inside the final message text, match
+`entity.text`, and not overlap. Invalid, stale, overlapping, or out-of-bounds entries fall back to
+ordinary text. Entities render in prose, including emphasis and link labels; ranges inside inline
+code, fenced code, or link destinations remain literal. Regular Markdown links, consumer remark
+plugins, and `components.span` overrides continue to work. Entity `data` is never serialized into
+the DOM.
+
 ### Opt-in streaming animation
 
 `useChat(...)` continues to own the real message state. Enable display smoothing only on the latest

--- a/apps/www/src/content/docs/react-ui/persistence.mdx
+++ b/apps/www/src/content/docs/react-ui/persistence.mdx
@@ -65,6 +65,22 @@ export function LocalChat() {
 A production route usually receives a thread id, authenticates the user, and stores messages or
 runtime events after the stream completes.
 
+`UIMessage.metadata` is preserved by the supported conversion path, including Composer entities:
+
+```ts
+import { coreMessagesToUIMessages, uiMessagesToCoreMessages } from "@anvia/core/ui";
+
+const coreMessages = uiMessagesToCoreMessages(uiMessages);
+await conversationStore.save(JSON.parse(JSON.stringify(coreMessages)));
+
+const restored = coreMessagesToUIMessages(await conversationStore.load());
+```
+
+Anvia's SQLite, Postgres, Prisma, and Drizzle memory adapters store complete core messages, and
+Studio persists message metadata in its normalized SQLite tables. Provider adapters omit this UI
+metadata from model requests. Consumers no longer need to rewrite mentions into fake links or
+reattach Composer metadata after rehydration.
+
 For memory-backed chats, load the saved core messages on the server with `session.messages()` and
 return them from your API as Anvia `Message[]`. The React page converts that payload with
 `initialMessagesFromMemory(...)` before passing it to `useChat`.

--- a/apps/www/src/content/docs/react-ui/reference.md
+++ b/apps/www/src/content/docs/react-ui/reference.md
@@ -18,6 +18,7 @@ import {
   Composer,
   type ComposerEntity,
   type ComposerEntityData,
+  type ComposerMessageMetadata,
   type ComposerTriggerDefinition,
   type ComposerTriggerItem,
   type ComposerTriggerItemsArgs,
@@ -196,11 +197,18 @@ type ComposerEntity = {
   range: { from: number; to: number };
   data?: ComposerEntityData;
 };
+
+type ComposerMessageMetadata = {
+  composer: { entities: ComposerEntity[] };
+};
 ```
 
 Use `entities`, `defaultEntities`, and `onEntitiesChange` on `Composer.Root` when selected entities
 need to be controlled by application state. For a full guide, see
 [Composer triggers](/docs/react-ui/composer-triggers).
+
+Entity ranges use JavaScript UTF-16 offsets. Default quote submission shifts them to match the
+prefixed message text.
 
 ## Message
 
@@ -214,7 +222,8 @@ provider supplied by that list.
 | `Message.Parts` | `div` | `filter`, child function | Renders message parts. |
 | `Message.Part` | `div` | child function | Provides one `UIMessagePart`. |
 | `Message.Text` | `span` | element props | Renders text part as plain text. |
-| `Message.Markdown` | `div` | `components`, `remarkPlugins` | Renders text with GitHub-flavored Markdown. |
+| `Message.Markdown` | `div` | `components`, `remarkPlugins`, `renderEntity` | Renders text with GitHub-flavored Markdown and validated Composer entities. |
+| `Message.Entity` | `span` | `entity`, span props | Renders headless semantic entity markup. |
 | `Message.CodeBlock` | `pre` | `code`, `language` | Markdown code block helper. |
 | `Message.Reasoning` | `details` | element props | Renders reasoning parts. |
 | `Message.Tool` | `div` | `renderWhen` | Renders tool parts. |
@@ -227,6 +236,16 @@ provider supplied by that list.
 
 Tool helpers: `Message.ToolName`, `Message.ToolStatus`, `Message.ToolInput`,
 `Message.ToolOutput`, and `Message.ToolError`.
+
+```ts
+type MessageEntityProps = React.HTMLAttributes<HTMLSpanElement> & {
+  entity: ComposerEntity;
+};
+```
+
+`Message.Entity` emits `data-anvia-message-entity`, `data-entity-id`, and `data-trigger-id` and uses
+`entity.text` as its default children. `Message.Markdown` reads entities from
+`message.metadata.composer.entities`; malformed ranges remain ordinary text.
 
 Child signatures:
 

--- a/packages/memory-drizzle/package.json
+++ b/packages/memory-drizzle/package.json
@@ -39,7 +39,7 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": ">=0.12.0 <1.0.0",
+    "@anvia/core": ">=0.13.0 <1.0.0",
     "drizzle-orm": ">=0.45.0 <1.0.0"
   }
 }

--- a/packages/memory-drizzle/src/message.ts
+++ b/packages/memory-drizzle/src/message.ts
@@ -1,4 +1,4 @@
-import type { JsonValue, Message } from "@anvia/core";
+import { isJsonValue, type JsonValue, type Message } from "@anvia/core";
 
 export function parseMemoryMessage(value: unknown): Message {
   if (!isMemoryMessage(value)) {
@@ -9,6 +9,9 @@ export function parseMemoryMessage(value: unknown): Message {
 
 export function isMemoryMessage(value: unknown): value is Message {
   if (!isRecord(value) || typeof value.role !== "string") {
+    return false;
+  }
+  if (value.metadata !== undefined && !isJsonValue(value.metadata)) {
     return false;
   }
 
@@ -39,25 +42,6 @@ export function serializeUnknownError(error: unknown): JsonValue {
   return {
     message: String(error),
   };
-}
-
-function isJsonValue(value: unknown): value is JsonValue {
-  if (
-    value === null ||
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  ) {
-    return Number.isFinite(value) || typeof value !== "number";
-  }
-
-  if (Array.isArray(value)) {
-    return value.every(isJsonValue);
-  }
-
-  return (
-    isRecord(value) && Object.values(value).every((item) => item === undefined || isJsonValue(item))
-  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/memory-drizzle/src/store.ts
+++ b/packages/memory-drizzle/src/store.ts
@@ -112,6 +112,7 @@ export class DrizzleMemoryStore implements MemoryStore {
     if (input.messages.length === 0) {
       return;
     }
+    this.validateInputMessages(input.messages);
 
     const scopeKey = this.scopeKey(input.context);
 
@@ -150,6 +151,7 @@ export class DrizzleMemoryStore implements MemoryStore {
     if (this.options.errors === "ignore") {
       return;
     }
+    this.validateInputMessages(input.messages);
 
     const scopeKey = this.scopeKey(input.context);
 
@@ -220,6 +222,14 @@ export class DrizzleMemoryStore implements MemoryStore {
       return this.options.scope(context);
     }
     return createDrizzleMemoryScopeKey(context, this.options.scope);
+  }
+
+  private validateInputMessages(messages: Message[]): void {
+    if (this.options.validateMessages) {
+      for (const message of messages) {
+        parseMemoryMessage(message);
+      }
+    }
   }
 }
 

--- a/packages/memory-drizzle/test/store.test.ts
+++ b/packages/memory-drizzle/test/store.test.ts
@@ -8,6 +8,7 @@ import {
   createDrizzleMemoryStore,
   drizzleMemorySchema,
 } from "../src/index.js";
+import { isMemoryMessage } from "../src/message.js";
 
 const userMessage: Message = {
   role: "user",
@@ -20,9 +21,10 @@ const assistantMessage: Message = {
 };
 
 const richMessages: Message[] = [
-  { role: "system", content: "System instructions" },
+  { role: "system", content: "System instructions", metadata: { source: "system" } },
   {
     role: "user",
+    metadata: { composer: { entities: [{ id: "document-1" }] } },
     content: [
       { type: "text", text: "Inspect these", signature: "user-signature" },
       {
@@ -62,6 +64,7 @@ const richMessages: Message[] = [
   {
     role: "assistant",
     id: "assistant-1",
+    metadata: { source: "assistant" },
     content: [
       { type: "text", text: "Working", signature: "assistant-signature" },
       {
@@ -92,6 +95,7 @@ const richMessages: Message[] = [
   },
   {
     role: "tool",
+    metadata: { source: "tool" },
     content: [
       {
         type: "tool_result",
@@ -108,6 +112,20 @@ const richMessages: Message[] = [
 ];
 
 describe("Drizzle memory public API", () => {
+  it("uses core strict JSON validation for message metadata", async () => {
+    expect(isMemoryMessage({ ...userMessage, metadata: { score: 1 } })).toBe(true);
+    expect(isMemoryMessage({ ...userMessage, metadata: { score: Number.NaN } })).toBe(false);
+    const store = createDrizzleMemoryStore(new FakeDrizzleDb());
+    await expect(
+      store.append({
+        context: { sessionId: "thread-invalid" },
+        runId: "run-invalid",
+        turn: 0,
+        messages: [{ ...userMessage, metadata: { score: Number.NaN } } as Message],
+      }),
+    ).rejects.toThrow("valid Anvia Message");
+  });
+
   it("exports schema tables users can include in their Drizzle schema", () => {
     expect(agentMemorySessions).toBe(drizzleMemorySchema.agentMemorySessions);
     expect(agentMemoryMessages).toBe(drizzleMemorySchema.agentMemoryMessages);

--- a/packages/memory-postgres/package.json
+++ b/packages/memory-postgres/package.json
@@ -42,6 +42,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": ">=0.12.0 <1.0.0"
+    "@anvia/core": ">=0.13.0 <1.0.0"
   }
 }

--- a/packages/memory-postgres/src/message.ts
+++ b/packages/memory-postgres/src/message.ts
@@ -1,4 +1,4 @@
-import type { JsonValue, Message } from "@anvia/core";
+import { isJsonValue, type JsonValue, type Message } from "@anvia/core";
 
 export function parseMemoryMessage(value: unknown): Message {
   if (!isMemoryMessage(value)) {
@@ -9,6 +9,9 @@ export function parseMemoryMessage(value: unknown): Message {
 
 export function isMemoryMessage(value: unknown): value is Message {
   if (!isRecord(value) || typeof value.role !== "string") {
+    return false;
+  }
+  if (value.metadata !== undefined && !isJsonValue(value.metadata)) {
     return false;
   }
 
@@ -39,25 +42,6 @@ export function serializeUnknownError(error: unknown): JsonValue {
   return {
     message: String(error),
   };
-}
-
-function isJsonValue(value: unknown): value is JsonValue {
-  if (
-    value === null ||
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  ) {
-    return Number.isFinite(value) || typeof value !== "number";
-  }
-
-  if (Array.isArray(value)) {
-    return value.every(isJsonValue);
-  }
-
-  return (
-    isRecord(value) && Object.values(value).every((item) => item === undefined || isJsonValue(item))
-  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/memory-postgres/src/store.ts
+++ b/packages/memory-postgres/src/store.ts
@@ -140,6 +140,7 @@ export class PostgresMemoryStore implements MemoryStore {
     if (input.messages.length === 0) {
       return;
     }
+    this.validateInputMessages(input.messages);
 
     const scopeKey = this.scopeKey(input.context);
 
@@ -172,6 +173,7 @@ export class PostgresMemoryStore implements MemoryStore {
     if (this.options.errors === "ignore") {
       return;
     }
+    this.validateInputMessages(input.messages);
 
     const scopeKey = this.scopeKey(input.context);
 
@@ -281,6 +283,14 @@ export class PostgresMemoryStore implements MemoryStore {
   private messageFromValue(value: unknown): Message {
     const parsed = typeof value === "string" ? (JSON.parse(value) as unknown) : value;
     return this.options.validateMessages ? parseMemoryMessage(parsed) : (parsed as Message);
+  }
+
+  private validateInputMessages(messages: Message[]): void {
+    if (this.options.validateMessages) {
+      for (const message of messages) {
+        parseMemoryMessage(message);
+      }
+    }
   }
 
   private scopeKey(context: MemoryContext): string {

--- a/packages/memory-postgres/test/store.test.ts
+++ b/packages/memory-postgres/test/store.test.ts
@@ -10,6 +10,7 @@ import {
   createPostgresMemoryScopeKey,
   createPostgresMemoryStore,
 } from "../src/index.js";
+import { isMemoryMessage } from "../src/message.js";
 
 const userMessage: Message = {
   role: "user",
@@ -22,9 +23,10 @@ const assistantMessage: Message = {
 };
 
 const richMessages: Message[] = [
-  { role: "system", content: "System instructions" },
+  { role: "system", content: "System instructions", metadata: { source: "system" } },
   {
     role: "user",
+    metadata: { composer: { entities: [{ id: "document-1" }] } },
     content: [
       { type: "text", text: "Inspect these", signature: "user-signature" },
       {
@@ -64,6 +66,7 @@ const richMessages: Message[] = [
   {
     role: "assistant",
     id: "assistant-1",
+    metadata: { source: "assistant" },
     content: [
       { type: "text", text: "Working", signature: "assistant-signature" },
       {
@@ -94,6 +97,7 @@ const richMessages: Message[] = [
   },
   {
     role: "tool",
+    metadata: { source: "tool" },
     content: [
       {
         type: "tool_result",
@@ -265,6 +269,23 @@ class FakePgPool extends FakePgClient {
 }
 
 describe("PostgresMemoryStore", () => {
+  it("uses core strict JSON validation for message metadata", async () => {
+    expect(isMemoryMessage({ ...userMessage, metadata: { score: 1 } })).toBe(true);
+    expect(isMemoryMessage({ ...userMessage, metadata: { score: Number.NaN } })).toBe(false);
+    const store = await createPostgresMemoryStore({
+      client: new FakePgClient(),
+      createIfMissing: false,
+    });
+    await expect(
+      store.append({
+        context: { sessionId: "thread-invalid" },
+        runId: "run-invalid",
+        turn: 0,
+        messages: [{ ...userMessage, metadata: { score: Number.NaN } } as Message],
+      }),
+    ).rejects.toThrow("valid Anvia Message");
+  });
+
   it("appends multiple turns, loads in position order, and clears scoped messages", async () => {
     const client = new FakePgClient();
     const store = await createPostgresMemoryStore({ client, createIfMissing: false });

--- a/packages/memory-prisma/package.json
+++ b/packages/memory-prisma/package.json
@@ -41,7 +41,7 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": ">=0.12.0 <1.0.0",
+    "@anvia/core": ">=0.13.0 <1.0.0",
     "@prisma/client": ">=6.2.0 <8.0.0"
   }
 }

--- a/packages/memory-prisma/src/message.ts
+++ b/packages/memory-prisma/src/message.ts
@@ -1,4 +1,4 @@
-import type { JsonValue, Message } from "@anvia/core";
+import { isJsonValue, type JsonValue, type Message } from "@anvia/core";
 
 export function parseMemoryMessage(value: unknown): Message {
   if (!isMemoryMessage(value)) {
@@ -9,6 +9,9 @@ export function parseMemoryMessage(value: unknown): Message {
 
 export function isMemoryMessage(value: unknown): value is Message {
   if (!isRecord(value)) {
+    return false;
+  }
+  if (value.metadata !== undefined && !isJsonValue(value.metadata)) {
     return false;
   }
 
@@ -227,25 +230,6 @@ function isDocumentContent(value: Record<string, unknown>): boolean {
   }
 
   return false;
-}
-
-function isJsonValue(value: unknown): value is JsonValue {
-  if (
-    value === null ||
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  ) {
-    return Number.isFinite(value) || typeof value !== "number";
-  }
-
-  if (Array.isArray(value)) {
-    return value.every(isJsonValue);
-  }
-
-  return (
-    isRecord(value) && Object.values(value).every((item) => item === undefined || isJsonValue(item))
-  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/memory-prisma/src/store.ts
+++ b/packages/memory-prisma/src/store.ts
@@ -76,6 +76,7 @@ export class PrismaMemoryStore implements MemoryStore {
     if (input.messages.length === 0) {
       return;
     }
+    this.validateInputMessages(input.messages);
 
     await this.delegates.transaction(async (tx) => {
       const session = await upsertSession(tx, input.context, this.scopeKey(input.context));
@@ -109,6 +110,7 @@ export class PrismaMemoryStore implements MemoryStore {
     if (this.options.errors === "ignore") {
       return;
     }
+    this.validateInputMessages(input.messages);
     if (this.delegates.errors === undefined) {
       throw new Error(
         'PrismaMemoryStore recordError requires an errors delegate. Pass errors: "ignore" to disable failed-run storage.',
@@ -137,6 +139,14 @@ export class PrismaMemoryStore implements MemoryStore {
       return this.options.scope(context);
     }
     return createPrismaMemoryScopeKey(context, this.options.scope);
+  }
+
+  private validateInputMessages(messages: Message[]): void {
+    if (this.options.validateMessages) {
+      for (const message of messages) {
+        parseMemoryMessage(message);
+      }
+    }
   }
 }
 

--- a/packages/memory-prisma/test/store.test.ts
+++ b/packages/memory-prisma/test/store.test.ts
@@ -9,6 +9,7 @@ import {
   PrismaMemoryStore,
   type PrismaMemoryTransactionOptions,
 } from "../src/index";
+import { isMemoryMessage } from "../src/message";
 
 type SessionRow = {
   id: string;
@@ -66,9 +67,10 @@ type CreateErrorArgs = {
 };
 
 const richMessages: MessageType[] = [
-  { role: "system", content: "System instructions" },
+  { role: "system", content: "System instructions", metadata: { source: "system" } },
   {
     role: "user",
+    metadata: { composer: { entities: [{ id: "document-1" }] } },
     content: [
       { type: "text", text: "Inspect these", signature: "user-signature" },
       {
@@ -108,6 +110,7 @@ const richMessages: MessageType[] = [
   {
     role: "assistant",
     id: "assistant-1",
+    metadata: { source: "assistant" },
     content: [
       { type: "text", text: "Working", signature: "assistant-signature" },
       {
@@ -138,6 +141,7 @@ const richMessages: MessageType[] = [
   },
   {
     role: "tool",
+    metadata: { source: "tool" },
     content: [
       {
         type: "tool_result",
@@ -250,6 +254,21 @@ class FakePrisma {
 }
 
 describe("PrismaMemoryStore", () => {
+  it("uses core strict JSON validation for message metadata", async () => {
+    const message = Message.user("hello");
+    expect(isMemoryMessage({ ...message, metadata: { score: 1 } })).toBe(true);
+    expect(isMemoryMessage({ ...message, metadata: { score: Number.NaN } })).toBe(false);
+    const store = createPrismaMemoryStore(new FakePrisma().client);
+    await expect(
+      store.append({
+        context: { sessionId: "thread-invalid" },
+        runId: "run-invalid",
+        turn: 0,
+        messages: [{ ...message, metadata: { score: Number.NaN } } as MessageType],
+      }),
+    ).rejects.toThrow("valid Anvia Message");
+  });
+
   it("appends and loads scoped messages in position order", async () => {
     const prisma = new FakePrisma();
     const store = createPrismaMemoryStore(prisma.client, {

--- a/packages/memory-sqlite/package.json
+++ b/packages/memory-sqlite/package.json
@@ -38,6 +38,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": ">=0.12.0 <1.0.0"
+    "@anvia/core": ">=0.13.0 <1.0.0"
   }
 }

--- a/packages/memory-sqlite/src/message.ts
+++ b/packages/memory-sqlite/src/message.ts
@@ -1,4 +1,4 @@
-import type { JsonValue, Message } from "@anvia/core";
+import { isJsonValue, type JsonValue, type Message } from "@anvia/core";
 
 export function parseMemoryMessage(value: unknown): Message {
   if (!isMemoryMessage(value)) {
@@ -9,6 +9,9 @@ export function parseMemoryMessage(value: unknown): Message {
 
 export function isMemoryMessage(value: unknown): value is Message {
   if (!isRecord(value)) {
+    return false;
+  }
+  if (value.metadata !== undefined && !isJsonValue(value.metadata)) {
     return false;
   }
 
@@ -227,25 +230,6 @@ function isDocumentContent(value: Record<string, unknown>): boolean {
   }
 
   return false;
-}
-
-function isJsonValue(value: unknown): value is JsonValue {
-  if (
-    value === null ||
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  ) {
-    return Number.isFinite(value) || typeof value !== "number";
-  }
-
-  if (Array.isArray(value)) {
-    return value.every(isJsonValue);
-  }
-
-  return (
-    isRecord(value) && Object.values(value).every((item) => item === undefined || isJsonValue(item))
-  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/memory-sqlite/src/store.ts
+++ b/packages/memory-sqlite/src/store.ts
@@ -86,6 +86,7 @@ export class SqliteMemoryStore implements MemoryStore {
     if (input.messages.length === 0) {
       return;
     }
+    this.validateInputMessages(input.messages);
 
     const db = this.database();
     const scopeKey = this.scopeKey(input.context);
@@ -156,6 +157,7 @@ export class SqliteMemoryStore implements MemoryStore {
     if (this.options.errors === "ignore") {
       return;
     }
+    this.validateInputMessages(input.messages);
 
     const db = this.database();
     const scopeKey = this.scopeKey(input.context);
@@ -272,6 +274,14 @@ export class SqliteMemoryStore implements MemoryStore {
   private messageFromJson(raw: string): Message {
     const value = JSON.parse(raw) as unknown;
     return this.options.validateMessages ? parseMemoryMessage(value) : (value as Message);
+  }
+
+  private validateInputMessages(messages: Message[]): void {
+    if (this.options.validateMessages) {
+      for (const message of messages) {
+        parseMemoryMessage(message);
+      }
+    }
   }
 
   private scopeKey(context: MemoryContext): string {

--- a/packages/memory-sqlite/test/store.test.ts
+++ b/packages/memory-sqlite/test/store.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import type { Message } from "@anvia/core";
 import { afterEach, describe, expect, it } from "vitest";
 import { createSqliteMemoryScopeKey, createSqliteMemoryStore } from "../src/index.js";
+import { isMemoryMessage } from "../src/message.js";
 
 const userMessage: Message = {
   role: "user",
@@ -17,9 +18,10 @@ const assistantMessage: Message = {
 };
 
 const richMessages: Message[] = [
-  { role: "system", content: "System instructions" },
+  { role: "system", content: "System instructions", metadata: { source: "system" } },
   {
     role: "user",
+    metadata: { composer: { entities: [{ id: "document-1" }] } },
     content: [
       { type: "text", text: "Inspect these", signature: "user-signature" },
       {
@@ -59,6 +61,7 @@ const richMessages: Message[] = [
   {
     role: "assistant",
     id: "assistant-1",
+    metadata: { source: "assistant" },
     content: [
       { type: "text", text: "Working", signature: "assistant-signature" },
       {
@@ -89,6 +92,7 @@ const richMessages: Message[] = [
   },
   {
     role: "tool",
+    metadata: { source: "tool" },
     content: [
       {
         type: "tool_result",
@@ -112,6 +116,20 @@ afterEach(async () => {
 });
 
 describe("SqliteMemoryStore", () => {
+  it("uses core strict JSON validation for message metadata", async () => {
+    expect(isMemoryMessage({ ...userMessage, metadata: { score: 1 } })).toBe(true);
+    expect(isMemoryMessage({ ...userMessage, metadata: { score: Number.NaN } })).toBe(false);
+    const store = createSqliteMemoryStore();
+    await expect(
+      store.append({
+        context: { sessionId: "thread-invalid" },
+        runId: "run-invalid",
+        turn: 0,
+        messages: [{ ...userMessage, metadata: { score: Number.NaN } } as Message],
+      }),
+    ).rejects.toThrow("valid Anvia Message");
+  });
+
   it("appends multiple turns, loads in position order, and clears scoped messages", async () => {
     const store = createSqliteMemoryStore();
     const context = { sessionId: "thread-1", userId: "user-1" };

--- a/packages/react-ui/src/chat/composer.tsx
+++ b/packages/react-ui/src/chat/composer.tsx
@@ -47,6 +47,7 @@ import {
   useChatContext,
   useComposer,
 } from "../contexts";
+import { shiftComposerEntityRanges } from "../entities";
 import { composeRefs, type PrimitiveProps, renderPrimitive } from "../primitives";
 
 type ComposerRootProps = PrimitiveProps<"form"> & {
@@ -246,10 +247,16 @@ const ComposerRoot = forwardRef<HTMLFormElement, ComposerRootProps>(function Com
     }
 
     const submittedAttachments = [...attachments];
-    const submittedEntities = [...entities];
     const submittedQuote = quote === undefined ? undefined : { ...quote };
-    const submittedText =
-      submittedQuote === undefined ? prompt : promptWithQuote(prompt, submittedQuote);
+    const formattedPrompt =
+      submittedQuote === undefined
+        ? { text: prompt, prefixLength: 0 }
+        : promptWithQuote(prompt, submittedQuote);
+    const submittedEntities = shiftComposerEntityRanges(
+      [...entities],
+      formattedPrompt.prefixLength,
+    );
+    const submittedText = formattedPrompt.text;
     const metadata = composerSubmitMetadata(submittedQuote, submittedEntities);
     const payload: Parameters<typeof chat.sendMessage>[0] =
       submittedAttachments.length === 0
@@ -1189,15 +1196,19 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
 }
 
-function promptWithQuote(prompt: string, quote: ComposerQuote): string {
+function promptWithQuote(
+  prompt: string,
+  quote: ComposerQuote,
+): { text: string; prefixLength: number } {
   const quotedText = quote.text
     .split(/\r?\n/)
     .map((line) => `> ${line}`)
     .join("\n");
   if (prompt.trim().length === 0) {
-    return quotedText;
+    return { text: quotedText, prefixLength: 0 };
   }
-  return `${quotedText}\n\n${prompt}`;
+  const prefix = `${quotedText}\n\n`;
+  return { text: `${prefix}${prompt}`, prefixLength: prefix.length };
 }
 
 function normalizeQuote(quote: ComposerQuote | undefined): ComposerQuote | undefined {

--- a/packages/react-ui/src/chat/index.ts
+++ b/packages/react-ui/src/chat/index.ts
@@ -7,6 +7,7 @@ export type {
   ComposerEntitiesUpdate,
   ComposerEntity,
   ComposerEntityData,
+  ComposerMessageMetadata,
   ComposerQuote,
   ComposerTriggerDefinition,
   ComposerTriggerItem,

--- a/packages/react-ui/src/contexts/composer.tsx
+++ b/packages/react-ui/src/contexts/composer.tsx
@@ -60,6 +60,11 @@ export type ComposerEntity = {
   };
   data?: ComposerEntityData | undefined;
 };
+export type ComposerMessageMetadata = {
+  composer: {
+    entities: ComposerEntity[];
+  };
+};
 export type ComposerTriggerState = {
   trigger: ComposerTriggerDefinition;
   query: string;

--- a/packages/react-ui/src/contexts/index.ts
+++ b/packages/react-ui/src/contexts/index.ts
@@ -13,6 +13,7 @@ export type {
   ComposerEntitiesUpdate,
   ComposerEntity,
   ComposerEntityData,
+  ComposerMessageMetadata,
   ComposerQuote,
   ComposerTriggerDefinition,
   ComposerTriggerItem,

--- a/packages/react-ui/src/entities.ts
+++ b/packages/react-ui/src/entities.ts
@@ -1,0 +1,151 @@
+import type { UIMessagePart } from "@anvia/react";
+import type { ComposerEntity } from "./contexts/composer";
+
+export type MessageTextSegment = {
+  part: Extract<UIMessagePart, { type: "text" }>;
+  from: number;
+  to: number;
+};
+
+export type MessageTextLayout = {
+  text: string;
+  segments: MessageTextSegment[];
+};
+
+export function messageTextLayout(parts: UIMessagePart[]): MessageTextLayout {
+  const textParts = parts.filter(
+    (part): part is Extract<UIMessagePart, { type: "text" }> => part.type === "text",
+  );
+  const segments: MessageTextSegment[] = [];
+  let offset = 0;
+
+  for (const [index, part] of textParts.entries()) {
+    const from = offset;
+    const to = from + part.text.length;
+    segments.push({ part, from, to });
+    offset = to + (index === textParts.length - 1 ? 0 : 2);
+  }
+
+  return {
+    text: textParts.map((part) => part.text).join("\n\n"),
+    segments,
+  };
+}
+
+export function validComposerEntities(text: string, metadata: unknown): ComposerEntity[] {
+  const candidates = composerEntityCandidates(metadata);
+  const individuallyValid = candidates.flatMap((entity, index) =>
+    isValidComposerEntity(entity, text) ? [{ entity, index }] : [],
+  );
+  individuallyValid.sort(
+    (left, right) =>
+      left.entity.range.from - right.entity.range.from ||
+      left.entity.range.to - right.entity.range.to ||
+      left.index - right.index,
+  );
+
+  const overlapping = new Set<number>();
+  let groupStart = 0;
+  let groupEnd = individuallyValid[0]?.entity.range.to ?? 0;
+  let groupHasOverlap = false;
+  for (let index = 1; index <= individuallyValid.length; index += 1) {
+    const current = individuallyValid[index];
+    if (current !== undefined && current.entity.range.from < groupEnd) {
+      groupHasOverlap = true;
+      groupEnd = Math.max(groupEnd, current.entity.range.to);
+      continue;
+    }
+    if (groupHasOverlap) {
+      for (let groupIndex = groupStart; groupIndex < index; groupIndex += 1) {
+        const candidate = individuallyValid[groupIndex];
+        if (candidate !== undefined) {
+          overlapping.add(candidate.index);
+        }
+      }
+    }
+    groupStart = index;
+    groupEnd = current?.entity.range.to ?? 0;
+    groupHasOverlap = false;
+  }
+
+  return individuallyValid
+    .filter((candidate) => !overlapping.has(candidate.index))
+    .map((candidate) => candidate.entity);
+}
+
+export function entitiesForTextSegment(
+  entities: ComposerEntity[],
+  segment: MessageTextSegment,
+): ComposerEntity[] {
+  return entities.flatMap((entity) => {
+    if (entity.range.from < segment.from || entity.range.to > segment.to) {
+      return [];
+    }
+    return [
+      {
+        ...entity,
+        range: {
+          from: entity.range.from - segment.from,
+          to: entity.range.to - segment.from,
+        },
+      },
+    ];
+  });
+}
+
+export function shiftComposerEntityRanges(
+  entities: ComposerEntity[],
+  offset: number,
+): ComposerEntity[] {
+  if (offset === 0) {
+    return entities;
+  }
+  return entities.map((entity) => ({
+    ...entity,
+    range: {
+      from: entity.range.from + offset,
+      to: entity.range.to + offset,
+    },
+  }));
+}
+
+function composerEntityCandidates(metadata: unknown): unknown[] {
+  if (!isRecord(metadata) || !isRecord(metadata.composer)) {
+    return [];
+  }
+  return Array.isArray(metadata.composer.entities) ? metadata.composer.entities : [];
+}
+
+function isValidComposerEntity(value: unknown, text: string): value is ComposerEntity {
+  if (!isRecord(value) || !isRecord(value.range)) {
+    return false;
+  }
+  if (
+    !isNonEmptyString(value.id) ||
+    !isNonEmptyString(value.triggerId) ||
+    !isNonEmptyString(value.trigger) ||
+    !isNonEmptyString(value.label) ||
+    !isNonEmptyString(value.text)
+  ) {
+    return false;
+  }
+  const { from, to } = value.range;
+  return (
+    typeof from === "number" &&
+    typeof to === "number" &&
+    Number.isInteger(from) &&
+    Number.isInteger(to) &&
+    from >= 0 &&
+    to > from &&
+    to <= text.length &&
+    text.slice(from, to) === value.text
+  );
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/react-ui/src/index.ts
+++ b/packages/react-ui/src/index.ts
@@ -24,6 +24,7 @@ export {
 export { Image, useImage } from "./image/index";
 export type {
   MessageAttachmentPart,
+  MessageEntityProps,
   MessagePartsFilter,
   MessageToolPart,
   MessageToolRenderWhen,
@@ -45,6 +46,7 @@ export type {
   ComposerEntitiesUpdate,
   ComposerEntity,
   ComposerEntityData,
+  ComposerMessageMetadata,
   ComposerQuote,
   ComposerTriggerDefinition,
   ComposerTriggerItem,

--- a/packages/react-ui/src/message/entity.tsx
+++ b/packages/react-ui/src/message/entity.tsx
@@ -1,0 +1,25 @@
+import { forwardRef, type HTMLAttributes } from "react";
+import type { ComposerEntity } from "../contexts";
+
+export type MessageEntityProps = HTMLAttributes<HTMLSpanElement> & {
+  entity: ComposerEntity;
+};
+
+const MessageEntity = forwardRef<HTMLSpanElement, MessageEntityProps>(function MessageEntity(
+  { children, entity, ...props },
+  ref,
+) {
+  return (
+    <span
+      {...props}
+      data-anvia-message-entity=""
+      data-entity-id={entity.id}
+      data-trigger-id={entity.triggerId}
+      ref={ref}
+    >
+      {children ?? entity.text}
+    </span>
+  );
+});
+
+export { MessageEntity };

--- a/packages/react-ui/src/message/index.ts
+++ b/packages/react-ui/src/message/index.ts
@@ -1,4 +1,5 @@
 import { MessageActions, MessageCopy, MessageRegenerate } from "./actions";
+import { MessageEntity } from "./entity";
 import {
   MessageAttachment,
   MessageCodeBlock,
@@ -25,6 +26,7 @@ export const Message = {
   Part: MessagePart,
   Text: MessageText,
   Markdown: MessageMarkdown,
+  Entity: MessageEntity,
   CodeBlock: MessageCodeBlock,
   Reasoning: MessageReasoning,
   Tool: MessageTool,
@@ -43,6 +45,7 @@ export const Message = {
 
 export type { MessageContextValue, MessagePartContextValue } from "../contexts";
 export { useChatContext, useMessage, useMessagePart } from "../contexts";
+export type { MessageEntityProps } from "./entity";
 export type {
   MessageAttachmentPart,
   MessagePartsFilter,

--- a/packages/react-ui/src/message/markdown-entities.ts
+++ b/packages/react-ui/src/message/markdown-entities.ts
@@ -1,0 +1,306 @@
+import type { Options as ReactMarkdownOptions } from "react-markdown";
+import type { ComposerEntity } from "../contexts";
+
+type MarkdownPoint = {
+  offset?: number | undefined;
+};
+
+type MarkdownPosition = {
+  start: MarkdownPoint;
+  end: MarkdownPoint;
+};
+
+type MarkdownNode = {
+  type: string;
+  value?: string | undefined;
+  children?: MarkdownNode[] | undefined;
+  position?: MarkdownPosition | undefined;
+  entityIndex?: number | undefined;
+};
+
+const phrasingParentTypes = new Set([
+  "paragraph",
+  "heading",
+  "emphasis",
+  "strong",
+  "delete",
+  "link",
+  "linkReference",
+  "tableCell",
+]);
+const literalNodeTypes = new Set(["code", "inlineCode", "html", "yaml"]);
+
+export function createMessageEntityRemarkPlugin(markdown: string, entities: ComposerEntity[]) {
+  return function messageEntityRemarkPlugin() {
+    return (tree: MarkdownNode): void => {
+      const rendered = new Set<number>();
+      transformNode(tree, markdown, entities, rendered);
+    };
+  };
+}
+
+export function messageEntityRehypeOptions(): ReactMarkdownOptions["remarkRehypeOptions"] {
+  return {
+    handlers: {
+      messageEntity(_state: unknown, node: MarkdownNode) {
+        const entityIndex = node.entityIndex;
+        return {
+          type: "element",
+          tagName: "span",
+          properties: {
+            dataAnviaMessageEntity: "",
+            dataAnviaEntityIndex: entityIndex === undefined ? "" : String(entityIndex),
+          },
+          children: [{ type: "text", value: node.value ?? "" }],
+        };
+      },
+    } as never,
+  };
+}
+
+function transformNode(
+  node: MarkdownNode,
+  markdown: string,
+  entities: ComposerEntity[],
+  rendered: Set<number>,
+): void {
+  if (literalNodeTypes.has(node.type) || node.children === undefined) {
+    return;
+  }
+
+  for (const child of node.children) {
+    transformNode(child, markdown, entities, rendered);
+  }
+  if (!phrasingParentTypes.has(node.type)) {
+    return;
+  }
+
+  for (let entityIndex = entities.length - 1; entityIndex >= 0; entityIndex -= 1) {
+    if (rendered.has(entityIndex)) {
+      continue;
+    }
+    const entity = entities[entityIndex];
+    if (entity !== undefined && replaceEntity(node, markdown, entity, entityIndex)) {
+      rendered.add(entityIndex);
+    }
+  }
+}
+
+function replaceEntity(
+  parent: MarkdownNode,
+  markdown: string,
+  entity: ComposerEntity,
+  entityIndex: number,
+): boolean {
+  const children = parent.children;
+  if (children === undefined) {
+    return false;
+  }
+  const firstIndex = children.findIndex((child) => containsStart(child, entity.range.from));
+  const lastIndex = findLastIndex(children, (child) => containsEnd(child, entity.range.to));
+  if (firstIndex < 0 || lastIndex < firstIndex) {
+    return false;
+  }
+
+  const first = children[firstIndex];
+  const last = children[lastIndex];
+  const firstPosition = offsets(first);
+  const lastPosition = offsets(last);
+  if (
+    first === undefined ||
+    last === undefined ||
+    firstPosition === undefined ||
+    lastPosition === undefined ||
+    entity.range.from < firstPosition.from ||
+    entity.range.to > lastPosition.to
+  ) {
+    return false;
+  }
+
+  if (firstIndex === lastIndex && literalNodeTypes.has(first.type)) {
+    return false;
+  }
+  const before = contentBefore(first, markdown, entity);
+  const after = contentAfter(last, markdown, entity);
+  if (before === undefined || after === undefined) {
+    return false;
+  }
+
+  const replacement: MarkdownNode[] = [];
+  replacement.push(...before);
+  replacement.push({
+    type: "messageEntity",
+    value: entity.text,
+    entityIndex,
+    position: {
+      start: { offset: entity.range.from },
+      end: { offset: entity.range.to },
+    },
+  });
+  replacement.push(...after);
+  children.splice(firstIndex, lastIndex - firstIndex + 1, ...replacement);
+  return true;
+}
+
+function contentBefore(
+  node: MarkdownNode,
+  markdown: string,
+  entity: ComposerEntity,
+): MarkdownNode[] | undefined {
+  const position = offsets(node);
+  if (position === undefined) {
+    return undefined;
+  }
+  if (entity.range.from === position.from) {
+    return [];
+  }
+  if (node.type !== "text" || node.value === undefined) {
+    if (node.children === undefined || literalNodeTypes.has(node.type)) {
+      return undefined;
+    }
+    const childIndex = node.children.findIndex((child) => containsStart(child, entity.range.from));
+    const child = node.children[childIndex];
+    if (child === undefined) {
+      return undefined;
+    }
+    const childContent = contentBefore(child, markdown, entity);
+    return childContent === undefined
+      ? undefined
+      : [...node.children.slice(0, childIndex), ...childContent];
+  }
+  const split = textValueRange(node, markdown, entity);
+  if (split === undefined) {
+    return undefined;
+  }
+  return [
+    {
+      ...node,
+      value: node.value.slice(0, split.from),
+      position: {
+        start: node.position?.start ?? {},
+        end: { offset: entity.range.from },
+      },
+    },
+  ];
+}
+
+function contentAfter(
+  node: MarkdownNode,
+  markdown: string,
+  entity: ComposerEntity,
+): MarkdownNode[] | undefined {
+  const position = offsets(node);
+  if (position === undefined) {
+    return undefined;
+  }
+  if (entity.range.to === position.to) {
+    return [];
+  }
+  if (node.type !== "text" || node.value === undefined) {
+    if (node.children === undefined || literalNodeTypes.has(node.type)) {
+      return undefined;
+    }
+    const childIndex = findLastIndex(node.children, (child) => containsEnd(child, entity.range.to));
+    const child = node.children[childIndex];
+    if (child === undefined) {
+      return undefined;
+    }
+    const childContent = contentAfter(child, markdown, entity);
+    return childContent === undefined
+      ? undefined
+      : [...childContent, ...node.children.slice(childIndex + 1)];
+  }
+  const split = textValueRange(node, markdown, entity);
+  if (split === undefined) {
+    return undefined;
+  }
+  return [
+    {
+      ...node,
+      value: node.value.slice(split.to),
+      position: {
+        start: { offset: entity.range.to },
+        end: node.position?.end ?? {},
+      },
+    },
+  ];
+}
+
+function textValueRange(
+  node: MarkdownNode,
+  markdown: string,
+  entity: ComposerEntity,
+): { from: number; to: number } | undefined {
+  const position = offsets(node);
+  const value = node.value;
+  if (position === undefined || value === undefined) {
+    return undefined;
+  }
+  const raw = markdown.slice(position.from, position.to);
+  const relativeFrom = entity.range.from - position.from;
+  const relativeTo = entity.range.to - position.from;
+  if (raw === value) {
+    return { from: relativeFrom, to: relativeTo };
+  }
+
+  const occurrence = countOccurrences(raw.slice(0, relativeFrom), entity.text);
+  const valueFrom = occurrenceIndex(value, entity.text, occurrence);
+  return valueFrom === undefined
+    ? undefined
+    : { from: valueFrom, to: valueFrom + entity.text.length };
+}
+
+function countOccurrences(value: string, search: string): number {
+  let count = 0;
+  let offset = 0;
+  while (offset <= value.length - search.length) {
+    const index = value.indexOf(search, offset);
+    if (index < 0) {
+      break;
+    }
+    count += 1;
+    offset = index + search.length;
+  }
+  return count;
+}
+
+function occurrenceIndex(value: string, search: string, occurrence: number): number | undefined {
+  let offset = 0;
+  for (let index = 0; index <= occurrence; index += 1) {
+    const found = value.indexOf(search, offset);
+    if (found < 0) {
+      return undefined;
+    }
+    if (index === occurrence) {
+      return found;
+    }
+    offset = found + search.length;
+  }
+  return undefined;
+}
+
+function containsStart(node: MarkdownNode, offset: number): boolean {
+  const position = offsets(node);
+  return position !== undefined && offset >= position.from && offset < position.to;
+}
+
+function containsEnd(node: MarkdownNode, offset: number): boolean {
+  const position = offsets(node);
+  return position !== undefined && offset > position.from && offset <= position.to;
+}
+
+function offsets(node: MarkdownNode | undefined): { from: number; to: number } | undefined {
+  const from = node?.position?.start.offset;
+  const to = node?.position?.end.offset;
+  return typeof from === "number" && typeof to === "number" ? { from, to } : undefined;
+}
+
+function findLastIndex<T>(items: T[], predicate: (item: T) => boolean): number {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const item = items[index];
+    if (item !== undefined && predicate(item)) {
+      return index;
+    }
+  }
+  return -1;
+}

--- a/packages/react-ui/src/message/parts.tsx
+++ b/packages/react-ui/src/message/parts.tsx
@@ -5,7 +5,7 @@ import {
   type UIMessagePart,
   useSmoothStreamText,
 } from "@anvia/react";
-import { type ComponentPropsWithoutRef, forwardRef, type ReactNode } from "react";
+import { type ComponentPropsWithoutRef, createElement, forwardRef, type ReactNode } from "react";
 import ReactMarkdown, {
   type Components,
   type Options as ReactMarkdownOptions,
@@ -13,6 +13,7 @@ import ReactMarkdown, {
 import remarkGfm from "remark-gfm";
 
 import { Attachment } from "../attachment/index";
+import type { ComposerEntity } from "../contexts";
 import {
   InternalAttachmentProvider,
   InternalMessagePartProvider,
@@ -20,8 +21,11 @@ import {
   useMessagePart,
   useOptionalMessagePart,
 } from "../contexts";
+import { entitiesForTextSegment, messageTextLayout, validComposerEntities } from "../entities";
 import { stringifyValue } from "../format";
 import { type PrimitiveProps, renderPrimitive } from "../primitives";
+import { MessageEntity } from "./entity";
+import { createMessageEntityRemarkPlugin, messageEntityRehypeOptions } from "./markdown-entities";
 
 type MessagePartChildren = ReactNode | ((part: UIMessagePart) => ReactNode);
 export type MessagePartsFilter = (part: UIMessagePart) => boolean;
@@ -150,6 +154,7 @@ type MessageMarkdownProps = Omit<PrimitiveProps<"div">, "children"> &
   MessageStreamAnimationProps & {
     children?: string;
     components?: Components;
+    renderEntity?: ((entity: ComposerEntity) => ReactNode) | undefined;
     remarkPlugins?: ReactMarkdownOptions["remarkPlugins"];
   };
 
@@ -164,16 +169,25 @@ const MessageMarkdown = forwardRef<HTMLDivElement, MessageMarkdownProps>(functio
     return null;
   }
 
-  const markdown =
-    children ??
-    (part?.type === "text"
-      ? part.text
-      : message.parts.flatMap((item) => (item.type === "text" ? [item.text] : [])).join("\n\n"));
+  const layout = messageTextLayout(message.parts);
+  const markdown = children ?? (part?.type === "text" ? part.text : layout.text);
+  const expectedMarkdown = part?.type === "text" ? part.text : layout.text;
+  const validEntities =
+    children === undefined || children === expectedMarkdown
+      ? validComposerEntities(layout.text, message.metadata)
+      : [];
+  const segment =
+    part?.type === "text"
+      ? layout.segments.find((candidate) => candidate.part.id === part.id)
+      : undefined;
+  const entities =
+    segment === undefined ? validEntities : entitiesForTextSegment(validEntities, segment);
 
-  return <MessageMarkdownContent {...props} markdown={markdown} ref={ref} />;
+  return <MessageMarkdownContent {...props} entities={entities} markdown={markdown} ref={ref} />;
 });
 
 type MessageMarkdownContentProps = Omit<MessageMarkdownProps, "children"> & {
+  entities: ComposerEntity[];
   markdown: string;
 };
 
@@ -186,7 +200,9 @@ const MessageMarkdownContent = forwardRef<HTMLDivElement, MessageMarkdownContent
       smoothingPreset,
       reducedMotion,
       components,
+      renderEntity,
       remarkPlugins,
+      entities,
       markdown,
       ...props
     },
@@ -201,6 +217,10 @@ const MessageMarkdownContent = forwardRef<HTMLDivElement, MessageMarkdownContent
     });
     const animationActive =
       animate && animationMode !== "none" && isStreaming !== false && reducedMotion !== true;
+    const renderedMarkdown = animate ? smooth.text : markdown;
+    const renderedEntities = validComposerEntities(renderedMarkdown, {
+      composer: { entities },
+    });
 
     return renderPrimitive(
       "div",
@@ -208,10 +228,14 @@ const MessageMarkdownContent = forwardRef<HTMLDivElement, MessageMarkdownContent
         ...props,
         children: (
           <ReactMarkdown
-            components={{ code: defaultCodeComponent, pre: defaultPreComponent, ...components }}
-            remarkPlugins={remarkPlugins ?? [remarkGfm]}
+            components={markdownComponents(components, renderedEntities, renderEntity)}
+            remarkPlugins={[
+              createMessageEntityRemarkPlugin(renderedMarkdown, renderedEntities),
+              ...(remarkPlugins ?? [remarkGfm]),
+            ]}
+            remarkRehypeOptions={messageEntityRehypeOptions()}
           >
-            {animate ? smooth.text : markdown}
+            {renderedMarkdown}
           </ReactMarkdown>
         ),
         "data-anvia-markdown": "",
@@ -222,6 +246,55 @@ const MessageMarkdownContent = forwardRef<HTMLDivElement, MessageMarkdownContent
     );
   },
 );
+
+function markdownComponents(
+  components: Components | undefined,
+  entities: ComposerEntity[],
+  renderEntity: ((entity: ComposerEntity) => ReactNode) | undefined,
+): Components {
+  const consumerSpan = components?.span;
+  return {
+    code: defaultCodeComponent,
+    pre: defaultPreComponent,
+    ...components,
+    span(spanProps) {
+      const internalProps = spanProps as typeof spanProps & {
+        "data-anvia-entity-index"?: string | undefined;
+      };
+      const entityIndexValue = internalProps["data-anvia-entity-index"];
+      const entityIndex =
+        typeof entityIndexValue === "string" && /^\d+$/.test(entityIndexValue)
+          ? Number(entityIndexValue)
+          : undefined;
+      const entity = entityIndex === undefined ? undefined : entities[entityIndex];
+      const consumerProps = { ...internalProps };
+      delete consumerProps["data-anvia-entity-index"];
+
+      if (entity !== undefined) {
+        if (renderEntity !== undefined) {
+          return renderEntity(entity);
+        }
+        const entityProps = {
+          ...consumerProps,
+          "data-anvia-message-entity": "",
+          "data-entity-id": entity.id,
+          "data-trigger-id": entity.triggerId,
+        };
+        if (consumerSpan !== undefined) {
+          return createElement(consumerSpan, entityProps);
+        }
+        const { node: _node, ...elementProps } = entityProps;
+        return <MessageEntity {...elementProps} entity={entity} />;
+      }
+
+      if (consumerSpan !== undefined) {
+        return createElement(consumerSpan, consumerProps);
+      }
+      const { node: _node, ...elementProps } = consumerProps;
+      return <span {...elementProps} />;
+    },
+  };
+}
 
 type MessageCodeBlockProps = Omit<PrimitiveProps<"pre">, "children"> & {
   children?: ReactNode;

--- a/packages/react-ui/src/shared.ts
+++ b/packages/react-ui/src/shared.ts
@@ -12,6 +12,7 @@ export type {
   ComposerEntitiesUpdate,
   ComposerEntity,
   ComposerEntityData,
+  ComposerMessageMetadata,
   ComposerQuote,
   ComposerTriggerDefinition,
   ComposerTriggerItem,

--- a/packages/react-ui/test/chat.test.tsx
+++ b/packages/react-ui/test/chat.test.tsx
@@ -282,7 +282,7 @@ describe("Chat primitives", () => {
         <Composer.Root
           defaultAttachments={[attachment]}
           defaultEntities={[entity]}
-          defaultInput="Hello"
+          defaultInput="@Ada says Hello"
           defaultQuote={quote}
         >
           <Composer.TextareaInput />
@@ -305,11 +305,13 @@ describe("Chat primitives", () => {
     });
 
     expect(payloadWhilePending).toEqual({
-      text: "> First line\n> Second line\n\nHello",
+      text: "> First line\n> Second line\n\n@Ada says Hello",
       attachments: [attachment],
       metadata: {
         quote,
-        composer: { entities: [entity] },
+        composer: {
+          entities: [{ ...entity, range: { from: 28, to: 32 } }],
+        },
       },
     });
     expect(stateWhilePending).toBe(

--- a/packages/react-ui/test/exports.test.ts
+++ b/packages/react-ui/test/exports.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, expectTypeOf, it } from "vitest";
 import type {
   ComposerAttachmentInput,
   ComposerAttachmentsUpdate,
+  ComposerEntity,
+  ComposerMessageMetadata,
   ComposerQuote,
   ComposerSubmitMessage,
   ComposerSubmitMessageArgs,
   ImageContextValue,
   MessageAttachmentPart,
+  MessageEntityProps,
   MessageToolPart,
   SelectionToolbarSelection,
   ThreadListController,
@@ -34,6 +37,7 @@ describe("public entrypoints", () => {
     expect(Composer.Root).toBeTypeOf("object");
     expect(Composer.AttachmentInput).toBeTypeOf("object");
     expect(Message.Root).toBeTypeOf("object");
+    expect(Message.Entity).toBeTypeOf("object");
     expect(HumanInput.Approvals).toBeTypeOf("object");
     expect(Completion.Root).toBeTypeOf("object");
     expect(Image.Root).toBeTypeOf("object");
@@ -51,6 +55,10 @@ describe("public entrypoints", () => {
   it("exports public helper types from domain barrels", () => {
     expectTypeOf<MessageToolPart>().toMatchTypeOf<{ type: "tool" }>();
     expectTypeOf<MessageAttachmentPart>().toMatchTypeOf<{ type: "attachment" }>();
+    expectTypeOf<MessageEntityProps>().toMatchTypeOf<{ entity: ComposerEntity }>();
+    expectTypeOf<ComposerMessageMetadata>().toMatchTypeOf<{
+      composer: { entities: ComposerEntity[] };
+    }>();
     expectTypeOf<File>().toMatchTypeOf<ComposerAttachmentInput>();
     expectTypeOf<
       Array<{ id: string; type: "image" | "document" | "file" }>

--- a/packages/react-ui/test/message.test.tsx
+++ b/packages/react-ui/test/message.test.tsx
@@ -1,9 +1,9 @@
 import type { UIMessage } from "@anvia/react";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import type { ComponentProps, ReactElement } from "react";
+import { type ComponentProps, type ReactElement, StrictMode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { ChatProvider, Message, Thread } from "../src";
+import { ChatProvider, type ComposerEntity, Message, Thread } from "../src";
 import { createChatController, textMessage } from "./helpers";
 
 const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
@@ -320,6 +320,263 @@ describe("Message primitives", () => {
     expect(screen.getAllByTestId("custom-code")).toHaveLength(2);
   });
 
+  it("renders valid Composer entities as semantic Markdown markup", () => {
+    const text = "See @Guide.pdf for details.";
+    const entity = composerEntity(text, "@Guide.pdf", "document-1");
+    const { container } = render(<StrictMode>{markdownEntityView(text, [entity])}</StrictMode>);
+
+    const element = container.querySelector("[data-anvia-message-entity]");
+    expect(element?.textContent).toBe("@Guide.pdf");
+    expect(element?.getAttribute("data-entity-id")).toBe("document-1");
+    expect(element?.getAttribute("data-trigger-id")).toBe("documents");
+    expect(element?.hasAttribute("data-anvia-entity-index")).toBe(false);
+    expect(container.querySelectorAll("[data-anvia-message-entity]")).toHaveLength(1);
+  });
+
+  it("renders multiple and adjacent entities without changing normal Markdown links", () => {
+    const text =
+      "See @One.pdf and [the guide](https://example.test/guide), then @Two.pdf@Three.pdf.";
+    const entities = [
+      composerEntity(text, "@One.pdf", "document-1"),
+      composerEntity(text, "@Two.pdf", "document-2"),
+      composerEntity(text, "@Three.pdf", "document-3"),
+    ];
+    const { container } = render(markdownEntityView(text, entities));
+
+    expect(
+      [...container.querySelectorAll("[data-anvia-message-entity]")].map(
+        (element) => element.textContent,
+      ),
+    ).toEqual(["@One.pdf", "@Two.pdf", "@Three.pdf"]);
+    expect(container.querySelector("a")?.getAttribute("href")).toBe("https://example.test/guide");
+    expect(container.querySelector("a")?.textContent).toBe("the guide");
+  });
+
+  it("renders Markdown punctuation inside entity text literally", () => {
+    const entityText = "@Guide[1]*draft*_copy_`v2`.pdf";
+    const text = `Open ${entityText} now.`;
+    const { container } = render(
+      markdownEntityView(text, [composerEntity(text, entityText, "document-1")]),
+    );
+
+    const element = container.querySelector("[data-anvia-message-entity]");
+    expect(element?.textContent).toBe(entityText);
+    expect(element?.querySelector("em, code, a")).toBeNull();
+    expect(container.querySelector("[data-anvia-markdown]")?.textContent).toBe(text);
+  });
+
+  it("keeps escaped and Unicode text aligned with UTF-16 entity offsets", () => {
+    const text = String.raw`Escaped \*literal\* 👋 before @文档.pdf.`;
+    const entity = composerEntity(text, "@文档.pdf", "document-unicode");
+    const { container } = render(markdownEntityView(text, [entity]));
+
+    expect(container.querySelector("[data-anvia-message-entity]")?.textContent).toBe("@文档.pdf");
+    expect(container.querySelector("[data-anvia-markdown]")?.textContent).toBe(
+      "Escaped *literal* 👋 before @文档.pdf.",
+    );
+    expect(() => JSON.stringify(entity.data)).not.toThrow();
+  });
+
+  it("renders entities only in eligible prose positions", () => {
+    const text = [
+      "**@Strong.pdf**",
+      "",
+      "`@Inline.pdf`",
+      "",
+      "```txt",
+      "@Fenced.pdf",
+      "```",
+      "",
+      "[@Label.pdf](https://example.test)",
+      "",
+      "[destination](@Destination.pdf)",
+      "",
+      "# @Heading.pdf",
+      "",
+      "- @List.pdf",
+      "",
+      "> @Quote.pdf",
+      "",
+      "| Document |",
+      "| --- |",
+      "| @Table.pdf |",
+    ].join("\n");
+    const entityTexts = [
+      "@Strong.pdf",
+      "@Inline.pdf",
+      "@Fenced.pdf",
+      "@Label.pdf",
+      "@Destination.pdf",
+      "@Heading.pdf",
+      "@List.pdf",
+      "@Quote.pdf",
+      "@Table.pdf",
+    ];
+    const entities = entityTexts.map((entityText, index) =>
+      composerEntity(text, entityText, `document-${index + 1}`),
+    );
+    const { container } = render(markdownEntityView(text, entities));
+
+    const rendered = [...container.querySelectorAll("[data-anvia-message-entity]")].map(
+      (element) => element.textContent,
+    );
+    expect(rendered).toEqual([
+      "@Strong.pdf",
+      "@Label.pdf",
+      "@Heading.pdf",
+      "@List.pdf",
+      "@Quote.pdf",
+      "@Table.pdf",
+    ]);
+    expect(container.querySelector("strong [data-anvia-message-entity]")).toBeTruthy();
+    expect(container.querySelector("a [data-anvia-message-entity]")?.textContent).toBe(
+      "@Label.pdf",
+    );
+    expect(container.querySelector("code")?.textContent).toBe("@Inline.pdf");
+    expect(container.querySelector('a[href="@Destination.pdf"]')?.textContent).toBe("destination");
+  });
+
+  it("falls back to ordinary text for malformed, stale, and overlapping entities", () => {
+    const text = "@One.pdf @Two.pdf";
+    const overlapping = composerEntity(text, text, "overlap-all", 0);
+    const second = composerEntity(text, "@Two.pdf", "overlap-second");
+    const malformed: ComposerEntity[] = [
+      overlapping,
+      second,
+      { ...composerEntity(text, "@One.pdf", "stale"), text: "@Stale.pdf" },
+      { ...composerEntity(text, "@One.pdf", "out-of-bounds"), range: { from: 0, to: 999 } },
+      { ...composerEntity(text, "@One.pdf", "fractional"), range: { from: 0.5, to: 8 } },
+      { ...composerEntity(text, "@One.pdf", ""), id: "" },
+    ];
+    const { container } = render(markdownEntityView(text, malformed));
+
+    expect(container.querySelector("[data-anvia-message-entity]")).toBeNull();
+    expect(container.querySelector("[data-anvia-markdown]")?.textContent).toBe(text);
+  });
+
+  it("supports renderEntity and components.span overrides", () => {
+    const text = "See @Guide.pdf.";
+    const entity = composerEntity(text, "@Guide.pdf", "document-1");
+    const custom = render(
+      markdownEntityView(text, [entity], {
+        renderEntity(current) {
+          return <mark data-testid="custom-entity">{current.label}</mark>;
+        },
+      }),
+    );
+    expect(screen.getByTestId("custom-entity").textContent).toBe("Guide.pdf");
+    expect(custom.container.querySelector("[data-anvia-message-entity]")).toBeNull();
+    custom.unmount();
+
+    const span = render(
+      markdownEntityView(text, [entity], {
+        components: {
+          span({ node: _node, ...props }) {
+            return <span {...props} data-testid="custom-span" />;
+          },
+        },
+      }),
+    );
+    const element = screen.getByTestId("custom-span");
+    expect(element.getAttribute("data-entity-id")).toBe("document-1");
+    expect(element.textContent).toBe("@Guide.pdf");
+    span.unmount();
+  });
+
+  it("maps message-level entity offsets across multiple text parts", () => {
+    const first = "First paragraph.";
+    const second = "Open @Guide.pdf.";
+    const joined = `${first}\n\n${second}`;
+    const entity = composerEntity(joined, "@Guide.pdf", "document-1");
+    const message: UIMessage = {
+      id: "msg_1",
+      role: "user",
+      parts: [
+        { id: "part_1", type: "text", text: first },
+        { id: "part_2", type: "text", text: second },
+      ],
+      metadata: { composer: { entities: [entity] } },
+    };
+    const { container } = render(
+      <ChatProvider controller={createChatController({ messages: [message] })}>
+        <Thread.Root>
+          <Thread.Messages>
+            <Message.Root>
+              <Message.Markdown />
+            </Message.Root>
+          </Thread.Messages>
+        </Thread.Root>
+      </ChatProvider>,
+    );
+
+    expect(container.querySelectorAll("p")).toHaveLength(2);
+    expect(container.querySelector("[data-anvia-message-entity]")?.textContent).toBe("@Guide.pdf");
+  });
+
+  it("runs the entity transform before consumer remark plugins", () => {
+    const text = "See @Guide.pdf.";
+    const entity = composerEntity(text, "@Guide.pdf", "document-1");
+    const visitedTypes: string[] = [];
+
+    function inspectPlugin() {
+      return (tree: unknown) => collectNodeTypes(tree, visitedTypes);
+    }
+
+    render(markdownEntityView(text, [entity], { remarkPlugins: [inspectPlugin] }));
+    expect(visitedTypes).toContain("messageEntity");
+  });
+
+  it("lets consumer remark plugins reconstruct entity nodes as exact text", () => {
+    const entityText = "@Guide[1]*draft*.pdf";
+    const text = `Open ${entityText}.`;
+
+    function literalizePlugin() {
+      return (tree: unknown) => literalizeEntityNodes(tree);
+    }
+
+    const { container } = render(
+      markdownEntityView(text, [composerEntity(text, entityText, "document-1")], {
+        remarkPlugins: [literalizePlugin],
+      }),
+    );
+    expect(container.querySelector("[data-anvia-message-entity]")).toBeNull();
+    expect(container.querySelector("[data-anvia-markdown]")?.textContent).toBe(text);
+  });
+
+  it("keeps copy and regenerate disabled for standalone tool messages", () => {
+    const toolMessage: UIMessage = {
+      id: "tool_message_1",
+      role: "tool",
+      parts: [
+        {
+          id: "tool_1",
+          type: "tool",
+          toolName: "lookup",
+          toolCallId: "tool_1",
+          state: "output-available",
+          input: { query: "Anvia" },
+          output: "done",
+        },
+      ],
+      metadata: { source: "tool" },
+    };
+    render(
+      <ChatProvider controller={createChatController({ messages: [toolMessage] })}>
+        <Thread.Root>
+          <Thread.Messages>
+            <Message.Root>
+              <Message.Copy />
+              <Message.Regenerate />
+            </Message.Root>
+          </Thread.Messages>
+        </Thread.Root>
+      </ChatProvider>,
+    );
+
+    expect((screen.getByText("Copy") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByText("Regenerate") as HTMLButtonElement).disabled).toBe(true);
+  });
+
   it("keeps Message.Markdown rendering immediate by default", () => {
     const raf = installAnimationFrame();
     const { container, rerender } = render(markdownView("Hello"));
@@ -569,6 +826,76 @@ function markdownView(
       </Thread.Root>
     </ChatProvider>
   );
+}
+
+function markdownEntityView(
+  markdown: string,
+  entities: ComposerEntity[],
+  props: ComponentProps<typeof Message.Markdown> = {},
+): ReactElement {
+  const message = {
+    ...textMessage("msg_1", "user", markdown),
+    metadata: { composer: { entities } },
+  };
+  return (
+    <ChatProvider controller={createChatController({ messages: [message] })}>
+      <Thread.Root>
+        <Thread.Messages>
+          <Message.Root>
+            <Message.Markdown {...props} />
+          </Message.Root>
+        </Thread.Messages>
+      </Thread.Root>
+    </ChatProvider>
+  );
+}
+
+function composerEntity(
+  text: string,
+  entityText: string,
+  id: string,
+  from = text.indexOf(entityText),
+): ComposerEntity {
+  return {
+    id,
+    triggerId: "documents",
+    trigger: "@",
+    label: entityText.slice(1),
+    text: entityText,
+    range: { from, to: from + entityText.length },
+    data: { kind: "document", documentId: id },
+  };
+}
+
+function collectNodeTypes(value: unknown, types: string[]): void {
+  if (typeof value !== "object" || value === null) {
+    return;
+  }
+  if ("type" in value && typeof value.type === "string") {
+    types.push(value.type);
+  }
+  if ("children" in value && Array.isArray(value.children)) {
+    for (const child of value.children) {
+      collectNodeTypes(child, types);
+    }
+  }
+}
+
+function literalizeEntityNodes(value: unknown): void {
+  if (typeof value !== "object" || value === null) {
+    return;
+  }
+  if ("type" in value && value.type === "messageEntity") {
+    value.type = "text";
+    if ("entityIndex" in value) {
+      delete value.entityIndex;
+    }
+  }
+  if ("children" in value && Array.isArray(value.children)) {
+    for (const child of value.children) {
+      literalizeEntityNodes(child);
+    }
+  }
 }
 
 function installAnimationFrame() {

--- a/packages/tool-studio/package.json
+++ b/packages/tool-studio/package.json
@@ -71,6 +71,6 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "@anvia/core": ">=0.7.1 <1.0.0"
+    "@anvia/core": ">=0.13.0 <1.0.0"
   }
 }

--- a/packages/tool-studio/src/runtime/pipelines.ts
+++ b/packages/tool-studio/src/runtime/pipelines.ts
@@ -28,7 +28,7 @@ import {
 } from "./pipeline-logs";
 import { AsyncEventQueue } from "./runs";
 import { streamStudioJsonl } from "./streams";
-import { isJsonObject, isObject } from "./type-guards";
+import { isJsonObject, isJsonValue, isObject } from "./type-guards";
 
 export function registerPipelineRoutes(
   app: Hono,
@@ -494,22 +494,4 @@ function parsePipelineLogAfter(value: string | undefined): number | undefined | 
     return false;
   }
   return after;
-}
-
-function isJsonValue(value: unknown): value is JsonValue {
-  if (
-    value === null ||
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  ) {
-    return Number.isFinite(value) || typeof value !== "number";
-  }
-  if (Array.isArray(value)) {
-    return value.every(isJsonValue);
-  }
-  if (isObject(value)) {
-    return Object.values(value).every((item) => item === undefined || isJsonValue(item));
-  }
-  return false;
 }

--- a/packages/tool-studio/src/runtime/type-guards.ts
+++ b/packages/tool-studio/src/runtime/type-guards.ts
@@ -1,4 +1,9 @@
-import type { JsonObject, JsonValue, Message } from "@anvia/core/completion";
+import {
+  isJsonValue as isCoreJsonValue,
+  type JsonObject,
+  type JsonValue,
+  type Message,
+} from "@anvia/core/completion";
 import type { AgentTraceOptions } from "../types";
 
 export function isObject(value: unknown): value is Record<string, unknown> {
@@ -6,22 +11,11 @@ export function isObject(value: unknown): value is Record<string, unknown> {
 }
 
 export function isJsonObject(value: unknown): value is JsonObject {
-  return isObject(value) && Object.values(value).every(isJsonValue);
+  return isObject(value) && isCoreJsonValue(value);
 }
 
 export function isJsonValue(value: unknown): value is JsonValue {
-  if (
-    value === null ||
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  ) {
-    return true;
-  }
-  if (Array.isArray(value)) {
-    return value.every(isJsonValue);
-  }
-  return isJsonObject(value);
+  return isCoreJsonValue(value);
 }
 
 export function isMessageInput(value: unknown): value is string | Message {

--- a/packages/tool-studio/src/storage/memory-store.ts
+++ b/packages/tool-studio/src/storage/memory-store.ts
@@ -2,6 +2,7 @@ import type { JsonObject, JsonValue, Message } from "@anvia/core/completion";
 import type { MemoryAppendInput, MemoryContext, MemoryErrorInput } from "@anvia/core/memory";
 import { compact } from "../runtime/compact";
 import { renumberTranscript, transcriptFromMessages } from "../runtime/transcript";
+import { isJsonObject, isJsonValue } from "../runtime/type-guards";
 import type {
   StudioPipelineLogAppendInput,
   StudioPipelineLogEntry,
@@ -327,23 +328,4 @@ function serializeJsonError(error: unknown): JsonValue {
     };
   }
   return isJsonValue(error) ? error : String(error);
-}
-
-function isJsonObject(value: unknown): value is JsonObject {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isJsonValue(value: unknown): value is JsonValue {
-  if (
-    value === null ||
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  ) {
-    return true;
-  }
-  if (Array.isArray(value)) {
-    return value.every(isJsonValue);
-  }
-  return isJsonObject(value) && Object.values(value).every(isJsonValue);
 }

--- a/packages/tool-studio/src/storage/sqlite-store.ts
+++ b/packages/tool-studio/src/storage/sqlite-store.ts
@@ -2,7 +2,7 @@ import { mkdirSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
 import type { DatabaseSync as DatabaseSyncType } from "node:sqlite";
-import type { JsonObject, JsonValue, Message } from "@anvia/core/completion";
+import { isJsonValue, type JsonObject, type JsonValue, type Message } from "@anvia/core/completion";
 import type { MemoryAppendInput, MemoryContext, MemoryErrorInput } from "@anvia/core/memory";
 import { compact } from "../runtime/compact";
 import { renumberTranscript, transcriptFromMessages } from "../runtime/transcript";
@@ -59,6 +59,7 @@ type MessageRow = {
   message_index: number;
   role: Message["role"];
   message_id: string | null;
+  metadata_json: string | null;
   created_at: string;
 };
 
@@ -891,6 +892,7 @@ class SqliteSessionStore
         message_index INTEGER NOT NULL,
         role TEXT NOT NULL,
         message_id TEXT,
+        metadata_json TEXT,
         created_at TEXT NOT NULL,
         PRIMARY KEY(session_id, message_index),
         FOREIGN KEY(session_id) REFERENCES anvia_studio_sessions(id) ON DELETE CASCADE
@@ -985,6 +987,7 @@ class SqliteSessionStore
       CREATE INDEX IF NOT EXISTS anvia_studio_traces_session_started_idx
         ON anvia_studio_traces(session_id, started_at DESC);
     `);
+    ensureMessageMetadataColumn(db);
 
     this.db = db;
     return db;
@@ -1047,7 +1050,7 @@ class SqliteSessionStore
     const db = this.database();
     const messageRows = db
       .prepare(
-        `SELECT session_id, message_index, role, message_id, created_at
+        `SELECT session_id, message_index, role, message_id, metadata_json, created_at
          FROM anvia_studio_session_messages
          WHERE session_id = $sessionId
          ORDER BY message_index ASC`,
@@ -1102,8 +1105,9 @@ class SqliteSessionStore
         message_index,
         role,
         message_id,
+        metadata_json,
         created_at
-      ) VALUES ($sessionId, $messageIndex, $role, $messageId, $createdAt)`,
+      ) VALUES ($sessionId, $messageIndex, $role, $messageId, $metadata, $createdAt)`,
     );
     const insertPart = db.prepare(
       `INSERT INTO anvia_studio_session_message_parts (
@@ -1117,11 +1121,15 @@ class SqliteSessionStore
 
     messages.forEach((message, messageOffset) => {
       const messageIndex = startIndex + messageOffset;
+      if (message.metadata !== undefined && !isJsonValue(message.metadata)) {
+        throw new TypeError("Studio message metadata must be a strict JSON value.");
+      }
       insertMessage.run({
         $sessionId: sessionId,
         $messageIndex: messageIndex,
         $role: message.role,
         $messageId: message.role === "assistant" ? (message.id ?? null) : null,
+        $metadata: message.metadata === undefined ? null : JSON.stringify(message.metadata),
         $createdAt: createdAt,
       });
 
@@ -1230,14 +1238,20 @@ function messageParts(message: Message): StoredMessagePart[] {
 
 function messageFromRows(row: MessageRow, partRows: MessagePartRow[]): Message {
   const parts = partRows.map((partRow) => JSON.parse(partRow.part_json) as unknown);
+  const metadata = parseJsonValue<JsonValue>(row.metadata_json);
+  if (metadata !== undefined && !isJsonValue(metadata)) {
+    throw new TypeError("Stored Studio message metadata is not a strict JSON value.");
+  }
+  const metadataProperties = compact({ metadata });
 
   if (row.role === "system") {
-    return { role: "system", content: systemContentFromParts(parts) };
+    return { role: "system", content: systemContentFromParts(parts), ...metadataProperties };
   }
   if (row.role === "user") {
     return {
       role: "user",
       content: parts as Extract<Message, { role: "user" }>["content"],
+      ...metadataProperties,
     };
   }
   if (row.role === "assistant") {
@@ -1245,12 +1259,14 @@ function messageFromRows(row: MessageRow, partRows: MessagePartRow[]): Message {
       role: "assistant",
       ...compact({ id: row.message_id ?? undefined }),
       content: parts as Extract<Message, { role: "assistant" }>["content"],
+      ...metadataProperties,
     };
   }
   if (row.role === "tool") {
     return {
       role: "tool",
       content: parts as Extract<Message, { role: "tool" }>["content"],
+      ...metadataProperties,
     };
   }
 
@@ -1278,6 +1294,15 @@ function guardAgainstLegacySessionSchema(db: DatabaseSyncType): void {
     throw new Error(
       "Existing Studio SQLite DB uses the legacy messages_json schema. Delete or recreate the Studio SQLite DB to use normalized session messages.",
     );
+  }
+}
+
+function ensureMessageMetadataColumn(db: DatabaseSyncType): void {
+  const columns = db
+    .prepare("PRAGMA table_info('anvia_studio_session_messages')")
+    .all() as TableInfoRow[];
+  if (!columns.some((column) => column.name === "metadata_json")) {
+    db.exec("ALTER TABLE anvia_studio_session_messages ADD COLUMN metadata_json TEXT");
   }
 }
 

--- a/packages/tool-studio/test/runner.test.ts
+++ b/packages/tool-studio/test/runner.test.ts
@@ -3422,20 +3422,58 @@ describe("Anvia studio", () => {
     });
   });
 
+  it("rejects non-JSON message metadata in the SQLite session store", async () => {
+    const store = createSqliteSessionStore({ path: ":memory:" });
+    store.createSession({ id: "session_1", agentId: "support" });
+    const invalidMessage = {
+      ...Message.user("hi"),
+      metadata: { score: Number.NaN },
+    } as CoreMessage;
+
+    expect(() =>
+      store.append({
+        context: { sessionId: "session_1" },
+        runId: "run_1",
+        turn: 1,
+        messages: [invalidMessage],
+      }),
+    ).toThrow("Studio message metadata must be a strict JSON value");
+    await expect(store.load({ sessionId: "session_1" })).resolves.toEqual([]);
+  });
+
   it("persists session messages and parts in normalized SQLite tables", async () => {
     const path = join(studioDbDir ?? tmpdir(), "normalized.sqlite");
     const store = createSqliteSessionStore({ path });
     store.createSession({ id: "session_1", agentId: "support" });
 
     const messages = [
-      Message.system("Use project policy."),
-      Message.user([
-        UserContent.text("hi"),
-        UserContent.imageUrl("https://example.test/image.png", { detail: "high" }),
-        UserContent.documentUrl("https://example.test/file.pdf", "application/pdf", {
-          filename: "file.pdf",
-        }),
-      ]),
+      Message.system("Use project policy.", { metadata: { source: "system" } }),
+      Message.user(
+        [
+          UserContent.text("hi @Guide.pdf"),
+          UserContent.imageUrl("https://example.test/image.png", { detail: "high" }),
+          UserContent.documentUrl("https://example.test/file.pdf", "application/pdf", {
+            filename: "file.pdf",
+          }),
+        ],
+        {
+          metadata: {
+            composer: {
+              entities: [
+                {
+                  id: "document-1",
+                  triggerId: "documents",
+                  trigger: "@",
+                  label: "Guide.pdf",
+                  text: "@Guide.pdf",
+                  range: { from: 3, to: 13 },
+                  data: { kind: "document", documentId: "document-1" },
+                },
+              ],
+            },
+          },
+        },
+      ),
       Message.assistant(
         [
           AssistantContent.text("hello"),
@@ -3443,7 +3481,7 @@ describe("Anvia studio", () => {
           AssistantContent.toolCall("tool_1", "lookup", { query: "x" }, "call_1"),
           AssistantContent.imageBase64("abc123", "image/png"),
         ],
-        "assistant_message_1",
+        { id: "assistant_message_1", metadata: { source: "assistant" } },
       ),
       Message.tool(
         ToolContent.toolResult(
@@ -3454,6 +3492,7 @@ describe("Anvia studio", () => {
           ],
           "call_1",
         ),
+        { metadata: { source: "tool" } },
       ),
     ];
 
@@ -3479,6 +3518,13 @@ describe("Anvia studio", () => {
       .get() as { count: number };
     expect(messageCount.count).toBe(4);
     expect(partCount.count).toBe(9);
+    expect(
+      db
+        .prepare(
+          "SELECT COUNT(*) AS count FROM anvia_studio_session_messages WHERE metadata_json IS NOT NULL",
+        )
+        .get(),
+    ).toEqual({ count: 4 });
     db.close();
 
     const reloaded = createSqliteSessionStore({ path });
@@ -3488,6 +3534,73 @@ describe("Anvia studio", () => {
       messageCount: 4,
       messages,
     });
+  });
+
+  it("migrates normalized SQLite message tables to persist metadata", async () => {
+    const path = join(studioDbDir ?? tmpdir(), "normalized-metadata-migration.sqlite");
+    const db = new DatabaseSync(path);
+    db.exec(`
+      PRAGMA foreign_keys = ON;
+      CREATE TABLE anvia_studio_sessions (
+        id TEXT PRIMARY KEY,
+        agent_id TEXT NOT NULL,
+        title TEXT,
+        metadata_json TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      ) STRICT;
+      CREATE TABLE anvia_studio_session_messages (
+        session_id TEXT NOT NULL,
+        message_index INTEGER NOT NULL,
+        role TEXT NOT NULL,
+        message_id TEXT,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY(session_id, message_index),
+        FOREIGN KEY(session_id) REFERENCES anvia_studio_sessions(id) ON DELETE CASCADE
+      ) STRICT;
+      CREATE TABLE anvia_studio_session_message_parts (
+        session_id TEXT NOT NULL,
+        message_index INTEGER NOT NULL,
+        part_index INTEGER NOT NULL,
+        type TEXT NOT NULL,
+        part_json TEXT NOT NULL,
+        PRIMARY KEY(session_id, message_index, part_index),
+        FOREIGN KEY(session_id, message_index)
+          REFERENCES anvia_studio_session_messages(session_id, message_index)
+          ON DELETE CASCADE
+      ) STRICT;
+      INSERT INTO anvia_studio_sessions
+        (id, agent_id, title, metadata_json, created_at, updated_at)
+      VALUES ('session_1', 'support', NULL, NULL, '2026-01-01', '2026-01-01');
+      INSERT INTO anvia_studio_session_messages
+        (session_id, message_index, role, message_id, created_at)
+      VALUES ('session_1', 0, 'user', NULL, '2026-01-01');
+      INSERT INTO anvia_studio_session_message_parts
+        (session_id, message_index, part_index, type, part_json)
+      VALUES ('session_1', 0, 0, 'text', '{"type":"text","text":"legacy"}');
+    `);
+    db.close();
+
+    const store = createSqliteSessionStore({ path });
+    await expect(store.load({ sessionId: "session_1" })).resolves.toEqual([Message.user("legacy")]);
+    const metadata = { composer: { entities: [{ id: "document-1" }] } };
+    await store.append({
+      context: { sessionId: "session_1" },
+      runId: "run_1",
+      turn: 1,
+      messages: [Message.user("new", { metadata })],
+    });
+    await expect(store.load({ sessionId: "session_1" })).resolves.toEqual([
+      Message.user("legacy"),
+      Message.user("new", { metadata }),
+    ]);
+
+    const migrated = new DatabaseSync(path);
+    const columns = migrated
+      .prepare("PRAGMA table_info('anvia_studio_session_messages')")
+      .all() as Array<{ name: string }>;
+    expect(columns.map((column) => column.name)).toContain("metadata_json");
+    migrated.close();
   });
 
   it("persists session audit logs with monotonic sequence and deletes them with sessions", async () => {


### PR DESCRIPTION
## Summary

- lands the feature work from #248, #249, and #250 directly on main
- persists JSON-safe Composer metadata in memory adapters and Studio
- renders validated Composer entities through headless Message.Entity markup
- keeps entity ranges aligned when quoted content prefixes submitted text
- includes the missing React UI, memory adapter, and Studio changesets and documentation

## Context

The original PRs were stacked on feature branches. They were marked merged, but only #247 targeted main, so the other three implementations and changesets never reached the release branch. Core metadata support is already published from #247 and is intentionally not duplicated here.

## Changeset impact

- minor: @anvia/react-ui
- patch: @anvia/memory-sqlite, @anvia/memory-postgres, @anvia/memory-prisma, @anvia/memory-drizzle, @anvia/studio
- dependent example bumps are calculated by Changesets

## Verification

- pnpm check
- pnpm changeset status
- pnpm --filter @anvia/core build
- pnpm --filter ./packages/** --filter !@anvia/core build
- pnpm --filter ./packages/** typecheck
- pnpm --filter ./packages/** test
- pnpm --filter www reference-check
- pnpm --filter www build

All passed. Docker sandbox integration tests remain skipped by the existing environment gate. No screenshots are included because this adds headless semantic markup without visual styling.