### PR TITLE
Reject malformed tool arguments

### DIFF
--- a/.changeset/strict-streamed-tool-arguments.md
+++ b/.changeset/strict-streamed-tool-arguments.md
@@ -1,0 +1,6 @@
+---
+"@anvia/core": patch
+"@anvia/openai": patch
+---
+
+Reject malformed JSON tool arguments before execution or persistence while preserving valid scalar and blank inputs.

--- a/packages/core/src/internal/prompt-runtime/stream-accumulator.ts
+++ b/packages/core/src/internal/prompt-runtime/stream-accumulator.ts
@@ -115,7 +115,9 @@ export class CompletionStreamAccumulator<RawResponse = unknown> {
 
       const toolCall = this.toolCalls.get(part.key);
       if (toolCall !== undefined) {
-        choice.push(toolCallContent(toolCall));
+        choice.push(
+          toolCallContent(toolCall, matchingFinalToolCall(toolCall, this.finalResponse?.choice)),
+        );
       }
     }
 
@@ -345,13 +347,17 @@ function reasoningContent(reasoning: ReasoningState): AssistantContentType {
   return reasoning.id === undefined ? content : { ...content, id: reasoning.id };
 }
 
-function toolCallContent(toolCall: PartialToolCall): ToolCall {
+function toolCallContent(toolCall: PartialToolCall, finalToolCall?: ToolCall): ToolCall {
+  const argumentsValue =
+    finalToolCall !== undefined && !isEmptyToolArguments(finalToolCall.function.arguments)
+      ? finalToolCall.function.arguments
+      : parseToolArguments(toolCall.id, toolCall.argumentsText);
   const content: ToolCall = {
     type: "tool_call",
     id: toolCall.id,
     function: {
       name: toolCall.name,
-      arguments: parseJsonValue(toolCall.argumentsText),
+      arguments: argumentsValue,
     },
   };
   if (toolCall.callId !== undefined) {
@@ -364,6 +370,22 @@ function toolCallContent(toolCall: PartialToolCall): ToolCall {
     content.additionalParams = toolCall.additionalParams;
   }
   return content;
+}
+
+function matchingFinalToolCall(
+  accumulated: PartialToolCall,
+  finalChoice: AssistantContentType[] | undefined,
+): ToolCall | undefined {
+  const byId = finalChoice?.find(
+    (content): content is ToolCall => content.type === "tool_call" && content.id === accumulated.id,
+  );
+  if (byId !== undefined || accumulated.callId === undefined) {
+    return byId;
+  }
+  return finalChoice?.find(
+    (content): content is ToolCall =>
+      content.type === "tool_call" && content.callId === accumulated.callId,
+  );
 }
 
 function mergeFinalToolCall(accumulated: ToolCall, finalToolCall: ToolCall): ToolCall {
@@ -407,13 +429,15 @@ function isEmptyToolArguments(value: unknown): boolean {
   return false;
 }
 
-function parseJsonValue(text: string): JsonValue {
+function parseToolArguments(toolCallId: string, text: string): JsonValue {
   if (text.trim().length === 0) {
     return {};
   }
   try {
     return JSON.parse(text) as JsonValue;
   } catch {
-    return text;
+    throw new Error(
+      `Completion returned tool call "${toolCallId}" with malformed JSON arguments; this indicates invalid provider output or incomplete stream assembly.`,
+    );
   }
 }

--- a/packages/core/src/request/prompt-request.ts
+++ b/packages/core/src/request/prompt-request.ts
@@ -441,6 +441,7 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
         let firstDeltaMs: number | undefined;
         const bufferResponseEvents = this.shouldBufferStreamResponseEvents();
         const emittedToolCallIds = new Set<string>();
+        let response: CompletionResponse;
         try {
           for await (const event of this.agent.model.streamCompletion(request)) {
             if (firstDeltaMs === undefined && isGenerationDeltaEvent(event.type)) {
@@ -464,13 +465,13 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
               }
             }
           }
+          response = accumulator.response();
         } catch (error) {
           await generationObservers.error({ turn: currentTurns, error });
           await this.runCompletionErrorHook(prompt, error, newMessages);
           throw error;
         }
 
-        let response = accumulator.response();
         const generationEndArgs: AgentGenerationEndArgs = {
           turn: currentTurns,
           response,

--- a/packages/core/test/memory.test.ts
+++ b/packages/core/test/memory.test.ts
@@ -205,6 +205,92 @@ describe("agent memory", () => {
     ]);
   });
 
+  it("rejects malformed streamed tool arguments before execution or assistant persistence", async () => {
+    const store = new RecordingMemoryStore();
+    const model = new StreamingQueueModel([
+      [
+        {
+          type: "tool_call_delta",
+          id: "tool_0",
+          name: "Probe",
+          argumentsDelta: "{}",
+        },
+        {
+          type: "tool_call_delta",
+          id: "tool_1",
+          callId: "call_abc",
+          name: "ExecCommand",
+          argumentsDelta: '{"command":"pwd"',
+        },
+      ],
+      [{ type: "text_delta", delta: "recovered" }],
+    ]);
+    let probeExecutions = 0;
+    let commandExecutions = 0;
+    const completionErrors: string[] = [];
+    const probeTool = createTool({
+      name: "Probe",
+      description: "Record whether a sibling tool executes",
+      input: z.object({}),
+      execute: () => {
+        probeExecutions += 1;
+        return "probed";
+      },
+    });
+    const execCommandTool = createTool({
+      name: "ExecCommand",
+      description: "Execute a command",
+      input: z.object({ command: z.string() }),
+      execute: () => {
+        commandExecutions += 1;
+        return "executed";
+      },
+    });
+    const agent = new AgentBuilder("test-agent", model)
+      .memory(store)
+      .tool(probeTool)
+      .tool(execCommandTool)
+      .hook(
+        createHook({
+          onCompletionError({ error }) {
+            completionErrors.push(error instanceof Error ? error.message : String(error));
+          },
+        }),
+      )
+      .build();
+    const session = agent.session("session_1");
+
+    const runMalformedStream = async () => {
+      for await (const _event of session.prompt("run tools").stream()) {
+        // exhaust the stream
+      }
+    };
+    await expect(runMalformedStream()).rejects.toThrow(
+      'Completion returned tool call "tool_1" with malformed JSON arguments; this indicates invalid provider output or incomplete stream assembly.',
+    );
+
+    expect(probeExecutions).toBe(0);
+    expect(commandExecutions).toBe(0);
+    expect(completionErrors).toEqual([
+      'Completion returned tool call "tool_1" with malformed JSON arguments; this indicates invalid provider output or incomplete stream assembly.',
+    ]);
+    expect(store.appendCalls.map((call) => call.messages.map((message) => message.role))).toEqual([
+      ["user"],
+    ]);
+    expect(store.errorCalls).toHaveLength(1);
+    expect(store.errorCalls[0]?.messages).toEqual([Message.user("run tools")]);
+    await expect(session.messages()).resolves.toEqual([Message.user("run tools")]);
+
+    for await (const _event of session.prompt("continue").stream()) {
+      // exhaust the stream
+    }
+
+    expect(model.requests[1]?.chatHistory).toEqual([
+      Message.user("run tools"),
+      Message.user("continue"),
+    ]);
+  });
+
   it("supports turn save policy", async () => {
     const store = new RecordingMemoryStore();
     const model = new QueueModel([

--- a/packages/core/test/stream-accumulator.test.ts
+++ b/packages/core/test/stream-accumulator.test.ts
@@ -118,6 +118,59 @@ describe("CompletionStreamAccumulator", () => {
     ]);
   });
 
+  it("assembles valid JSON tool arguments across multiple fragments", () => {
+    const accumulator = new CompletionStreamAccumulator();
+
+    accumulator.accept({
+      type: "tool_call_delta",
+      id: "tool_0",
+      name: "ExecCommand",
+      argumentsDelta: '{"command":',
+    });
+    accumulator.accept({
+      type: "tool_call_delta",
+      id: "tool_0",
+      argumentsDelta: '"pwd"}',
+    });
+
+    expect(accumulator.response().choice).toEqual([
+      AssistantContent.toolCall("tool_0", "ExecCommand", { command: "pwd" }),
+    ]);
+  });
+
+  it("preserves valid scalar JSON tool arguments", () => {
+    const accumulator = new CompletionStreamAccumulator();
+
+    accumulator.accept({
+      type: "tool_call_delta",
+      id: "tool_0",
+      name: "Echo",
+      argumentsDelta: '"hello"',
+    });
+
+    expect(accumulator.response().choice).toEqual([
+      AssistantContent.toolCall("tool_0", "Echo", "hello"),
+    ]);
+  });
+
+  it.each([
+    ["empty", ""],
+    ["whitespace-only", " \n\t"],
+  ])("normalizes %s streamed tool arguments to an empty object", (_label, argumentsDelta) => {
+    const accumulator = new CompletionStreamAccumulator();
+
+    accumulator.accept({
+      type: "tool_call_delta",
+      id: "tool_0",
+      name: "NoOp",
+      argumentsDelta,
+    });
+
+    expect(accumulator.response().choice).toEqual([
+      AssistantContent.toolCall("tool_0", "NoOp", {}),
+    ]);
+  });
+
   it("does not replace accumulated tool metadata with empty continuation placeholders", () => {
     const accumulator = new CompletionStreamAccumulator();
 
@@ -415,25 +468,48 @@ describe("CompletionStreamAccumulator", () => {
     ]);
   });
 
-  it("preserves invalid partial JSON and streamed tool metadata", () => {
+  it("rejects malformed streamed tool arguments during response finalization", () => {
     const accumulator = new CompletionStreamAccumulator();
     accumulator.accept({
       type: "tool_call_delta",
-      id: "tool_1",
-      callId: "call_1",
-      name: "lookup",
-      signature: "signature_1",
-      argumentsDelta: '{"query":',
+      id: "tool_0",
+      callId: "call_abc",
+      name: "ExecCommand",
+      argumentsDelta: '{"command":"pwd"',
+    });
+    accumulator.accept({
+      type: "final",
+      response: {
+        choice: [],
+        usage: Usage.empty(),
+        rawResponse: {},
+      },
+    });
+
+    expect(() => accumulator.response()).toThrow(
+      'Completion returned tool call "tool_0" with malformed JSON arguments; this indicates invalid provider output or incomplete stream assembly.',
+    );
+  });
+
+  it("uses a valid completed tool call when streamed argument fragments are malformed", () => {
+    const accumulator = new CompletionStreamAccumulator();
+    accumulator.accept({
+      type: "tool_call_delta",
+      id: "tool_0",
+      name: "ExecCommand",
+      argumentsDelta: '{"command":"pwd"',
+    });
+    accumulator.accept({
+      type: "final",
+      response: {
+        choice: [AssistantContent.toolCall("tool_0", "ExecCommand", { command: "pwd" })],
+        usage: Usage.empty(),
+        rawResponse: {},
+      },
     });
 
     expect(accumulator.response().choice).toEqual([
-      {
-        type: "tool_call",
-        id: "tool_1",
-        callId: "call_1",
-        signature: "signature_1",
-        function: { name: "lookup", arguments: '{"query":' },
-      },
+      AssistantContent.toolCall("tool_0", "ExecCommand", { command: "pwd" }),
     ]);
   });
 

--- a/packages/provider-openai/src/openai/chat-completion.ts
+++ b/packages/provider-openai/src/openai/chat-completion.ts
@@ -20,7 +20,7 @@ import {
 } from "@anvia/core/completion";
 import type { OpenAI } from "openai";
 import { orderedRequestMessages } from "../request-messages";
-import { isPlainObject, numberFrom, parseJsonValue, schemaName, stringFrom } from "../utils";
+import { isPlainObject, numberFrom, parseToolArguments, schemaName, stringFrom } from "../utils";
 import type { OpenAICompletionModelName } from "./models";
 
 type ChatCompletionParams = Record<string, unknown>;
@@ -223,7 +223,7 @@ export function fromOpenAIChatCompletionResponse(response: unknown): CompletionR
     const id = typeof toolCall.id === "string" ? toolCall.id : crypto.randomUUID();
     const name = typeof fn.name === "string" ? fn.name : "";
     const argsText = typeof fn.arguments === "string" ? fn.arguments : "{}";
-    choice.push(AssistantContent.toolCall(id, name, parseJsonValue(argsText)));
+    choice.push(AssistantContent.toolCall(id, name, parseToolArguments(id, argsText)));
   }
 
   const result: CompletionResponse = {

--- a/packages/provider-openai/src/openai/responses.ts
+++ b/packages/provider-openai/src/openai/responses.ts
@@ -23,7 +23,7 @@ import {
 } from "@anvia/core/completion";
 import type { OpenAI } from "openai";
 import { orderedRequestMessages } from "../request-messages";
-import { isPlainObject, numberFrom, parseJsonValue, schemaName, stringFrom } from "../utils";
+import { isPlainObject, numberFrom, parseToolArguments, schemaName, stringFrom } from "../utils";
 import type { OpenAICompletionModelName } from "./models";
 
 type ResponsesCreateParams = Record<string, unknown>;
@@ -214,7 +214,7 @@ export function fromOpenAIResponse(response: unknown): CompletionResponse {
       const callId = typeof item.call_id === "string" ? item.call_id : undefined;
       const name = typeof item.name === "string" ? item.name : "";
       const argsText = typeof item.arguments === "string" ? item.arguments : "{}";
-      choice.push(AssistantContent.toolCall(id, name, parseJsonValue(argsText), callId));
+      choice.push(AssistantContent.toolCall(id, name, parseToolArguments(id, argsText), callId));
     }
 
     if (item.type === "reasoning") {
@@ -315,12 +315,13 @@ export function fromOpenAIStreamEvent(event: unknown): CompletionStreamEvent | u
   if (event.type === "response.output_item.done" && isPlainObject(event.item)) {
     const item = event.item;
     if (item.type === "function_call") {
+      const id = stringFrom(item.id) ?? crypto.randomUUID();
       return {
         type: "tool_call",
         toolCall: AssistantContent.toolCall(
-          stringFrom(item.id) ?? crypto.randomUUID(),
+          id,
           stringFrom(item.name) ?? "",
-          parseJsonValue(typeof item.arguments === "string" ? item.arguments : "{}"),
+          parseToolArguments(id, typeof item.arguments === "string" ? item.arguments : "{}"),
           stringFrom(item.call_id),
         ),
       };

--- a/packages/provider-openai/src/utils.ts
+++ b/packages/provider-openai/src/utils.ts
@@ -12,11 +12,16 @@ export function stringFrom(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
-export function parseJsonValue(text: string): JsonValue {
+export function parseToolArguments(toolCallId: string, text: string): JsonValue {
+  if (text.trim().length === 0) {
+    return {};
+  }
   try {
     return JSON.parse(text) as JsonValue;
   } catch {
-    return text;
+    throw new Error(
+      `Completion returned tool call "${toolCallId}" with malformed JSON arguments; this indicates invalid provider output or incomplete stream assembly.`,
+    );
   }
 }
 

--- a/packages/provider-openai/test/openai-chat-completion.test.ts
+++ b/packages/provider-openai/test/openai-chat-completion.test.ts
@@ -106,6 +106,27 @@ describe("OpenAI chat-completions client path", () => {
     ]);
   });
 
+  it("serializes valid scalar tool arguments in assistant history as JSON", () => {
+    const params = toOpenAIChatCompletionParams("custom-chat-model", {
+      chatHistory: [Message.assistant([AssistantContent.toolCall("tool_0", "Echo", "hello")])],
+      documents: [],
+      tools: [],
+    });
+
+    expect(params.messages).toEqual([
+      {
+        role: "assistant",
+        tool_calls: [
+          {
+            id: "tool_0",
+            type: "function",
+            function: { name: "Echo", arguments: '"hello"' },
+          },
+        ],
+      },
+    ]);
+  });
+
   it("adds compatible content to reasoning-only assistant history", () => {
     const chatHistory = [
       Message.user("First question"),
@@ -191,6 +212,58 @@ describe("OpenAI chat-completions client path", () => {
     expect(response.choice).toEqual([
       AssistantContent.text("created"),
       AssistantContent.reasoning("provider reasoning text"),
+    ]);
+  });
+
+  it("rejects malformed non-streaming tool arguments", () => {
+    expect(() =>
+      fromOpenAIChatCompletionResponse({
+        choices: [
+          {
+            message: {
+              role: "assistant",
+              tool_calls: [
+                {
+                  id: "tool_0",
+                  type: "function",
+                  function: { name: "ExecCommand", arguments: '{"command":"pwd"' },
+                },
+              ],
+            },
+          },
+        ],
+        usage: {},
+      }),
+    ).toThrow(
+      'Completion returned tool call "tool_0" with malformed JSON arguments; this indicates invalid provider output or incomplete stream assembly.',
+    );
+  });
+
+  it.each([
+    ["scalar", '"hello"', "hello"],
+    ["empty", "", {}],
+    ["whitespace-only", " \n\t", {}],
+  ])("maps %s non-streaming tool arguments", (_label, argumentsText, expectedArguments) => {
+    const response = fromOpenAIChatCompletionResponse({
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            tool_calls: [
+              {
+                id: "tool_0",
+                type: "function",
+                function: { name: "Echo", arguments: argumentsText },
+              },
+            ],
+          },
+        },
+      ],
+      usage: {},
+    });
+
+    expect(response.choice).toEqual([
+      AssistantContent.toolCall("tool_0", "Echo", expectedArguments),
     ]);
   });
 

--- a/packages/provider-openai/test/openai-responses.test.ts
+++ b/packages/provider-openai/test/openai-responses.test.ts
@@ -231,6 +231,48 @@ describe("OpenAI Responses mapping", () => {
     expect(response.messageId).toBe("resp_1");
   });
 
+  it("rejects malformed non-streaming Responses tool arguments", () => {
+    expect(() =>
+      fromOpenAIResponse({
+        output: [
+          {
+            type: "function_call",
+            id: "tool_0",
+            call_id: "call_abc",
+            name: "ExecCommand",
+            arguments: '{"command":"pwd"',
+          },
+        ],
+        usage: {},
+      }),
+    ).toThrow(
+      'Completion returned tool call "tool_0" with malformed JSON arguments; this indicates invalid provider output or incomplete stream assembly.',
+    );
+  });
+
+  it.each([
+    ["scalar", '"hello"', "hello"],
+    ["empty", "", {}],
+    ["whitespace-only", " \n\t", {}],
+  ])("maps %s non-streaming Responses tool arguments", (_label, argumentsText, expectedArguments) => {
+    const response = fromOpenAIResponse({
+      output: [
+        {
+          type: "function_call",
+          id: "tool_0",
+          call_id: "call_abc",
+          name: "Echo",
+          arguments: argumentsText,
+        },
+      ],
+      usage: {},
+    });
+
+    expect(response.choice).toEqual([
+      AssistantContent.toolCall("tool_0", "Echo", expectedArguments, "call_abc"),
+    ]);
+  });
+
   it("maps Responses refusals to visible assistant text", () => {
     const response = fromOpenAIResponse({
       output: [
@@ -285,6 +327,22 @@ describe("OpenAI Responses mapping", () => {
         call_id: "fc_1",
         name: "lookup",
         arguments: '{"query":"x"}',
+      },
+    ]);
+  });
+
+  it("serializes valid scalar tool arguments in Responses assistant history as JSON", () => {
+    expect(
+      openaiMessageHelpers.messageToResponsesInput(
+        Message.assistant([AssistantContent.toolCall("tool_0", "Echo", "hello", "call_abc")]),
+      ),
+    ).toEqual([
+      {
+        type: "function_call",
+        id: "tool_0",
+        call_id: "call_abc",
+        name: "Echo",
+        arguments: '"hello"',
       },
     ]);
   });
@@ -372,6 +430,23 @@ describe("OpenAI Responses mapping", () => {
       type: "tool_call",
       toolCall: AssistantContent.toolCall("call_1", "lookup", { query: "x" }, "fc_1"),
     });
+  });
+
+  it("rejects malformed arguments in completed Responses stream items", () => {
+    expect(() =>
+      fromOpenAIStreamEvent({
+        type: "response.output_item.done",
+        item: {
+          type: "function_call",
+          id: "tool_0",
+          call_id: "call_abc",
+          name: "ExecCommand",
+          arguments: '{"command":"pwd"',
+        },
+      }),
+    ).toThrow(
+      'Completion returned tool call "tool_0" with malformed JSON arguments; this indicates invalid provider output or incomplete stream assembly.',
+    );
   });
 
   it("maps Responses terminal stream failure and incomplete events", () => {


### PR DESCRIPTION
## Summary

- reject malformed nonblank JSON tool arguments at core stream finalization and OpenAI provider mapping boundaries
- preserve valid fragmented JSON and scalar inputs, while normalizing blank or whitespace-only arguments to `{}`
- fail streaming completion before tool execution, assistant-message persistence, or poisoned-history replay
- add patch changesets for `@anvia/core` and `@anvia/openai`

## Root cause

Core and provider-openai caught tool-argument `JSON.parse` failures and returned the raw argument text as a normal string-valued tool input. That erased the distinction between a valid JSON scalar string and malformed raw JSON. The malformed assistant call could then execute, be persisted, and later be serialized as a JSON string literal in provider history.

## Impact

Malformed streamed arguments now fail with a sanitized provider-output error during response finalization. The failure occurs before response middleware, assistant construction, memory commit, or batch tool execution. Non-streaming Chat Completions and Responses mappings, plus completed Responses stream items, use the same strict parsing behavior.

Existing poisoned sessions are not mutated. Because their raw-input provenance is already lost, affected sessions must be cleared or replaced with a new session ID.

## Validation

- focused core accumulator, prompt-request, streaming, memory, and tool tests — 110 passed
- `pnpm --filter @anvia/core test` — 320 tests passed
- `pnpm --filter @anvia/openai test` — 57 tests passed
- `pnpm --filter @anvia/core typecheck`
- `pnpm --filter @anvia/openai typecheck`
- `pnpm --filter @anvia/core build`
- `pnpm --filter @anvia/openai build`
- Biome check on all changed source and test files
- `git diff --check`
- `pnpm exec changeset status`
