### PR TITLE
Fix OpenAI streamed tool call identity

### DIFF
--- a/.changeset/safe-openai-chat-tool-streams.md
+++ b/.changeset/safe-openai-chat-tool-streams.md
@@ -1,0 +1,5 @@
+---
+"@anvia/openai": patch
+---
+
+Reject invalid Chat Completions streaming tool indices, isolate the primary completion choice, and fail safely when a streamed tool call ends without valid terminal metadata.

--- a/packages/core/test/stream-accumulator.test.ts
+++ b/packages/core/test/stream-accumulator.test.ts
@@ -491,6 +491,26 @@ describe("CompletionStreamAccumulator", () => {
     );
   });
 
+  it.each([
+    ["cumulative", ["{", '{"command":"pwd"}']],
+    ["duplicated final fragment", ['{"command":"pwd"', "}", "}"]],
+  ])("rejects %s streamed tool arguments", (_label, fragments) => {
+    const accumulator = new CompletionStreamAccumulator();
+    for (const argumentsDelta of fragments) {
+      accumulator.accept({
+        type: "tool_call_delta",
+        id: "tool_0",
+        callId: "call_abc",
+        name: "ExecCommand",
+        argumentsDelta,
+      });
+    }
+
+    expect(() => accumulator.response()).toThrow(
+      'Completion returned tool call "tool_0" with malformed JSON arguments; this indicates invalid provider output or incomplete stream assembly.',
+    );
+  });
+
   it("uses a valid completed tool call when streamed argument fragments are malformed", () => {
     const accumulator = new CompletionStreamAccumulator();
     accumulator.accept({

--- a/packages/provider-openai/src/openai/chat-completion.ts
+++ b/packages/provider-openai/src/openai/chat-completion.ts
@@ -26,6 +26,28 @@ import type { OpenAICompletionModelName } from "./models";
 type ChatCompletionParams = Record<string, unknown>;
 type ChatMessage = Record<string, unknown>;
 
+type ChatCompletionStreamChunkMapping = {
+  events: CompletionStreamEvent[];
+  hasToolCalls: boolean;
+  hasFinishReason: boolean;
+  finishReason?: unknown;
+};
+
+const INVALID_TOOL_INDEX_ERROR =
+  "OpenAI Chat Completions stream returned a tool call with an invalid index; expected a finite nonnegative integer.";
+const AMBIGUOUS_CHOICE_ERROR =
+  "OpenAI Chat Completions stream returned ambiguous completion choices without valid indices; provider output cannot be assembled safely.";
+const MISSING_TOOL_FINISH_ERROR =
+  "OpenAI Chat Completions tool-call stream ended without a terminal finish reason; provider output may be incomplete.";
+const LENGTH_TOOL_FINISH_ERROR =
+  'OpenAI Chat Completions tool-call stream ended with finish_reason "length"; provider output may be incomplete.';
+const CONTENT_FILTER_TOOL_FINISH_ERROR =
+  'OpenAI Chat Completions tool-call stream ended with finish_reason "content_filter"; tool calls will not be executed.';
+const UNSUPPORTED_TOOL_FINISH_ERROR =
+  "OpenAI Chat Completions tool-call stream ended with an unsupported finish reason; provider output cannot be assembled safely.";
+const CONFLICTING_TOOL_FINISH_ERROR =
+  "OpenAI Chat Completions tool-call stream returned conflicting terminal finish reasons; provider output cannot be assembled safely.";
+
 export class OpenAIChatCompletionModel
   implements StreamingCompletionModel<unknown, OpenAICompletionModelName>
 {
@@ -78,11 +100,15 @@ export class OpenAIChatCompletionModel
     const streamOptions = isPlainObject(params.stream_options) ? params.stream_options : {};
     params.stream_options = { ...streamOptions, include_usage: true };
     const stream = await this.client.chat.completions.create(params as never);
+    const streamState = new OpenAIChatCompletionToolStreamState();
     for await (const chunk of stream as unknown as AsyncIterable<unknown>) {
-      for (const event of fromOpenAIChatCompletionStreamChunk(chunk)) {
+      const mapping = mapOpenAIChatCompletionStreamChunk(chunk);
+      streamState.accept(mapping);
+      for (const event of mapping.events) {
         yield event;
       }
     }
+    streamState.assertComplete();
   }
 }
 
@@ -196,7 +222,9 @@ function requestMessages(request: CompletionRequest<OpenAICompletionModelName>):
 export function fromOpenAIChatCompletionResponse(response: unknown): CompletionResponse {
   const raw = response as Record<string, unknown>;
   const choices = Array.isArray(raw.choices) ? raw.choices : [];
-  const firstChoice = choices.find(isPlainObject);
+  const firstChoice =
+    choices.find((choice) => isPlainObject(choice) && choice.index === 0) ??
+    choices.find(isPlainObject);
   const message = isPlainObject(firstChoice?.message) ? firstChoice.message : {};
   const choice: AssistantContentType[] = [];
 
@@ -240,17 +268,19 @@ export function fromOpenAIChatCompletionResponse(response: unknown): CompletionR
 }
 
 export function fromOpenAIChatCompletionStreamChunk(chunk: unknown): CompletionStreamEvent[] {
+  return mapOpenAIChatCompletionStreamChunk(chunk).events;
+}
+
+function mapOpenAIChatCompletionStreamChunk(chunk: unknown): ChatCompletionStreamChunkMapping {
   if (!isPlainObject(chunk)) {
-    return [];
+    return { events: [], hasToolCalls: false, hasFinishReason: false };
   }
 
   const events: CompletionStreamEvent[] = [];
-  const choices = Array.isArray(chunk.choices) ? chunk.choices : [];
-  for (const choice of choices) {
-    if (!isPlainObject(choice) || !isPlainObject(choice.delta)) {
-      continue;
-    }
+  const choice = primaryStreamChoice(chunk.choices);
+  let hasToolCalls = false;
 
+  if (choice !== undefined && isPlainObject(choice.delta)) {
     const delta = choice.delta;
     if (typeof delta.content === "string" && delta.content.length > 0) {
       events.push({ type: "text_delta", delta: delta.content });
@@ -270,8 +300,9 @@ export function fromOpenAIChatCompletionStreamChunk(chunk: unknown): CompletionS
       if (!isPlainObject(toolCall)) {
         continue;
       }
+      hasToolCalls = true;
       const fn = isPlainObject(toolCall.function) ? toolCall.function : {};
-      const index = numberFrom(toolCall.index);
+      const index = toolCallIndex(toolCall.index);
       const id = `tool_${index}`;
       events.push(
         toolCallDelta(id, {
@@ -299,7 +330,112 @@ export function fromOpenAIChatCompletionStreamChunk(chunk: unknown): CompletionS
     events.push({ type: "final", response });
   }
 
-  return events;
+  const mapping: ChatCompletionStreamChunkMapping = {
+    events,
+    hasToolCalls,
+    hasFinishReason: choice !== undefined && isTerminalFinishReason(choice.finish_reason),
+  };
+  if (mapping.hasFinishReason) {
+    mapping.finishReason = choice?.finish_reason;
+  }
+  return mapping;
+}
+
+class OpenAIChatCompletionToolStreamState {
+  private hasToolCalls = false;
+  private hasFinishReason = false;
+  private finishReason: unknown;
+
+  accept(mapping: ChatCompletionStreamChunkMapping): void {
+    this.hasToolCalls ||= mapping.hasToolCalls;
+    if (!mapping.hasFinishReason) {
+      return;
+    }
+    if (this.hasFinishReason && mapping.finishReason !== this.finishReason) {
+      throw new Error(CONFLICTING_TOOL_FINISH_ERROR);
+    }
+    this.hasFinishReason = true;
+    this.finishReason = mapping.finishReason;
+    if (this.hasToolCalls) {
+      this.assertSupportedFinishReason();
+    }
+  }
+
+  assertComplete(): void {
+    if (!this.hasToolCalls) {
+      return;
+    }
+    if (!this.hasFinishReason) {
+      throw new Error(MISSING_TOOL_FINISH_ERROR);
+    }
+    this.assertSupportedFinishReason();
+  }
+
+  private assertSupportedFinishReason(): void {
+    if (this.finishReason === "length") {
+      throw new Error(LENGTH_TOOL_FINISH_ERROR);
+    }
+    if (this.finishReason === "content_filter") {
+      throw new Error(CONTENT_FILTER_TOOL_FINISH_ERROR);
+    }
+    if (
+      this.finishReason !== "tool_calls" &&
+      this.finishReason !== "stop" &&
+      this.finishReason !== "function_call"
+    ) {
+      throw new Error(UNSUPPORTED_TOOL_FINISH_ERROR);
+    }
+  }
+}
+
+function primaryStreamChoice(value: unknown): Record<string, unknown> | undefined {
+  const choices = Array.isArray(value) ? value.filter(isPlainObject) : [];
+  if (choices.length === 0) {
+    return undefined;
+  }
+
+  const indexedChoices: Array<{ choice: Record<string, unknown>; index: number }> = [];
+  const unindexedChoices: Record<string, unknown>[] = [];
+  for (const choice of choices) {
+    if (choice.index === undefined) {
+      unindexedChoices.push(choice);
+      continue;
+    }
+    if (!isStreamIndex(choice.index)) {
+      throw new Error(AMBIGUOUS_CHOICE_ERROR);
+    }
+    indexedChoices.push({ choice, index: choice.index });
+  }
+
+  if (unindexedChoices.length > 0) {
+    if (indexedChoices.length > 0 || unindexedChoices.length > 1) {
+      throw new Error(AMBIGUOUS_CHOICE_ERROR);
+    }
+    return unindexedChoices[0];
+  }
+
+  const primaryChoices = indexedChoices.filter(({ index }) => index === 0);
+  if (primaryChoices.length > 1) {
+    throw new Error(AMBIGUOUS_CHOICE_ERROR);
+  }
+  return primaryChoices[0]?.choice;
+}
+
+function toolCallIndex(value: unknown): number {
+  if (!isStreamIndex(value)) {
+    throw new Error(INVALID_TOOL_INDEX_ERROR);
+  }
+  return value;
+}
+
+function isStreamIndex(value: unknown): value is number {
+  return (
+    typeof value === "number" && Number.isFinite(value) && Number.isInteger(value) && value >= 0
+  );
+}
+
+function isTerminalFinishReason(value: unknown): boolean {
+  return value !== undefined && value !== null;
 }
 
 function usageFromOpenAIChatCompletion(usage: unknown): Usage {

--- a/packages/provider-openai/test/openai-chat-completion.test.ts
+++ b/packages/provider-openai/test/openai-chat-completion.test.ts
@@ -1,6 +1,8 @@
+import { AgentBuilder, type Tool } from "@anvia/core";
 import {
   AssistantContent,
   type CompletionRequest,
+  type CompletionStreamEvent,
   Message,
   ToolContent,
   UserContent,
@@ -12,6 +14,21 @@ import {
   fromOpenAIChatCompletionStreamChunk,
   toOpenAIChatCompletionParams,
 } from "../src/openai/chat-completion";
+
+const INVALID_TOOL_INDEX_ERROR =
+  "OpenAI Chat Completions stream returned a tool call with an invalid index; expected a finite nonnegative integer.";
+const AMBIGUOUS_CHOICE_ERROR =
+  "OpenAI Chat Completions stream returned ambiguous completion choices without valid indices; provider output cannot be assembled safely.";
+const MISSING_TOOL_FINISH_ERROR =
+  "OpenAI Chat Completions tool-call stream ended without a terminal finish reason; provider output may be incomplete.";
+const LENGTH_TOOL_FINISH_ERROR =
+  'OpenAI Chat Completions tool-call stream ended with finish_reason "length"; provider output may be incomplete.';
+const CONTENT_FILTER_TOOL_FINISH_ERROR =
+  'OpenAI Chat Completions tool-call stream ended with finish_reason "content_filter"; tool calls will not be executed.';
+const UNSUPPORTED_TOOL_FINISH_ERROR =
+  "OpenAI Chat Completions tool-call stream ended with an unsupported finish reason; provider output cannot be assembled safely.";
+const CONFLICTING_TOOL_FINISH_ERROR =
+  "OpenAI Chat Completions tool-call stream returned conflicting terminal finish reasons; provider output cannot be assembled safely.";
 
 describe("OpenAI chat-completions client path", () => {
   it("exposes OpenAI chat-completions capability metadata", () => {
@@ -300,6 +317,247 @@ describe("OpenAI chat-completions client path", () => {
     ]);
   });
 
+  it("assembles Devscale-style streamed tool fragments into one valid call", async () => {
+    const calls: unknown[] = [];
+    const model = openAIChatModelWithStreams([
+      [
+        chatChunk([chatChoice([toolCallDelta(0, "call_exec", "ExecCommand")])]),
+        chatChunk([chatChoice([toolCallDelta(0, "", "", "{")])]),
+        chatChunk([chatChoice([toolCallDelta(0, "", "", '"command": ')])]),
+        chatChunk([chatChoice([toolCallDelta(0, "", "", '"pwd"')])]),
+        chatChunk([chatChoice([toolCallDelta(0, "", "", "}")])]),
+        chatChunk([chatChoice([], 0, "tool_calls")]),
+      ],
+      finalTextStream(),
+    ]);
+    const agent = new AgentBuilder("test-agent", model)
+      .tool(recordingTool("ExecCommand", calls))
+      .build();
+
+    const events = await collect(agent.prompt("run pwd").stream());
+
+    expect(events).toContainEqual({
+      type: "tool_call",
+      turn: 1,
+      toolCall: AssistantContent.toolCall("tool_0", "ExecCommand", { command: "pwd" }, "call_exec"),
+    });
+    expect(calls).toEqual([{ command: "pwd" }]);
+  });
+
+  it("keeps interleaved streamed tool calls separate and ordered", async () => {
+    const execCalls: unknown[] = [];
+    const readCalls: unknown[] = [];
+    const model = openAIChatModelWithStreams([
+      [
+        chatChunk([
+          chatChoice([
+            toolCallDelta(0, "call_exec", "ExecCommand"),
+            toolCallDelta(1, "call_read", "ReadFile"),
+          ]),
+        ]),
+        chatChunk([chatChoice([toolCallDelta(1, "", "", "{")])]),
+        chatChunk([chatChoice([toolCallDelta(0, "", "", "{")])]),
+        chatChunk([chatChoice([toolCallDelta(1, "", "", '"file_path":"README.md"')])]),
+        chatChunk([chatChoice([toolCallDelta(0, "", "", '"command":"pwd"')])]),
+        chatChunk([chatChoice([toolCallDelta(1, "", "", "}"), toolCallDelta(0, "", "", "}")])]),
+        chatChunk([chatChoice([], 0, "tool_calls")]),
+      ],
+      finalTextStream(),
+    ]);
+    const agent = new AgentBuilder("test-agent", model)
+      .tool(recordingTool("ExecCommand", execCalls))
+      .tool(recordingTool("ReadFile", readCalls))
+      .build();
+
+    const events = await collect(agent.prompt("run tools").stream());
+
+    expect(events.flatMap((event) => (event.type === "tool_call" ? [event.toolCall] : []))).toEqual(
+      [
+        AssistantContent.toolCall("tool_0", "ExecCommand", { command: "pwd" }, "call_exec"),
+        AssistantContent.toolCall("tool_1", "ReadFile", { file_path: "README.md" }, "call_read"),
+      ],
+    );
+    expect(execCalls).toEqual([{ command: "pwd" }]);
+    expect(readCalls).toEqual([{ file_path: "README.md" }]);
+  });
+
+  it("rejects two streamed tool calls with missing indices instead of merging them", async () => {
+    const calls: unknown[] = [];
+    const model = openAIChatModelWithStreams([
+      [
+        chatChunk([
+          chatChoice([
+            toolCallDelta(undefined, "call_exec", "ExecCommand", '{"command":"pwd"}'),
+            toolCallDelta(undefined, "call_read", "ReadFile", '{"file_path":"README.md"}'),
+          ]),
+        ]),
+        chatChunk([chatChoice([], 0, "tool_calls")]),
+      ],
+    ]);
+    const agent = new AgentBuilder("test-agent", model)
+      .tool(recordingTool("ExecCommand", calls))
+      .tool(recordingTool("ReadFile", calls))
+      .build();
+
+    await expect(collect(agent.prompt("run tools").stream())).rejects.toThrow(
+      INVALID_TOOL_INDEX_ERROR,
+    );
+    expect(calls).toHaveLength(0);
+  });
+
+  it.each([
+    ["string", "0"],
+    ["nonnumeric", "not-a-number"],
+    ["NaN", Number.NaN],
+    ["negative", -1],
+    ["fractional", 0.5],
+    ["missing", undefined],
+  ])("rejects a %s streamed tool-call index", (_label, index) => {
+    expect(() =>
+      fromOpenAIChatCompletionStreamChunk(
+        chatChunk([chatChoice([toolCallDelta(index, "call_echo", "Echo", "{}")])]),
+      ),
+    ).toThrow(INVALID_TOOL_INDEX_ERROR);
+  });
+
+  it("selects completion choice zero without merging alternatives", () => {
+    const events = fromOpenAIChatCompletionStreamChunk(
+      chatChunk([
+        chatChoice([toolCallDelta(0, "call_exec", "ExecCommand", '{"command":"pwd"}')], 0),
+        chatChoice([toolCallDelta(0, "call_read", "ReadFile", '{"file_path":"README.md"}')], 1),
+      ]),
+    );
+
+    expect(events.filter((event) => event.type === "tool_call_delta")).toEqual([
+      {
+        type: "tool_call_delta",
+        id: "tool_0",
+        callId: "call_exec",
+        name: "ExecCommand",
+        argumentsDelta: '{"command":"pwd"}',
+      },
+    ]);
+    expect(
+      fromOpenAIChatCompletionResponse({
+        choices: [
+          { index: 1, message: { content: "second" } },
+          { index: 0, message: { content: "first" } },
+        ],
+        usage: {},
+      }).choice,
+    ).toEqual([AssistantContent.text("first")]);
+  });
+
+  it("rejects ambiguous unindexed completion choices", () => {
+    expect(() =>
+      fromOpenAIChatCompletionStreamChunk({
+        choices: [{ delta: { content: "first" } }, { delta: { content: "second" } }],
+      }),
+    ).toThrow(AMBIGUOUS_CHOICE_ERROR);
+  });
+
+  it("rejects a tool-call stream that ends without a terminal finish reason", async () => {
+    const model = openAIChatModelWithStreams([
+      [
+        chatChunk([
+          chatChoice([toolCallDelta(0, "call_exec", "ExecCommand", '{"command":"pwd"}')]),
+        ]),
+      ],
+    ]);
+
+    await expect(collectStreamEvents(model)).rejects.toThrow(MISSING_TOOL_FINISH_ERROR);
+    await expect(
+      collectStreamEvents(
+        openAIChatModelWithStreams([
+          [
+            {
+              choices: [{ index: 0, finish_reason: null, delta: { content: "partial" } }],
+            },
+          ],
+        ]),
+      ),
+    ).resolves.toEqual([{ type: "text_delta", delta: "partial" }]);
+    expect(MISSING_TOOL_FINISH_ERROR).not.toContain("pwd");
+  });
+
+  it.each([
+    "tool_calls",
+    "stop",
+    "function_call",
+  ])("accepts a completed tool-call stream ending with %s", async (finishReason) => {
+    const model = openAIChatModelWithStreams([
+      [
+        chatChunk([
+          chatChoice(
+            [toolCallDelta(0, "call_exec", "ExecCommand", '{"command":"pwd"}')],
+            0,
+            finishReason,
+          ),
+        ]),
+      ],
+    ]);
+
+    await expect(collectStreamEvents(model)).resolves.toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: "tool_call_delta", id: "tool_0" })]),
+    );
+  });
+
+  it.each([
+    ["length", LENGTH_TOOL_FINISH_ERROR],
+    ["content_filter", CONTENT_FILTER_TOOL_FINISH_ERROR],
+    ["abort", UNSUPPORTED_TOOL_FINISH_ERROR],
+  ])("rejects a tool-call stream ending with %s", async (finishReason, expectedError) => {
+    const model = openAIChatModelWithStreams([
+      [
+        chatChunk([
+          chatChoice(
+            [toolCallDelta(0, "call_exec", "ExecCommand", '{"command":"pwd"')],
+            0,
+            finishReason,
+          ),
+        ]),
+      ],
+    ]);
+
+    await expect(collectStreamEvents(model)).rejects.toThrow(expectedError);
+    expect(expectedError).not.toContain("pwd");
+  });
+
+  it("rejects conflicting terminal finish reasons", async () => {
+    const model = openAIChatModelWithStreams([
+      [
+        chatChunk([
+          chatChoice(
+            [toolCallDelta(0, "call_exec", "ExecCommand", '{"command":"pwd"}')],
+            0,
+            "tool_calls",
+          ),
+        ]),
+        chatChunk([chatChoice([], 0, "stop")]),
+      ],
+    ]);
+
+    await expect(collectStreamEvents(model)).rejects.toThrow(CONFLICTING_TOOL_FINISH_ERROR);
+  });
+
+  it("attributes malformed arguments after a terminal tool finish to provider output", async () => {
+    const calls: unknown[] = [];
+    const model = openAIChatModelWithStreams([
+      [
+        chatChunk([chatChoice([toolCallDelta(0, "call_exec", "ExecCommand", '{"command":"pwd"')])]),
+        chatChunk([chatChoice([], 0, "tool_calls")]),
+      ],
+    ]);
+    const agent = new AgentBuilder("test-agent", model)
+      .tool(recordingTool("ExecCommand", calls))
+      .build();
+
+    await expect(collect(agent.prompt("run pwd").stream())).rejects.toThrow(
+      'Completion returned tool call "tool_0" with malformed JSON arguments; this indicates invalid provider output or incomplete stream assembly.',
+    );
+    expect(calls).toHaveLength(0);
+  });
+
   it("omits empty streamed tool metadata while preserving argument fragments", () => {
     expect(
       fromOpenAIChatCompletionStreamChunk({
@@ -377,3 +635,88 @@ describe("OpenAI chat-completions client path", () => {
     expect(calls).toHaveLength(0);
   });
 });
+
+function openAIChatModelWithStreams(streams: unknown[][]): OpenAIChatCompletionModel {
+  return new OpenAIChatCompletionModel(
+    {
+      chat: {
+        completions: {
+          create: async () => streamFrom(streams.shift() ?? []),
+        },
+      },
+    } as never,
+    "chat-test",
+  );
+}
+
+function chatChunk(choices: unknown[]): unknown {
+  return { id: "chatcmpl_test", choices };
+}
+
+function chatChoice(toolCalls: unknown[], index = 0, finishReason: unknown = null): unknown {
+  return {
+    index,
+    finish_reason: finishReason,
+    delta: { tool_calls: toolCalls },
+  };
+}
+
+function toolCallDelta(index: unknown, id: string, name: string, argumentsText?: string): unknown {
+  const fn: Record<string, unknown> = { name };
+  if (argumentsText !== undefined) {
+    fn.arguments = argumentsText;
+  }
+  return { index, id, function: fn };
+}
+
+function recordingTool(name: string, calls: unknown[]): Tool {
+  return {
+    name,
+    definition() {
+      return { name, description: `Record ${name} calls`, parameters: { type: "object" } };
+    },
+    call(args) {
+      calls.push(args);
+      return "ok";
+    },
+  };
+}
+
+function finalTextStream(): unknown[] {
+  return [
+    {
+      id: "chatcmpl_final",
+      choices: [{ index: 0, finish_reason: null, delta: { content: "done" } }],
+    },
+    {
+      id: "chatcmpl_final",
+      choices: [{ index: 0, finish_reason: "stop", delta: {} }],
+    },
+  ];
+}
+
+async function collectStreamEvents(
+  model: OpenAIChatCompletionModel,
+): Promise<CompletionStreamEvent[]> {
+  return collect(
+    model.streamCompletion({
+      chatHistory: [Message.user("run a tool")],
+      documents: [],
+      tools: [],
+    }),
+  );
+}
+
+async function* streamFrom(events: unknown[]): AsyncIterable<unknown> {
+  for (const event of events) {
+    yield event;
+  }
+}
+
+async function collect<T>(events: AsyncIterable<T>): Promise<T[]> {
+  const result: T[] = [];
+  for await (const event of events) {
+    result.push(event);
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary

- validate streamed Chat Completions tool indices as finite nonnegative integers instead of coercing invalid values to zero
- assemble only completion choice zero, matching the non-streaming single-response contract
- distinguish missing, truncated, filtered, conflicting, and unsupported tool-stream termination
- add end-to-end Devscale-style, interleaved, malformed-fragment, lifecycle, and compatibility regressions
- add a patch changeset for `@anvia/openai`

## Root cause

The Chat Completions mapper used the generic numeric fallback for `toolCall.index`. Missing, string, nonnumeric, and NaN values became `0`, allowing unrelated argument fragments to collapse into `tool_0`. The mapper also processed all completion choices even though Anvia represents one assistant response, so tool index zero from multiple alternatives could collide.

The resulting concatenated arguments were correctly rejected by core's strict JSON parser, but the error was attributed too late and could not distinguish malformed identity from incomplete provider output.

## Impact

Valid indexed tool streams preserve their existing internal IDs, provider call IDs, metadata, order, scalar JSON support, and empty-argument behavior. Nonconforming streams now fail with sanitized provider-output errors before tool execution or assistant-memory persistence. No JSON repair, raw-string fallback, or tool-concurrency behavior was added.

## Validation

- `pnpm --filter @anvia/openai test` — 77 passed
- `pnpm --filter @anvia/core test` — 322 passed
- `pnpm --filter @anvia/openai typecheck`
- `pnpm --filter @anvia/core typecheck`
- `pnpm --filter @anvia/core build`
- `pnpm --filter @anvia/openai build`
- Biome on every changed TypeScript source/test file
- `git diff --check`
- `pnpm exec changeset status`
