### PR TITLE
Preserve streamed tool call metadata

### DIFF
--- a/.changeset/tidy-tools-stream.md
+++ b/.changeset/tidy-tools-stream.md
@@ -1,0 +1,6 @@
+---
+"@anvia/core": patch
+"@anvia/openai": patch
+---
+
+Preserve streamed tool call names and provider call IDs when continuation chunks contain empty metadata placeholders.

--- a/packages/core/src/internal/prompt-runtime/stream-accumulator.ts
+++ b/packages/core/src/internal/prompt-runtime/stream-accumulator.ts
@@ -54,8 +54,8 @@ export class CompletionStreamAccumulator<RawResponse = unknown> {
 
     if (event.type === "tool_call_delta") {
       const toolCall = this.toolCallStateForId(event.id);
-      if (event.callId !== undefined) toolCall.callId = event.callId;
-      if (event.name !== undefined) toolCall.name = event.name;
+      if (event.callId !== undefined && event.callId.length > 0) toolCall.callId = event.callId;
+      if (event.name !== undefined && event.name.length > 0) toolCall.name = event.name;
       if (event.signature !== undefined) toolCall.signature = event.signature;
       if (event.argumentsDelta !== undefined) {
         toolCall.argumentsText += event.argumentsDelta;

--- a/packages/core/src/internal/prompt-runtime/tool-execution.ts
+++ b/packages/core/src/internal/prompt-runtime/tool-execution.ts
@@ -89,6 +89,14 @@ export class ToolCallExecutor {
     onStreamEvent?: (event: AgentToolEventPayload) => void,
     observation?: ToolExecutionObservation,
   ): Promise<ToolResult[]> {
+    for (const toolCall of toolCalls) {
+      if (toolCall.function.name.length === 0) {
+        throw new Error(
+          `Completion returned tool call "${toolCall.id}" with an empty function name; this indicates invalid provider output or provider mapping.`,
+        );
+      }
+    }
+
     return mapWithConcurrency(toolCalls, this.concurrency, async (toolCall) => {
       const args = JSON.stringify(toolCall.function.arguments ?? {});
       const internalCallId = globalThis.crypto.randomUUID();

--- a/packages/core/test/prompt-request.test.ts
+++ b/packages/core/test/prompt-request.test.ts
@@ -154,6 +154,19 @@ describe("PromptRequest", () => {
     );
   });
 
+  it("rejects empty completion tool names before dispatch", async () => {
+    const model = new QueueModel([
+      response([AssistantContent.toolCall("tool_0", "", { command: "pwd" }, "call_abc")]),
+      response([AssistantContent.text("should not continue")]),
+    ]);
+    const agent = new AgentBuilder("test-agent", model).build();
+
+    await expect(agent.prompt("run a command").send()).rejects.toThrow(
+      'Completion returned tool call "tool_0" with an empty function name; this indicates invalid provider output or provider mapping.',
+    );
+    expect(model.requests).toHaveLength(1);
+  });
+
   it("executes multiple tool calls in one turn", async () => {
     const model = new QueueModel([
       response([

--- a/packages/core/test/stream-accumulator.test.ts
+++ b/packages/core/test/stream-accumulator.test.ts
@@ -118,6 +118,28 @@ describe("CompletionStreamAccumulator", () => {
     ]);
   });
 
+  it("does not replace accumulated tool metadata with empty continuation placeholders", () => {
+    const accumulator = new CompletionStreamAccumulator();
+
+    accumulator.accept({
+      type: "tool_call_delta",
+      id: "tool_0",
+      callId: "call_abc",
+      name: "ExecCommand",
+    });
+    accumulator.accept({
+      type: "tool_call_delta",
+      id: "tool_0",
+      callId: "",
+      name: "",
+      argumentsDelta: '{"command":"pwd"}',
+    });
+
+    expect(accumulator.response().choice).toEqual([
+      AssistantContent.toolCall("tool_0", "ExecCommand", { command: "pwd" }, "call_abc"),
+    ]);
+  });
+
   it("preserves accumulated order when the final choice is empty", () => {
     const accumulator = new CompletionStreamAccumulator();
     const rawResponse = { provider: "test" };

--- a/packages/provider-openai/src/openai/chat-completion.ts
+++ b/packages/provider-openai/src/openai/chat-completion.ts
@@ -462,8 +462,8 @@ function toolCallDelta(
   },
 ): CompletionStreamEvent {
   const event: CompletionStreamEvent = { type: "tool_call_delta", id };
-  if (values.callId !== undefined) event.callId = values.callId;
-  if (values.name !== undefined) event.name = values.name;
+  if (values.callId !== undefined && values.callId.length > 0) event.callId = values.callId;
+  if (values.name !== undefined && values.name.length > 0) event.name = values.name;
   if (values.argumentsDelta !== undefined) event.argumentsDelta = values.argumentsDelta;
   return event;
 }

--- a/packages/provider-openai/test/openai-chat-completion.test.ts
+++ b/packages/provider-openai/test/openai-chat-completion.test.ts
@@ -227,6 +227,55 @@ describe("OpenAI chat-completions client path", () => {
     ]);
   });
 
+  it("omits empty streamed tool metadata while preserving argument fragments", () => {
+    expect(
+      fromOpenAIChatCompletionStreamChunk({
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "",
+                  function: {
+                    name: "",
+                    arguments: '{"command":"pwd"}',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        type: "tool_call_delta",
+        id: "tool_0",
+        argumentsDelta: '{"command":"pwd"}',
+      },
+    ]);
+  });
+
+  it("preserves empty streamed tool argument fragments", () => {
+    expect(
+      fromOpenAIChatCompletionStreamChunk({
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "",
+                  function: { name: "", arguments: "" },
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    ).toEqual([{ type: "tool_call_delta", id: "tool_0", argumentsDelta: "" }]);
+  });
+
   it("rejects unsupported document file input before provider calls", async () => {
     const calls: unknown[] = [];
     const model = new OpenAIChatCompletionModel(


### PR DESCRIPTION
## Summary

- omit empty streamed OpenAI tool names and provider call IDs while preserving argument fragments
- keep previously accumulated non-empty tool metadata when continuation deltas contain empty placeholders
- reject empty tool names before concurrent dispatch with a clear provider-output/mapping error
- add patch changesets for `@anvia/core` and `@anvia/openai`

## Root cause

OpenAI-compatible Chat Completions streams can emit `id: ""` and `function.name: ""` on continuation chunks. The OpenAI adapter forwarded those values as defined metadata, and the core stream accumulator treated every defined value as authoritative. Valid names and provider call IDs from earlier deltas were therefore overwritten even though argument accumulation remained correct.

## Impact

Streamed tool calls now retain their original tool name and provider call ID across empty continuation placeholders. Empty argument fragments are still preserved. If a completion never supplies a usable tool name, Anvia now fails before tool dispatch instead of calling the tool set with an empty name.

Missing or non-numeric streamed tool-call index handling was inspected but is not changed here because it did not contribute to this failure.

## Validation

- `pnpm --filter @anvia/core test` — 314 tests passed
- `pnpm --filter @anvia/core typecheck`
- `pnpm --filter @anvia/core build`
- `pnpm --filter @anvia/openai test` — 46 tests passed
- `pnpm --filter @anvia/openai typecheck`
- `pnpm --filter @anvia/openai build`
- focused Biome check on all changed source and test files
- `git diff --check`
- `pnpm exec changeset status`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved tool names and provider call IDs during streaming when continuation data contains empty metadata.
  - Prevented invalid tool calls with missing names from being executed.
  - Improved handling of streamed tool-call argument fragments, including empty fragments.

- **Tests**
  - Added coverage for preserving tool metadata and rejecting invalid tool calls before execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->