### PR TITLE
Add prompt-level completion retries

### DIFF
--- a/.changeset/calm-models-retry.md
+++ b/.changeset/calm-models-retry.md
@@ -1,0 +1,5 @@
+---
+"@anvia/core": patch
+---
+
+Add prompt-scoped completion retries for transient non-streaming and pre-output streaming failures.

--- a/apps/www/src/content/docs/advanced/errors-and-limits.md
+++ b/apps/www/src/content/docs/advanced/errors-and-limits.md
@@ -77,9 +77,26 @@ Provider failures should be classified before retrying. Retry bounded transient 
 
 ## Retry Policy
 
-Retries belong outside the prompt. A runner or job worker should decide whether an error is retryable, how many attempts are allowed, and whether the workflow has already performed a side effect.
+Completion retries belong on the prompt request, outside prompt text. Enable them when a runner needs bounded recovery from transient provider failures:
 
-For read-only completions, bounded retries are usually safe. For tool-calling agents, retries require more care. A failed final model call may happen after a tool already changed product state. Use idempotency records around side-effect tools before retrying the full run.
+```ts
+const response = await agent
+  .prompt(input)
+  .withCompletionRetries({
+    maxAttempts: 3,
+    initialDelayMs: 100,
+    maxDelayMs: 1_000,
+  })
+  .send();
+```
+
+This policy retries only the failed model invocation in its current turn. It does not restart the agent run or replay completed tools. Request middleware, completion hooks, turn accounting, and memory writes retain their logical once-per-call behavior.
+
+For streaming, core retries only when the provider fails before producing any non-error stream event. Once text, reasoning, tool-call data, a message id, or a final response has arrived, the existing stream fails instead of restarting and duplicating output.
+
+For read-only completions, bounded retries are usually safe. Keep side-effecting tools idempotent even though completion retries do not replay them: the provider may have processed a request before the connection failed, and application-level retries or job retries can still replay a wider workflow. Provider SDK retries and Anvia request retries stack, so set both budgets intentionally.
+
+Use `shouldRetry` for provider-specific errors that the default transient classifier cannot recognize. Do not classify authentication, permission, invalid-request, or ordinary model-not-found failures as transient unless the provider contract explicitly guarantees temporary behavior.
 
 ## Runner Error Mapping
 

--- a/apps/www/src/content/docs/advanced/runtime-lifecycle.md
+++ b/apps/www/src/content/docs/advanced/runtime-lifecycle.md
@@ -49,7 +49,7 @@ For a session run, core performs the same sequence for `.send()` and `.stream()`
 5. Resolve dynamic context and dynamic tool definitions from the current prompt text.
 6. Build the provider-neutral completion request.
 7. Apply completion request middleware.
-8. Call the model.
+8. Call the model, applying any request-scoped completion retry policy without consuming another turn.
 9. Apply completion response middleware and run completion hooks.
 10. Store the assistant message according to the memory save policy.
 11. Execute requested tools, including approvals, tool hooks, tool middleware, and tool observers.
@@ -74,6 +74,8 @@ for await (const event of request.stream()) {
 ```
 
 Streaming emits runtime events, not only text. It can include turn starts, text deltas, reasoning deltas, tool calls, tool results, nested agent tool events, final output, and errors. Filter events before sending them to browser clients if tool arguments or results may contain private data.
+
+`withCompletionRetries(...)` applies to both send and stream execution. Recovered attempts are transparent to the public event stream and are recorded as sanitized `completion.retry` observer events. Streaming retries stop permanently after the first non-error provider event, including provider events that are used internally and not emitted to the caller.
 
 ## Memory And Event Storage
 

--- a/apps/www/src/content/docs/packages/core/reference/request.md
+++ b/apps/www/src/content/docs/packages/core/reference/request.md
@@ -14,6 +14,7 @@ Import from `@anvia/core/request` when a reusable package needs prompt-run contr
 ```ts
 class PromptRequest<M extends CompletionModel = CompletionModel> {
   maxTurns(maxTurns: number): this;
+  withCompletionRetries(options?: CompletionRetryOptions): this;
   withHook(hook: PromptHook): this;
   /** @deprecated Use withHook instead. */
   requestHook(hook: PromptHook): this;
@@ -35,6 +36,39 @@ class PromptRequest<M extends CompletionModel = CompletionModel> {
 Purpose: per-run request state returned by `agent.prompt(...)` or `agent.session(...).prompt(...)`.
 
 Return behavior: `send()` resolves a final response; `stream()` yields agent run events and ends with a `final` event; `readableStream()` wraps the async iterable in a web stream.
+
+`withCompletionRetries(...)` retries only a failed model invocation within the current turn. It does not restart the run, consume another turn, replay completed tools, or re-run request middleware and hooks. Streaming calls are retried only when the provider fails before yielding any non-error event.
+
+## CompletionRetryOptions
+
+```ts
+type CompletionRetryOptions = {
+  maxAttempts?: number;
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+  shouldRetry?: (context: CompletionRetryContext) => boolean;
+};
+```
+
+Purpose: opt-in, request-scoped retry policy for model calls made by `send()`, `stream()`, and `readableStream()`.
+
+Defaults: three total attempts, a 100 ms initial delay, a 1,000 ms maximum delay, factor-two exponential backoff with full jitter, and conservative transient-error classification. The built-in classifier retries status codes 408, 409, 425, 429, and 5xx responses plus common timeout and connection errors. Abort, authentication, permission, invalid-request, and unrecognized errors are not retried.
+
+`maxAttempts` includes the initial call. A custom `shouldRetry` replaces the built-in classifier. Anvia retries are additional to retries performed by the provider SDK. Core uses its configured local backoff and does not interpret provider `Retry-After` headers.
+
+## CompletionRetryContext
+
+```ts
+type CompletionRetryContext = {
+  error: unknown;
+  attempt: number;
+  maxAttempts: number;
+  turn: number;
+  streaming: boolean;
+};
+```
+
+Purpose: context passed to a custom completion retry classifier. `attempt` identifies the failed attempt and is one-based.
 
 ## PromptResponse
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,6 +72,7 @@ export {
 } from "./hooks";
 export type { MemoryStore } from "./memory";
 export { MaxTurnsError, PromptCancelledError, ToolApprovalRequiredError } from "./request/errors";
+export type { CompletionRetryContext, CompletionRetryOptions } from "./request/retry";
 export type {
   AgentChildStreamEvent,
   AgentStreamEvent,

--- a/packages/core/src/request/index.ts
+++ b/packages/core/src/request/index.ts
@@ -1,5 +1,6 @@
 export { MaxTurnsError, PromptCancelledError, ToolApprovalRequiredError } from "./errors";
 export { PromptRequest } from "./prompt-request";
+export type { CompletionRetryContext, CompletionRetryOptions } from "./retry";
 export type {
   AgentChildStreamEvent,
   AgentDeltaEvent,

--- a/packages/core/src/request/prompt-request.ts
+++ b/packages/core/src/request/prompt-request.ts
@@ -52,6 +52,14 @@ import { toReadableStream } from "../streaming";
 import type { ToolApprovalsOptions } from "../tool";
 import type { AgentMiddleware, ToolMiddleware } from "../tool/middleware";
 import { MaxTurnsError, PromptCancelledError } from "./errors";
+import {
+  type CompletionRetryOptions,
+  completionRetryDelayMs,
+  completionRetryErrorAttributes,
+  type ResolvedCompletionRetryOptions,
+  resolveCompletionRetryOptions,
+  waitForCompletionRetry,
+} from "./retry";
 import type { AgentStreamEvent, PromptResponse } from "./types";
 
 export class PromptRequest<M extends CompletionModel = CompletionModel> {
@@ -63,6 +71,7 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
   private guardrailDecisions: GuardrailDecisionRecord[] = [];
   private concurrency = 1;
   private traceOptions: AgentTraceOptions | undefined;
+  private completionRetryOptions: ResolvedCompletionRetryOptions | undefined;
   private requestMiddlewares: AgentMiddleware[] = [];
   private readonly steeringMessages: MessageType[] = [];
   private runState: "idle" | "running" | "completed" | "errored" | "cancelled" = "idle";
@@ -93,6 +102,11 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
 
   maxTurns(maxTurns: number): this {
     this.maxTurnCount = maxTurns;
+    return this;
+  }
+
+  withCompletionRetries(options: CompletionRetryOptions = {}): this {
+    this.completionRetryOptions = resolveCompletionRetryOptions(options);
     return this;
   }
 
@@ -443,29 +457,51 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
         const emittedToolCallIds = new Set<string>();
         let response: CompletionResponse;
         try {
-          for await (const event of this.agent.model.streamCompletion(request)) {
-            if (firstDeltaMs === undefined && isGenerationDeltaEvent(event.type)) {
-              firstDeltaMs = Date.now() - generationStartedAt;
-            }
-            const mapped = accumulator.accept(event);
-            if (event.type === "error") {
-              throw event.error;
-            }
-            if (mapped !== undefined) {
-              await generationObservers.update?.({ turn: currentTurns, delta: mapped });
-              if (mapped.type === "tool_call") {
-                emittedToolCallIds.add(mapped.toolCall.id);
+          for (let attempt = 1; ; attempt += 1) {
+            let hasProviderProgress = false;
+            try {
+              for await (const event of this.agent.model.streamCompletion(request)) {
+                if (event.type === "error") {
+                  throw event.error;
+                }
+                hasProviderProgress = true;
+                if (firstDeltaMs === undefined && isGenerationDeltaEvent(event.type)) {
+                  firstDeltaMs = Date.now() - generationStartedAt;
+                }
+                const mapped = accumulator.accept(event);
+                if (mapped !== undefined) {
+                  await generationObservers.update?.({ turn: currentTurns, delta: mapped });
+                  if (mapped.type === "tool_call") {
+                    emittedToolCallIds.add(mapped.toolCall.id);
+                  }
+                  const shouldBuffer =
+                    bufferResponseEvents ||
+                    (bufferOutputDeltas &&
+                      (mapped.type === "text_delta" || mapped.type === "reasoning_delta"));
+                  if (!shouldBuffer) {
+                    yield await emit(addTurn(currentTurns, mapped));
+                  }
+                }
               }
-              const shouldBuffer =
-                bufferResponseEvents ||
-                (bufferOutputDeltas &&
-                  (mapped.type === "text_delta" || mapped.type === "reasoning_delta"));
-              if (!shouldBuffer) {
-                yield await emit(addTurn(currentTurns, mapped));
+              response = accumulator.response();
+              break;
+            } catch (error) {
+              const retryOptions = hasProviderProgress
+                ? undefined
+                : this.retryOptionsForFailure(error, attempt, currentTurns, true);
+              if (retryOptions === undefined) {
+                throw error;
               }
+              await this.scheduleCompletionRetry(
+                error,
+                attempt,
+                currentTurns,
+                true,
+                retryOptions,
+                runObservers,
+              );
             }
           }
-          response = accumulator.response();
         } catch (error) {
           await generationObservers.error({ turn: currentTurns, error });
           await this.runCompletionErrorHook(prompt, error, newMessages);
@@ -655,9 +691,28 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
       this.generationStartArgs(turn, request, providerRequest),
     );
     try {
-      const response = await this.agent.model.completion(request);
-      await generationObservers.end({ turn, response });
-      return response;
+      for (let attempt = 1; ; attempt += 1) {
+        let response: CompletionResponse;
+        try {
+          response = await this.agent.model.completion(request);
+        } catch (error) {
+          const retryOptions = this.retryOptionsForFailure(error, attempt, turn, false);
+          if (retryOptions === undefined) {
+            throw error;
+          }
+          await this.scheduleCompletionRetry(
+            error,
+            attempt,
+            turn,
+            false,
+            retryOptions,
+            runObservers,
+          );
+          continue;
+        }
+        await generationObservers.end({ turn, response });
+        return response;
+      }
     } catch (error) {
       await generationObservers.error({ turn, error });
       throw error;
@@ -695,6 +750,51 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
       args.providerRequest = providerRequest;
     }
     return args;
+  }
+
+  private retryOptionsForFailure(
+    error: unknown,
+    attempt: number,
+    turn: number,
+    streaming: boolean,
+  ): ResolvedCompletionRetryOptions | undefined {
+    const options = this.completionRetryOptions;
+    if (options === undefined || attempt >= options.maxAttempts) {
+      return undefined;
+    }
+    const shouldRetry = options.shouldRetry({
+      error,
+      attempt,
+      maxAttempts: options.maxAttempts,
+      turn,
+      streaming,
+    });
+    return shouldRetry ? options : undefined;
+  }
+
+  private async scheduleCompletionRetry(
+    error: unknown,
+    attempt: number,
+    turn: number,
+    streaming: boolean,
+    options: ResolvedCompletionRetryOptions,
+    runObservers: ActiveAgentRunObservers,
+  ): Promise<void> {
+    const delayMs = completionRetryDelayMs(options, attempt);
+    await runObservers.event({
+      name: "completion.retry",
+      level: "WARNING",
+      attributes: {
+        turn,
+        attempt,
+        nextAttempt: attempt + 1,
+        maxAttempts: options.maxAttempts,
+        delayMs,
+        streaming,
+        ...completionRetryErrorAttributes(error),
+      },
+    });
+    await waitForCompletionRetry(delayMs);
   }
 
   private async executeToolCalls(

--- a/packages/core/src/request/retry.ts
+++ b/packages/core/src/request/retry.ts
@@ -1,0 +1,201 @@
+import type { JsonValue } from "../completion";
+
+export type CompletionRetryContext = {
+  error: unknown;
+  attempt: number;
+  maxAttempts: number;
+  turn: number;
+  streaming: boolean;
+};
+
+export type CompletionRetryOptions = {
+  maxAttempts?: number | undefined;
+  initialDelayMs?: number | undefined;
+  maxDelayMs?: number | undefined;
+  shouldRetry?: ((context: CompletionRetryContext) => boolean) | undefined;
+};
+
+export type ResolvedCompletionRetryOptions = {
+  maxAttempts: number;
+  initialDelayMs: number;
+  maxDelayMs: number;
+  shouldRetry: (context: CompletionRetryContext) => boolean;
+};
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_INITIAL_DELAY_MS = 100;
+const DEFAULT_MAX_DELAY_MS = 1_000;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+const RETRYABLE_STATUS_CODES = new Set([408, 409, 425, 429]);
+const RETRYABLE_NUMERIC_ERROR_CODES = new Set([4, 8, 14]);
+const RETRYABLE_ERROR_NAMES = new Set([
+  "APIConnectionError",
+  "APIConnectionTimeoutError",
+  "TimeoutError",
+]);
+const RETRYABLE_ERROR_CODES = new Set([
+  "DEADLINE_EXCEEDED",
+  "EAI_AGAIN",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETDOWN",
+  "ENETUNREACH",
+  "EPIPE",
+  "ETIMEDOUT",
+  "RESOURCE_EXHAUSTED",
+  "UNAVAILABLE",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+
+export function resolveCompletionRetryOptions(
+  options: CompletionRetryOptions,
+): ResolvedCompletionRetryOptions {
+  const maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const initialDelayMs = options.initialDelayMs ?? DEFAULT_INITIAL_DELAY_MS;
+  const maxDelayMs = options.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
+
+  if (!Number.isSafeInteger(maxAttempts) || maxAttempts < 1) {
+    throw new RangeError("Completion retry maxAttempts must be a positive integer.");
+  }
+  assertDelay(initialDelayMs, "initialDelayMs");
+  assertDelay(maxDelayMs, "maxDelayMs");
+  if (maxDelayMs < initialDelayMs) {
+    throw new RangeError(
+      "Completion retry maxDelayMs must be greater than or equal to initialDelayMs.",
+    );
+  }
+  if (options.shouldRetry !== undefined && typeof options.shouldRetry !== "function") {
+    throw new TypeError("Completion retry shouldRetry must be a function.");
+  }
+
+  return {
+    maxAttempts,
+    initialDelayMs,
+    maxDelayMs,
+    shouldRetry: options.shouldRetry ?? defaultShouldRetry,
+  };
+}
+
+export function completionRetryDelayMs(
+  options: ResolvedCompletionRetryOptions,
+  failedAttempt: number,
+): number {
+  const exponentialDelay = options.initialDelayMs * 2 ** (failedAttempt - 1);
+  const cappedDelay = Math.min(options.maxDelayMs, exponentialDelay);
+  return Math.random() * cappedDelay;
+}
+
+export function completionRetryErrorAttributes(
+  error: unknown,
+): Record<string, JsonValue | undefined> {
+  const errors = errorChain(error);
+  const errorName = errors
+    .map((candidate) => stringProperty(candidate, "name"))
+    .find((value) => value !== undefined);
+  const statusCode = firstStatusCode(errors);
+  const errorCode = errors
+    .map((candidate) => errorCodeProperty(candidate))
+    .find((value) => value !== undefined);
+
+  return {
+    errorName,
+    statusCode,
+    errorCode,
+  };
+}
+
+export async function waitForCompletionRetry(delayMs: number): Promise<void> {
+  if (delayMs === 0) {
+    return;
+  }
+  await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+}
+
+function defaultShouldRetry(context: CompletionRetryContext): boolean {
+  const errors = errorChain(context.error);
+  if (errors.some((error) => stringProperty(error, "name") === "AbortError")) {
+    return false;
+  }
+
+  const statusCode = firstStatusCode(errors);
+  if (statusCode !== undefined) {
+    return RETRYABLE_STATUS_CODES.has(statusCode) || (statusCode >= 500 && statusCode <= 599);
+  }
+
+  return errors.some((error) => {
+    const name = stringProperty(error, "name");
+    if (name !== undefined && RETRYABLE_ERROR_NAMES.has(name)) {
+      return true;
+    }
+    const code = stringProperty(error, "code")?.toUpperCase();
+    if (code !== undefined && RETRYABLE_ERROR_CODES.has(code)) {
+      return true;
+    }
+    const numericCode = numberProperty(error, "code");
+    return numericCode !== undefined && RETRYABLE_NUMERIC_ERROR_CODES.has(numericCode);
+  });
+}
+
+function firstStatusCode(errors: Record<string, unknown>[]): number | undefined {
+  for (const error of errors) {
+    const status = numberProperty(error, "status") ?? numberProperty(error, "statusCode");
+    if (status !== undefined) {
+      return status;
+    }
+    const code = numberProperty(error, "code");
+    if (code !== undefined && code >= 100 && code <= 599) {
+      return code;
+    }
+  }
+  return undefined;
+}
+
+function errorChain(error: unknown): Record<string, unknown>[] {
+  const errors: Record<string, unknown>[] = [];
+  const seen = new Set<object>();
+  let current = error;
+  while (isObject(current) && !seen.has(current)) {
+    seen.add(current);
+    errors.push(current);
+    current = property(current, "cause");
+  }
+  return errors;
+}
+
+function assertDelay(value: number, name: string): void {
+  if (!Number.isFinite(value) || value < 0 || value > MAX_TIMER_DELAY_MS) {
+    throw new RangeError(
+      `Completion retry ${name} must be between 0 and ${MAX_TIMER_DELAY_MS} milliseconds.`,
+    );
+  }
+}
+
+function numberProperty(value: Record<string, unknown>, name: string): number | undefined {
+  const candidate = property(value, name);
+  return typeof candidate === "number" && Number.isFinite(candidate) ? candidate : undefined;
+}
+
+function stringProperty(value: Record<string, unknown>, name: string): string | undefined {
+  const candidate = property(value, name);
+  return typeof candidate === "string" && candidate.length > 0 ? candidate : undefined;
+}
+
+function errorCodeProperty(value: Record<string, unknown>): string | number | undefined {
+  return stringProperty(value, "code") ?? numberProperty(value, "code");
+}
+
+function property(value: Record<string, unknown>, name: string): unknown {
+  try {
+    return value[name];
+  } catch {
+    return undefined;
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/packages/core/test/completion-retry.test.ts
+++ b/packages/core/test/completion-retry.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { completionRetryDelayMs, resolveCompletionRetryOptions } from "../src/request/retry";
+
+describe("completion retry policy", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses capped exponential backoff with full jitter", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const options = resolveCompletionRetryOptions({
+      initialDelayMs: 100,
+      maxDelayMs: 250,
+    });
+
+    expect(completionRetryDelayMs(options, 1)).toBe(50);
+    expect(completionRetryDelayMs(options, 2)).toBe(100);
+    expect(completionRetryDelayMs(options, 3)).toBe(125);
+    expect(completionRetryDelayMs(options, 4)).toBe(125);
+  });
+
+  it("classifies HTTP, nested network, gRPC, and abort errors conservatively", () => {
+    const shouldRetry = resolveCompletionRetryOptions({}).shouldRetry;
+    const context = (error: unknown) => ({
+      error,
+      attempt: 1,
+      maxAttempts: 3,
+      turn: 1,
+      streaming: false,
+    });
+
+    expect(shouldRetry(context({ status: 503 }))).toBe(true);
+    expect(shouldRetry(context({ status: 404 }))).toBe(false);
+    expect(shouldRetry(context(new Error("outer", { cause: { code: "ECONNRESET" } })))).toBe(true);
+    expect(shouldRetry(context({ code: 14 }))).toBe(true);
+    expect(shouldRetry(context({ name: "AbortError", status: 503 }))).toBe(false);
+    expect(shouldRetry(context(new Error("unknown")))).toBe(false);
+  });
+});

--- a/packages/core/test/memory.test.ts
+++ b/packages/core/test/memory.test.ts
@@ -162,6 +162,39 @@ describe("agent memory", () => {
     ]);
   });
 
+  it("applies completion retries to session prompts without duplicating memory", async () => {
+    const store = new RecordingMemoryStore();
+    const delegate = new QueueModel([response([AssistantContent.text("recovered")])]);
+    let attempts = 0;
+    const model: CompletionModel = {
+      provider: delegate.provider,
+      defaultModel: delegate.defaultModel,
+      capabilities: delegate.capabilities,
+      async completion(request) {
+        attempts += 1;
+        if (attempts === 1) {
+          throw Object.assign(new Error("temporarily unavailable"), { status: 503 });
+        }
+        return delegate.completion(request);
+      },
+    };
+    const agent = new AgentBuilder("test-agent", model).memory(store).build();
+
+    await expect(
+      agent
+        .session("session_1")
+        .prompt("hello")
+        .withCompletionRetries({ initialDelayMs: 0, maxDelayMs: 0 })
+        .send(),
+    ).resolves.toMatchObject({ output: "recovered" });
+
+    expect(attempts).toBe(2);
+    expect(store.appendCalls.map((call) => call.messages.map((message) => message.role))).toEqual([
+      ["user"],
+      ["assistant"],
+    ]);
+  });
+
   it("saves messages incrementally by default", async () => {
     const store = new RecordingMemoryStore();
     const model = new QueueModel([

--- a/packages/core/test/observability.test.ts
+++ b/packages/core/test/observability.test.ts
@@ -149,6 +149,9 @@ class RecordingObserver implements AgentObserver {
       error: (errorArgs: AgentRunErrorArgs) => {
         this.events.push({ type: "run_error", args: errorArgs });
       },
+      event: (eventArgs: AgentRunEventArgs) => {
+        this.events.push({ type: "run_event", args: eventArgs });
+      },
     };
   }
 }
@@ -209,6 +212,60 @@ describe("agent observability", () => {
         }),
       }),
     );
+  });
+
+  it("records recovered completion retries as sanitized run events", async () => {
+    const observer = new RecordingObserver();
+    const retryError = Object.assign(new Error("private provider detail"), {
+      status: 503,
+      code: "EAI_AGAIN",
+    });
+    const delegate = new QueueModel([response([AssistantContent.text("recovered")])]);
+    let attempts = 0;
+    const model: CompletionModel = {
+      provider: delegate.provider,
+      defaultModel: delegate.defaultModel,
+      capabilities: delegate.capabilities,
+      async completion(request) {
+        attempts += 1;
+        if (attempts === 1) {
+          throw retryError;
+        }
+        return delegate.completion(request);
+      },
+    };
+    const agent = new AgentBuilder("test-agent", model).observe(observer).build();
+
+    await expect(
+      agent.prompt("hello").withCompletionRetries({ initialDelayMs: 0, maxDelayMs: 0 }).send(),
+    ).resolves.toMatchObject({ output: "recovered" });
+
+    expect(eventTypes(observer)).toEqual([
+      "run_start",
+      "generation_start",
+      "run_event",
+      "generation_end",
+      "run_end",
+    ]);
+    expect(observer.events[2]).toEqual({
+      type: "run_event",
+      args: {
+        name: "completion.retry",
+        level: "WARNING",
+        attributes: {
+          turn: 1,
+          attempt: 1,
+          nextAttempt: 2,
+          maxAttempts: 3,
+          delayMs: 0,
+          streaming: false,
+          errorName: "Error",
+          statusCode: 503,
+          errorCode: "EAI_AGAIN",
+        },
+      },
+    });
+    expect(JSON.stringify(observer.events[2])).not.toContain("private provider detail");
   });
 
   it("records multiple turns and tool calls", async () => {

--- a/packages/core/test/prompt-request.test.ts
+++ b/packages/core/test/prompt-request.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import {
   AgentBuilder,
@@ -46,6 +46,41 @@ class QueueModel implements CompletionModel {
   }
 }
 
+type CompletionOutcome =
+  | { response: CompletionResponse }
+  | {
+      error: unknown;
+    };
+
+class FlakyQueueModel implements CompletionModel {
+  readonly provider = "test";
+  readonly defaultModel = "test";
+  readonly capabilities = {
+    streaming: false,
+    tools: true,
+    toolChoice: true,
+    imageInput: true,
+    documentInput: true,
+    outputSchema: true,
+    reasoning: true,
+  };
+  readonly requests: CompletionRequest[] = [];
+
+  constructor(private readonly outcomes: CompletionOutcome[]) {}
+
+  async completion(request: CompletionRequest): Promise<CompletionResponse> {
+    this.requests.push(request);
+    const outcome = this.outcomes.shift();
+    if (outcome === undefined) {
+      throw new Error("No queued outcome");
+    }
+    if ("error" in outcome) {
+      throw outcome.error;
+    }
+    return outcome.response;
+  }
+}
+
 function response(choice: CompletionResponse["choice"]): CompletionResponse {
   return {
     choice,
@@ -82,6 +117,218 @@ describe("PromptRequest", () => {
     expect(result.output).toBe("done");
     expect(model.requests[0]?.instructions).toBe("system");
     expect(model.requests[0]?.chatHistory[0]).toEqual(Message.user("hello"));
+  });
+
+  it("retries transient completion failures with the default policy", async () => {
+    const error = Object.assign(new Error("temporarily unavailable"), { status: 503 });
+    const model = new FlakyQueueModel([
+      { error },
+      { response: response([AssistantContent.text("recovered")]) },
+    ]);
+    const agent = new AgentBuilder("test-agent", model).build();
+    const random = vi.spyOn(Math, "random").mockReturnValue(0);
+
+    try {
+      const result = await agent.prompt("hello").withCompletionRetries().send();
+
+      expect(result.output).toBe("recovered");
+      expect(model.requests).toHaveLength(2);
+      expect(model.requests[1]).toBe(model.requests[0]);
+    } finally {
+      random.mockRestore();
+    }
+  });
+
+  it("stops after the configured completion attempts and reports one logical error", async () => {
+    const errors = [
+      Object.assign(new Error("unavailable 1"), { status: 503 }),
+      Object.assign(new Error("unavailable 2"), { status: 503 }),
+      Object.assign(new Error("unavailable 3"), { status: 503 }),
+    ];
+    const model = new FlakyQueueModel(errors.map((error) => ({ error })));
+    const hookCalls = { completionCall: 0, completionError: 0 };
+    const agent = new AgentBuilder("test-agent", model)
+      .hook(
+        createHook({
+          onCompletionCall() {
+            hookCalls.completionCall += 1;
+          },
+          onCompletionError() {
+            hookCalls.completionError += 1;
+          },
+        }),
+      )
+      .build();
+
+    await expect(
+      agent.prompt("hello").withCompletionRetries({ initialDelayMs: 0, maxDelayMs: 0 }).send(),
+    ).rejects.toBe(errors[2]);
+
+    expect(model.requests).toHaveLength(3);
+    expect(hookCalls).toEqual({ completionCall: 1, completionError: 1 });
+  });
+
+  it("does not retry non-transient completion failures", async () => {
+    const error = Object.assign(new Error("invalid request"), { status: 400 });
+    const model = new FlakyQueueModel([
+      { error },
+      { response: response([AssistantContent.text("unexpected")]) },
+    ]);
+    const agent = new AgentBuilder("test-agent", model).build();
+
+    await expect(
+      agent.prompt("hello").withCompletionRetries({ initialDelayMs: 0, maxDelayMs: 0 }).send(),
+    ).rejects.toBe(error);
+
+    expect(model.requests).toHaveLength(1);
+  });
+
+  it("recognizes transient network codes through error causes", async () => {
+    const cause = Object.assign(new Error("socket reset"), { code: "ECONNRESET" });
+    const error = new Error("provider connection failed", { cause });
+    const model = new FlakyQueueModel([
+      { error },
+      { response: response([AssistantContent.text("recovered")]) },
+    ]);
+    const agent = new AgentBuilder("test-agent", model).build();
+
+    await expect(
+      agent.prompt("hello").withCompletionRetries({ initialDelayMs: 0, maxDelayMs: 0 }).send(),
+    ).resolves.toMatchObject({ output: "recovered" });
+
+    expect(model.requests).toHaveLength(2);
+  });
+
+  it("never retries abort errors", async () => {
+    const error = Object.assign(new Error("aborted"), { name: "AbortError", status: 503 });
+    const model = new FlakyQueueModel([
+      { error },
+      { response: response([AssistantContent.text("unexpected")]) },
+    ]);
+    const agent = new AgentBuilder("test-agent", model).build();
+
+    await expect(
+      agent.prompt("hello").withCompletionRetries({ initialDelayMs: 0, maxDelayMs: 0 }).send(),
+    ).rejects.toBe(error);
+
+    expect(model.requests).toHaveLength(1);
+  });
+
+  it("supports request-specific completion retry classification", async () => {
+    const error = new Error("warming up");
+    const model = new FlakyQueueModel([
+      { error },
+      { response: response([AssistantContent.text("ready")]) },
+    ]);
+    const contexts: unknown[] = [];
+    const agent = new AgentBuilder("test-agent", model).build();
+
+    const result = await agent
+      .prompt("hello")
+      .withCompletionRetries({
+        maxAttempts: 2,
+        initialDelayMs: 0,
+        maxDelayMs: 0,
+        shouldRetry(context) {
+          contexts.push(context);
+          return context.error === error;
+        },
+      })
+      .send();
+
+    expect(result.output).toBe("ready");
+    expect(contexts).toEqual([
+      {
+        error,
+        attempt: 1,
+        maxAttempts: 2,
+        turn: 1,
+        streaming: false,
+      },
+    ]);
+  });
+
+  it("validates completion retry options when configuring the request", () => {
+    const agent = new AgentBuilder(
+      "test-agent",
+      new QueueModel([response([AssistantContent.text("unused")])]),
+    ).build();
+
+    expect(() => agent.prompt("hello").withCompletionRetries({ maxAttempts: 0 })).toThrow(
+      RangeError,
+    );
+    expect(() => agent.prompt("hello").withCompletionRetries({ maxAttempts: 1.5 })).toThrow(
+      RangeError,
+    );
+    expect(() => agent.prompt("hello").withCompletionRetries({ initialDelayMs: -1 })).toThrow(
+      RangeError,
+    );
+    expect(() =>
+      agent.prompt("hello").withCompletionRetries({ initialDelayMs: 200, maxDelayMs: 100 }),
+    ).toThrow(RangeError);
+    expect(() =>
+      agent
+        .prompt("hello")
+        .withCompletionRetries({ shouldRetry: true as unknown as () => boolean }),
+    ).toThrow(TypeError);
+  });
+
+  it("retries a later completion turn without replaying tools or request hooks", async () => {
+    let toolExecutions = 0;
+    let middlewareCalls = 0;
+    let completionCalls = 0;
+    let completionErrors = 0;
+    const countingTool = createTool({
+      name: "counted_add",
+      description: "Add numbers and count executions",
+      input: z.object({ x: z.number(), y: z.number() }),
+      output: z.number(),
+      execute: ({ x, y }) => {
+        toolExecutions += 1;
+        return x + y;
+      },
+    });
+    const model = new FlakyQueueModel([
+      {
+        response: response([AssistantContent.toolCall("call_1", "counted_add", { x: 2, y: 5 })]),
+      },
+      { error: Object.assign(new Error("temporarily unavailable"), { status: 503 }) },
+      { response: response([AssistantContent.text("7")]) },
+    ]);
+    const agent = new AgentBuilder("test-agent", model)
+      .tool(countingTool)
+      .middleware(
+        createMiddleware({
+          onCompletionRequest() {
+            middlewareCalls += 1;
+            return undefined;
+          },
+        }),
+      )
+      .hook(
+        createHook({
+          onCompletionCall() {
+            completionCalls += 1;
+          },
+          onCompletionError() {
+            completionErrors += 1;
+          },
+        }),
+      )
+      .build();
+
+    const result = await agent
+      .prompt("add")
+      .withCompletionRetries({ initialDelayMs: 0, maxDelayMs: 0 })
+      .send();
+
+    expect(result.output).toBe("7");
+    expect(model.requests).toHaveLength(3);
+    expect(toolExecutions).toBe(1);
+    expect(middlewareCalls).toBe(2);
+    expect(completionCalls).toBe(2);
+    expect(completionErrors).toBe(0);
+    expect(result.messages.filter((message) => message.role === "tool")).toHaveLength(1);
   });
 
   it("send consumes steering queued before no-tool finalization", async () => {

--- a/packages/core/test/public-exports.test.ts
+++ b/packages/core/test/public-exports.test.ts
@@ -14,7 +14,11 @@ import * as extractor from "../src/extractor";
 import * as guardrails from "../src/guardrails";
 import * as hooks from "../src/hooks";
 import * as imageGeneration from "../src/image-generation";
-import type { ToolContent as RootToolContentType } from "../src/index";
+import type {
+  CompletionRetryContext as RootCompletionRetryContext,
+  CompletionRetryOptions as RootCompletionRetryOptions,
+  ToolContent as RootToolContentType,
+} from "../src/index";
 import * as publicCore from "../src/index";
 import { Message as RootMessage, ToolContent as RootToolContent } from "../src/index";
 import * as internalAgent from "../src/internal/agent";
@@ -23,6 +27,10 @@ import * as mcp from "../src/mcp";
 import * as modelListing from "../src/model-listing";
 import * as observability from "../src/observability";
 import * as pipeline from "../src/pipeline";
+import type {
+  CompletionRetryContext as RequestCompletionRetryContext,
+  CompletionRetryOptions as RequestCompletionRetryOptions,
+} from "../src/request";
 import * as request from "../src/request";
 import * as skills from "../src/skills";
 import * as streaming from "../src/streaming";
@@ -82,6 +90,8 @@ describe("public exports", () => {
     expect("PromptCancelledError" in request).toBe(true);
     expect("MaxTurnsError" in request).toBe(true);
     expect("ToolApprovalRequiredError" in request).toBe(true);
+    expectTypeOf<RootCompletionRetryContext>().toEqualTypeOf<RequestCompletionRetryContext>();
+    expectTypeOf<RootCompletionRetryOptions>().toEqualTypeOf<RequestCompletionRetryOptions>();
   });
 
   it("does not expose removed experimental UI stream creators", () => {

--- a/packages/core/test/streaming.test.ts
+++ b/packages/core/test/streaming.test.ts
@@ -58,6 +58,14 @@ class StreamingQueueModel implements StreamingCompletionModel {
   }
 }
 
+async function* streamThenThrow(
+  events: CompletionStreamEvent[],
+  error: unknown,
+): AsyncIterable<CompletionStreamEvent> {
+  yield* events;
+  throw error;
+}
+
 class RecordingEventStore implements AgentEventStore {
   readonly appendCalls: AgentEventAppendInput[] = [];
 
@@ -109,6 +117,109 @@ describe("PromptRequest streaming", () => {
     expect(events.at(-1)).toMatchObject({ type: "final", output: "hello" });
     expect(model.requests[0]?.instructions).toBe("system");
     expect(model.requests[0]?.chatHistory[0]).toEqual(Message.user("hi"));
+  });
+
+  it("retries a transient stream failure before the first provider event", async () => {
+    const error = Object.assign(new Error("temporarily unavailable"), { status: 503 });
+    const model = new StreamingQueueModel([
+      streamThenThrow([], error),
+      [{ type: "text_delta", delta: "recovered" }],
+    ]);
+    const agent = new AgentBuilder("test-agent", model).build();
+
+    const events = await collect(
+      agent.prompt("hi").withCompletionRetries({ initialDelayMs: 0, maxDelayMs: 0 }).stream(),
+    );
+
+    expect(events.map((event) => event.type)).toEqual([
+      "turn_start",
+      "text_delta",
+      "turn_end",
+      "final",
+    ]);
+    expect(events.at(-1)).toMatchObject({ type: "final", output: "recovered" });
+    expect(model.requests).toHaveLength(2);
+    expect(model.requests[1]).toBe(model.requests[0]);
+  });
+
+  it("retries an initial provider error event without exposing it", async () => {
+    const error = Object.assign(new Error("temporarily unavailable"), { statusCode: 503 });
+    const model = new StreamingQueueModel([
+      [{ type: "error", error }],
+      [{ type: "text_delta", delta: "ready" }],
+    ]);
+    const agent = new AgentBuilder("test-agent", model).build();
+
+    const events = await collect(
+      agent.prompt("hi").withCompletionRetries({ initialDelayMs: 0, maxDelayMs: 0 }).stream(),
+    );
+
+    expect(events.some((event) => event.type === "error")).toBe(false);
+    expect(events.at(-1)).toMatchObject({ type: "final", output: "ready" });
+    expect(model.requests).toHaveLength(2);
+  });
+
+  it("applies completion retries through PromptRequest readable streams", async () => {
+    const error = Object.assign(new Error("temporarily unavailable"), { status: 503 });
+    const model = new StreamingQueueModel([
+      streamThenThrow([], error),
+      [{ type: "text_delta", delta: "ready" }],
+    ]);
+    const agent = new AgentBuilder("test-agent", model).build();
+
+    const text = await readAll(
+      agent
+        .prompt("hi")
+        .withCompletionRetries({ initialDelayMs: 0, maxDelayMs: 0 })
+        .readableStream(),
+    );
+    const events = text
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+
+    expect(events.some((event) => event.type === "error")).toBe(false);
+    expect(events.at(-1)).toMatchObject({ type: "final", output: "ready" });
+    expect(model.requests).toHaveLength(2);
+  });
+
+  it("does not retry after a provider delta has been observed", async () => {
+    const error = Object.assign(new Error("stream interrupted"), { status: 503 });
+    const model = new StreamingQueueModel([
+      streamThenThrow([{ type: "text_delta", delta: "partial" }], error),
+      [{ type: "text_delta", delta: "duplicate" }],
+    ]);
+    const agent = new AgentBuilder("test-agent", model).build();
+    const iterator = agent
+      .prompt("hi")
+      .withCompletionRetries({ initialDelayMs: 0, maxDelayMs: 0 })
+      .stream()
+      [Symbol.asyncIterator]();
+
+    expect(await nextEvent(iterator)).toMatchObject({ type: "turn_start" });
+    expect(await nextEvent(iterator)).toMatchObject({ type: "text_delta", delta: "partial" });
+    expect(await nextEvent(iterator)).toEqual({ type: "error", error });
+    await expect(iterator.next()).rejects.toBe(error);
+    expect(model.requests).toHaveLength(1);
+  });
+
+  it("does not retry after a non-emitted provider event has been observed", async () => {
+    const error = Object.assign(new Error("stream interrupted"), { status: 503 });
+    const model = new StreamingQueueModel([
+      streamThenThrow([{ type: "message_id", id: "msg_1" }], error),
+      [{ type: "text_delta", delta: "duplicate" }],
+    ]);
+    const agent = new AgentBuilder("test-agent", model).build();
+    const iterator = agent
+      .prompt("hi")
+      .withCompletionRetries({ initialDelayMs: 0, maxDelayMs: 0 })
+      .stream()
+      [Symbol.asyncIterator]();
+
+    expect(await nextEvent(iterator)).toMatchObject({ type: "turn_start" });
+    expect(await nextEvent(iterator)).toEqual({ type: "error", error });
+    await expect(iterator.next()).rejects.toBe(error);
+    expect(model.requests).toHaveLength(1);
   });
 
   it("streams post-middleware response content when response middleware is registered", async () => {


### PR DESCRIPTION
## Summary

- add request-scoped completion retries through `agent.prompt(...).withCompletionRetries(...)`
- retry transient non-streaming failures and streaming failures that occur before provider output
- add bounded exponential backoff with full jitter, conservative default classification, and a custom `shouldRetry` hook
- preserve logical-once behavior for turns, middleware, hooks, tools, memory writes, and public stream events
- emit sanitized `completion.retry` observer events and document retry stacking with provider SDKs
- add a patch changeset for `@anvia/core`

## Why

Core previously had no prompt-level retry boundary. Applications either had to wrap a `CompletionModel` or retry an entire agent run, which could replay hooks, tools, and memory effects. This adds an opt-in retry boundary around only the current provider invocation.

For streams, retries stop after the first non-error provider event so output and tool-call deltas cannot be duplicated.

## Validation

- `pnpm check`
- `pnpm --filter @anvia/core typecheck`
- `pnpm --filter @anvia/core test` — 339 tests passed
- `pnpm --filter @anvia/core build`
- `pnpm --filter './packages/**' typecheck`
- `pnpm --filter './packages/**' --filter '!@anvia/react' test`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @anvia/react test` — 97 tests passed
- `pnpm --filter www reference-check`
- `pnpm --filter www build` — 521 pages built

The unmodified all-package test command was also attempted under Node 25.5.0; `@anvia/react` encountered Node's experimental web-storage global collision. Its complete suite passed with experimental Node web storage disabled as shown above. Docker integration tests remain skipped unless `ANVIA_SANDBOX_DOCKER_TESTS=1` is configured.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional, prompt-scoped retries for transient completion failures.
  * Supports both standard and streaming completions, with streaming retries limited to failures before output begins.
  * Added configurable attempt limits, backoff delays, and custom retry decisions.
  * Retry events are recorded for observability without exposing provider error details.

* **Documentation**
  * Updated retry guidance, streaming behavior, lifecycle details, and request API reference.
  * Clarified that retries do not replay completed tools, middleware, memory writes, or agent runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->