### PR TITLE
Fix OpenAI reasoning-only assistant history serialization

### DIFF
--- a/.changeset/fix-openai-reasoning-history.md
+++ b/.changeset/fix-openai-reasoning-history.md
@@ -1,0 +1,5 @@
+---
+"@anvia/openai": patch
+---
+
+Keep reasoning-only and empty assistant history compatible with providers that require content or tool calls.

--- a/packages/provider-openai/src/openai/chat-completion.ts
+++ b/packages/provider-openai/src/openai/chat-completion.ts
@@ -368,6 +368,8 @@ function messageToChatMessages(message: MessageType): ChatMessage[] {
   };
   if (text.length > 0) {
     chatMessage.content = text;
+  } else if (toolCalls.length === 0) {
+    chatMessage.content = " ";
   }
   if (reasoning.length > 0) {
     chatMessage.reasoning_content = reasoning;

--- a/packages/provider-openai/test/openai-chat-completion.test.ts
+++ b/packages/provider-openai/test/openai-chat-completion.test.ts
@@ -106,6 +106,52 @@ describe("OpenAI chat-completions client path", () => {
     ]);
   });
 
+  it("adds compatible content to reasoning-only assistant history", () => {
+    const chatHistory = [
+      Message.user("First question"),
+      Message.assistant([AssistantContent.reasoning("internal reasoning only")]),
+      Message.user("Continue"),
+    ];
+    const originalChatHistory = structuredClone(chatHistory);
+
+    const params = toOpenAIChatCompletionParams("deepseek-v4-flash", {
+      chatHistory,
+      documents: [],
+      tools: [],
+    });
+
+    expect(params.messages).toEqual([
+      { role: "user", content: "First question" },
+      {
+        role: "assistant",
+        content: " ",
+        reasoning_content: "internal reasoning only",
+      },
+      { role: "user", content: "Continue" },
+    ]);
+    expect(chatHistory).toEqual(originalChatHistory);
+  });
+
+  it("preserves ordinary assistant text history", () => {
+    const params = toOpenAIChatCompletionParams("deepseek-v4-flash", {
+      chatHistory: [Message.assistant("visible response")],
+      documents: [],
+      tools: [],
+    });
+
+    expect(params.messages).toEqual([{ role: "assistant", content: "visible response" }]);
+  });
+
+  it("adds compatible content to empty assistant history", () => {
+    const params = toOpenAIChatCompletionParams("deepseek-v4-flash", {
+      chatHistory: [Message.assistant([])],
+      documents: [],
+      tools: [],
+    });
+
+    expect(params.messages).toEqual([{ role: "assistant", content: " " }]);
+  });
+
   it("summarizes provider request metadata for traces", () => {
     const model = new OpenAIChatCompletionModel({} as never, "chat-test");
     const request: CompletionRequest = {


### PR DESCRIPTION
## Summary

- add non-empty compatibility content when serialized assistant history has neither visible text nor tool calls
- preserve reasoning content, ordinary assistant text, tool-call IDs, and reasoning-plus-tool-call payloads
- cover reasoning-only, text, tool-call, empty-content, and input-immutability cases
- add a patch changeset for @anvia/openai

## Intended behavior

A reasoning-only assistant message previously serialized as:

```json
{"role":"assistant","reasoning_content":"internal reasoning only"}
```

It now serializes as:

```json
{"role":"assistant","content":" ","reasoning_content":"internal reasoning only"}
```

The compatibility value is only added when both visible text and tool calls are absent. Reasoning is not copied into visible content.

## Verification

- `pnpm --filter @anvia/openai typecheck`
- `pnpm exec biome check packages/provider-openai/src/openai/chat-completion.ts packages/provider-openai/test/openai-chat-completion.test.ts`
- `pnpm --filter @anvia/openai test` — 43 tests passed
- `pnpm --filter @anvia/openai build`
- `git diff --check`

## Limitations

No paid LiteLLM or DeepSeek endpoint call was made. The regression is deterministic at the provider serialization boundary and does not require API credentials.