### PR TITLE
Add sandbox website preview ports

### DIFF
--- a/.changeset/quiet-previews-smile.md
+++ b/.changeset/quiet-previews-smile.md
@@ -1,0 +1,5 @@
+---
+"@anvia/sandbox": minor
+---
+
+Add loopback-only Docker port publishing, managed long-running processes, readiness checks, and opt-in agent tools for application-proxied website previews.

--- a/apps/www/src/content/docs/basics/sandbox-tools.md
+++ b/apps/www/src/content/docs/basics/sandbox-tools.md
@@ -72,6 +72,11 @@ const agent = new AgentBuilder("workspace", model)
 
 The tool policy controls which commands are allowed, how long commands can run, and how much file content can pass through the tools.
 
+Managed website previews are available as opt-in tools. Application code pre-authorizes a
+container port, while the agent can start a long-running development server, inspect its logs, and
+wait for the port to become ready. See the package [usage patterns](/docs/packages/sandbox/usage-patterns#live-website-previews)
+for the complete application-owned proxy boundary.
+
 ## Clean up
 
 Destroy the session when your app is done with it:

--- a/apps/www/src/content/docs/packages/sandbox/examples.md
+++ b/apps/www/src/content/docs/packages/sandbox/examples.md
@@ -105,6 +105,49 @@ function imageContentType(path: string): string | undefined {
 }
 ```
 
+## Agent-managed website preview
+
+Pre-authorize the container port in application code. The optional tools let the agent discover
+that port, launch any allowed development server, inspect its logs, wait for readiness, and stop
+it. Your application owns the public preview URL and reverse proxy.
+
+```ts
+const sandbox = DockerSandbox.node({
+  network: true,
+  limits: { maxProcesses: 2 },
+});
+const session = await sandbox.createSession({ ports: [5173] });
+
+const tools = createSandboxTools(session, {
+  include: [
+    "exec_command",
+    "read_file",
+    "write_file",
+    "list_files",
+    "list_ports",
+    "start_process",
+    "list_processes",
+    "read_process_logs",
+    "wait_for_port",
+    "stop_process",
+  ],
+  exec: {
+    allowedCommands: ["node", "pnpm"],
+  },
+  process: {
+    maxLogBytes: 64_000,
+    maxWaitTimeoutMs: 30_000,
+  },
+});
+
+const agent = new AgentBuilder("website-agent", model)
+  .instructions(
+    "Use the published port and bind the development server to 0.0.0.0. Wait for readiness before reporting completion.",
+  )
+  .tools(tools)
+  .build();
+```
+
 ## Harness shape
 
 ```ts

--- a/apps/www/src/content/docs/packages/sandbox/reference.md
+++ b/apps/www/src/content/docs/packages/sandbox/reference.md
@@ -18,7 +18,7 @@ class DockerSandbox implements Sandbox {
   static node(options?: DockerSandboxOptions): DockerSandbox;
   static python(options?: DockerSandboxOptions): DockerSandbox;
   static deno(options?: DockerSandboxOptions): DockerSandbox;
-  createSession(options?: SandboxCreateSessionOptions): Promise<SandboxSession>;
+  createSession(options?: DockerSandboxCreateSessionOptions): Promise<DockerSandboxSession>;
 }
 ```
 
@@ -55,6 +55,9 @@ Purpose: provider-neutral contracts for sandbox clients and live workspace sessi
 
 Return behavior: file paths are sandbox-relative; absolute paths and traversal outside the workspace are rejected.
 
+`DockerSandboxSession` adds published-port and managed-process capabilities without making them
+required for other `SandboxSession` providers.
+
 ## Session Options
 
 ```ts
@@ -63,6 +66,10 @@ type SandboxCreateSessionOptions = {
   workspace?: SandboxWorkspaceOptions;
   manifest?: SandboxManifest;
   metadata?: Record<string, string>;
+};
+
+type DockerSandboxCreateSessionOptions = SandboxCreateSessionOptions & {
+  ports?: readonly number[];
 };
 
 type SandboxWorkspaceOptions =
@@ -86,6 +93,7 @@ type SandboxLimits = {
   memoryMb?: number;
   cpus?: number;
   pidsLimit?: number;
+  maxProcesses?: number;
 };
 
 type SandboxLifecycleOptions = {
@@ -96,6 +104,10 @@ type SandboxLifecycleOptions = {
 ```
 
 Purpose: seed files, directories, environment, metadata, workspace mode, lifecycle cleanup, and runtime limits for a sandbox session.
+
+`ports` contains unique TCP ports from 1 through 65535. Published ports require `network: true`
+or a bridge-capable custom network. Docker binds them to random ports on host address
+`127.0.0.1`; the application remains responsible for any authenticated public proxy.
 
 ## Docker Options
 
@@ -180,6 +192,86 @@ type SandboxFileEntry = {
 
 Purpose: typed file-listing results from `SandboxSession.listFiles(...)`.
 
+## Published ports and managed processes
+
+```ts
+interface SandboxPortSession extends SandboxSession {
+  readonly publishedPorts: readonly SandboxPublishedPort[];
+  waitForPort(
+    containerPort: number,
+    options?: SandboxWaitForPortOptions,
+  ): Promise<SandboxPublishedPort>;
+}
+
+interface SandboxProcessSession extends SandboxSession {
+  startProcess(options: SandboxProcessStartOptions): Promise<SandboxProcessInfo>;
+  listProcesses(): Promise<SandboxProcessInfo[]>;
+  readProcessLogs(
+    processId: string,
+    options?: SandboxProcessLogsOptions,
+  ): Promise<SandboxProcessLogs>;
+  stopProcess(
+    processId: string,
+    options?: SandboxProcessStopOptions,
+  ): Promise<SandboxProcessInfo>;
+}
+
+interface DockerSandboxSession extends SandboxPortSession, SandboxProcessSession {}
+
+type SandboxPublishedPort = {
+  containerPort: number;
+  host: "127.0.0.1";
+  hostPort: number;
+  protocol: "tcp";
+};
+
+type SandboxProcessStartOptions = {
+  command: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+};
+
+type SandboxProcessStatus = "running" | "exited" | "stopped";
+
+type SandboxProcessInfo = {
+  id: string;
+  command: string;
+  args: string[];
+  cwd?: string;
+  status: SandboxProcessStatus;
+  exitCode?: number;
+  startedAt: string;
+  endedAt?: string;
+};
+
+type SandboxProcessLogs = {
+  stdout: string;
+  stderr: string;
+  stdoutTruncated: boolean;
+  stderrTruncated: boolean;
+};
+
+type SandboxProcessLogsOptions = { tailBytes?: number };
+type SandboxProcessStopOptions = { gracePeriodMs?: number };
+type SandboxWaitForPortOptions = {
+  timeoutMs?: number;
+  intervalMs?: number;
+  signal?: AbortSignal;
+};
+
+function isSandboxPortSession(session: SandboxSession): session is SandboxPortSession;
+function isSandboxProcessSession(session: SandboxSession): session is SandboxProcessSession;
+```
+
+`startProcess(...)` starts an arbitrary structured command and returns after launch. Output is
+retained in a bounded tail buffer. `maxProcesses` caps concurrent processes and retained process
+records; the oldest completed records are pruned when capacity is needed. `waitForPort(...)`
+confirms that the pre-authorized port is listening on all container interfaces; web servers must
+bind to `0.0.0.0`, not container localhost. Idle timeout, TTL, and explicit session destruction
+still clean up managed processes. Managed commands should remain in the foreground rather than
+daemonizing, so the session can track their exit status and stop them reliably.
+
 ## Agent Tools
 
 ```ts
@@ -195,13 +287,20 @@ type SandboxToolsOptions = {
   exec?: SandboxExecToolPolicy;
   readFile?: SandboxFileToolPolicy;
   writeFile?: SandboxFileToolPolicy;
+  process?: SandboxProcessToolPolicy;
 };
 
 type SandboxToolName =
   | "exec_command"
   | "read_file"
   | "write_file"
-  | "list_files";
+  | "list_files"
+  | "list_ports"
+  | "start_process"
+  | "list_processes"
+  | "read_process_logs"
+  | "stop_process"
+  | "wait_for_port";
 
 type SandboxExecToolPolicy = {
   allowedCommands?: string[];
@@ -214,13 +313,22 @@ type SandboxFileToolPolicy = {
   maxBytes?: number;
 };
 
+type SandboxProcessToolPolicy = {
+  maxLogBytes?: number;
+  defaultWaitTimeoutMs?: number;
+  maxWaitTimeoutMs?: number;
+  stopGracePeriodMs?: number;
+};
+
 type SandboxToolsFactory = (
   session: SandboxSession,
   options?: SandboxToolsOptions,
 ) => AnyTool[];
 ```
 
-Purpose: expose a live sandbox session as Anvia tools. The default bundle includes `exec_command`, `read_file`, `write_file`, and `list_files`. Use `allow` or `include` to select tools and `SandboxExecToolPolicy` or `SandboxFileToolPolicy` to bound model-facing operations.
+Purpose: expose a live sandbox session as Anvia tools. The default bundle remains `exec_command`,
+`read_file`, `write_file`, and `list_files`. Published-port and managed-process tools are opt-in.
+They use the existing executable allow/block policy plus `SandboxProcessToolPolicy` limits.
 
 ## Hooks
 
@@ -255,7 +363,9 @@ type SandboxFileWriteEvent = SandboxSessionEvent & {
 };
 ```
 
-Purpose: observe session creation, command execution, file writes, and cleanup without exposing those details to the model.
+Purpose: observe session creation, command execution, managed process start/exit, file writes, and
+cleanup without exposing those details to the model. Managed processes emit `onExecStart` when
+launched and `onExecEnd` when they exit or are stopped.
 
 For workflow guidance, see [Sandbox](/docs/basics/sandbox-tools).
 
@@ -270,6 +380,9 @@ class SandboxPathError extends SandboxError {}
 class SandboxTimeoutError extends SandboxError {}
 class SandboxFileSizeError extends SandboxError {}
 class SandboxToolPolicyError extends SandboxError {}
+class SandboxPortError extends SandboxError {}
+class SandboxProcessError extends SandboxError {}
 ```
 
-Purpose: typed failures for Docker setup, path validation, destroyed sessions, file size limits, tool policy limits, and sandbox operations.
+Purpose: typed failures for Docker setup, path and port validation, managed processes, destroyed
+sessions, file size limits, tool policy limits, and sandbox operations.

--- a/apps/www/src/content/docs/packages/sandbox/usage-patterns.md
+++ b/apps/www/src/content/docs/packages/sandbox/usage-patterns.md
@@ -37,6 +37,42 @@ Do not treat the sandbox as a static asset server. Ephemeral workspaces are remo
 session is destroyed, so long-lived links should point to host storage, object storage, or another
 artifact store that your application owns.
 
+## Live website previews
+
+For a development server such as Vite, pre-authorize its container port when creating the
+session. Start the server as a managed process, wait for readiness, and proxy the returned host
+binding through an authenticated application route or preview subdomain.
+
+```ts
+const sandbox = DockerSandbox.node({
+  network: true,
+  limits: { maxProcesses: 2 },
+});
+const session = await sandbox.createSession({ ports: [5173] });
+
+const process = await session.startProcess({
+  command: "pnpm",
+  args: ["dev", "--", "--host", "0.0.0.0", "--port", "5173"],
+});
+
+const target = await session.waitForPort(5173);
+// Application proxy target: http://${target.host}:${target.hostPort}
+```
+
+The host binding is intentionally loopback-only and has a random port. Do not send that internal
+address to a remote browser. The consuming application should translate it into its own authorized
+URL and proxy HTTP and WebSocket traffic as needed. Stop the process explicitly when the preview
+ends, or destroy the session to clean up the process and port mapping together.
+
+This loopback target assumes the consuming application runs on the Docker host. An application in
+another container cannot reach the Docker host through its own `127.0.0.1`; use a host-side proxy
+for this version of the feature.
+
+To let an agent own this flow, opt into `list_ports`, `start_process`, `list_processes`,
+`read_process_logs`, `wait_for_port`, and `stop_process` when calling `createSandboxTools(...)`.
+The process command is supplied programmatically by the agent and remains subject to the existing
+allowed and blocked executable policy.
+
 ## Do and do not
 
 Do set explicit workspace, file-size, timeout, and lifecycle policy. Do keep secrets out of

--- a/packages/tool-sandbox/src/capabilities.ts
+++ b/packages/tool-sandbox/src/capabilities.ts
@@ -1,0 +1,16 @@
+import type { SandboxPortSession, SandboxProcessSession, SandboxSession } from "./types";
+
+export function isSandboxPortSession(session: SandboxSession): session is SandboxPortSession {
+  const candidate = session as Partial<SandboxPortSession>;
+  return Array.isArray(candidate.publishedPorts) && typeof candidate.waitForPort === "function";
+}
+
+export function isSandboxProcessSession(session: SandboxSession): session is SandboxProcessSession {
+  const candidate = session as Partial<SandboxProcessSession>;
+  return (
+    typeof candidate.startProcess === "function" &&
+    typeof candidate.listProcesses === "function" &&
+    typeof candidate.readProcessLogs === "function" &&
+    typeof candidate.stopProcess === "function"
+  );
+}

--- a/packages/tool-sandbox/src/docker-process.ts
+++ b/packages/tool-sandbox/src/docker-process.ts
@@ -17,16 +17,23 @@ import type {
 } from "./types";
 
 const processMarkerPrefix = "ANVIA_PROCESS";
-// Report the supervisor and direct-child PIDs through a private stdout marker, then supervise the
-// command so stopProcess can signal it without interpolating user-provided arguments into a shell.
+// Report the supervisor, direct-child, and process-group PIDs through a private stdout marker. Use
+// a dedicated session when setsid is available; Docker exec otherwise gives the supervisor its own
+// process group. User-provided command arguments remain positional rather than shell-interpolated.
 const processWrapper = [
   'marker="$1"',
   "shift",
-  '"$@" &',
-  "child=$!",
-  `printf '\\036%s:%s:%s\\036' "$marker" "$$" "$child"`,
+  "if command -v setsid >/dev/null 2>&1; then",
+  '  setsid "$@" &',
+  "  child=$!",
+  "  group=$child",
+  "else",
+  '  "$@" &',
+  "  child=$!",
+  "  group=$$",
+  "fi",
+  `printf '\\036%s:%s:%s:%s\\036' "$marker" "$$" "$child" "$group"`,
   "terminate() {",
-  '  kill -TERM "$child" 2>/dev/null || true',
   '  wait "$child" 2>/dev/null || true',
   "  exit 143",
   "}",
@@ -43,6 +50,7 @@ interface DockerProcessManagerOptions {
   maxOutputBytes: number;
   maxProcesses: number;
   startupTimeoutMs: number;
+  onStart?: (process: SandboxProcessInfo) => void | Promise<void>;
   onExit?: (
     process: SandboxProcessInfo,
     logs: SandboxProcessLogs,
@@ -60,6 +68,8 @@ interface ManagedProcessRecord {
   markerBuffer: Buffer;
   supervisorPid?: number;
   childPid?: number;
+  processGroupId?: number;
+  spawnFailed: boolean;
   stopRequested: boolean;
   startResolved: boolean;
   exitNotified: boolean;
@@ -89,14 +99,12 @@ export class DockerProcessManager {
   async start(options: SandboxProcessStartOptions): Promise<SandboxProcessInfo> {
     this.assertActive();
     assertStartOptions(options);
-    this.pruneCompletedRecords();
+    await this.pruneCompletedRecords();
 
-    const runningCount = [...this.records.values()].filter(
-      (record) => record.info.status === "running",
-    ).length;
-    if (runningCount >= this.options.maxProcesses) {
+    const trackedCount = this.records.size;
+    if (trackedCount >= this.options.maxProcesses) {
       throw new SandboxProcessError(
-        `Sandbox process limit reached (${runningCount} >= ${this.options.maxProcesses}).`,
+        `Sandbox process limit reached (${trackedCount} >= ${this.options.maxProcesses}).`,
       );
     }
 
@@ -136,6 +144,7 @@ export class DockerProcessManager {
       stderr: new TailOutputCollector(this.options.maxOutputBytes),
       markerStart: Buffer.from(`\u001e${marker}:`),
       markerBuffer: Buffer.alloc(0),
+      spawnFailed: false,
       stopRequested: false,
       startResolved: false,
       exitNotified: false,
@@ -150,13 +159,12 @@ export class DockerProcessManager {
 
     try {
       await this.waitForStart(record);
+      await this.options.onStart?.(copyProcessInfo(record.info));
       record.startResolved = true;
       if (record.info.status !== "running") this.notifyExit(record);
       return copyProcessInfo(record.info);
     } catch (error) {
-      this.records.delete(id);
-      record.stopRequested = true;
-      child.kill("SIGKILL");
+      if (await this.cleanupFailedStart(record)) this.records.delete(id);
       throw error;
     }
   }
@@ -185,28 +193,18 @@ export class DockerProcessManager {
   ): Promise<SandboxProcessInfo> {
     this.assertActive();
     const record = this.getRecord(processId);
-    if (record.info.status !== "running") {
-      return copyProcessInfo(record.info);
-    }
-
     const gracePeriodMs = options.gracePeriodMs ?? 5_000;
     if (!Number.isInteger(gracePeriodMs) || gracePeriodMs < 0) {
       throw new SandboxProcessError("Process gracePeriodMs must be a non-negative integer.");
     }
 
-    record.stopRequested = true;
     try {
-      await this.signal(record, "TERM");
+      if (!(await this.terminateRecord(record, gracePeriodMs))) {
+        throw new SandboxProcessError(`Sandbox process did not stop: ${processId}`);
+      }
     } catch (error) {
       if (record.info.status === "running") record.stopRequested = false;
       throw error;
-    }
-    if (!(await waitForPromise(record.closed, gracePeriodMs))) {
-      await this.signal(record, "KILL");
-      if (!(await waitForPromise(record.closed, 1_000))) {
-        record.child.kill("SIGKILL");
-        throw new SandboxProcessError(`Sandbox process did not stop: ${processId}`);
-      }
     }
 
     return copyProcessInfo(record.info);
@@ -216,13 +214,11 @@ export class DockerProcessManager {
     if (this.disposed) return;
     this.disposed = true;
 
-    const running = [...this.records.values()].filter((record) => record.info.status === "running");
-    for (const record of running) record.stopRequested = true;
-
-    await Promise.all(running.map((record) => waitForPromise(record.closed, 1_000)));
-    for (const record of running) {
-      if (record.info.status === "running") record.child.kill("SIGKILL");
-    }
+    await Promise.all(
+      [...this.records.values()].map(async (record) => {
+        await this.terminateRecord(record, 1_000).catch(() => false);
+      }),
+    );
   }
 
   private createExecArgs(options: SandboxProcessStartOptions, marker: string): string[] {
@@ -248,6 +244,7 @@ export class DockerProcessManager {
     record.child.stderr.on("data", (chunk: Buffer) => record.stderr.accept(chunk));
 
     record.child.on("error", (error) => {
+      record.spawnFailed = true;
       const normalized =
         (error as NodeJS.ErrnoException).code === "ENOENT"
           ? new SandboxDockerUnavailableError("Docker CLI was not found.", error)
@@ -307,7 +304,8 @@ export class DockerProcessManager {
       .split(":");
     const supervisorPid = Number(rawPids[0]);
     const childPid = Number(rawPids[1]);
-    if (!isProcessId(supervisorPid) || !isProcessId(childPid)) {
+    const processGroupId = Number(rawPids[2]);
+    if (!isProcessId(supervisorPid) || !isProcessId(childPid) || !isProcessId(processGroupId)) {
       record.rejectStarted(
         new SandboxProcessError("Sandbox process returned invalid process IDs."),
       );
@@ -321,6 +319,7 @@ export class DockerProcessManager {
     record.markerBuffer = Buffer.alloc(0);
     record.supervisorPid = supervisorPid;
     record.childPid = childPid;
+    record.processGroupId = processGroupId;
     record.resolveStarted();
   }
 
@@ -340,22 +339,85 @@ export class DockerProcessManager {
     }
   }
 
-  private async signal(record: ManagedProcessRecord, signal: "TERM" | "KILL"): Promise<void> {
-    if (record.supervisorPid === undefined || record.childPid === undefined) return;
-    const script =
-      signal === "TERM"
-        ? 'kill -TERM "$1" 2>/dev/null || true'
-        : 'kill -KILL "$1" "$2" 2>/dev/null || true';
+  private async cleanupFailedStart(record: ManagedProcessRecord): Promise<boolean> {
+    record.stopRequested = true;
+    if (record.processGroupId === undefined && record.info.status === "running") {
+      await waitForPromise(record.closed, 250);
+    }
+
+    try {
+      return await this.terminateRecord(record, 1_000);
+    } catch {
+      return false;
+    }
+  }
+
+  private async terminateRecord(
+    record: ManagedProcessRecord,
+    gracePeriodMs: number,
+  ): Promise<boolean> {
+    record.stopRequested = true;
+
+    if (record.processGroupId === undefined) {
+      if (record.info.status === "running") {
+        await waitForPromise(record.closed, Math.min(gracePeriodMs, 250));
+      }
+      if (record.processGroupId === undefined) {
+        return record.spawnFailed && record.info.status !== "running";
+      }
+    }
+
+    if (!(await this.isProcessGroupRunning(record))) {
+      return this.finishAfterGroupExit(record);
+    }
+
+    await this.signal(record, "TERM");
+    if (await this.waitForRecordExit(record, gracePeriodMs)) return true;
+
+    await this.signal(record, "KILL");
+    if (await this.waitForRecordExit(record, 1_000)) return true;
+
+    return false;
+  }
+
+  private async waitForRecordExit(
+    record: ManagedProcessRecord,
+    timeoutMs: number,
+  ): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (true) {
+      if (!(await this.isProcessGroupRunning(record))) {
+        return this.finishAfterGroupExit(record);
+      }
+
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) return false;
+      const intervalMs = Math.min(50, remainingMs);
+      if (record.info.status === "running") {
+        await waitForPromise(record.closed, intervalMs);
+      } else {
+        await waitForDelay(intervalMs);
+      }
+    }
+  }
+
+  private async finishAfterGroupExit(record: ManagedProcessRecord): Promise<boolean> {
+    if (record.info.status !== "running") return true;
+    record.child.kill("SIGKILL");
+    return waitForPromise(record.closed, 1_000);
+  }
+
+  private async isProcessGroupRunning(record: ManagedProcessRecord): Promise<boolean> {
+    if (record.processGroupId === undefined) return false;
     const result = await runDockerCli(
       [
         "exec",
         this.options.containerName,
         "sh",
         "-c",
-        script,
-        "anvia-process-signal",
-        String(record.supervisorPid),
-        String(record.childPid),
+        'kill -0 "-$1" 2>/dev/null',
+        "anvia-process-group-check",
+        String(record.processGroupId),
       ],
       {
         dockerPath: this.options.dockerPath,
@@ -363,7 +425,29 @@ export class DockerProcessManager {
         maxOutputBytes: this.options.maxOutputBytes,
       },
     );
-    if (result.exitCode !== 0 && record.info.status === "running") {
+    return result.exitCode === 0;
+  }
+
+  private async signal(record: ManagedProcessRecord, signal: "TERM" | "KILL"): Promise<void> {
+    if (record.processGroupId === undefined) return;
+    const result = await runDockerCli(
+      [
+        "exec",
+        this.options.containerName,
+        "sh",
+        "-c",
+        'kill "-$2" "-$1" 2>/dev/null || ! kill -0 "-$1" 2>/dev/null',
+        "anvia-process-signal",
+        String(record.processGroupId),
+        signal,
+      ],
+      {
+        dockerPath: this.options.dockerPath,
+        timeoutMs: 5_000,
+        maxOutputBytes: this.options.maxOutputBytes,
+      },
+    );
+    if (result.exitCode !== 0) {
       throw new SandboxDockerCommandError(
         `Unable to stop sandbox process: ${record.info.id}`,
         result,
@@ -379,10 +463,16 @@ export class DockerProcessManager {
     return record;
   }
 
-  private pruneCompletedRecords(): void {
+  private async pruneCompletedRecords(): Promise<void> {
     for (const [id, record] of this.records) {
       if (this.records.size < this.options.maxProcesses) return;
-      if (record.info.status !== "running") this.records.delete(id);
+      const cleanupConfirmed =
+        record.processGroupId === undefined
+          ? record.spawnFailed
+          : !(await this.isProcessGroupRunning(record));
+      if (record.info.status !== "running" && cleanupConfirmed) {
+        this.records.delete(id);
+      }
     }
   }
 
@@ -506,4 +596,11 @@ async function waitForPromise(promise: Promise<void>, timeoutMs: number): Promis
   } finally {
     if (timeout !== undefined) clearTimeout(timeout);
   }
+}
+
+async function waitForDelay(timeoutMs: number): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const timeout = setTimeout(resolve, timeoutMs);
+    timeout.unref?.();
+  });
 }

--- a/packages/tool-sandbox/src/docker-process.ts
+++ b/packages/tool-sandbox/src/docker-process.ts
@@ -1,0 +1,509 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { runDockerCli } from "./docker-cli";
+import {
+  SandboxDockerCommandError,
+  SandboxDockerUnavailableError,
+  SandboxProcessError,
+  SandboxTimeoutError,
+} from "./errors";
+import { containerPath } from "./path";
+import type {
+  SandboxProcessInfo,
+  SandboxProcessLogs,
+  SandboxProcessLogsOptions,
+  SandboxProcessStartOptions,
+  SandboxProcessStopOptions,
+} from "./types";
+
+const processMarkerPrefix = "ANVIA_PROCESS";
+// Report the supervisor and direct-child PIDs through a private stdout marker, then supervise the
+// command so stopProcess can signal it without interpolating user-provided arguments into a shell.
+const processWrapper = [
+  'marker="$1"',
+  "shift",
+  '"$@" &',
+  "child=$!",
+  `printf '\\036%s:%s:%s\\036' "$marker" "$$" "$child"`,
+  "terminate() {",
+  '  kill -TERM "$child" 2>/dev/null || true',
+  '  wait "$child" 2>/dev/null || true',
+  "  exit 143",
+  "}",
+  "trap terminate TERM INT",
+  'wait "$child"',
+  "exit $?",
+].join("\n");
+
+interface DockerProcessManagerOptions {
+  containerName: string;
+  dockerPath: string;
+  workdir: string;
+  env: Record<string, string>;
+  maxOutputBytes: number;
+  maxProcesses: number;
+  startupTimeoutMs: number;
+  onExit?: (
+    process: SandboxProcessInfo,
+    logs: SandboxProcessLogs,
+    durationMs: number,
+  ) => void | Promise<void>;
+}
+
+interface ManagedProcessRecord {
+  info: SandboxProcessInfo;
+  startedAtMs: number;
+  child: ChildProcessWithoutNullStreams;
+  stdout: TailOutputCollector;
+  stderr: TailOutputCollector;
+  markerStart: Buffer;
+  markerBuffer: Buffer;
+  supervisorPid?: number;
+  childPid?: number;
+  stopRequested: boolean;
+  startResolved: boolean;
+  exitNotified: boolean;
+  resolveStarted: () => void;
+  rejectStarted: (error: unknown) => void;
+  started: Promise<void>;
+  resolveClosed: () => void;
+  closed: Promise<void>;
+}
+
+export class DockerProcessManager {
+  private readonly records = new Map<string, ManagedProcessRecord>();
+  private disposed = false;
+
+  constructor(private readonly options: DockerProcessManagerOptions) {
+    if (!Number.isInteger(options.maxProcesses) || options.maxProcesses < 0) {
+      throw new SandboxProcessError("Sandbox maxProcesses must be a non-negative integer.");
+    }
+    if (!Number.isInteger(options.maxOutputBytes) || options.maxOutputBytes < 0) {
+      throw new SandboxProcessError("Sandbox maxOutputBytes must be a non-negative integer.");
+    }
+    if (!Number.isInteger(options.startupTimeoutMs) || options.startupTimeoutMs <= 0) {
+      throw new SandboxProcessError("Sandbox process startup timeout must be a positive integer.");
+    }
+  }
+
+  async start(options: SandboxProcessStartOptions): Promise<SandboxProcessInfo> {
+    this.assertActive();
+    assertStartOptions(options);
+    this.pruneCompletedRecords();
+
+    const runningCount = [...this.records.values()].filter(
+      (record) => record.info.status === "running",
+    ).length;
+    if (runningCount >= this.options.maxProcesses) {
+      throw new SandboxProcessError(
+        `Sandbox process limit reached (${runningCount} >= ${this.options.maxProcesses}).`,
+      );
+    }
+
+    const id = randomUUID();
+    const marker = `${processMarkerPrefix}:${id}`;
+    const dockerArgs = this.createExecArgs(options, marker);
+    const child = spawn(this.options.dockerPath, dockerArgs, {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    child.stdin.end();
+
+    let resolveStarted!: () => void;
+    let rejectStarted!: (error: unknown) => void;
+    const started = new Promise<void>((resolve, reject) => {
+      resolveStarted = resolve;
+      rejectStarted = reject;
+    });
+    let resolveClosed!: () => void;
+    const closed = new Promise<void>((resolve) => {
+      resolveClosed = resolve;
+    });
+
+    const info: SandboxProcessInfo = {
+      id,
+      command: options.command,
+      args: [...(options.args ?? [])],
+      status: "running",
+      startedAt: new Date().toISOString(),
+    };
+    if (options.cwd !== undefined) info.cwd = options.cwd;
+
+    const record: ManagedProcessRecord = {
+      info,
+      startedAtMs: Date.now(),
+      child,
+      stdout: new TailOutputCollector(this.options.maxOutputBytes),
+      stderr: new TailOutputCollector(this.options.maxOutputBytes),
+      markerStart: Buffer.from(`\u001e${marker}:`),
+      markerBuffer: Buffer.alloc(0),
+      stopRequested: false,
+      startResolved: false,
+      exitNotified: false,
+      resolveStarted,
+      rejectStarted,
+      started,
+      resolveClosed,
+      closed,
+    };
+    this.records.set(id, record);
+    this.observe(record);
+
+    try {
+      await this.waitForStart(record);
+      record.startResolved = true;
+      if (record.info.status !== "running") this.notifyExit(record);
+      return copyProcessInfo(record.info);
+    } catch (error) {
+      this.records.delete(id);
+      record.stopRequested = true;
+      child.kill("SIGKILL");
+      throw error;
+    }
+  }
+
+  list(): SandboxProcessInfo[] {
+    this.assertActive();
+    return [...this.records.values()].map((record) => copyProcessInfo(record.info));
+  }
+
+  logs(processId: string, options: SandboxProcessLogsOptions = {}): SandboxProcessLogs {
+    this.assertActive();
+    const record = this.getRecord(processId);
+    const stdout = record.stdout.snapshot(options.tailBytes);
+    const stderr = record.stderr.snapshot(options.tailBytes);
+    return {
+      stdout: stdout.text,
+      stderr: stderr.text,
+      stdoutTruncated: stdout.truncated,
+      stderrTruncated: stderr.truncated,
+    };
+  }
+
+  async stop(
+    processId: string,
+    options: SandboxProcessStopOptions = {},
+  ): Promise<SandboxProcessInfo> {
+    this.assertActive();
+    const record = this.getRecord(processId);
+    if (record.info.status !== "running") {
+      return copyProcessInfo(record.info);
+    }
+
+    const gracePeriodMs = options.gracePeriodMs ?? 5_000;
+    if (!Number.isInteger(gracePeriodMs) || gracePeriodMs < 0) {
+      throw new SandboxProcessError("Process gracePeriodMs must be a non-negative integer.");
+    }
+
+    record.stopRequested = true;
+    try {
+      await this.signal(record, "TERM");
+    } catch (error) {
+      if (record.info.status === "running") record.stopRequested = false;
+      throw error;
+    }
+    if (!(await waitForPromise(record.closed, gracePeriodMs))) {
+      await this.signal(record, "KILL");
+      if (!(await waitForPromise(record.closed, 1_000))) {
+        record.child.kill("SIGKILL");
+        throw new SandboxProcessError(`Sandbox process did not stop: ${processId}`);
+      }
+    }
+
+    return copyProcessInfo(record.info);
+  }
+
+  async dispose(): Promise<void> {
+    if (this.disposed) return;
+    this.disposed = true;
+
+    const running = [...this.records.values()].filter((record) => record.info.status === "running");
+    for (const record of running) record.stopRequested = true;
+
+    await Promise.all(running.map((record) => waitForPromise(record.closed, 1_000)));
+    for (const record of running) {
+      if (record.info.status === "running") record.child.kill("SIGKILL");
+    }
+  }
+
+  private createExecArgs(options: SandboxProcessStartOptions, marker: string): string[] {
+    const args = ["exec", "-w", containerPath(this.options.workdir, options.cwd ?? ".")];
+    for (const [key, value] of Object.entries({ ...this.options.env, ...options.env })) {
+      args.push("-e", `${key}=${value}`);
+    }
+    args.push(
+      this.options.containerName,
+      "sh",
+      "-c",
+      processWrapper,
+      "anvia-managed-process",
+      marker,
+      options.command,
+      ...(options.args ?? []),
+    );
+    return args;
+  }
+
+  private observe(record: ManagedProcessRecord): void {
+    record.child.stdout.on("data", (chunk: Buffer) => this.acceptStdout(record, chunk));
+    record.child.stderr.on("data", (chunk: Buffer) => record.stderr.accept(chunk));
+
+    record.child.on("error", (error) => {
+      const normalized =
+        (error as NodeJS.ErrnoException).code === "ENOENT"
+          ? new SandboxDockerUnavailableError("Docker CLI was not found.", error)
+          : error;
+      record.rejectStarted(normalized);
+    });
+
+    record.child.on("close", (code) => {
+      if (record.markerBuffer.length > 0) {
+        record.stdout.accept(record.markerBuffer);
+        record.markerBuffer = Buffer.alloc(0);
+      }
+      record.info.status = record.stopRequested ? "stopped" : "exited";
+      record.info.exitCode = code ?? 1;
+      record.info.endedAt = new Date().toISOString();
+      record.rejectStarted(
+        new SandboxProcessError(
+          `Sandbox process exited before startup completed: ${record.info.id}`,
+        ),
+      );
+      record.resolveClosed();
+
+      if (record.startResolved) this.notifyExit(record);
+    });
+  }
+
+  private acceptStdout(record: ManagedProcessRecord, chunk: Buffer): void {
+    if (record.supervisorPid !== undefined) {
+      record.stdout.accept(chunk);
+      return;
+    }
+
+    record.markerBuffer = Buffer.concat([record.markerBuffer, chunk]);
+    const start = record.markerBuffer.indexOf(record.markerStart);
+    if (start < 0) {
+      const retainedBytes = Math.max(0, record.markerStart.length - 1);
+      if (record.markerBuffer.length > retainedBytes) {
+        const split = record.markerBuffer.length - retainedBytes;
+        record.stdout.accept(record.markerBuffer.subarray(0, split));
+        record.markerBuffer = record.markerBuffer.subarray(split);
+      }
+      return;
+    }
+
+    const end = record.markerBuffer.indexOf(0x1e, start + record.markerStart.length);
+    if (end < 0) {
+      if (start > 0) {
+        record.stdout.accept(record.markerBuffer.subarray(0, start));
+        record.markerBuffer = record.markerBuffer.subarray(start);
+      }
+      return;
+    }
+
+    const rawPids = record.markerBuffer
+      .subarray(start + record.markerStart.length, end)
+      .toString("utf8")
+      .split(":");
+    const supervisorPid = Number(rawPids[0]);
+    const childPid = Number(rawPids[1]);
+    if (!isProcessId(supervisorPid) || !isProcessId(childPid)) {
+      record.rejectStarted(
+        new SandboxProcessError("Sandbox process returned invalid process IDs."),
+      );
+      return;
+    }
+
+    if (start > 0) record.stdout.accept(record.markerBuffer.subarray(0, start));
+    if (end + 1 < record.markerBuffer.length) {
+      record.stdout.accept(record.markerBuffer.subarray(end + 1));
+    }
+    record.markerBuffer = Buffer.alloc(0);
+    record.supervisorPid = supervisorPid;
+    record.childPid = childPid;
+    record.resolveStarted();
+  }
+
+  private async waitForStart(record: ManagedProcessRecord) {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeout = setTimeout(() => {
+        reject(new SandboxTimeoutError("Starting sandbox process timed out."));
+      }, this.options.startupTimeoutMs);
+      timeout.unref?.();
+    });
+
+    try {
+      await Promise.race([record.started, timeoutPromise]);
+    } finally {
+      if (timeout !== undefined) clearTimeout(timeout);
+    }
+  }
+
+  private async signal(record: ManagedProcessRecord, signal: "TERM" | "KILL"): Promise<void> {
+    if (record.supervisorPid === undefined || record.childPid === undefined) return;
+    const script =
+      signal === "TERM"
+        ? 'kill -TERM "$1" 2>/dev/null || true'
+        : 'kill -KILL "$1" "$2" 2>/dev/null || true';
+    const result = await runDockerCli(
+      [
+        "exec",
+        this.options.containerName,
+        "sh",
+        "-c",
+        script,
+        "anvia-process-signal",
+        String(record.supervisorPid),
+        String(record.childPid),
+      ],
+      {
+        dockerPath: this.options.dockerPath,
+        timeoutMs: 5_000,
+        maxOutputBytes: this.options.maxOutputBytes,
+      },
+    );
+    if (result.exitCode !== 0 && record.info.status === "running") {
+      throw new SandboxDockerCommandError(
+        `Unable to stop sandbox process: ${record.info.id}`,
+        result,
+      );
+    }
+  }
+
+  private getRecord(processId: string): ManagedProcessRecord {
+    const record = this.records.get(processId);
+    if (record === undefined) {
+      throw new SandboxProcessError(`Unknown sandbox process: ${processId}`);
+    }
+    return record;
+  }
+
+  private pruneCompletedRecords(): void {
+    for (const [id, record] of this.records) {
+      if (this.records.size < this.options.maxProcesses) return;
+      if (record.info.status !== "running") this.records.delete(id);
+    }
+  }
+
+  private logsUnsafe(record: ManagedProcessRecord): SandboxProcessLogs {
+    const stdout = record.stdout.snapshot();
+    const stderr = record.stderr.snapshot();
+    return {
+      stdout: stdout.text,
+      stderr: stderr.text,
+      stdoutTruncated: stdout.truncated,
+      stderrTruncated: stderr.truncated,
+    };
+  }
+
+  private notifyExit(record: ManagedProcessRecord): void {
+    if (record.exitNotified) return;
+    record.exitNotified = true;
+    const durationMs = Date.now() - record.startedAtMs;
+    const notify = async () =>
+      this.options.onExit?.(copyProcessInfo(record.info), this.logsUnsafe(record), durationMs);
+    void notify().catch(() => undefined);
+  }
+
+  private assertActive(): void {
+    if (this.disposed) {
+      throw new SandboxProcessError("Sandbox process manager has been disposed.");
+    }
+  }
+}
+
+class TailOutputCollector {
+  private chunks: Buffer[] = [];
+  private length = 0;
+  private didTruncate = false;
+
+  constructor(private readonly maxBytes: number) {}
+
+  accept(chunk: Buffer): void {
+    if (chunk.length === 0) return;
+    if (this.maxBytes <= 0) {
+      this.didTruncate = true;
+      return;
+    }
+
+    if (chunk.length >= this.maxBytes) {
+      this.chunks = [chunk.subarray(chunk.length - this.maxBytes)];
+      this.length = this.maxBytes;
+      this.didTruncate = true;
+      return;
+    }
+
+    this.chunks.push(chunk);
+    this.length += chunk.length;
+    while (this.length > this.maxBytes) {
+      const first = this.chunks[0];
+      if (first === undefined) break;
+      const overflow = this.length - this.maxBytes;
+      if (first.length <= overflow) {
+        this.chunks.shift();
+        this.length -= first.length;
+      } else {
+        this.chunks[0] = first.subarray(overflow);
+        this.length -= overflow;
+      }
+      this.didTruncate = true;
+    }
+  }
+
+  snapshot(tailBytes?: number): { text: string; truncated: boolean } {
+    if (tailBytes !== undefined && (!Number.isInteger(tailBytes) || tailBytes < 0)) {
+      throw new SandboxProcessError("Process tailBytes must be a non-negative integer.");
+    }
+    const bytes = Buffer.concat(this.chunks, this.length);
+    const selected =
+      tailBytes === 0
+        ? Buffer.alloc(0)
+        : tailBytes === undefined || bytes.length <= tailBytes
+          ? bytes
+          : bytes.subarray(bytes.length - tailBytes);
+    return {
+      text: selected.toString("utf8"),
+      truncated: this.didTruncate || selected.length < bytes.length,
+    };
+  }
+}
+
+function assertStartOptions(options: SandboxProcessStartOptions): void {
+  if (options.command.trim().length === 0) {
+    throw new SandboxProcessError("Sandbox process command cannot be empty.");
+  }
+}
+
+function isProcessId(value: number): boolean {
+  return Number.isSafeInteger(value) && value > 0;
+}
+
+function copyProcessInfo(info: SandboxProcessInfo): SandboxProcessInfo {
+  const copy: SandboxProcessInfo = {
+    id: info.id,
+    command: info.command,
+    args: [...info.args],
+    status: info.status,
+    startedAt: info.startedAt,
+  };
+  if (info.cwd !== undefined) copy.cwd = info.cwd;
+  if (info.exitCode !== undefined) copy.exitCode = info.exitCode;
+  if (info.endedAt !== undefined) copy.endedAt = info.endedAt;
+  return copy;
+}
+
+async function waitForPromise(promise: Promise<void>, timeoutMs: number): Promise<boolean> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.then(() => true),
+      new Promise<boolean>((resolve) => {
+        timeout = setTimeout(() => resolve(false), timeoutMs);
+        timeout.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}

--- a/packages/tool-sandbox/src/docker-sandbox.ts
+++ b/packages/tool-sandbox/src/docker-sandbox.ts
@@ -3,17 +3,20 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { assertDockerCli, type DockerCliOptions, runDockerCli } from "./docker-cli";
+import { DockerProcessManager } from "./docker-process";
 import {
   SandboxDockerCommandError,
   SandboxFileSizeError,
+  SandboxPortError,
   SandboxSessionDestroyedError,
   SandboxTimeoutError,
 } from "./errors";
 import { containerPath, normalizeSandboxPath, parentSandboxPath } from "./path";
 import type {
+  DockerSandboxCreateSessionOptions,
   DockerSandboxOptions,
+  DockerSandboxSession,
   Sandbox,
-  SandboxCreateSessionOptions,
   SandboxExecEndEvent,
   SandboxExecEvent,
   SandboxExecOptions,
@@ -25,8 +28,14 @@ import type {
   SandboxLifecycleOptions,
   SandboxLimits,
   SandboxManifest,
-  SandboxSession,
+  SandboxProcessInfo,
+  SandboxProcessLogs,
+  SandboxProcessLogsOptions,
+  SandboxProcessStartOptions,
+  SandboxProcessStopOptions,
+  SandboxPublishedPort,
   SandboxSessionEvent,
+  SandboxWaitForPortOptions,
   SandboxWorkspaceOptions,
 } from "./types";
 
@@ -34,6 +43,23 @@ const defaultImage = "node:22-bookworm";
 const defaultWorkdir = "/workspace";
 const defaultTimeoutMs = 30_000;
 const defaultMaxOutputBytes = 1024 * 1024;
+const defaultMaxProcesses = 4;
+// Docker Desktop may accept a host-side TCP connection before a container service is ready. Probe
+// Linux socket state in the container so readiness requires an all-interface listening socket.
+const portProbeScript = [
+  'port="$(printf \'%04X\' "$1")"',
+  "for table in /proc/net/tcp /proc/net/tcp6; do",
+  '  [ -r "$table" ] || continue',
+  "  while read -r _ local _ state _; do",
+  '    case "$local" in',
+  '      "00000000:$port"|"00000000000000000000000000000000:$port")',
+  '        [ "$state" = "0A" ] && exit 0',
+  "        ;;",
+  "    esac",
+  '  done < "$table"',
+  "done",
+  "exit 1",
+].join("\n");
 
 export class DockerSandbox implements Sandbox {
   readonly provider = "docker";
@@ -91,7 +117,11 @@ export class DockerSandbox implements Sandbox {
     return new DockerSandbox({ ...options, image: options.image ?? "denoland/deno:debian" });
   }
 
-  async createSession(options: SandboxCreateSessionOptions = {}): Promise<SandboxSession> {
+  async createSession(
+    options: DockerSandboxCreateSessionOptions = {},
+  ): Promise<DockerSandboxSession> {
+    const ports = validatePublishedPorts(options.ports ?? []);
+    this.assertPortNetworkCompatible(ports);
     await this.ensureImage();
 
     const id = sanitizeResourceId(options.id ?? randomUUID());
@@ -105,14 +135,16 @@ export class DockerSandbox implements Sandbox {
 
     try {
       await assertDockerCli(
-        this.createRunArgs(containerName, volumeName, workspace, options.metadata),
+        this.createRunArgs(containerName, volumeName, workspace, options.metadata, ports),
         {
           ...this.cliOptions(),
           timeoutMs: this.limits.timeoutMs ?? defaultTimeoutMs,
         },
       );
 
-      const session = new DockerSandboxSession({
+      const publishedPorts = await this.inspectPublishedPorts(containerName, ports);
+
+      const session = new DockerSandboxSessionImpl({
         id,
         containerName,
         volumeName,
@@ -123,6 +155,7 @@ export class DockerSandbox implements Sandbox {
         removeVolumeOnDestroy,
         env: options.manifest?.env ?? {},
         hooks: this.hooks,
+        publishedPorts,
       });
 
       await session.applyManifest(options.manifest);
@@ -153,6 +186,7 @@ export class DockerSandbox implements Sandbox {
     volumeName: string,
     workspace: SandboxWorkspaceOptions,
     metadata: Record<string, string> | undefined,
+    ports: readonly number[],
   ): string[] {
     const args = [
       "run",
@@ -182,6 +216,9 @@ export class DockerSandbox implements Sandbox {
     }
 
     this.appendNetworkArgs(args);
+    for (const port of ports) {
+      args.push("--publish", `127.0.0.1::${port}/tcp`);
+    }
     this.appendLimitArgs(args);
     this.appendSecurityArgs(args);
 
@@ -209,6 +246,67 @@ export class DockerSandbox implements Sandbox {
     if (mode !== true) {
       args.push("--network", mode);
     }
+  }
+
+  private assertPortNetworkCompatible(ports: readonly number[]): void {
+    if (ports.length === 0) return;
+    const mode = typeof this.network === "object" ? this.network.mode : this.network;
+    if (
+      mode === false ||
+      mode === "none" ||
+      mode === "host" ||
+      (typeof mode === "string" && mode.startsWith("container:"))
+    ) {
+      throw new SandboxPortError(
+        "Published sandbox ports require network: true or a bridge-capable Docker network.",
+      );
+    }
+  }
+
+  private async inspectPublishedPorts(
+    containerName: string,
+    ports: readonly number[],
+  ): Promise<SandboxPublishedPort[]> {
+    if (ports.length === 0) return [];
+
+    const raw = await assertDockerCli(
+      ["container", "inspect", "--format", "{{json .NetworkSettings.Ports}}", containerName],
+      this.cliOptions(),
+    );
+    let mappings: unknown;
+    try {
+      mappings = JSON.parse(raw);
+    } catch (error) {
+      throw new SandboxPortError("Docker returned invalid published port metadata.", error);
+    }
+    if (!isRecord(mappings)) {
+      throw new SandboxPortError("Docker returned invalid published port metadata.");
+    }
+
+    return ports.map((containerPort) => {
+      const entries = mappings[`${containerPort}/tcp`];
+      if (!Array.isArray(entries)) {
+        throw new SandboxPortError(`Docker did not publish sandbox port ${containerPort}/tcp.`);
+      }
+      const entry = entries.find(
+        (candidate) =>
+          isRecord(candidate) &&
+          candidate.HostIp === "127.0.0.1" &&
+          typeof candidate.HostPort === "string",
+      );
+      if (!isRecord(entry) || typeof entry.HostPort !== "string") {
+        throw new SandboxPortError(
+          `Docker did not bind sandbox port ${containerPort}/tcp to 127.0.0.1.`,
+        );
+      }
+      const hostPort = Number(entry.HostPort);
+      if (!isValidPort(hostPort)) {
+        throw new SandboxPortError(
+          `Docker returned an invalid host port for ${containerPort}/tcp.`,
+        );
+      }
+      return { containerPort, host: "127.0.0.1", hostPort, protocol: "tcp" };
+    });
   }
 
   private appendLimitArgs(args: string[]): void {
@@ -257,10 +355,11 @@ export class DockerSandbox implements Sandbox {
   }
 }
 
-class DockerSandboxSession implements SandboxSession {
+class DockerSandboxSessionImpl implements DockerSandboxSession {
   readonly provider = "docker";
   readonly id: string;
   readonly workdir: string;
+  readonly publishedPorts: readonly SandboxPublishedPort[];
 
   private readonly containerName: string;
   private readonly volumeName: string;
@@ -271,6 +370,7 @@ class DockerSandboxSession implements SandboxSession {
   private readonly removeVolumeOnDestroy: boolean;
   private readonly env: Record<string, string>;
   private readonly hooks: SandboxHooks;
+  private readonly processManager: DockerProcessManager;
   private ttlTimer: ReturnType<typeof setTimeout> | undefined;
   private idleTimer: ReturnType<typeof setTimeout> | undefined;
   private activeOperations = 0;
@@ -288,6 +388,7 @@ class DockerSandboxSession implements SandboxSession {
     removeVolumeOnDestroy: boolean;
     env: Record<string, string>;
     hooks: SandboxHooks;
+    publishedPorts: SandboxPublishedPort[];
   }) {
     this.id = options.id;
     this.containerName = options.containerName;
@@ -299,6 +400,35 @@ class DockerSandboxSession implements SandboxSession {
     this.removeVolumeOnDestroy = options.removeVolumeOnDestroy;
     this.env = options.env;
     this.hooks = options.hooks;
+    this.publishedPorts = options.publishedPorts;
+    this.processManager = new DockerProcessManager({
+      containerName: this.containerName,
+      dockerPath: this.dockerPath,
+      workdir: this.workdir,
+      env: this.env,
+      maxOutputBytes: this.limits.maxOutputBytes ?? defaultMaxOutputBytes,
+      maxProcesses: this.limits.maxProcesses ?? defaultMaxProcesses,
+      startupTimeoutMs: this.limits.timeoutMs ?? defaultTimeoutMs,
+      onExit: async (process, logs, durationMs) => {
+        const event: SandboxExecEndEvent = {
+          ...this.event(),
+          command: process.command,
+          args: process.args,
+          result: {
+            stdout: logs.stdout,
+            stderr: logs.stderr,
+            exitCode: process.exitCode ?? 1,
+            durationMs,
+            timedOut: false,
+            aborted: process.status === "stopped",
+            stdoutTruncated: logs.stdoutTruncated,
+            stderrTruncated: logs.stderrTruncated,
+          },
+        };
+        if (process.cwd !== undefined) event.cwd = process.cwd;
+        await this.hooks.onExecEnd?.(event);
+      },
+    });
     this.startLifecycleTimers();
   }
 
@@ -398,6 +528,70 @@ class DockerSandboxSession implements SandboxSession {
     }
   }
 
+  async startProcess(options: SandboxProcessStartOptions): Promise<SandboxProcessInfo> {
+    return this.runOperation(async () => {
+      const event: SandboxExecEvent = {
+        ...this.event(),
+        command: options.command,
+        args: options.args ?? [],
+      };
+      if (options.cwd !== undefined) event.cwd = options.cwd;
+      await this.hooks.onExecStart?.(event);
+      return this.processManager.start(options);
+    });
+  }
+
+  async listProcesses(): Promise<SandboxProcessInfo[]> {
+    return this.runOperation(async () => this.processManager.list());
+  }
+
+  async readProcessLogs(
+    processId: string,
+    options?: SandboxProcessLogsOptions,
+  ): Promise<SandboxProcessLogs> {
+    return this.runOperation(async () => this.processManager.logs(processId, options));
+  }
+
+  async stopProcess(
+    processId: string,
+    options?: SandboxProcessStopOptions,
+  ): Promise<SandboxProcessInfo> {
+    return this.runOperation(async () => this.processManager.stop(processId, options));
+  }
+
+  async waitForPort(
+    containerPort: number,
+    options: SandboxWaitForPortOptions = {},
+  ): Promise<SandboxPublishedPort> {
+    return this.runOperation(async () => {
+      const publishedPort = this.publishedPorts.find(
+        (candidate) => candidate.containerPort === containerPort,
+      );
+      if (publishedPort === undefined) {
+        throw new SandboxPortError(`Sandbox port is not published: ${containerPort}/tcp`);
+      }
+
+      const timeoutMs = options.timeoutMs ?? this.limits.timeoutMs ?? defaultTimeoutMs;
+      const intervalMs = options.intervalMs ?? 250;
+      assertWaitOptions(timeoutMs, intervalMs);
+      const deadline = Date.now() + timeoutMs;
+
+      while (true) {
+        this.assertActive();
+        if (options.signal?.aborted === true) throw abortReason(options.signal);
+        const probeTimeoutMs = Math.max(1, Math.min(1_000, deadline - Date.now()));
+        if (await this.isPortListening(containerPort, probeTimeoutMs)) {
+          return publishedPort;
+        }
+        const remainingMs = deadline - Date.now();
+        if (remainingMs <= 0) {
+          throw new SandboxTimeoutError(`Waiting for sandbox port ${containerPort}/tcp timed out.`);
+        }
+        await waitWithSignal(Math.min(intervalMs, remainingMs), options.signal);
+      }
+    });
+  }
+
   async readFile(filePath: string): Promise<Uint8Array> {
     return this.runOperation(async () => {
       const normalized = normalizeSandboxPath(filePath);
@@ -482,7 +676,9 @@ class DockerSandboxSession implements SandboxSession {
 
     this.destroyed = true;
     this.clearLifecycleTimers();
+    const processCleanup = this.processManager.dispose();
     await runDockerCli(["rm", "-f", this.containerName], this.cliOptions()).catch(() => undefined);
+    await processCleanup;
 
     if (this.removeVolumeOnDestroy) {
       await runDockerCli(["volume", "rm", "-f", this.volumeName], this.cliOptions()).catch(
@@ -532,6 +728,25 @@ class DockerSandboxSession implements SandboxSession {
       dockerPath: this.dockerPath,
       maxOutputBytes: this.limits.maxOutputBytes ?? defaultMaxOutputBytes,
     };
+  }
+
+  private async isPortListening(containerPort: number, timeoutMs: number): Promise<boolean> {
+    const result = await runDockerCli(
+      [
+        "exec",
+        this.containerName,
+        "sh",
+        "-c",
+        portProbeScript,
+        "anvia-port-probe",
+        String(containerPort),
+      ],
+      {
+        ...this.cliOptions(),
+        timeoutMs: Math.max(1, timeoutMs),
+      },
+    );
+    return result.exitCode === 0;
   }
 
   private async execCommand(options: SandboxExecOptions): Promise<SandboxExecResult> {
@@ -701,4 +916,54 @@ function mapFindType(type: string | undefined): SandboxFileType {
     return "symlink";
   }
   return "other";
+}
+
+function validatePublishedPorts(ports: readonly number[]): number[] {
+  const unique = new Set<number>();
+  for (const port of ports) {
+    if (!isValidPort(port)) {
+      throw new SandboxPortError(`Sandbox port must be an integer from 1 to 65535: ${port}`);
+    }
+    if (unique.has(port)) {
+      throw new SandboxPortError(`Sandbox port is duplicated: ${port}`);
+    }
+    unique.add(port);
+  }
+  return [...unique];
+}
+
+function isValidPort(port: number): boolean {
+  return Number.isInteger(port) && port >= 1 && port <= 65_535;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertWaitOptions(timeoutMs: number, intervalMs: number): void {
+  if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new SandboxPortError("Port wait timeoutMs must be a positive integer.");
+  }
+  if (!Number.isInteger(intervalMs) || intervalMs <= 0) {
+    throw new SandboxPortError("Port wait intervalMs must be a positive integer.");
+  }
+}
+
+async function waitWithSignal(timeoutMs: number, signal: AbortSignal | undefined): Promise<void> {
+  if (signal?.aborted === true) throw abortReason(signal);
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener("abort", abort);
+      resolve();
+    }, timeoutMs);
+    const abort = () => {
+      clearTimeout(timeout);
+      reject(abortReason(signal));
+    };
+    signal?.addEventListener("abort", abort, { once: true });
+  });
+}
+
+function abortReason(signal: AbortSignal | undefined): unknown {
+  return signal?.reason ?? new SandboxPortError("Waiting for sandbox port was aborted.");
 }

--- a/packages/tool-sandbox/src/docker-sandbox.ts
+++ b/packages/tool-sandbox/src/docker-sandbox.ts
@@ -409,6 +409,15 @@ class DockerSandboxSessionImpl implements DockerSandboxSession {
       maxOutputBytes: this.limits.maxOutputBytes ?? defaultMaxOutputBytes,
       maxProcesses: this.limits.maxProcesses ?? defaultMaxProcesses,
       startupTimeoutMs: this.limits.timeoutMs ?? defaultTimeoutMs,
+      onStart: async (process) => {
+        const event: SandboxExecEvent = {
+          ...this.event(),
+          command: process.command,
+          args: process.args,
+        };
+        if (process.cwd !== undefined) event.cwd = process.cwd;
+        await this.hooks.onExecStart?.(event);
+      },
       onExit: async (process, logs, durationMs) => {
         const event: SandboxExecEndEvent = {
           ...this.event(),
@@ -529,16 +538,7 @@ class DockerSandboxSessionImpl implements DockerSandboxSession {
   }
 
   async startProcess(options: SandboxProcessStartOptions): Promise<SandboxProcessInfo> {
-    return this.runOperation(async () => {
-      const event: SandboxExecEvent = {
-        ...this.event(),
-        command: options.command,
-        args: options.args ?? [],
-      };
-      if (options.cwd !== undefined) event.cwd = options.cwd;
-      await this.hooks.onExecStart?.(event);
-      return this.processManager.start(options);
-    });
+    return this.runOperation(async () => this.processManager.start(options));
   }
 
   async listProcesses(): Promise<SandboxProcessInfo[]> {
@@ -579,15 +579,19 @@ class DockerSandboxSessionImpl implements DockerSandboxSession {
       while (true) {
         this.assertActive();
         if (options.signal?.aborted === true) throw abortReason(options.signal);
-        const probeTimeoutMs = Math.max(1, Math.min(1_000, deadline - Date.now()));
-        if (await this.isPortListening(containerPort, probeTimeoutMs)) {
-          return publishedPort;
-        }
         const remainingMs = deadline - Date.now();
         if (remainingMs <= 0) {
           throw new SandboxTimeoutError(`Waiting for sandbox port ${containerPort}/tcp timed out.`);
         }
-        await waitWithSignal(Math.min(intervalMs, remainingMs), options.signal);
+        const probeTimeoutMs = Math.min(1_000, remainingMs);
+        if (await this.isPortListening(containerPort, probeTimeoutMs)) {
+          return publishedPort;
+        }
+        const remainingAfterProbeMs = deadline - Date.now();
+        if (remainingAfterProbeMs <= 0) {
+          throw new SandboxTimeoutError(`Waiting for sandbox port ${containerPort}/tcp timed out.`);
+        }
+        await waitWithSignal(Math.min(intervalMs, remainingAfterProbeMs), options.signal);
       }
     });
   }
@@ -676,9 +680,8 @@ class DockerSandboxSessionImpl implements DockerSandboxSession {
 
     this.destroyed = true;
     this.clearLifecycleTimers();
-    const processCleanup = this.processManager.dispose();
+    await this.processManager.dispose();
     await runDockerCli(["rm", "-f", this.containerName], this.cliOptions()).catch(() => undefined);
-    await processCleanup;
 
     if (this.removeVolumeOnDestroy) {
       await runDockerCli(["volume", "rm", "-f", this.volumeName], this.cliOptions()).catch(

--- a/packages/tool-sandbox/src/errors.ts
+++ b/packages/tool-sandbox/src/errors.ts
@@ -32,3 +32,7 @@ export class SandboxTimeoutError extends SandboxError {}
 export class SandboxFileSizeError extends SandboxError {}
 
 export class SandboxToolPolicyError extends SandboxError {}
+
+export class SandboxPortError extends SandboxError {}
+
+export class SandboxProcessError extends SandboxError {}

--- a/packages/tool-sandbox/src/index.ts
+++ b/packages/tool-sandbox/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./capabilities";
 export * from "./docker-sandbox";
 export * from "./errors";
 export * from "./tools";

--- a/packages/tool-sandbox/src/tools.ts
+++ b/packages/tool-sandbox/src/tools.ts
@@ -1,9 +1,14 @@
 import { type AnyTool, createTool } from "@anvia/core/tool";
 import { z } from "zod";
+import { isSandboxPortSession, isSandboxProcessSession } from "./capabilities";
 import { SandboxToolPolicyError } from "./errors";
 import type {
   SandboxExecOptions,
   SandboxExecResult,
+  SandboxPortSession,
+  SandboxProcessInfo,
+  SandboxProcessSession,
+  SandboxProcessStartOptions,
   SandboxSession,
   SandboxToolName,
   SandboxToolsOptions,
@@ -43,7 +48,50 @@ const listFilesInput = z.object({
     .describe("Relative directory path inside the sandbox. Defaults to root."),
 });
 
+const emptyInput = z.object({});
+
+const startProcessInput = z.object({
+  command: z.string().min(1).describe("Executable to run as a managed sandbox process."),
+  args: z.array(z.string()).optional().describe("Command arguments."),
+  cwd: z.string().optional().describe("Relative working directory inside the sandbox."),
+  env: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe("Environment variables for this process."),
+});
+
+const processIdInput = z.object({
+  processId: z.string().min(1).describe("Managed process identifier."),
+});
+
+const readProcessLogsInput = processIdInput.extend({
+  tailBytes: z
+    .number()
+    .int()
+    .nonnegative()
+    .max(1024 * 1024)
+    .optional()
+    .describe("Maximum trailing bytes to return from each output stream."),
+});
+
+const waitForPortInput = z.object({
+  containerPort: z
+    .number()
+    .int()
+    .min(1)
+    .max(65_535)
+    .describe("Pre-authorized TCP port inside the sandbox container."),
+  timeoutMs: z
+    .number()
+    .int()
+    .positive()
+    .max(300_000)
+    .optional()
+    .describe("Maximum time to wait for the port to accept connections."),
+});
+
 const textOutput = z.string();
+const maxToolLogBytes = 1024 * 1024;
 
 export function createSandboxTools(
   session: SandboxSession,
@@ -68,6 +116,39 @@ export function createSandboxTools(
 
   if (include.has("list_files")) {
     tools.push(createListFilesTool(session));
+  }
+
+  const portToolsRequested = include.has("list_ports") || include.has("wait_for_port");
+  const portSession = portToolsRequested ? requirePortSession(session) : undefined;
+  if (include.has("list_ports") && portSession !== undefined) {
+    tools.push(createListPortsTool(portSession));
+  }
+
+  const processToolsRequested =
+    include.has("start_process") ||
+    include.has("list_processes") ||
+    include.has("read_process_logs") ||
+    include.has("stop_process");
+  if (include.has("wait_for_port") || processToolsRequested) assertProcessToolPolicy(options);
+  const processSession = processToolsRequested ? requireProcessSession(session) : undefined;
+  if (include.has("start_process") && processSession !== undefined) {
+    tools.push(createStartProcessTool(processSession, options));
+  }
+
+  if (include.has("list_processes") && processSession !== undefined) {
+    tools.push(createListProcessesTool(processSession));
+  }
+
+  if (include.has("read_process_logs") && processSession !== undefined) {
+    tools.push(createReadProcessLogsTool(processSession, options));
+  }
+
+  if (include.has("stop_process") && processSession !== undefined) {
+    tools.push(createStopProcessTool(processSession, options));
+  }
+
+  if (include.has("wait_for_port") && portSession !== undefined) {
+    tools.push(createWaitForPortTool(portSession, options));
   }
 
   return tools;
@@ -165,6 +246,132 @@ function createListFilesTool(session: SandboxSession): AnyTool {
   });
 }
 
+function createListPortsTool(session: SandboxPortSession): AnyTool {
+  return createTool({
+    name: "list_ports",
+    description:
+      "List pre-authorized sandbox preview ports. Servers must bind to 0.0.0.0 on a listed container port.",
+    input: emptyInput,
+    output: textOutput,
+    execute: async () => {
+      if (session.publishedPorts.length === 0) {
+        return "No sandbox ports are published.";
+      }
+      return session.publishedPorts
+        .map((port) => `${port.containerPort}/${port.protocol}\t${port.host}:${port.hostPort}`)
+        .join("\n");
+    },
+  });
+}
+
+function createStartProcessTool(
+  session: SandboxProcessSession,
+  options: SandboxToolsOptions,
+): AnyTool {
+  return createTool({
+    name: "start_process",
+    description:
+      "Start a managed long-running process inside the sandbox. Use list_ports first and bind web servers to 0.0.0.0.",
+    input: startProcessInput,
+    output: textOutput,
+    execute: async ({ command, args, cwd, env }) => {
+      assertCommandAllowed(command, options);
+      const processOptions: SandboxProcessStartOptions = { command };
+      if (args !== undefined) processOptions.args = args;
+      if (cwd !== undefined) processOptions.cwd = cwd;
+      if (env !== undefined) processOptions.env = env;
+      return formatProcessInfo(await session.startProcess(processOptions));
+    },
+  });
+}
+
+function createListProcessesTool(session: SandboxProcessSession): AnyTool {
+  return createTool({
+    name: "list_processes",
+    description: "List managed sandbox processes and their current status.",
+    input: emptyInput,
+    output: textOutput,
+    execute: async () => {
+      const processes = await session.listProcesses();
+      if (processes.length === 0) return "No managed processes.";
+      return processes.map(formatProcessInfo).join("\n\n");
+    },
+  });
+}
+
+function createReadProcessLogsTool(
+  session: SandboxProcessSession,
+  options: SandboxToolsOptions,
+): AnyTool {
+  return createTool({
+    name: "read_process_logs",
+    description: "Read recent stdout and stderr from a managed sandbox process.",
+    input: readProcessLogsInput,
+    output: textOutput,
+    execute: async ({ processId, tailBytes }) => {
+      const configuredMaxLogBytes = options.process?.maxLogBytes ?? 64 * 1024;
+      if (!Number.isInteger(configuredMaxLogBytes) || configuredMaxLogBytes < 0) {
+        throw new SandboxToolPolicyError("Process maxLogBytes must be a non-negative integer.");
+      }
+      const maxLogBytes = Math.min(configuredMaxLogBytes, maxToolLogBytes);
+      const effectiveTailBytes = tailBytes ?? maxLogBytes;
+      if (effectiveTailBytes > maxLogBytes) {
+        throw new SandboxToolPolicyError(
+          `Process log request exceeds sandbox tool policy (${effectiveTailBytes} > ${maxLogBytes}).`,
+        );
+      }
+      const logs = await session.readProcessLogs(processId, {
+        tailBytes: effectiveTailBytes,
+      });
+      const parts: string[] = [];
+      if (logs.stdout.length > 0) parts.push(`stdout:\n${logs.stdout.trimEnd()}`);
+      if (logs.stderr.length > 0) parts.push(`stderr:\n${logs.stderr.trimEnd()}`);
+      if (logs.stdoutTruncated || logs.stderrTruncated) parts.push("output_truncated: true");
+      return parts.length > 0 ? parts.join("\n\n") : "No process output.";
+    },
+  });
+}
+
+function createStopProcessTool(
+  session: SandboxProcessSession,
+  options: SandboxToolsOptions,
+): AnyTool {
+  return createTool({
+    name: "stop_process",
+    description: "Stop a managed sandbox process.",
+    input: processIdInput,
+    output: textOutput,
+    execute: async ({ processId }) =>
+      formatProcessInfo(
+        await session.stopProcess(processId, {
+          gracePeriodMs: options.process?.stopGracePeriodMs ?? 5_000,
+        }),
+      ),
+  });
+}
+
+function createWaitForPortTool(session: SandboxPortSession, options: SandboxToolsOptions): AnyTool {
+  return createTool({
+    name: "wait_for_port",
+    description: "Wait until a pre-authorized sandbox TCP port is accepting connections.",
+    input: waitForPortInput,
+    output: textOutput,
+    execute: async ({ containerPort, timeoutMs }) => {
+      const effectiveTimeoutMs = timeoutMs ?? options.process?.defaultWaitTimeoutMs ?? 30_000;
+      const maxWaitTimeoutMs = options.process?.maxWaitTimeoutMs ?? 300_000;
+      if (effectiveTimeoutMs > maxWaitTimeoutMs) {
+        throw new SandboxToolPolicyError(
+          `Port wait timeout exceeds sandbox tool policy (${effectiveTimeoutMs} > ${maxWaitTimeoutMs}).`,
+        );
+      }
+      const port = await session.waitForPort(containerPort, {
+        timeoutMs: effectiveTimeoutMs,
+      });
+      return `ready: ${port.containerPort}/${port.protocol} -> ${port.host}:${port.hostPort}`;
+    },
+  });
+}
+
 function formatExecResult(result: SandboxExecResult): string {
   const parts = [`exit_code: ${result.exitCode}`];
 
@@ -189,6 +396,67 @@ function formatExecResult(result: SandboxExecResult): string {
   }
 
   return parts.join("\n\n");
+}
+
+function formatProcessInfo(process: SandboxProcessInfo): string {
+  const parts = [
+    `process_id: ${process.id}`,
+    `status: ${process.status}`,
+    `command: ${[process.command, ...process.args].join(" ")}`,
+  ];
+  if (process.exitCode !== undefined) parts.push(`exit_code: ${process.exitCode}`);
+  return parts.join("\n");
+}
+
+function requirePortSession(session: SandboxSession): SandboxPortSession {
+  if (!isSandboxPortSession(session)) {
+    throw new SandboxToolPolicyError("The sandbox session does not support published port tools.");
+  }
+  return session;
+}
+
+function requireProcessSession(session: SandboxSession): SandboxProcessSession {
+  if (!isSandboxProcessSession(session)) {
+    throw new SandboxToolPolicyError("The sandbox session does not support managed process tools.");
+  }
+  return session;
+}
+
+function assertProcessToolPolicy(options: SandboxToolsOptions): void {
+  const policy = options.process;
+  if (policy === undefined) return;
+  if (
+    policy.maxLogBytes !== undefined &&
+    (!Number.isInteger(policy.maxLogBytes) ||
+      policy.maxLogBytes < 0 ||
+      policy.maxLogBytes > maxToolLogBytes)
+  ) {
+    throw new SandboxToolPolicyError(
+      `Process maxLogBytes must be an integer from 0 to ${maxToolLogBytes}.`,
+    );
+  }
+  const maxWaitTimeoutMs = policy.maxWaitTimeoutMs ?? 300_000;
+  if (!Number.isInteger(maxWaitTimeoutMs) || maxWaitTimeoutMs <= 0 || maxWaitTimeoutMs > 300_000) {
+    throw new SandboxToolPolicyError(
+      "Process maxWaitTimeoutMs must be an integer from 1 to 300000.",
+    );
+  }
+  if (
+    policy.defaultWaitTimeoutMs !== undefined &&
+    (!Number.isInteger(policy.defaultWaitTimeoutMs) ||
+      policy.defaultWaitTimeoutMs <= 0 ||
+      policy.defaultWaitTimeoutMs > maxWaitTimeoutMs)
+  ) {
+    throw new SandboxToolPolicyError(
+      "Process defaultWaitTimeoutMs must be positive and no greater than maxWaitTimeoutMs.",
+    );
+  }
+  if (
+    policy.stopGracePeriodMs !== undefined &&
+    (!Number.isInteger(policy.stopGracePeriodMs) || policy.stopGracePeriodMs < 0)
+  ) {
+    throw new SandboxToolPolicyError("Process stopGracePeriodMs must be a non-negative integer.");
+  }
 }
 
 function assertCommandAllowed(command: string, options: SandboxToolsOptions): void {

--- a/packages/tool-sandbox/src/types.ts
+++ b/packages/tool-sandbox/src/types.ts
@@ -41,11 +41,36 @@ export interface SandboxSession {
   destroy(): Promise<void>;
 }
 
+export interface SandboxPortSession extends SandboxSession {
+  readonly publishedPorts: readonly SandboxPublishedPort[];
+
+  waitForPort(
+    containerPort: number,
+    options?: SandboxWaitForPortOptions,
+  ): Promise<SandboxPublishedPort>;
+}
+
+export interface SandboxProcessSession extends SandboxSession {
+  startProcess(options: SandboxProcessStartOptions): Promise<SandboxProcessInfo>;
+  listProcesses(): Promise<SandboxProcessInfo[]>;
+  readProcessLogs(
+    processId: string,
+    options?: SandboxProcessLogsOptions,
+  ): Promise<SandboxProcessLogs>;
+  stopProcess(processId: string, options?: SandboxProcessStopOptions): Promise<SandboxProcessInfo>;
+}
+
+export interface DockerSandboxSession extends SandboxPortSession, SandboxProcessSession {}
+
 export interface SandboxCreateSessionOptions {
   id?: string;
   workspace?: SandboxWorkspaceOptions;
   manifest?: SandboxManifest;
   metadata?: Record<string, string>;
+}
+
+export interface DockerSandboxCreateSessionOptions extends SandboxCreateSessionOptions {
+  ports?: readonly number[];
 }
 
 export interface SandboxManifest {
@@ -61,6 +86,7 @@ export interface SandboxLimits {
   memoryMb?: number;
   cpus?: number;
   pidsLimit?: number;
+  maxProcesses?: number;
 }
 
 export interface SandboxExecOptions {
@@ -106,6 +132,54 @@ export interface SandboxFileEntry {
   path: string;
   type: SandboxFileType;
   size?: number;
+}
+
+export interface SandboxPublishedPort {
+  containerPort: number;
+  host: "127.0.0.1";
+  hostPort: number;
+  protocol: "tcp";
+}
+
+export interface SandboxWaitForPortOptions {
+  timeoutMs?: number;
+  intervalMs?: number;
+  signal?: AbortSignal;
+}
+
+export interface SandboxProcessStartOptions {
+  command: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+}
+
+export type SandboxProcessStatus = "running" | "exited" | "stopped";
+
+export interface SandboxProcessInfo {
+  id: string;
+  command: string;
+  args: string[];
+  cwd?: string;
+  status: SandboxProcessStatus;
+  exitCode?: number;
+  startedAt: string;
+  endedAt?: string;
+}
+
+export interface SandboxProcessLogsOptions {
+  tailBytes?: number;
+}
+
+export interface SandboxProcessLogs {
+  stdout: string;
+  stderr: string;
+  stdoutTruncated: boolean;
+  stderrTruncated: boolean;
+}
+
+export interface SandboxProcessStopOptions {
+  gracePeriodMs?: number;
 }
 
 export interface DockerSandboxSecurityOptions {
@@ -169,9 +243,20 @@ export interface SandboxToolsOptions {
   exec?: SandboxExecToolPolicy;
   readFile?: SandboxFileToolPolicy;
   writeFile?: SandboxFileToolPolicy;
+  process?: SandboxProcessToolPolicy;
 }
 
-export type SandboxToolName = "exec_command" | "read_file" | "write_file" | "list_files";
+export type SandboxToolName =
+  | "exec_command"
+  | "read_file"
+  | "write_file"
+  | "list_files"
+  | "list_ports"
+  | "start_process"
+  | "list_processes"
+  | "read_process_logs"
+  | "stop_process"
+  | "wait_for_port";
 
 export interface SandboxExecToolPolicy {
   allowedCommands?: string[];
@@ -182,6 +267,13 @@ export interface SandboxExecToolPolicy {
 
 export interface SandboxFileToolPolicy {
   maxBytes?: number;
+}
+
+export interface SandboxProcessToolPolicy {
+  maxLogBytes?: number;
+  defaultWaitTimeoutMs?: number;
+  maxWaitTimeoutMs?: number;
+  stopGracePeriodMs?: number;
 }
 
 export type SandboxToolsFactory = (

--- a/packages/tool-sandbox/test/docker-sandbox.integration.test.ts
+++ b/packages/tool-sandbox/test/docker-sandbox.integration.test.ts
@@ -128,6 +128,9 @@ describe.skipIf(!runDockerTests)("DockerSandbox integration", () => {
     await session.writeTextFile("out/result.txt", "ok");
     await session.listFiles("out");
     await session.exec({ command: "node", args: ["-e", "console.log('hook')"] });
+    const eventsBeforeRejectedStart = [...events];
+    await expect(session.startProcess({ command: " " })).rejects.toThrow("cannot be empty");
+    expect(events).toEqual(eventsBeforeRejectedStart);
     const process = await session.startProcess({
       command: "node",
       args: ["-e", "console.log('managed hook')"],
@@ -153,6 +156,7 @@ describe.skipIf(!runDockerTests)("DockerSandbox integration", () => {
 
   it("publishes a preview port and manages a long-running server", async () => {
     const containerPort = 4310;
+    const lifecycleEvents: string[] = [];
     const sandbox = DockerSandbox.node({
       pull: "missing",
       network: true,
@@ -160,6 +164,14 @@ describe.skipIf(!runDockerTests)("DockerSandbox integration", () => {
         timeoutMs: 10_000,
         maxOutputBytes: 64_000,
         maxProcesses: 1,
+      },
+      hooks: {
+        onExecStart: () => {
+          lifecycleEvents.push("start");
+        },
+        onExecEnd: () => {
+          lifecycleEvents.push("end");
+        },
       },
     });
     const session = await sandbox.createSession({
@@ -187,6 +199,7 @@ describe.skipIf(!runDockerTests)("DockerSandbox integration", () => {
         ],
       });
       expect(process.status).toBe("running");
+      expect(lifecycleEvents).toEqual(["start"]);
 
       const publishedPort = await session.waitForPort(containerPort, { timeoutMs: 10_000 });
       const running = await session.listProcesses();
@@ -213,10 +226,33 @@ describe.skipIf(!runDockerTests)("DockerSandbox integration", () => {
       await expect(
         session.startProcess({ command: "node", args: ["-e", "setInterval(() => {}, 1000)"] }),
       ).rejects.toThrow("process limit");
+      expect(lifecycleEvents).toEqual(["start"]);
 
       const stopped = await session.stopProcess(process.id, { gracePeriodMs: 2_000 });
       expect(stopped.status).toBe("stopped");
       expect(await session.listProcesses()).toEqual([stopped]);
+
+      const grandchildServer = [
+        'const http = require("node:http");',
+        `http.createServer((_request, response) => response.end("grandchild"))`,
+        `.listen(${containerPort}, "0.0.0.0");`,
+      ].join("");
+      const grandchild = await session.startProcess({
+        command: "node",
+        args: [
+          "-e",
+          [
+            'const { spawn } = require("node:child_process");',
+            `spawn(process.execPath, ["-e", ${JSON.stringify(grandchildServer)}], { stdio: "inherit" });`,
+            "setInterval(() => {}, 1000);",
+          ].join(""),
+        ],
+      });
+      await session.waitForPort(containerPort, { timeoutMs: 10_000 });
+      await session.stopProcess(grandchild.id, { gracePeriodMs: 2_000 });
+      await expect(
+        session.waitForPort(containerPort, { timeoutMs: 500, intervalMs: 50 }),
+      ).rejects.toThrow("timed out");
 
       const loopbackOnly = await session.startProcess({
         command: "node",

--- a/packages/tool-sandbox/test/docker-sandbox.integration.test.ts
+++ b/packages/tool-sandbox/test/docker-sandbox.integration.test.ts
@@ -46,7 +46,7 @@ describe.skipIf(!runDockerTests)("DockerSandbox integration", () => {
       image: "node:22-bookworm",
       pull: "missing",
       limits: {
-        timeoutMs: 500,
+        timeoutMs: 10_000,
       },
     });
     const session = await sandbox.createSession({ id: `timeout-${Date.now()}` });
@@ -55,6 +55,7 @@ describe.skipIf(!runDockerTests)("DockerSandbox integration", () => {
       const result = await session.exec({
         command: "node",
         args: ["-e", "setTimeout(() => {}, 10_000)"],
+        timeoutMs: 500,
       });
       expect(result.timedOut).toBe(true);
       expect(result.exitCode).not.toBe(0);
@@ -84,7 +85,13 @@ describe.skipIf(!runDockerTests)("DockerSandbox integration", () => {
         events.push(event);
       }
 
-      expect(events.map((event) => event.type)).toEqual(["stdout", "stderr", "exit"]);
+      expect(events.at(-1)?.type).toBe("exit");
+      expect(
+        events
+          .slice(0, -1)
+          .map((event) => event.type)
+          .sort(),
+      ).toEqual(["stderr", "stdout"]);
       expect(events.find((event) => event.type === "stdout")?.text.trim()).toBe("one");
       expect(events.find((event) => event.type === "stderr")?.text.trim()).toBe("two");
       await expect(session.writeTextFile("too-large.txt", "12345")).rejects.toThrow("maxFileBytes");
@@ -121,6 +128,16 @@ describe.skipIf(!runDockerTests)("DockerSandbox integration", () => {
     await session.writeTextFile("out/result.txt", "ok");
     await session.listFiles("out");
     await session.exec({ command: "node", args: ["-e", "console.log('hook')"] });
+    const process = await session.startProcess({
+      command: "node",
+      args: ["-e", "console.log('managed hook')"],
+    });
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      if ((await session.listProcesses())[0]?.status === "exited") break;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    expect((await session.listProcesses())[0]?.status).toBe("exited");
+    expect((await session.readProcessLogs(process.id)).stdout).toContain("managed hook");
     await session.destroy();
 
     expect(events).toEqual([
@@ -128,8 +145,114 @@ describe.skipIf(!runDockerTests)("DockerSandbox integration", () => {
       "write:out/result.txt:2",
       "exec:start:node",
       "exec:end:0",
+      "exec:start:node",
+      "exec:end:0",
       `destroy:${session.id}`,
     ]);
+  }, 60_000);
+
+  it("publishes a preview port and manages a long-running server", async () => {
+    const containerPort = 4310;
+    const sandbox = DockerSandbox.node({
+      pull: "missing",
+      network: true,
+      limits: {
+        timeoutMs: 10_000,
+        maxOutputBytes: 64_000,
+        maxProcesses: 1,
+      },
+    });
+    const session = await sandbox.createSession({
+      id: `preview-${Date.now()}`,
+      ports: [containerPort],
+    });
+
+    try {
+      expect(session.publishedPorts).toHaveLength(1);
+      expect(session.publishedPorts[0]).toMatchObject({
+        containerPort,
+        host: "127.0.0.1",
+        protocol: "tcp",
+      });
+
+      const process = await session.startProcess({
+        command: "node",
+        args: [
+          "-e",
+          [
+            'const http = require("node:http");',
+            `http.createServer((_request, response) => response.end("sandbox preview"))`,
+            `.listen(${containerPort}, "0.0.0.0", () => console.log("preview-ready"));`,
+          ].join(""),
+        ],
+      });
+      expect(process.status).toBe("running");
+
+      const publishedPort = await session.waitForPort(containerPort, { timeoutMs: 10_000 });
+      const running = await session.listProcesses();
+      const startupLogs = await session.readProcessLogs(process.id);
+      expect(running[0]?.status, JSON.stringify(startupLogs)).toBe("running");
+      const response = await fetch(`http://${publishedPort.host}:${publishedPort.hostPort}`).catch(
+        (error: unknown) => {
+          throw new Error(
+            `Unable to fetch sandbox preview: ${JSON.stringify({ running, startupLogs })}`,
+            { cause: error },
+          );
+        },
+      );
+      expect(await response.text()).toBe("sandbox preview");
+
+      const logs = await session.readProcessLogs(process.id);
+      expect(logs.stdout).toContain("preview-ready");
+      const tailLogs = await session.readProcessLogs(process.id, { tailBytes: 5 });
+      expect(tailLogs.stdout).toBe("eady\n");
+      expect(tailLogs.stdoutTruncated).toBe(true);
+      const emptyLogs = await session.readProcessLogs(process.id, { tailBytes: 0 });
+      expect(emptyLogs.stdout).toBe("");
+      expect(emptyLogs.stdoutTruncated).toBe(true);
+      await expect(
+        session.startProcess({ command: "node", args: ["-e", "setInterval(() => {}, 1000)"] }),
+      ).rejects.toThrow("process limit");
+
+      const stopped = await session.stopProcess(process.id, { gracePeriodMs: 2_000 });
+      expect(stopped.status).toBe("stopped");
+      expect(await session.listProcesses()).toEqual([stopped]);
+
+      const loopbackOnly = await session.startProcess({
+        command: "node",
+        args: [
+          "-e",
+          `require("node:http").createServer(() => {}).listen(${containerPort}, "127.0.0.1");`,
+        ],
+      });
+      await expect(
+        session.waitForPort(containerPort, { timeoutMs: 500, intervalMs: 50 }),
+      ).rejects.toThrow("timed out");
+      await session.stopProcess(loopbackOnly.id, { gracePeriodMs: 2_000 });
+      await expect(session.waitForPort(9999)).rejects.toThrow("not published");
+    } finally {
+      await session.destroy();
+    }
+  }, 60_000);
+
+  it("applies idle cleanup while a managed process is running", async () => {
+    const sandbox = DockerSandbox.node({
+      pull: "missing",
+      lifecycle: { idleTimeoutMs: 250 },
+      limits: { timeoutMs: 10_000 },
+    });
+    const session = await sandbox.createSession({ id: `process-idle-${Date.now()}` });
+
+    try {
+      await session.startProcess({
+        command: "node",
+        args: ["-e", "setInterval(() => {}, 1000)"],
+      });
+      await new Promise((resolve) => setTimeout(resolve, 750));
+      await expect(session.listProcesses()).rejects.toThrow("has been destroyed");
+    } finally {
+      await session.destroy();
+    }
   }, 60_000);
 
   it("can reuse an explicit persistent workspace", async () => {

--- a/packages/tool-sandbox/test/docker-sandbox.test.ts
+++ b/packages/tool-sandbox/test/docker-sandbox.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { DockerSandbox } from "../src/docker-sandbox";
+import { SandboxPortError } from "../src/errors";
+
+describe("DockerSandbox port validation", () => {
+  it("rejects published ports while networking is disabled", async () => {
+    const sandbox = new DockerSandbox({ pull: "never", network: false });
+
+    await expect(sandbox.createSession({ ports: [5173] })).rejects.toThrow(SandboxPortError);
+  });
+
+  it("rejects invalid and duplicate published ports before using Docker", async () => {
+    const sandbox = new DockerSandbox({ pull: "never", network: true });
+
+    await expect(sandbox.createSession({ ports: [0] })).rejects.toThrow("1 to 65535");
+    await expect(sandbox.createSession({ ports: [65_536] })).rejects.toThrow("1 to 65535");
+    await expect(sandbox.createSession({ ports: [5173, 5173] })).rejects.toThrow("duplicated");
+  });
+
+  it("rejects Docker network modes that cannot publish ports", async () => {
+    for (const network of ["none", "host", "container:another"] as const) {
+      const sandbox = new DockerSandbox({ pull: "never", network });
+      await expect(sandbox.createSession({ ports: [5173] })).rejects.toThrow(
+        "bridge-capable Docker network",
+      );
+    }
+  });
+});

--- a/packages/tool-sandbox/test/tools.test.ts
+++ b/packages/tool-sandbox/test/tools.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createSandboxTools } from "../src/tools";
-import type { SandboxSession } from "../src/types";
+import type { DockerSandboxSession, SandboxSession } from "../src/types";
 
 describe("createSandboxTools", () => {
   it("creates the default sandbox tool bundle", () => {
@@ -105,6 +105,100 @@ describe("createSandboxTools", () => {
     expect(read).toBe("file content");
     expect(list).toContain("file 12b\ta.txt");
   });
+
+  it("creates opt-in published port and managed process tools", () => {
+    const tools = createSandboxTools(createManagedSession(), {
+      include: [
+        "list_ports",
+        "start_process",
+        "list_processes",
+        "read_process_logs",
+        "stop_process",
+        "wait_for_port",
+      ],
+    });
+
+    expect(tools.map((tool) => tool.name)).toEqual([
+      "list_ports",
+      "start_process",
+      "list_processes",
+      "read_process_logs",
+      "stop_process",
+      "wait_for_port",
+    ]);
+  });
+
+  it("delegates managed process and port tools with structured input", async () => {
+    const session = createManagedSession();
+    const tools = Object.fromEntries(
+      createSandboxTools(session, {
+        include: [
+          "list_ports",
+          "start_process",
+          "list_processes",
+          "read_process_logs",
+          "stop_process",
+          "wait_for_port",
+        ],
+        exec: { allowedCommands: ["pnpm"] },
+        process: {
+          maxLogBytes: 1024,
+          defaultWaitTimeoutMs: 1234,
+          stopGracePeriodMs: 250,
+        },
+      }).map((tool) => [tool.name, tool] as const),
+    );
+
+    const ports = await tools.list_ports?.call({});
+    const started = await tools.start_process?.call({
+      command: "pnpm",
+      args: ["dev"],
+      cwd: "site",
+    });
+    await tools.list_processes?.call({});
+    const logs = await tools.read_process_logs?.call({ processId: "process_1", tailBytes: 512 });
+    await tools.stop_process?.call({ processId: "process_1" });
+    const ready = await tools.wait_for_port?.call({ containerPort: 5173 });
+
+    expect(ports).toContain("5173/tcp");
+    expect(started).toContain("process_id: process_1");
+    expect(logs).toContain("stdout:");
+    expect(ready).toContain("ready: 5173/tcp");
+    expect(session.startProcess).toHaveBeenCalledWith({
+      command: "pnpm",
+      args: ["dev"],
+      cwd: "site",
+    });
+    expect(session.readProcessLogs).toHaveBeenCalledWith("process_1", { tailBytes: 512 });
+    expect(session.stopProcess).toHaveBeenCalledWith("process_1", { gracePeriodMs: 250 });
+    expect(session.waitForPort).toHaveBeenCalledWith(5173, { timeoutMs: 1234 });
+  });
+
+  it("applies command and log policies to managed process tools", async () => {
+    const tools = Object.fromEntries(
+      createSandboxTools(createManagedSession(), {
+        include: ["start_process", "read_process_logs"],
+        exec: { allowedCommands: ["node"] },
+        process: { maxLogBytes: 128 },
+      }).map((tool) => [tool.name, tool] as const),
+    );
+
+    await expect(tools.start_process?.call({ command: "pnpm" })).rejects.toThrow(
+      "Command is not allowed",
+    );
+    await expect(
+      tools.read_process_logs?.call({ processId: "process_1", tailBytes: 129 }),
+    ).rejects.toThrow("exceeds sandbox tool policy");
+  });
+
+  it("rejects process tools for sessions without the capability", () => {
+    expect(() => createSandboxTools(createSession(), { include: ["start_process"] })).toThrow(
+      "does not support managed process tools",
+    );
+    expect(() => createSandboxTools(createSession(), { include: ["list_ports"] })).toThrow(
+      "does not support published port tools",
+    );
+  });
 });
 
 function createSession(): SandboxSession {
@@ -143,5 +237,49 @@ function createSession(): SandboxSession {
     writeTextFile: vi.fn(async () => undefined),
     listFiles: vi.fn(async () => [{ path: "a.txt", type: "file" as const, size: 12 }]),
     destroy: vi.fn(async () => undefined),
+  };
+}
+
+function createManagedSession(): DockerSandboxSession {
+  return {
+    ...createSession(),
+    publishedPorts: [{ containerPort: 5173, host: "127.0.0.1", hostPort: 49_152, protocol: "tcp" }],
+    waitForPort: vi.fn(async () => ({
+      containerPort: 5173,
+      host: "127.0.0.1" as const,
+      hostPort: 49_152,
+      protocol: "tcp" as const,
+    })),
+    startProcess: vi.fn(async () => ({
+      id: "process_1",
+      command: "pnpm",
+      args: ["dev"],
+      status: "running" as const,
+      startedAt: "2026-07-15T00:00:00.000Z",
+    })),
+    listProcesses: vi.fn(async () => [
+      {
+        id: "process_1",
+        command: "pnpm",
+        args: ["dev"],
+        status: "running" as const,
+        startedAt: "2026-07-15T00:00:00.000Z",
+      },
+    ]),
+    readProcessLogs: vi.fn(async () => ({
+      stdout: "ready\n",
+      stderr: "",
+      stdoutTruncated: false,
+      stderrTruncated: false,
+    })),
+    stopProcess: vi.fn(async () => ({
+      id: "process_1",
+      command: "pnpm",
+      args: ["dev"],
+      status: "stopped" as const,
+      exitCode: 143,
+      startedAt: "2026-07-15T00:00:00.000Z",
+      endedAt: "2026-07-15T00:00:01.000Z",
+    })),
   };
 }


### PR DESCRIPTION
## Summary

- allow Docker sandbox sessions to pre-authorize TCP ports and receive random loopback host bindings
- add generic managed-process lifecycle, bounded logs, readiness checks, and cleanup
- expose opt-in agent tools for discovering ports and starting, inspecting, waiting for, and stopping preview servers
- document the application-owned authenticated reverse-proxy boundary and add a minor changeset

## Why

Agents could create website files in a sandbox, but they could not keep a development server running or provide the application with a safe host target for a live preview. This adds those primitives without hardcoding a framework or exposing Docker ports publicly.

## Impact

- the existing default sandbox tool bundle is unchanged
- preview ports must be declared when the session is created and require a bridge-capable Docker network
- Docker binds each preview to a random port on `127.0.0.1`; the consuming application remains responsible for authentication and public HTTP/WebSocket proxying
- managed process output and retained process records are bounded by sandbox limits

## Validation

- `ANVIA_SANDBOX_DOCKER_TESTS=1 pnpm --filter @anvia/sandbox test` — 25 tests passed
- `pnpm --filter @anvia/sandbox typecheck`
- `pnpm --filter @anvia/sandbox build`
- `pnpm check`
- `pnpm --filter www reference-check`
- `pnpm --filter www build` — 521 pages built
- `pnpm changeset status --since upstream/main`
- `git diff --check`

No generated files were intentionally changed. Documentation changes were verified through the static build; no browser screenshot was taken.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in website preview support for sandboxed applications.
  * Agents can start, monitor, inspect logs for, and stop long-running development servers.
  * Added published-port readiness checks and safe loopback-only port access.
  * Added configurable process limits and controls for preview-related agent tools.

* **Documentation**
  * Added setup examples and usage guidance for agent-managed live website previews.
  * Expanded the sandbox API reference with port, process, policy, and error details.

* **Bug Fixes**
  * Improved cleanup of managed processes and handling of process and port errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->