### PR TITLE
Add sandbox image builder and Studio completion retries

### DIFF
--- a/.changeset/calm-sandboxes-build.md
+++ b/.changeset/calm-sandboxes-build.md
@@ -3,5 +3,5 @@
 ---
 
 Add `pnpm dlx @anvia/sandbox create-image`, an interactive and scriptable CLI that generates and
-builds local Docker images composed from Node.js, Bun, Python, reporting, Playwright, and custom
-package capabilities.
+builds local Docker images composed from Node.js, Bun, Python, reporting, Playwright, and curated
+apt, npm, and uv package selections.

--- a/.changeset/calm-sandboxes-build.md
+++ b/.changeset/calm-sandboxes-build.md
@@ -1,0 +1,7 @@
+---
+"@anvia/sandbox": minor
+---
+
+Add `pnpm dlx @anvia/sandbox create-image`, an interactive and scriptable CLI that generates and
+builds local Docker images composed from Node.js, Bun, Python, reporting, Playwright, and custom
+package capabilities.

--- a/.changeset/studio-completion-retries.md
+++ b/.changeset/studio-completion-retries.md
@@ -1,0 +1,5 @@
+---
+"@anvia/studio": patch
+---
+
+Automatically retry transient completion failures for buffered and pre-output streaming agent runs.

--- a/apps/www/src/content/docs/packages/sandbox/getting-started.md
+++ b/apps/www/src/content/docs/packages/sandbox/getting-started.md
@@ -33,7 +33,9 @@ pnpm dlx @anvia/sandbox create-image \
 
 The command saves the build context under `.anvia/sandbox-images/reports`, builds the local image,
 and prints the `DockerSandbox` constructor configuration. Pass `--no-build` to generate the source
-without invoking Docker, or add repeatable `--apt`, `--npm`, and `--pip` flags for extra packages.
+without invoking Docker, or add repeatable `--apt`, `--npm`, and `--uv` flags for extra packages.
+The wizard offers common apt, npm, and Python packages as checkboxes. Python dependencies are
+managed in a generated `pyproject.toml` and installed into the image with `uv sync`.
 
 The `artifacts` feature includes Matplotlib, Seaborn, Pillow, ReportLab, pypdf, pandas, openpyxl,
 XlsxWriter, and python-docx. The `playwright` feature installs Chromium and automatically adds

--- a/apps/www/src/content/docs/packages/sandbox/getting-started.md
+++ b/apps/www/src/content/docs/packages/sandbox/getting-started.md
@@ -13,6 +13,33 @@ sidebar:
 pnpm add @anvia/sandbox @anvia/core
 ```
 
+## Create a custom image
+
+Run the interactive image builder to select Node.js, Bun, Python, reporting tools, or Playwright:
+
+```sh
+pnpm dlx @anvia/sandbox create-image
+```
+
+For scripts and CI, provide the image name and capabilities as flags:
+
+```sh
+pnpm dlx @anvia/sandbox create-image \
+  --name reports \
+  --runtime bun \
+  --feature artifacts \
+  --feature playwright
+```
+
+The command saves the build context under `.anvia/sandbox-images/reports`, builds the local image,
+and prints the `DockerSandbox` constructor configuration. Pass `--no-build` to generate the source
+without invoking Docker, or add repeatable `--apt`, `--npm`, and `--pip` flags for extra packages.
+
+The `artifacts` feature includes Matplotlib, Seaborn, Pillow, ReportLab, pypdf, pandas, openpyxl,
+XlsxWriter, and python-docx. The `playwright` feature installs Chromium and automatically adds
+Node.js. It is intended for local development and testing; do not treat a root-run browser as a
+strong security boundary for untrusted websites.
+
 ## Minimum setup
 
 ```ts

--- a/apps/www/src/content/docs/packages/sandbox/reference.md
+++ b/apps/www/src/content/docs/packages/sandbox/reference.md
@@ -19,11 +19,15 @@ The CLI requires Node.js 20.12 or newer. With a terminal it prompts for runtimes
 non-interactive environment, provide `--name` and at least one repeatable `--runtime` or `--feature`
 flag.
 
+The wizard always shows curated checkbox lists for common apt tools, npm libraries, and Python
+libraries. Use the package flags below for entries that are not in those lists. Python packages are
+written to `pyproject.toml` and installed with `uv sync`.
+
 | Option | Behavior |
 | --- | --- |
 | `--runtime node\|bun\|python` | Add a runtime; repeatable. |
 | `--feature artifacts\|playwright` | Add a curated capability; repeatable. |
-| `--apt`, `--npm`, `--pip` | Add a package; repeatable. Unpinned packages produce a warning. |
+| `--apt`, `--npm`, `--uv` | Add an apt, npm, or Python package; repeatable. Unpinned npm and Python packages produce a warning. |
 | `--tag <tag>` | Set the local image tag. Defaults to `anvia-sandbox-<name>:latest`. |
 | `--output <path>` | Set the generated context path. Defaults to `.anvia/sandbox-images/<name>`. |
 | `--no-build` | Write the context without running `docker build`. |

--- a/apps/www/src/content/docs/packages/sandbox/reference.md
+++ b/apps/www/src/content/docs/packages/sandbox/reference.md
@@ -9,6 +9,36 @@ sidebar:
 ---
 Import from `@anvia/sandbox`.
 
+## Image builder CLI
+
+```sh
+pnpm dlx @anvia/sandbox create-image [options]
+```
+
+The CLI requires Node.js 20.12 or newer. With a terminal it prompts for runtimes and features. In a
+non-interactive environment, provide `--name` and at least one repeatable `--runtime` or `--feature`
+flag.
+
+| Option | Behavior |
+| --- | --- |
+| `--runtime node\|bun\|python` | Add a runtime; repeatable. |
+| `--feature artifacts\|playwright` | Add a curated capability; repeatable. |
+| `--apt`, `--npm`, `--pip` | Add a package; repeatable. Unpinned packages produce a warning. |
+| `--tag <tag>` | Set the local image tag. Defaults to `anvia-sandbox-<name>:latest`. |
+| `--output <path>` | Set the generated context path. Defaults to `.anvia/sandbox-images/<name>`. |
+| `--no-build` | Write the context without running `docker build`. |
+| `--dry-run` | Print the generated files without writing or building. |
+| `--force` | Regenerate files in a context previously created by this CLI. |
+
+Runtime versions can be overridden with `--node-version`, `--pnpm-version`, `--bun-version`,
+`--python-version`, `--uv-version`, and `--playwright-version`. `--docker-path` selects a non-default
+Docker executable.
+
+Generated contexts contain a Dockerfile, a restrictive `.dockerignore`, and
+`anvia-sandbox.json`. The manifest records selected capabilities, versions, packages, and generated
+files. Regeneration never recursively deletes the directory or overwrites a directory without a
+recognized manifest.
+
 ## DockerSandbox
 
 ```ts

--- a/apps/www/src/content/docs/packages/studio/reference/runtime.md
+++ b/apps/www/src/content/docs/packages/studio/reference/runtime.md
@@ -100,4 +100,9 @@ Purpose: route-level runtime behavior for Studio agent runs.
 
 Return behavior: non-streaming runs return `PromptResponse`; streaming runs emit newline-delimited Studio run events.
 
+Studio automatically applies core's default completion retry policy to every agent run. Transient
+model failures receive up to three total attempts with bounded jittered backoff. Streaming model
+calls retry only when the provider fails before emitting any non-error event, so partial output is
+never replayed.
+
 Notable errors: invalid request bodies return `StudioErrorResponse` with `bad_request`.

--- a/packages/tool-sandbox/package.json
+++ b/packages/tool-sandbox/package.json
@@ -19,6 +19,9 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "anvia-sandbox": "./dist/cli.js"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -26,12 +29,13 @@
     }
   },
   "scripts": {
-    "build": "pnpm run build:deps && tsup src/index.ts --format esm --dts --sourcemap --clean",
+    "build": "pnpm run build:deps && tsup src/index.ts src/cli.ts --format esm --dts --sourcemap --clean && chmod +x dist/cli.js",
     "build:deps": "test -f ../core/dist/index.d.ts || pnpm --filter @anvia/core build",
     "test": "pnpm run build:deps && vitest run",
     "typecheck": "pnpm run build:deps && tsc --noEmit"
   },
   "dependencies": {
+    "@clack/prompts": "^1.7.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -43,5 +47,8 @@
   },
   "peerDependencies": {
     "@anvia/core": ">=0.7.1 <1.0.0"
+  },
+  "engines": {
+    "node": ">=20.12.0"
   }
 }

--- a/packages/tool-sandbox/src/cli.ts
+++ b/packages/tool-sandbox/src/cli.ts
@@ -1,0 +1,650 @@
+#!/usr/bin/env node
+import { lstat, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { assertDockerCli } from "./docker-cli";
+import {
+  renderSandboxImageContext,
+  resolveSandboxImageSpec,
+  type SandboxImageFeature,
+  type SandboxImageInput,
+  type SandboxImageManifest,
+  type SandboxImageRuntime,
+  type SandboxImageVersions,
+  unpinnedSandboxImagePackages,
+} from "./image-builder";
+
+interface CliOptions {
+  command?: string;
+  name?: string;
+  tag?: string;
+  output?: string;
+  runtimes: SandboxImageRuntime[];
+  features: SandboxImageFeature[];
+  apt: string[];
+  npm: string[];
+  pip: string[];
+  versions: Partial<SandboxImageVersions>;
+  dockerPath: string;
+  build: boolean;
+  buildExplicit: boolean;
+  dryRun: boolean;
+  force: boolean;
+  help: boolean;
+}
+
+export interface SandboxImageCliIo {
+  log(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+  stdout(chunk: Uint8Array): void;
+  stderr(chunk: Uint8Array): void;
+}
+
+export interface SandboxImagePromptResult {
+  name: string;
+  runtimes: SandboxImageRuntime[];
+  features: SandboxImageFeature[];
+  apt: string[];
+  npm: string[];
+  pip: string[];
+  tag?: string;
+  output?: string;
+  build: boolean;
+}
+
+export interface SandboxImageCliDependencies {
+  isTTY?: boolean;
+  packageVersion?: string;
+  prompt?: (options: Readonly<CliOptions>) => Promise<SandboxImagePromptResult | undefined>;
+  buildImage?: (input: {
+    contextPath: string;
+    tag: string;
+    dockerPath: string;
+    io: SandboxImageCliIo;
+  }) => Promise<void>;
+}
+
+const generatedFileNames = new Set([
+  ".dockerignore",
+  "Dockerfile",
+  "anvia-sandbox.json",
+  "package.json",
+  "requirements.txt",
+]);
+
+const defaultIo: SandboxImageCliIo = {
+  log: console.log,
+  warn: console.warn,
+  error: console.error,
+  stdout: (chunk) => process.stdout.write(chunk),
+  stderr: (chunk) => process.stderr.write(chunk),
+};
+
+export async function runCli(
+  argv: string[] = process.argv.slice(2),
+  cwd = process.cwd(),
+  io: SandboxImageCliIo = defaultIo,
+  dependencies: SandboxImageCliDependencies = {},
+): Promise<number> {
+  let options: CliOptions;
+  try {
+    options = parseArgs(argv);
+  } catch (error) {
+    io.error(errorMessage(error));
+    io.log(helpText());
+    return 1;
+  }
+
+  if (options.help || options.command === undefined) {
+    io.log(helpText());
+    return 0;
+  }
+  if (options.command !== "create-image") {
+    io.error(`Unknown command: ${options.command}`);
+    io.log(helpText());
+    return 1;
+  }
+
+  try {
+    const shouldPrompt =
+      options.name === undefined ||
+      (options.runtimes.length === 0 &&
+        options.features.length === 0 &&
+        options.npm.length === 0 &&
+        options.pip.length === 0);
+    if (shouldPrompt) {
+      const isTTY = dependencies.isTTY ?? (process.stdin.isTTY && process.stdout.isTTY);
+      if (!isTTY) {
+        throw new Error(
+          "Non-interactive create-image requires --name and at least one --runtime or --feature.",
+        );
+      }
+      const prompt = dependencies.prompt ?? promptForImage;
+      const result = await prompt(options);
+      if (result === undefined) return 130;
+      options = applyPromptResult(options, result);
+    }
+
+    const input: SandboxImageInput = {
+      name: required(options.name, "Image name is required."),
+      runtimes: options.runtimes,
+      features: options.features,
+      packages: {
+        apt: options.apt,
+        npm: options.npm,
+        pip: options.pip,
+      },
+      versions: options.versions,
+    };
+    if (options.tag !== undefined) input.tag = options.tag;
+
+    const spec = resolveSandboxImageSpec(input);
+    const packageVersion = dependencies.packageVersion ?? (await readPackageVersion());
+    const context = renderSandboxImageContext(spec, packageVersion);
+    const outputPath = path.resolve(
+      cwd,
+      options.output ?? path.join(".anvia", "sandbox-images", spec.name),
+    );
+    const displayPath = relativeDisplayPath(cwd, outputPath);
+    const unpinned = unpinnedSandboxImagePackages(spec);
+    if (unpinned.length > 0) {
+      io.warn(`Unpinned custom packages may change on rebuild: ${unpinned.join(", ")}`);
+    }
+
+    if (options.dryRun) {
+      printDryRun(context.files, displayPath, spec.tag, io);
+      return 0;
+    }
+
+    await writeImageContext(outputPath, context.manifest, context.files, options.force);
+    io.log(`Created ${displayPath}`);
+
+    if (!options.build) {
+      io.log("");
+      io.log("Build later:");
+      io.log(`  ${shellCommand([options.dockerPath, "build", "--tag", spec.tag, displayPath])}`);
+      printUsageSnippet(spec.tag, io);
+      return 0;
+    }
+
+    const buildImage = dependencies.buildImage ?? buildDockerImage;
+    await buildImage({
+      contextPath: outputPath,
+      tag: spec.tag,
+      dockerPath: options.dockerPath,
+      io,
+    });
+    io.log(`Built ${spec.tag}`);
+    printUsageSnippet(spec.tag, io);
+    return 0;
+  } catch (error) {
+    io.error(errorMessage(error));
+    return 1;
+  }
+}
+
+async function promptForImage(
+  options: Readonly<CliOptions>,
+): Promise<SandboxImagePromptResult | undefined> {
+  assertInteractiveNodeVersion();
+  const prompts = await import("@clack/prompts");
+  prompts.intro("Create an Anvia sandbox image");
+
+  const nameResult =
+    options.name ??
+    (await prompts.text({
+      message: "Image name",
+      placeholder: "reports",
+      validate: (value) =>
+        /^[a-z0-9][a-z0-9-]{0,62}$/.test(value ?? "")
+          ? undefined
+          : "Use 1-63 lowercase letters, numbers, or hyphens.",
+    }));
+  if (prompts.isCancel(nameResult)) return cancelPrompt(prompts);
+  const name = String(nameResult);
+
+  let runtimes = [...options.runtimes];
+  let features = [...options.features];
+  if (
+    runtimes.length === 0 &&
+    features.length === 0 &&
+    options.npm.length === 0 &&
+    options.pip.length === 0
+  ) {
+    const capabilities = await prompts.multiselect<SandboxImageRuntime | SandboxImageFeature>({
+      message: "Select runtimes and features",
+      required: true,
+      options: [
+        { value: "node", label: "Node.js", hint: "Includes npm and pnpm" },
+        { value: "bun", label: "Bun", hint: "Includes bun and bunx" },
+        { value: "python", label: "Python", hint: "Includes pip, uv, and uvx" },
+        { value: "artifacts", label: "Reporting and artifacts", hint: "Adds Python automatically" },
+        { value: "playwright", label: "Playwright + Chromium", hint: "Adds Node.js automatically" },
+      ],
+    });
+    if (prompts.isCancel(capabilities)) return cancelPrompt(prompts);
+    runtimes = capabilities.filter(isRuntime);
+    features = capabilities.filter(isFeature);
+  }
+
+  const apt = await optionalPackagePrompt(prompts, "Extra apt packages", options.apt);
+  if (apt === undefined) return cancelPrompt(prompts);
+  const npm = await optionalPackagePrompt(prompts, "Extra npm packages", options.npm);
+  if (npm === undefined) return cancelPrompt(prompts);
+  const pip = await optionalPackagePrompt(prompts, "Extra pip requirements", options.pip);
+  if (pip === undefined) return cancelPrompt(prompts);
+
+  const tagResult =
+    options.tag ??
+    (await prompts.text({
+      message: "Docker image tag",
+      initialValue: `anvia-sandbox-${name}:latest`,
+    }));
+  if (prompts.isCancel(tagResult)) return cancelPrompt(prompts);
+  const outputResult =
+    options.output ??
+    (await prompts.text({
+      message: "Generated source directory",
+      initialValue: path.join(".anvia", "sandbox-images", name),
+    }));
+  if (prompts.isCancel(outputResult)) return cancelPrompt(prompts);
+
+  const buildResult = options.buildExplicit
+    ? options.build
+    : await prompts.confirm({ message: "Build the image now?", initialValue: true });
+  if (prompts.isCancel(buildResult)) return cancelPrompt(prompts);
+  const confirmed = await prompts.confirm({
+    message: "Create this sandbox image?",
+    initialValue: true,
+  });
+  if (prompts.isCancel(confirmed) || !confirmed) return cancelPrompt(prompts);
+
+  prompts.outro("Configuration ready");
+  return {
+    name,
+    runtimes,
+    features,
+    apt,
+    npm,
+    pip,
+    tag: String(tagResult),
+    output: String(outputResult),
+    build: Boolean(buildResult),
+  };
+}
+
+async function optionalPackagePrompt(
+  prompts: typeof import("@clack/prompts"),
+  message: string,
+  existing: readonly string[],
+): Promise<string[] | undefined> {
+  if (existing.length > 0) return [...existing];
+  const result = await prompts.text({
+    message,
+    placeholder: "Optional; separate entries with commas",
+  });
+  if (prompts.isCancel(result)) return undefined;
+  return splitPackageList(result);
+}
+
+function cancelPrompt(prompts: typeof import("@clack/prompts")): undefined {
+  prompts.cancel("Image creation cancelled.");
+  return undefined;
+}
+
+async function buildDockerImage(input: {
+  contextPath: string;
+  tag: string;
+  dockerPath: string;
+  io: SandboxImageCliIo;
+}): Promise<void> {
+  await assertDockerCli(["build", "--tag", input.tag, input.contextPath], {
+    dockerPath: input.dockerPath,
+    onStdout: input.io.stdout,
+    onStderr: input.io.stderr,
+  });
+}
+
+async function writeImageContext(
+  outputPath: string,
+  manifest: SandboxImageManifest,
+  files: ReadonlyMap<string, string>,
+  force: boolean,
+): Promise<void> {
+  const outputStat = await safeLstat(outputPath);
+  if (outputStat?.isSymbolicLink()) {
+    throw new Error(`Refusing to write through symlink: ${outputPath}`);
+  }
+
+  if (outputStat !== undefined) {
+    if (!outputStat.isDirectory()) throw new Error(`Output path is not a directory: ${outputPath}`);
+    const previousManifest = await readGeneratedManifest(outputPath);
+    if (previousManifest === undefined) {
+      throw new Error(
+        `Output directory already exists but was not generated by @anvia/sandbox: ${outputPath}`,
+      );
+    }
+    if (!force) throw new Error(`Output directory already exists. Use --force to regenerate it.`);
+
+    for (const filename of previousManifest.generatedFiles) {
+      const target = path.join(outputPath, filename);
+      const targetStat = await safeLstat(target);
+      if (targetStat?.isSymbolicLink()) throw new Error(`Refusing to replace symlink: ${target}`);
+      if (targetStat !== undefined) await rm(target);
+    }
+  } else {
+    await mkdir(outputPath, { recursive: true });
+  }
+
+  for (const [filename, content] of files) {
+    if (!generatedFileNames.has(filename))
+      throw new Error(`Unexpected generated filename: ${filename}`);
+    const target = path.join(outputPath, filename);
+    const targetStat = await safeLstat(target);
+    if (targetStat?.isSymbolicLink()) throw new Error(`Refusing to replace symlink: ${target}`);
+    await writeFile(target, content, "utf8");
+  }
+
+  if (!files.has("anvia-sandbox.json") || manifest.generatedFiles.length !== files.size) {
+    throw new Error("Generated image context manifest is inconsistent.");
+  }
+}
+
+async function readGeneratedManifest(
+  outputPath: string,
+): Promise<SandboxImageManifest | undefined> {
+  const manifestPath = path.join(outputPath, "anvia-sandbox.json");
+  const stat = await safeLstat(manifestPath);
+  if (stat === undefined) return undefined;
+  if (stat.isSymbolicLink() || !stat.isFile()) {
+    throw new Error(`Invalid generated manifest: ${manifestPath}`);
+  }
+
+  let value: unknown;
+  try {
+    value = JSON.parse(await readFile(manifestPath, "utf8"));
+  } catch (error) {
+    throw new Error(`Unable to read generated manifest: ${manifestPath}`, { cause: error });
+  }
+  if (!isGeneratedManifest(value)) {
+    throw new Error(
+      `Output manifest is not recognized as an @anvia/sandbox manifest: ${manifestPath}`,
+    );
+  }
+  return value;
+}
+
+function isGeneratedManifest(value: unknown): value is SandboxImageManifest {
+  if (typeof value !== "object" || value === null) return false;
+  const record = value as Record<string, unknown>;
+  const generatedBy = record.generatedBy as Record<string, unknown> | undefined;
+  const files = record.generatedFiles;
+  return (
+    record.schemaVersion === 1 &&
+    generatedBy?.package === "@anvia/sandbox" &&
+    Array.isArray(files) &&
+    files.every((file) => typeof file === "string" && generatedFileNames.has(file))
+  );
+}
+
+async function safeLstat(target: string) {
+  try {
+    return await lstat(target);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+}
+
+function printDryRun(
+  files: ReadonlyMap<string, string>,
+  outputPath: string,
+  tag: string,
+  io: SandboxImageCliIo,
+): void {
+  io.log(`Would create ${outputPath}`);
+  for (const [filename, content] of files) {
+    io.log("");
+    io.log(`--- ${filename}`);
+    io.log(content.trimEnd());
+  }
+  io.log("");
+  io.log(`Would build ${tag}`);
+}
+
+function printUsageSnippet(tag: string, io: SandboxImageCliIo): void {
+  io.log("");
+  io.log("Use with @anvia/sandbox:");
+  io.log("  const sandbox = new DockerSandbox({");
+  io.log(`    image: ${JSON.stringify(tag)},`);
+  io.log('    pull: "never",');
+  io.log("  });");
+}
+
+function applyPromptResult(options: CliOptions, result: SandboxImagePromptResult): CliOptions {
+  const next: CliOptions = {
+    ...options,
+    name: result.name,
+    runtimes: result.runtimes,
+    features: result.features,
+    apt: result.apt,
+    npm: result.npm,
+    pip: result.pip,
+    build: result.build,
+    buildExplicit: true,
+  };
+  if (result.tag !== undefined) next.tag = result.tag;
+  if (result.output !== undefined) next.output = result.output;
+  return next;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    runtimes: [],
+    features: [],
+    apt: [],
+    npm: [],
+    pip: [],
+    versions: {},
+    dockerPath: "docker",
+    build: true,
+    buildExplicit: false,
+    dryRun: false,
+    force: false,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index] ?? "";
+    if (!argument.startsWith("-")) {
+      if (options.command !== undefined) throw new Error(`Unexpected argument: ${argument}`);
+      options.command = argument;
+      continue;
+    }
+
+    const [flag, inlineValue] = splitFlag(argument);
+    const value = () => inlineValue ?? required(argv[++index], `${flag} requires a value.`);
+    switch (flag) {
+      case "-h":
+      case "--help":
+        options.help = true;
+        break;
+      case "--name":
+        options.name = value();
+        break;
+      case "--tag":
+        options.tag = value();
+        break;
+      case "--output":
+        options.output = value();
+        break;
+      case "--runtime":
+        options.runtimes.push(parseRuntime(value()));
+        break;
+      case "--feature":
+        options.features.push(parseFeature(value()));
+        break;
+      case "--apt":
+        options.apt.push(value());
+        break;
+      case "--npm":
+        options.npm.push(value());
+        break;
+      case "--pip":
+        options.pip.push(value());
+        break;
+      case "--node-version":
+        options.versions.node = value();
+        break;
+      case "--pnpm-version":
+        options.versions.pnpm = value();
+        break;
+      case "--bun-version":
+        options.versions.bun = value();
+        break;
+      case "--python-version":
+        options.versions.python = value();
+        break;
+      case "--uv-version":
+        options.versions.uv = value();
+        break;
+      case "--playwright-version":
+        options.versions.playwright = value();
+        break;
+      case "--docker-path":
+        options.dockerPath = value();
+        break;
+      case "--no-build":
+        rejectInlineValue(flag, inlineValue);
+        options.build = false;
+        options.buildExplicit = true;
+        break;
+      case "--dry-run":
+        rejectInlineValue(flag, inlineValue);
+        options.dryRun = true;
+        break;
+      case "--force":
+        rejectInlineValue(flag, inlineValue);
+        options.force = true;
+        break;
+      default:
+        throw new Error(`Unknown option: ${flag}`);
+    }
+  }
+  return options;
+}
+
+function splitFlag(argument: string): [string, string | undefined] {
+  const separator = argument.indexOf("=");
+  return separator === -1
+    ? [argument, undefined]
+    : [argument.slice(0, separator), argument.slice(separator + 1)];
+}
+
+function rejectInlineValue(flag: string, value: string | undefined): void {
+  if (value !== undefined) throw new Error(`${flag} does not accept a value.`);
+}
+
+function parseRuntime(value: string): SandboxImageRuntime {
+  if (isRuntime(value)) return value;
+  throw new Error(`Unknown runtime: ${value}. Expected node, bun, or python.`);
+}
+
+function parseFeature(value: string): SandboxImageFeature {
+  if (isFeature(value)) return value;
+  throw new Error(`Unknown feature: ${value}. Expected artifacts or playwright.`);
+}
+
+function isRuntime(value: string): value is SandboxImageRuntime {
+  return value === "node" || value === "bun" || value === "python";
+}
+
+function isFeature(value: string): value is SandboxImageFeature {
+  return value === "artifacts" || value === "playwright";
+}
+
+function splitPackageList(value: string): string[] {
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function assertInteractiveNodeVersion(): void {
+  const [major = 0, minor = 0] = process.versions.node.split(".").map(Number);
+  if (major < 20 || (major === 20 && minor < 12)) {
+    throw new Error("The interactive create-image wizard requires Node.js 20.12 or newer.");
+  }
+}
+
+async function readPackageVersion(): Promise<string> {
+  const packageJson = JSON.parse(
+    await readFile(new URL("../package.json", import.meta.url), "utf8"),
+  ) as {
+    version?: unknown;
+  };
+  return typeof packageJson.version === "string" ? packageJson.version : "unknown";
+}
+
+function relativeDisplayPath(cwd: string, target: string): string {
+  const relative = path.relative(cwd, target);
+  return relative && !relative.startsWith("..") ? relative : target;
+}
+
+function shellCommand(args: readonly string[]): string {
+  return args.map(shellArgument).join(" ");
+}
+
+function shellArgument(value: string): string {
+  if (/^[a-zA-Z0-9_./:@+-]+$/.test(value)) return value;
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function required<T>(value: T | undefined, message: string): T {
+  if (value === undefined || value === "") throw new Error(message);
+  return value;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function helpText(): string {
+  return `Usage:
+  pnpm dlx @anvia/sandbox create-image [options]
+
+Options:
+  --name <slug>                  Image profile name
+  --runtime <node|bun|python>    Runtime to include; repeatable
+  --feature <artifacts|playwright>
+                                 Curated feature to include; repeatable
+  --apt <package>                Additional apt package; repeatable
+  --npm <package[@version]>      Additional npm package; repeatable
+  --pip <requirement>            Additional pip requirement; repeatable
+  --tag <tag>                    Local image tag
+  --output <directory>           Generated context directory
+  --node-version <version>       Override Node.js version
+  --pnpm-version <version>       Override pnpm version
+  --bun-version <version>        Override Bun version
+  --python-version <version>     Override Python version
+  --uv-version <version>         Override uv version
+  --playwright-version <version> Override Playwright and browser image version
+  --docker-path <path>           Docker CLI path (default: docker)
+  --no-build                     Generate files without building
+  --dry-run                      Print generated files without writing or building
+  --force                        Regenerate a context previously created by this CLI
+  -h, --help                     Show this help
+
+Examples:
+  pnpm dlx @anvia/sandbox create-image
+  pnpm dlx @anvia/sandbox create-image --name reports --feature artifacts
+  pnpm dlx @anvia/sandbox create-image --name browser --runtime bun --feature playwright`;
+}
+
+const invokedPath = process.argv[1] === undefined ? undefined : path.resolve(process.argv[1]);
+if (invokedPath !== undefined && invokedPath === fileURLToPath(import.meta.url)) {
+  runCli().then((code) => {
+    process.exitCode = code;
+  });
+}

--- a/packages/tool-sandbox/src/cli.ts
+++ b/packages/tool-sandbox/src/cli.ts
@@ -23,7 +23,7 @@ interface CliOptions {
   features: SandboxImageFeature[];
   apt: string[];
   npm: string[];
-  pip: string[];
+  uv: string[];
   versions: Partial<SandboxImageVersions>;
   dockerPath: string;
   build: boolean;
@@ -47,7 +47,7 @@ export interface SandboxImagePromptResult {
   features: SandboxImageFeature[];
   apt: string[];
   npm: string[];
-  pip: string[];
+  uv: string[];
   tag?: string;
   output?: string;
   build: boolean;
@@ -70,8 +70,34 @@ const generatedFileNames = new Set([
   "Dockerfile",
   "anvia-sandbox.json",
   "package.json",
-  "requirements.txt",
+  "pyproject.toml",
 ]);
+
+const commonAptPackages = [
+  { value: "git", label: "Git", hint: "Source control and repository operations" },
+  { value: "curl", label: "curl", hint: "HTTP downloads and API debugging" },
+  { value: "jq", label: "jq", hint: "JSON processing from the shell" },
+  { value: "ffmpeg", label: "FFmpeg", hint: "Audio and video processing" },
+  { value: "imagemagick", label: "ImageMagick", hint: "Image conversion and editing" },
+  { value: "poppler-utils", label: "Poppler tools", hint: "PDF inspection and conversion" },
+  { value: "libreoffice", label: "LibreOffice", hint: "Large; office document conversion" },
+] as const;
+
+const commonNpmPackages = [
+  { value: "pdfkit@0.19.1", label: "PDFKit", hint: "Generate PDF documents" },
+  { value: "sharp@0.35.3", label: "Sharp", hint: "Resize and transform images" },
+  { value: "exceljs@4.4.0", label: "ExcelJS", hint: "Read and write Excel workbooks" },
+  { value: "docx@9.7.1", label: "docx", hint: "Generate Word documents" },
+  { value: "pptxgenjs@4.0.1", label: "PptxGenJS", hint: "Generate PowerPoint presentations" },
+] as const;
+
+const commonUvPackages = [
+  { value: "httpx==0.28.1", label: "HTTPX", hint: "Modern HTTP client" },
+  { value: "beautifulsoup4==4.15.0", label: "Beautiful Soup", hint: "HTML and XML parsing" },
+  { value: "scipy==1.18.0", label: "SciPy", hint: "Scientific computing" },
+  { value: "scikit-learn==1.9.0", label: "scikit-learn", hint: "Machine learning utilities" },
+  { value: "polars==1.42.1", label: "Polars", hint: "Fast dataframe processing" },
+] as const;
 
 const defaultIo: SandboxImageCliIo = {
   log: console.log,
@@ -112,7 +138,7 @@ export async function runCli(
       (options.runtimes.length === 0 &&
         options.features.length === 0 &&
         options.npm.length === 0 &&
-        options.pip.length === 0);
+        options.uv.length === 0);
     if (shouldPrompt) {
       const isTTY = dependencies.isTTY ?? (process.stdin.isTTY && process.stdout.isTTY);
       if (!isTTY) {
@@ -133,7 +159,7 @@ export async function runCli(
       packages: {
         apt: options.apt,
         npm: options.npm,
-        pip: options.pip,
+        uv: options.uv,
       },
       versions: options.versions,
     };
@@ -210,7 +236,7 @@ async function promptForImage(
     runtimes.length === 0 &&
     features.length === 0 &&
     options.npm.length === 0 &&
-    options.pip.length === 0
+    options.uv.length === 0
   ) {
     const capabilities = await prompts.multiselect<SandboxImageRuntime | SandboxImageFeature>({
       message: "Select runtimes and features",
@@ -218,7 +244,7 @@ async function promptForImage(
       options: [
         { value: "node", label: "Node.js", hint: "Includes npm and pnpm" },
         { value: "bun", label: "Bun", hint: "Includes bun and bunx" },
-        { value: "python", label: "Python", hint: "Includes pip, uv, and uvx" },
+        { value: "python", label: "Python", hint: "Includes uv and uvx" },
         { value: "artifacts", label: "Reporting and artifacts", hint: "Adds Python automatically" },
         { value: "playwright", label: "Playwright + Chromium", hint: "Adds Node.js automatically" },
       ],
@@ -228,12 +254,27 @@ async function promptForImage(
     features = capabilities.filter(isFeature);
   }
 
-  const apt = await optionalPackagePrompt(prompts, "Extra apt packages", options.apt);
-  if (apt === undefined) return cancelPrompt(prompts);
-  const npm = await optionalPackagePrompt(prompts, "Extra npm packages", options.npm);
-  if (npm === undefined) return cancelPrompt(prompts);
-  const pip = await optionalPackagePrompt(prompts, "Extra pip requirements", options.pip);
-  if (pip === undefined) return cancelPrompt(prompts);
+  const aptResult = await selectCommonPackages(
+    prompts,
+    "Select common apt tools (optional)",
+    commonAptPackages,
+    options.apt,
+  );
+  if (aptResult === undefined) return cancelPrompt(prompts);
+  const npmResult = await selectCommonPackages(
+    prompts,
+    "Select common npm libraries (optional)",
+    commonNpmPackages,
+    options.npm,
+  );
+  if (npmResult === undefined) return cancelPrompt(prompts);
+  const uvResult = await selectCommonPackages(
+    prompts,
+    "Select common Python libraries with uv (optional)",
+    commonUvPackages,
+    options.uv,
+  );
+  if (uvResult === undefined) return cancelPrompt(prompts);
 
   const tagResult =
     options.tag ??
@@ -265,27 +306,30 @@ async function promptForImage(
     name,
     runtimes,
     features,
-    apt,
-    npm,
-    pip,
+    apt: aptResult,
+    npm: npmResult,
+    uv: uvResult,
     tag: String(tagResult),
     output: String(outputResult),
     build: Boolean(buildResult),
   };
 }
 
-async function optionalPackagePrompt(
+async function selectCommonPackages(
   prompts: typeof import("@clack/prompts"),
   message: string,
+  options: readonly { value: string; label: string; hint: string }[],
   existing: readonly string[],
 ): Promise<string[] | undefined> {
-  if (existing.length > 0) return [...existing];
-  const result = await prompts.text({
+  const commonValues = new Set(options.map((option) => option.value));
+  const result = await prompts.multiselect<string>({
     message,
-    placeholder: "Optional; separate entries with commas",
+    required: false,
+    options: [...options],
+    initialValues: existing.filter((value) => commonValues.has(value)),
   });
   if (prompts.isCancel(result)) return undefined;
-  return splitPackageList(result);
+  return [...new Set([...existing, ...result])];
 }
 
 function cancelPrompt(prompts: typeof import("@clack/prompts")): undefined {
@@ -430,7 +474,7 @@ function applyPromptResult(options: CliOptions, result: SandboxImagePromptResult
     features: result.features,
     apt: result.apt,
     npm: result.npm,
-    pip: result.pip,
+    uv: result.uv,
     build: result.build,
     buildExplicit: true,
   };
@@ -445,7 +489,7 @@ function parseArgs(argv: string[]): CliOptions {
     features: [],
     apt: [],
     npm: [],
-    pip: [],
+    uv: [],
     versions: {},
     dockerPath: "docker",
     build: true,
@@ -491,8 +535,8 @@ function parseArgs(argv: string[]): CliOptions {
       case "--npm":
         options.npm.push(value());
         break;
-      case "--pip":
-        options.pip.push(value());
+      case "--uv":
+        options.uv.push(value());
         break;
       case "--node-version":
         options.versions.node = value();
@@ -564,13 +608,6 @@ function isFeature(value: string): value is SandboxImageFeature {
   return value === "artifacts" || value === "playwright";
 }
 
-function splitPackageList(value: string): string[] {
-  return value
-    .split(",")
-    .map((entry) => entry.trim())
-    .filter(Boolean);
-}
-
 function assertInteractiveNodeVersion(): void {
   const [major = 0, minor = 0] = process.versions.node.split(".").map(Number);
   if (major < 20 || (major === 20 && minor < 12)) {
@@ -621,7 +658,7 @@ Options:
                                  Curated feature to include; repeatable
   --apt <package>                Additional apt package; repeatable
   --npm <package[@version]>      Additional npm package; repeatable
-  --pip <requirement>            Additional pip requirement; repeatable
+  --uv <requirement>             Additional Python package installed with uv; repeatable
   --tag <tag>                    Local image tag
   --output <directory>           Generated context directory
   --node-version <version>       Override Node.js version

--- a/packages/tool-sandbox/src/image-builder.ts
+++ b/packages/tool-sandbox/src/image-builder.ts
@@ -13,7 +13,7 @@ export interface SandboxImageVersions {
 export interface SandboxImagePackages {
   apt: string[];
   npm: string[];
-  pip: string[];
+  uv: string[];
 }
 
 export interface SandboxImageInput {
@@ -81,16 +81,16 @@ export function resolveSandboxImageSpec(input: SandboxImageInput): SandboxImageS
   const packages: SandboxImagePackages = {
     apt: unique(input.packages?.apt ?? []),
     npm: unique(input.packages?.npm ?? []),
-    pip: unique(input.packages?.pip ?? []),
+    uv: unique(input.packages?.uv ?? []),
   };
 
   for (const runtime of runtimes) validateRuntime(runtime);
   for (const feature of features) validateFeature(feature);
   for (const packageName of packages.apt) validateAptPackage(packageName);
   for (const packageSpec of packages.npm) parseNpmPackageSpec(packageSpec);
-  for (const requirement of packages.pip) validatePipRequirement(requirement);
+  for (const requirement of packages.uv) validateUvRequirement(requirement);
 
-  if (features.has("artifacts") || packages.pip.length > 0) runtimes.add("python");
+  if (features.has("artifacts") || packages.uv.length > 0) runtimes.add("python");
   if (features.has("playwright")) runtimes.add("node");
   if (packages.npm.length > 0 && !runtimes.has("node") && !runtimes.has("bun")) {
     runtimes.add("node");
@@ -121,20 +121,20 @@ export function renderSandboxImageContext(
   generatorVersion: string,
 ): SandboxImageContext {
   const files = new Map<string, string>();
-  const pipRequirements = [
+  const pythonRequirements = [
     ...(spec.features.includes("artifacts") ? artifactPythonPackages : []),
-    ...spec.packages.pip,
+    ...spec.packages.uv,
   ];
   const npmDependencies = npmDependenciesFor(spec);
 
-  files.set("Dockerfile", `${renderDockerfile(spec, pipRequirements, npmDependencies)}\n`);
+  files.set("Dockerfile", `${renderDockerfile(spec, pythonRequirements, npmDependencies)}\n`);
   files.set(
     ".dockerignore",
-    renderDockerignore(pipRequirements.length > 0, npmDependencies.size > 0),
+    renderDockerignore(pythonRequirements.length > 0, npmDependencies.size > 0),
   );
 
-  if (pipRequirements.length > 0) {
-    files.set("requirements.txt", `${unique(pipRequirements).join("\n")}\n`);
+  if (pythonRequirements.length > 0) {
+    files.set("pyproject.toml", renderPythonProject(spec, unique(pythonRequirements)));
   }
   if (npmDependencies.size > 0) {
     files.set(
@@ -167,11 +167,11 @@ export function renderSandboxImageContext(
 }
 
 export function unpinnedSandboxImagePackages(spec: SandboxImageSpec): string[] {
-  const unpinned = spec.packages.apt.filter((value) => !value.includes("="));
+  const unpinned: string[] = [];
   for (const value of spec.packages.npm) {
     if (parseNpmPackageSpec(value).version === "latest") unpinned.push(value);
   }
-  for (const value of spec.packages.pip) {
+  for (const value of spec.packages.uv) {
     if (!/===|==|@\s*https?:/i.test(value)) unpinned.push(value);
   }
   return unpinned;
@@ -179,7 +179,7 @@ export function unpinnedSandboxImagePackages(spec: SandboxImageSpec): string[] {
 
 function renderDockerfile(
   spec: SandboxImageSpec,
-  pipRequirements: readonly string[],
+  pythonRequirements: readonly string[],
   npmDependencies: ReadonlyMap<string, string>,
 ): string {
   const hasNode = spec.runtimes.includes("node");
@@ -244,12 +244,14 @@ function renderDockerfile(
     );
   }
 
-  if (pipRequirements.length > 0) {
+  if (pythonRequirements.length > 0) {
     lines.push(
       "",
-      "COPY requirements.txt /tmp/anvia/requirements.txt",
-      "RUN uv pip install --system --no-cache --requirement /tmp/anvia/requirements.txt \\",
-      "  && rm -rf /tmp/anvia",
+      "COPY pyproject.toml /opt/anvia-python/pyproject.toml",
+      "RUN cd /opt/anvia-python \\",
+      "  && uv sync --no-dev --no-cache --no-install-project",
+      "ENV VIRTUAL_ENV=/opt/anvia-python/.venv",
+      "ENV PATH=/opt/anvia-python/.venv/bin:$PATH",
     );
   }
 
@@ -284,14 +286,28 @@ function renderDockerfile(
   return lines.join("\n");
 }
 
-function renderDockerignore(hasPip: boolean, hasNpm: boolean): string {
+function renderDockerignore(hasPython: boolean, hasNpm: boolean): string {
   return [
     "**",
     "!Dockerfile",
     "!.dockerignore",
     "!anvia-sandbox.json",
-    ...(hasPip ? ["!requirements.txt"] : []),
+    ...(hasPython ? ["!pyproject.toml"] : []),
     ...(hasNpm ? ["!package.json"] : []),
+    "",
+  ].join("\n");
+}
+
+function renderPythonProject(spec: SandboxImageSpec, requirements: readonly string[]): string {
+  const [major, minor] = spec.versions.python.split(".");
+  return [
+    "[project]",
+    `name = ${JSON.stringify(`anvia-sandbox-${spec.name}`)}`,
+    'version = "0.0.0"',
+    `requires-python = ${JSON.stringify(`>=${major}.${minor}`)}`,
+    "dependencies = [",
+    ...requirements.map((requirement) => `  ${JSON.stringify(requirement)},`),
+    "]",
     "",
   ].join("\n");
 }
@@ -364,9 +380,9 @@ function parseNpmPackageSpec(packageSpec: string): { name: string; version: stri
   return { name, version };
 }
 
-function validatePipRequirement(requirement: string): void {
+function validateUvRequirement(requirement: string): void {
   if (!requirement || requirement.startsWith("-") || hasControlCharacter(requirement)) {
-    throw new Error(`Invalid pip requirement: ${requirement}`);
+    throw new Error(`Invalid uv package requirement: ${requirement}`);
   }
 }
 

--- a/packages/tool-sandbox/src/image-builder.ts
+++ b/packages/tool-sandbox/src/image-builder.ts
@@ -1,0 +1,401 @@
+export type SandboxImageRuntime = "node" | "bun" | "python";
+export type SandboxImageFeature = "artifacts" | "playwright";
+
+export interface SandboxImageVersions {
+  node: string;
+  pnpm: string;
+  bun: string;
+  python: string;
+  uv: string;
+  playwright: string;
+}
+
+export interface SandboxImagePackages {
+  apt: string[];
+  npm: string[];
+  pip: string[];
+}
+
+export interface SandboxImageInput {
+  name: string;
+  tag?: string;
+  runtimes?: readonly SandboxImageRuntime[];
+  features?: readonly SandboxImageFeature[];
+  packages?: Partial<SandboxImagePackages>;
+  versions?: Partial<SandboxImageVersions>;
+}
+
+export interface SandboxImageSpec {
+  name: string;
+  tag: string;
+  runtimes: SandboxImageRuntime[];
+  features: SandboxImageFeature[];
+  packages: SandboxImagePackages;
+  versions: SandboxImageVersions;
+}
+
+export interface SandboxImageManifest extends SandboxImageSpec {
+  schemaVersion: 1;
+  generatedBy: {
+    package: "@anvia/sandbox";
+    version: string;
+  };
+  generatedFiles: string[];
+}
+
+export interface SandboxImageContext {
+  manifest: SandboxImageManifest;
+  files: ReadonlyMap<string, string>;
+}
+
+export const defaultSandboxImageVersions: Readonly<SandboxImageVersions> = {
+  node: "24.18.0",
+  pnpm: "11.0.4",
+  bun: "1.3.14",
+  python: "3.13.14",
+  uv: "0.11.29",
+  playwright: "1.61.0",
+};
+
+export const artifactPythonPackages = [
+  "matplotlib==3.11.1",
+  "seaborn==0.13.2",
+  "Pillow==12.3.0",
+  "ReportLab==5.0.0",
+  "pypdf==6.14.2",
+  "pandas==3.0.3",
+  "openpyxl==3.1.5",
+  "XlsxWriter==3.2.9",
+  "python-docx==1.2.0",
+] as const;
+
+const runtimeOrder: SandboxImageRuntime[] = ["node", "bun", "python"];
+const featureOrder: SandboxImageFeature[] = ["artifacts", "playwright"];
+const commonAptPackages = ["bash", "ca-certificates", "findutils", "libstdc++6", "procps"];
+
+export function resolveSandboxImageSpec(input: SandboxImageInput): SandboxImageSpec {
+  validateName(input.name);
+
+  const runtimes = new Set(input.runtimes ?? []);
+  const features = new Set(input.features ?? []);
+  const packages: SandboxImagePackages = {
+    apt: unique(input.packages?.apt ?? []),
+    npm: unique(input.packages?.npm ?? []),
+    pip: unique(input.packages?.pip ?? []),
+  };
+
+  for (const runtime of runtimes) validateRuntime(runtime);
+  for (const feature of features) validateFeature(feature);
+  for (const packageName of packages.apt) validateAptPackage(packageName);
+  for (const packageSpec of packages.npm) parseNpmPackageSpec(packageSpec);
+  for (const requirement of packages.pip) validatePipRequirement(requirement);
+
+  if (features.has("artifacts") || packages.pip.length > 0) runtimes.add("python");
+  if (features.has("playwright")) runtimes.add("node");
+  if (packages.npm.length > 0 && !runtimes.has("node") && !runtimes.has("bun")) {
+    runtimes.add("node");
+  }
+
+  if (runtimes.size === 0) {
+    throw new Error("Select at least one runtime or feature.");
+  }
+
+  const versions = { ...defaultSandboxImageVersions, ...input.versions };
+  for (const [name, version] of Object.entries(versions)) validateVersion(name, version);
+
+  const tag = input.tag ?? `anvia-sandbox-${input.name}:latest`;
+  validateImageTag(tag);
+
+  return {
+    name: input.name,
+    tag,
+    runtimes: runtimeOrder.filter((runtime) => runtimes.has(runtime)),
+    features: featureOrder.filter((feature) => features.has(feature)),
+    packages,
+    versions,
+  };
+}
+
+export function renderSandboxImageContext(
+  spec: SandboxImageSpec,
+  generatorVersion: string,
+): SandboxImageContext {
+  const files = new Map<string, string>();
+  const pipRequirements = [
+    ...(spec.features.includes("artifacts") ? artifactPythonPackages : []),
+    ...spec.packages.pip,
+  ];
+  const npmDependencies = npmDependenciesFor(spec);
+
+  files.set("Dockerfile", `${renderDockerfile(spec, pipRequirements, npmDependencies)}\n`);
+  files.set(
+    ".dockerignore",
+    renderDockerignore(pipRequirements.length > 0, npmDependencies.size > 0),
+  );
+
+  if (pipRequirements.length > 0) {
+    files.set("requirements.txt", `${unique(pipRequirements).join("\n")}\n`);
+  }
+  if (npmDependencies.size > 0) {
+    files.set(
+      "package.json",
+      `${JSON.stringify(
+        {
+          private: true,
+          description: `Generated dependencies for ${spec.name}`,
+          dependencies: Object.fromEntries(npmDependencies),
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  }
+
+  const generatedFiles = [...files.keys(), "anvia-sandbox.json"].sort();
+  const manifest: SandboxImageManifest = {
+    schemaVersion: 1,
+    generatedBy: {
+      package: "@anvia/sandbox",
+      version: generatorVersion,
+    },
+    ...spec,
+    generatedFiles,
+  };
+  files.set("anvia-sandbox.json", `${JSON.stringify(manifest, null, 2)}\n`);
+
+  return { manifest, files };
+}
+
+export function unpinnedSandboxImagePackages(spec: SandboxImageSpec): string[] {
+  const unpinned = spec.packages.apt.filter((value) => !value.includes("="));
+  for (const value of spec.packages.npm) {
+    if (parseNpmPackageSpec(value).version === "latest") unpinned.push(value);
+  }
+  for (const value of spec.packages.pip) {
+    if (!/===|==|@\s*https?:/i.test(value)) unpinned.push(value);
+  }
+  return unpinned;
+}
+
+function renderDockerfile(
+  spec: SandboxImageSpec,
+  pipRequirements: readonly string[],
+  npmDependencies: ReadonlyMap<string, string>,
+): string {
+  const hasNode = spec.runtimes.includes("node");
+  const hasBun = spec.runtimes.includes("bun");
+  const hasPython = spec.runtimes.includes("python");
+  const hasPlaywright = spec.features.includes("playwright");
+  const lines = [
+    "# Generated by @anvia/sandbox. Edit the manifest and regenerate instead of editing this file.",
+  ];
+
+  if (hasNode) lines.push(`FROM node:${spec.versions.node}-bookworm-slim AS node-runtime`);
+  if (hasPython) lines.push(`FROM python:${spec.versions.python}-slim-bookworm AS python-runtime`);
+  if (hasBun) lines.push(`FROM oven/bun:${spec.versions.bun}-slim AS bun-runtime`);
+  if (hasPython) lines.push(`FROM ghcr.io/astral-sh/uv:${spec.versions.uv} AS uv-runtime`);
+
+  if (hasPlaywright) {
+    lines.push(`FROM mcr.microsoft.com/playwright:v${spec.versions.playwright}-noble AS final`);
+  } else if (hasPython) {
+    lines.push("FROM python-runtime AS final");
+  } else if (hasNode) {
+    lines.push("FROM node-runtime AS final");
+  } else {
+    lines.push("FROM bun-runtime AS final");
+  }
+
+  lines.push("", "USER root");
+
+  if (hasPython && (hasPlaywright || !isFinalRuntime(spec, "python"))) {
+    lines.push("COPY --from=python-runtime /usr/local/ /usr/local/");
+  }
+  if (hasNode && (hasPlaywright || !isFinalRuntime(spec, "node"))) {
+    lines.push("COPY --from=node-runtime /usr/local/bin/ /usr/local/bin/");
+    lines.push(
+      "COPY --from=node-runtime /usr/local/lib/node_modules/ /usr/local/lib/node_modules/",
+    );
+  }
+  if (hasBun && !isFinalRuntime(spec, "bun")) {
+    lines.push("COPY --from=bun-runtime /usr/local/bin/bun /usr/local/bin/bun");
+    lines.push("RUN ln -sf /usr/local/bin/bun /usr/local/bin/bunx");
+  }
+  if (hasPython) {
+    lines.push("COPY --from=uv-runtime /uv /uvx /usr/local/bin/");
+  }
+
+  const aptPackages = unique([
+    ...commonAptPackages,
+    ...(spec.features.includes("artifacts") ? ["fonts-dejavu-core"] : []),
+    ...spec.packages.apt,
+  ]).sort();
+  lines.push(
+    "",
+    "RUN apt-get update \\",
+    `  && apt-get install -y --no-install-recommends ${aptPackages.map(shellQuote).join(" ")} \\`,
+    "  && rm -rf /var/lib/apt/lists/*",
+  );
+
+  if (hasNode) {
+    lines.push(
+      "",
+      `RUN npm install --global ${shellQuote(`pnpm@${spec.versions.pnpm}`)} --no-audit --no-fund \\`,
+      "  && npm cache clean --force",
+    );
+  }
+
+  if (pipRequirements.length > 0) {
+    lines.push(
+      "",
+      "COPY requirements.txt /tmp/anvia/requirements.txt",
+      "RUN uv pip install --system --no-cache --requirement /tmp/anvia/requirements.txt \\",
+      "  && rm -rf /tmp/anvia",
+    );
+  }
+
+  if (npmDependencies.size > 0) {
+    lines.push("", "COPY package.json /opt/anvia-js/package.json");
+    if (hasNode) {
+      lines.push(
+        "RUN npm install --prefix /opt/anvia-js --omit=dev --no-audit --no-fund \\",
+        "  && ln -s /opt/anvia-js/node_modules /node_modules \\",
+        "  && npm cache clean --force",
+      );
+    } else {
+      lines.push(
+        "RUN cd /opt/anvia-js \\",
+        "  && bun install --production --no-save \\",
+        "  && ln -s /opt/anvia-js/node_modules /node_modules",
+      );
+    }
+    lines.push("ENV NODE_PATH=/opt/anvia-js/node_modules");
+    lines.push("ENV PATH=/opt/anvia-js/node_modules/.bin:$PATH");
+  }
+
+  lines.push(
+    "",
+    ...(hasPlaywright ? ["ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright"] : []),
+    "RUN mkdir -p /workspace",
+    "WORKDIR /workspace",
+    "ENTRYPOINT []",
+    'CMD ["sh", "-c", "trap \'exit 0\' TERM INT; while :; do sleep 3600 & wait $!; done"]',
+  );
+
+  return lines.join("\n");
+}
+
+function renderDockerignore(hasPip: boolean, hasNpm: boolean): string {
+  return [
+    "**",
+    "!Dockerfile",
+    "!.dockerignore",
+    "!anvia-sandbox.json",
+    ...(hasPip ? ["!requirements.txt"] : []),
+    ...(hasNpm ? ["!package.json"] : []),
+    "",
+  ].join("\n");
+}
+
+function npmDependenciesFor(spec: SandboxImageSpec): Map<string, string> {
+  const dependencies = new Map<string, string>();
+  if (spec.features.includes("playwright")) {
+    dependencies.set("playwright", spec.versions.playwright);
+  }
+  for (const packageSpec of spec.packages.npm) {
+    const parsed = parseNpmPackageSpec(packageSpec);
+    if (dependencies.has(parsed.name)) {
+      throw new Error(`Duplicate npm package: ${parsed.name}`);
+    }
+    dependencies.set(parsed.name, parsed.version);
+  }
+  return new Map([...dependencies.entries()].sort(([left], [right]) => left.localeCompare(right)));
+}
+
+function isFinalRuntime(spec: SandboxImageSpec, runtime: SandboxImageRuntime): boolean {
+  if (spec.features.includes("playwright")) return false;
+  if (spec.runtimes.includes("python")) return runtime === "python";
+  if (spec.runtimes.includes("node")) return runtime === "node";
+  return runtime === "bun";
+}
+
+function validateName(name: string): void {
+  if (!/^[a-z0-9][a-z0-9-]{0,62}$/.test(name)) {
+    throw new Error(
+      "Image name must be 1-63 lowercase letters, numbers, or hyphens and cannot start with a hyphen.",
+    );
+  }
+}
+
+function validateRuntime(runtime: string): asserts runtime is SandboxImageRuntime {
+  if (!runtimeOrder.includes(runtime as SandboxImageRuntime)) {
+    throw new Error(`Unknown runtime: ${runtime}. Expected node, bun, or python.`);
+  }
+}
+
+function validateFeature(feature: string): asserts feature is SandboxImageFeature {
+  if (!featureOrder.includes(feature as SandboxImageFeature)) {
+    throw new Error(`Unknown feature: ${feature}. Expected artifacts or playwright.`);
+  }
+}
+
+function validateAptPackage(packageName: string): void {
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9.+:~=-]*$/.test(packageName)) {
+    throw new Error(`Invalid apt package: ${packageName}`);
+  }
+}
+
+function parseNpmPackageSpec(packageSpec: string): { name: string; version: string } {
+  if (/\s/.test(packageSpec) || hasControlCharacter(packageSpec)) {
+    throw new Error(`Invalid npm package spec: ${packageSpec}`);
+  }
+
+  const separator = packageSpec.startsWith("@")
+    ? packageSpec.indexOf("@", packageSpec.indexOf("/") + 1)
+    : packageSpec.indexOf("@");
+  const name = separator === -1 ? packageSpec : packageSpec.slice(0, separator);
+  const version = separator === -1 ? "latest" : packageSpec.slice(separator + 1);
+
+  if (!/^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/i.test(name) || !version) {
+    throw new Error(`Invalid npm package spec: ${packageSpec}`);
+  }
+  if (/[\s'"`$;&|<>\\]/.test(version) || hasControlCharacter(version)) {
+    throw new Error(`Invalid npm package version in: ${packageSpec}`);
+  }
+  return { name, version };
+}
+
+function validatePipRequirement(requirement: string): void {
+  if (!requirement || requirement.startsWith("-") || hasControlCharacter(requirement)) {
+    throw new Error(`Invalid pip requirement: ${requirement}`);
+  }
+}
+
+function validateVersion(name: string, version: string): void {
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(version)) {
+    throw new Error(`Invalid ${name} version: ${version}`);
+  }
+}
+
+function validateImageTag(tag: string): void {
+  if (
+    !tag ||
+    tag.startsWith("-") ||
+    tag.includes("@") ||
+    /\s/.test(tag) ||
+    hasControlCharacter(tag)
+  ) {
+    throw new Error(`Invalid Docker image tag: ${tag}`);
+  }
+}
+
+function unique(values: readonly string[]): string[] {
+  return [...new Set(values)];
+}
+
+function hasControlCharacter(value: string): boolean {
+  return [...value].some((character) => character.charCodeAt(0) < 32);
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}

--- a/packages/tool-sandbox/test/cli.test.ts
+++ b/packages/tool-sandbox/test/cli.test.ts
@@ -113,6 +113,43 @@ describe("anvia-sandbox CLI", () => {
     );
   });
 
+  it("records apt, npm, and uv packages without renaming the package groups", async () => {
+    const directory = await temporaryDirectory();
+    const code = await runCli(
+      [
+        "create-image",
+        "--name",
+        "documents",
+        "--runtime",
+        "node",
+        "--apt",
+        "poppler-utils",
+        "--npm",
+        "pdfkit@0.19.1",
+        "--uv",
+        "httpx==0.28.1",
+        "--no-build",
+      ],
+      directory,
+      captureIo().io,
+      dependencies(),
+    );
+
+    expect(code).toBe(0);
+    const contextPath = path.join(directory, ".anvia", "sandbox-images", "documents");
+    const manifest = JSON.parse(
+      await readFile(path.join(contextPath, "anvia-sandbox.json"), "utf8"),
+    ) as { packages: Record<string, string[]> };
+    expect(manifest.packages).toEqual({
+      apt: ["poppler-utils"],
+      npm: ["pdfkit@0.19.1"],
+      uv: ["httpx==0.28.1"],
+    });
+    await expect(readFile(path.join(contextPath, "pyproject.toml"), "utf8")).resolves.toContain(
+      '"httpx==0.28.1"',
+    );
+  });
+
   it("shell-quotes deferred build paths without allowing expansion", async () => {
     const directory = await temporaryDirectory();
     const output = captureIo();
@@ -155,9 +192,7 @@ describe("anvia-sandbox CLI", () => {
 
     expect(refreshed).toBe(0);
     await expect(readFile(path.join(contextPath, "notes.txt"), "utf8")).resolves.toBe("keep");
-    await expect(
-      readFile(path.join(contextPath, "requirements.txt"), "utf8"),
-    ).rejects.toMatchObject({
+    await expect(readFile(path.join(contextPath, "pyproject.toml"), "utf8")).rejects.toMatchObject({
       code: "ENOENT",
     });
   });
@@ -204,7 +239,7 @@ describe("anvia-sandbox CLI", () => {
         features: [],
         apt: [],
         npm: [],
-        pip: [],
+        uv: [],
         build: false,
       }),
     });

--- a/packages/tool-sandbox/test/cli.test.ts
+++ b/packages/tool-sandbox/test/cli.test.ts
@@ -1,0 +1,280 @@
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { runCli, type SandboxImageCliDependencies, type SandboxImageCliIo } from "../src/cli";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true })),
+  );
+});
+
+describe("anvia-sandbox CLI", () => {
+  it("prints help and rejects unknown input", async () => {
+    const help = captureIo();
+    await expect(runCli(["--help"], process.cwd(), help.io)).resolves.toBe(0);
+    expect(help.logs.join("\n")).toContain("pnpm dlx @anvia/sandbox create-image");
+
+    const unknown = captureIo();
+    await expect(runCli(["other"], process.cwd(), unknown.io)).resolves.toBe(1);
+    expect(unknown.errors).toEqual(["Unknown command: other"]);
+  });
+
+  it("requires complete flags outside a TTY", async () => {
+    const directory = await temporaryDirectory();
+    const output = captureIo();
+    const code = await runCli(["create-image", "--name", "reports"], directory, output.io, {
+      isTTY: false,
+    });
+
+    expect(code).toBe(1);
+    expect(output.errors[0]).toContain("Non-interactive");
+  });
+
+  it("supports a dry run without writing or building", async () => {
+    const directory = await temporaryDirectory();
+    const output = captureIo();
+    let built = false;
+    const code = await runCli(
+      ["create-image", "--name", "reports", "--feature", "artifacts", "--dry-run"],
+      directory,
+      output.io,
+      dependencies({
+        buildImage: async () => {
+          built = true;
+        },
+      }),
+    );
+
+    expect(code).toBe(0);
+    expect(built).toBe(false);
+    await expect(stat(path.join(directory, ".anvia"))).rejects.toMatchObject({ code: "ENOENT" });
+    expect(output.logs.join("\n")).toContain("--- Dockerfile");
+    expect(output.logs.join("\n")).toContain("matplotlib==3.11.1");
+  });
+
+  it("writes the context, builds it, and prints the constructor snippet", async () => {
+    const directory = await temporaryDirectory();
+    const output = captureIo();
+    const builds: Array<{ contextPath: string; tag: string; dockerPath: string }> = [];
+    const code = await runCli(
+      [
+        "create-image",
+        "--name",
+        "browser",
+        "--runtime",
+        "bun",
+        "--feature",
+        "playwright",
+        "--docker-path",
+        "/opt/docker",
+      ],
+      directory,
+      output.io,
+      dependencies({
+        buildImage: async ({ contextPath, tag, dockerPath }) => {
+          builds.push({ contextPath, tag, dockerPath });
+        },
+      }),
+    );
+
+    const contextPath = path.join(directory, ".anvia", "sandbox-images", "browser");
+    expect(code).toBe(0);
+    expect(builds).toEqual([
+      { contextPath, tag: "anvia-sandbox-browser:latest", dockerPath: "/opt/docker" },
+    ]);
+    expect(
+      JSON.parse(await readFile(path.join(contextPath, "anvia-sandbox.json"), "utf8")),
+    ).toMatchObject({
+      generatedBy: { package: "@anvia/sandbox", version: "0.5.0-test" },
+      runtimes: ["node", "bun"],
+      features: ["playwright"],
+    });
+    expect(output.logs.join("\n")).toContain('image: "anvia-sandbox-browser:latest"');
+    expect(output.logs.join("\n")).toContain('pull: "never"');
+  });
+
+  it("generates without building and prints the deferred command", async () => {
+    const directory = await temporaryDirectory();
+    const output = captureIo();
+    const code = await runCli(
+      ["create-image", "--name", "node-dev", "--runtime", "node", "--no-build"],
+      directory,
+      output.io,
+      dependencies(),
+    );
+
+    expect(code).toBe(0);
+    expect(output.logs.join("\n")).toContain(
+      "docker build --tag anvia-sandbox-node-dev:latest .anvia/sandbox-images/node-dev",
+    );
+  });
+
+  it("shell-quotes deferred build paths without allowing expansion", async () => {
+    const directory = await temporaryDirectory();
+    const output = captureIo();
+    const code = await runCli(
+      [
+        "create-image",
+        "--name",
+        "quoted",
+        "--runtime",
+        "node",
+        "--output",
+        "custom $HOME",
+        "--no-build",
+      ],
+      directory,
+      output.io,
+      dependencies(),
+    );
+
+    expect(code).toBe(0);
+    expect(output.logs.join("\n")).toContain(
+      "docker build --tag anvia-sandbox-quoted:latest 'custom $HOME'",
+    );
+  });
+
+  it("only force-regenerates recognized files and preserves unrelated files", async () => {
+    const directory = await temporaryDirectory();
+    const initial = ["create-image", "--name", "refresh", "--feature", "artifacts", "--no-build"];
+    expect(await runCli(initial, directory, captureIo().io, dependencies())).toBe(0);
+    expect(await runCli(initial, directory, captureIo().io, dependencies())).toBe(1);
+
+    const contextPath = path.join(directory, ".anvia", "sandbox-images", "refresh");
+    await writeFile(path.join(contextPath, "notes.txt"), "keep", "utf8");
+    const refreshed = await runCli(
+      ["create-image", "--name", "refresh", "--runtime", "node", "--no-build", "--force"],
+      directory,
+      captureIo().io,
+      dependencies(),
+    );
+
+    expect(refreshed).toBe(0);
+    await expect(readFile(path.join(contextPath, "notes.txt"), "utf8")).resolves.toBe("keep");
+    await expect(
+      readFile(path.join(contextPath, "requirements.txt"), "utf8"),
+    ).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("refuses to overwrite an unrelated directory even with force", async () => {
+    const directory = await temporaryDirectory();
+    const outputPath = path.join(directory, "existing");
+    await mkdir(outputPath);
+    await writeFile(path.join(outputPath, "Dockerfile"), "FROM scratch\n", "utf8");
+    const output = captureIo();
+
+    const code = await runCli(
+      [
+        "create-image",
+        "--name",
+        "safe",
+        "--runtime",
+        "node",
+        "--output",
+        outputPath,
+        "--no-build",
+        "--force",
+      ],
+      directory,
+      output.io,
+      dependencies(),
+    );
+
+    expect(code).toBe(1);
+    expect(output.errors[0]).toContain("was not generated by @anvia/sandbox");
+    await expect(readFile(path.join(outputPath, "Dockerfile"), "utf8")).resolves.toBe(
+      "FROM scratch\n",
+    );
+  });
+
+  it("uses the interactive prompt adapter and handles cancellation", async () => {
+    const directory = await temporaryDirectory();
+    const prompted = await runCli(["create-image"], directory, captureIo().io, {
+      ...dependencies(),
+      isTTY: true,
+      prompt: async () => ({
+        name: "wizard",
+        runtimes: ["python"],
+        features: [],
+        apt: [],
+        npm: [],
+        pip: [],
+        build: false,
+      }),
+    });
+    expect(prompted).toBe(0);
+
+    const cancelled = await runCli(["create-image"], directory, captureIo().io, {
+      ...dependencies(),
+      isTTY: true,
+      prompt: async () => undefined,
+    });
+    expect(cancelled).toBe(130);
+  });
+
+  it("keeps generated sources when a Docker build fails", async () => {
+    const directory = await temporaryDirectory();
+    const output = captureIo();
+    const code = await runCli(
+      ["create-image", "--name", "failed", "--runtime", "node"],
+      directory,
+      output.io,
+      dependencies({
+        buildImage: async () => {
+          throw new Error("Docker build failed");
+        },
+      }),
+    );
+
+    expect(code).toBe(1);
+    expect(output.errors).toEqual(["Docker build failed"]);
+    await expect(
+      readFile(path.join(directory, ".anvia", "sandbox-images", "failed", "Dockerfile"), "utf8"),
+    ).resolves.toContain("FROM node:");
+    expect(output.logs.join("\n")).not.toContain("Use with @anvia/sandbox");
+  });
+});
+
+function dependencies(overrides: SandboxImageCliDependencies = {}): SandboxImageCliDependencies {
+  return {
+    isTTY: false,
+    packageVersion: "0.5.0-test",
+    buildImage: async () => {},
+    ...overrides,
+  };
+}
+
+function captureIo(): {
+  io: SandboxImageCliIo;
+  logs: string[];
+  warnings: string[];
+  errors: string[];
+} {
+  const logs: string[] = [];
+  const warnings: string[] = [];
+  const errors: string[] = [];
+  return {
+    logs,
+    warnings,
+    errors,
+    io: {
+      log: (message) => logs.push(message),
+      warn: (message) => warnings.push(message),
+      error: (message) => errors.push(message),
+      stdout: (chunk) => logs.push(new TextDecoder().decode(chunk)),
+      stderr: (chunk) => errors.push(new TextDecoder().decode(chunk)),
+    },
+  };
+}
+
+async function temporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "anvia-sandbox-cli-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}

--- a/packages/tool-sandbox/test/image-builder.integration.test.ts
+++ b/packages/tool-sandbox/test/image-builder.integration.test.ts
@@ -1,0 +1,133 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { runCli } from "../src/cli";
+import { runDockerCli } from "../src/docker-cli";
+import { DockerSandbox } from "../src/docker-sandbox";
+
+const runDockerTests = process.env.ANVIA_SANDBOX_DOCKER_TESTS === "1";
+
+describe.skipIf(!runDockerTests)("sandbox image builder integration", () => {
+  it("builds and runs the complete runtime and artifact toolchain", async () => {
+    const temporaryDirectory = await mkdtemp(path.join(os.tmpdir(), "anvia-sandbox-image-"));
+    const imageTag = `anvia-sandbox-integration:${Date.now()}`;
+    let session: Awaited<ReturnType<DockerSandbox["createSession"]>> | undefined;
+
+    try {
+      const exitCode = await runCli(
+        [
+          "create-image",
+          "--name",
+          "integration",
+          "--runtime",
+          "bun",
+          "--feature",
+          "artifacts",
+          "--feature",
+          "playwright",
+          "--tag",
+          imageTag,
+          "--output",
+          path.join(temporaryDirectory, "context"),
+        ],
+        temporaryDirectory,
+        {
+          log: () => {},
+          warn: () => {},
+          error: () => {},
+          stdout: () => {},
+          stderr: () => {},
+        },
+        { isTTY: false, packageVersion: "integration" },
+      );
+      expect(exitCode).toBe(0);
+
+      const sandbox = new DockerSandbox({
+        image: imageTag,
+        pull: "never",
+        network: false,
+        limits: { timeoutMs: 120_000, maxOutputBytes: 256_000 },
+      });
+      session = await sandbox.createSession({
+        id: `image-builder-${Date.now()}`,
+        manifest: {
+          files: {
+            "artifacts.py": pythonArtifactScript,
+            "browser.mjs": playwrightScript,
+          },
+        },
+      });
+
+      const versions = await session.exec({
+        command: "sh",
+        args: [
+          "-lc",
+          "node --version && pnpm --version && bun --version && python --version && uv --version",
+        ],
+      });
+      expect(versions.exitCode, versions.stderr).toBe(0);
+      expect(versions.stdout).toContain("v24.18.0");
+      expect(versions.stdout).toContain("11.0.4");
+      expect(versions.stdout).toContain("1.3.14");
+      expect(versions.stdout).toContain("Python 3.13.14");
+
+      const artifacts = await session.exec({ command: "python", args: ["artifacts.py"] });
+      expect(artifacts.exitCode, artifacts.stderr).toBe(0);
+      const browser = await session.exec({ command: "node", args: ["browser.mjs"] });
+      expect(browser.exitCode, browser.stderr).toBe(0);
+
+      const files = await session.listFiles("output");
+      expect(files.map((file) => file.path).sort()).toEqual([
+        "output/chart.png",
+        "output/report.pdf",
+        "output/screenshot.png",
+        "output/workbook.xlsx",
+      ]);
+    } finally {
+      await session?.destroy();
+      await runDockerCli(["image", "rm", imageTag], { dockerPath: "docker" });
+      await rm(temporaryDirectory, { recursive: true, force: true });
+    }
+  }, 600_000);
+});
+
+const pythonArtifactScript = `
+from pathlib import Path
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sns
+from PIL import Image
+from docx import Document
+from openpyxl import Workbook
+from pypdf import PdfReader
+from reportlab.pdfgen import canvas
+import xlsxwriter
+
+output = Path("output")
+output.mkdir(exist_ok=True)
+sns.set_theme()
+plt.plot([1, 2, 3], [1, 4, 9])
+plt.savefig(output / "chart.png")
+pdf = canvas.Canvas(str(output / "report.pdf"))
+pdf.drawString(72, 720, "Anvia sandbox report")
+pdf.showPage()
+pdf.save()
+Workbook().save(output / "workbook.xlsx")
+assert Image.open(output / "chart.png").size[0] > 0
+assert len(PdfReader(output / "report.pdf").pages) == 1
+assert pd.DataFrame({"value": [1]}).iloc[0, 0] == 1
+assert Document() is not None
+assert xlsxwriter.__version__
+`;
+
+const playwrightScript = `
+import { chromium } from "playwright";
+const browser = await chromium.launch({ headless: true, args: ["--no-sandbox"] });
+const page = await browser.newPage({ viewport: { width: 640, height: 480 } });
+await page.setContent("<main><h1>Anvia sandbox</h1></main>");
+await page.screenshot({ path: "output/screenshot.png" });
+await browser.close();
+`;

--- a/packages/tool-sandbox/test/image-builder.test.ts
+++ b/packages/tool-sandbox/test/image-builder.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import {
+  artifactPythonPackages,
+  renderSandboxImageContext,
+  resolveSandboxImageSpec,
+  unpinnedSandboxImagePackages,
+} from "../src/image-builder";
+
+describe("sandbox image builder", () => {
+  it("normalizes composable features and their runtime dependencies", () => {
+    const spec = resolveSandboxImageSpec({
+      name: "creative-suite",
+      runtimes: ["bun"],
+      features: ["playwright", "artifacts"],
+      packages: {
+        apt: ["imagemagick=8:7.1.1.43+dfsg1-1"],
+        npm: ["sharp@0.34.4"],
+        pip: ["scipy==1.17.0"],
+      },
+    });
+
+    expect(spec.runtimes).toEqual(["node", "bun", "python"]);
+    expect(spec.features).toEqual(["artifacts", "playwright"]);
+    expect(spec.tag).toBe("anvia-sandbox-creative-suite:latest");
+  });
+
+  it("renders a combined context with pinned dependencies", () => {
+    const spec = resolveSandboxImageSpec({
+      name: "reports",
+      features: ["artifacts", "playwright"],
+    });
+    const context = renderSandboxImageContext(spec, "0.5.0");
+    const dockerfile = context.files.get("Dockerfile");
+    const requirements = context.files.get("requirements.txt");
+    const packageJson = JSON.parse(context.files.get("package.json") ?? "{}") as {
+      dependencies?: Record<string, string>;
+    };
+
+    expect(dockerfile).toContain("FROM node:24.18.0-bookworm-slim AS node-runtime");
+    expect(dockerfile).toContain("FROM python:3.13.14-slim-bookworm AS python-runtime");
+    expect(dockerfile).toContain("mcr.microsoft.com/playwright:v1.61.0-noble");
+    expect(dockerfile).toContain("COPY --from=uv-runtime /uv /uvx /usr/local/bin/");
+    expect(dockerfile).toContain("WORKDIR /workspace");
+    expect(dockerfile).toContain("ENTRYPOINT []");
+    expect(requirements?.trim().split("\n")).toEqual(artifactPythonPackages);
+    expect(packageJson.dependencies).toEqual({ playwright: "1.61.0" });
+    expect(context.manifest).toMatchObject({
+      schemaVersion: 1,
+      generatedBy: { package: "@anvia/sandbox", version: "0.5.0" },
+      runtimes: ["node", "python"],
+    });
+    expect(context.manifest.generatedFiles).toEqual([
+      ".dockerignore",
+      "Dockerfile",
+      "anvia-sandbox.json",
+      "package.json",
+      "requirements.txt",
+    ]);
+  });
+
+  it("uses Bun to install npm-registry packages when Node is absent", () => {
+    const spec = resolveSandboxImageSpec({
+      name: "bun-tools",
+      runtimes: ["bun"],
+      packages: { npm: ["prettier@3.8.2"] },
+    });
+    const context = renderSandboxImageContext(spec, "0.5.0");
+
+    expect(spec.runtimes).toEqual(["bun"]);
+    expect(context.files.get("Dockerfile")).toContain("cd /opt/anvia-js");
+    expect(context.files.get("Dockerfile")).toContain("bun install --production --no-save");
+    expect(context.files.get("Dockerfile")).toContain(
+      "ENV PATH=/opt/anvia-js/node_modules/.bin:$PATH",
+    );
+    expect(context.files.get("Dockerfile")).not.toContain("FROM node:");
+  });
+
+  it("adds a runtime for runtime-specific custom packages", () => {
+    expect(
+      resolveSandboxImageSpec({ name: "python-extra", packages: { pip: ["rich==14.3.3"] } })
+        .runtimes,
+    ).toEqual(["python"]);
+    expect(
+      resolveSandboxImageSpec({ name: "node-extra", packages: { npm: ["tsx@4.21.0"] } }).runtimes,
+    ).toEqual(["node"]);
+  });
+
+  it("rejects unsafe or ambiguous inputs", () => {
+    expect(() => resolveSandboxImageSpec({ name: "Invalid", runtimes: ["node"] })).toThrow(
+      "Image name",
+    );
+    expect(() =>
+      resolveSandboxImageSpec({
+        name: "bad-apt",
+        runtimes: ["node"],
+        packages: { apt: ["git curl"] },
+      }),
+    ).toThrow("Invalid apt package");
+    expect(() =>
+      resolveSandboxImageSpec({
+        name: "bad-npm",
+        runtimes: ["node"],
+        packages: { npm: ["package@1.0.0;rm"] },
+      }),
+    ).toThrow("Invalid npm package version");
+    expect(() => resolveSandboxImageSpec({ name: "empty", runtimes: [], features: [] })).toThrow(
+      "Select at least one",
+    );
+  });
+
+  it("reports custom packages whose versions can drift", () => {
+    const spec = resolveSandboxImageSpec({
+      name: "unpinned",
+      runtimes: ["node"],
+      packages: {
+        apt: ["git", "curl=8.0"],
+        npm: ["prettier", "tsx@4.21.0"],
+        pip: ["rich", "pydantic==2.12.5"],
+      },
+    });
+
+    expect(unpinnedSandboxImagePackages(spec)).toEqual(["git", "prettier", "rich"]);
+  });
+});

--- a/packages/tool-sandbox/test/image-builder.test.ts
+++ b/packages/tool-sandbox/test/image-builder.test.ts
@@ -15,7 +15,7 @@ describe("sandbox image builder", () => {
       packages: {
         apt: ["imagemagick=8:7.1.1.43+dfsg1-1"],
         npm: ["sharp@0.34.4"],
-        pip: ["scipy==1.17.0"],
+        uv: ["scipy==1.17.0"],
       },
     });
 
@@ -31,7 +31,7 @@ describe("sandbox image builder", () => {
     });
     const context = renderSandboxImageContext(spec, "0.5.0");
     const dockerfile = context.files.get("Dockerfile");
-    const requirements = context.files.get("requirements.txt");
+    const pythonProject = context.files.get("pyproject.toml");
     const packageJson = JSON.parse(context.files.get("package.json") ?? "{}") as {
       dependencies?: Record<string, string>;
     };
@@ -40,9 +40,14 @@ describe("sandbox image builder", () => {
     expect(dockerfile).toContain("FROM python:3.13.14-slim-bookworm AS python-runtime");
     expect(dockerfile).toContain("mcr.microsoft.com/playwright:v1.61.0-noble");
     expect(dockerfile).toContain("COPY --from=uv-runtime /uv /uvx /usr/local/bin/");
+    expect(dockerfile).toContain("uv sync --no-dev --no-cache --no-install-project");
+    expect(dockerfile).toContain("ENV VIRTUAL_ENV=/opt/anvia-python/.venv");
+    expect(dockerfile).toContain("ENV PATH=/opt/anvia-python/.venv/bin:$PATH");
     expect(dockerfile).toContain("WORKDIR /workspace");
     expect(dockerfile).toContain("ENTRYPOINT []");
-    expect(requirements?.trim().split("\n")).toEqual(artifactPythonPackages);
+    for (const requirement of artifactPythonPackages) {
+      expect(pythonProject).toContain(JSON.stringify(requirement));
+    }
     expect(packageJson.dependencies).toEqual({ playwright: "1.61.0" });
     expect(context.manifest).toMatchObject({
       schemaVersion: 1,
@@ -54,7 +59,7 @@ describe("sandbox image builder", () => {
       "Dockerfile",
       "anvia-sandbox.json",
       "package.json",
-      "requirements.txt",
+      "pyproject.toml",
     ]);
   });
 
@@ -77,7 +82,7 @@ describe("sandbox image builder", () => {
 
   it("adds a runtime for runtime-specific custom packages", () => {
     expect(
-      resolveSandboxImageSpec({ name: "python-extra", packages: { pip: ["rich==14.3.3"] } })
+      resolveSandboxImageSpec({ name: "python-extra", packages: { uv: ["rich==14.3.3"] } })
         .runtimes,
     ).toEqual(["python"]);
     expect(
@@ -115,10 +120,10 @@ describe("sandbox image builder", () => {
       packages: {
         apt: ["git", "curl=8.0"],
         npm: ["prettier", "tsx@4.21.0"],
-        pip: ["rich", "pydantic==2.12.5"],
+        uv: ["rich", "pydantic==2.12.5"],
       },
     });
 
-    expect(unpinnedSandboxImagePackages(spec)).toEqual(["git", "prettier", "rich"]);
+    expect(unpinnedSandboxImagePackages(spec)).toEqual(["prettier", "rich"]);
   });
 });

--- a/packages/tool-studio/package.json
+++ b/packages/tool-studio/package.json
@@ -71,6 +71,6 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "@anvia/core": ">=0.13.0 <1.0.0"
+    "@anvia/core": ">=0.13.4 <1.0.0"
   }
 }

--- a/packages/tool-studio/src/runtime/agent-runs.ts
+++ b/packages/tool-studio/src/runtime/agent-runs.ts
@@ -313,6 +313,7 @@ function createRunRequest(props: {
             ? [...props.body.history, props.promptMessage]
             : props.body.message,
         );
+  request.withCompletionRetries();
   if (props.body.maxTurns !== undefined) {
     request.maxTurns(props.body.maxTurns);
   }

--- a/packages/tool-studio/test/runner.test.ts
+++ b/packages/tool-studio/test/runner.test.ts
@@ -39,7 +39,7 @@ import {
   type VectorSearchToolOptions,
 } from "@anvia/core/vector-store";
 import { Hono } from "hono";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import {
   createInMemoryStudioStore,
@@ -88,6 +88,37 @@ class QueueModel {
   }
 }
 
+type CompletionOutcome = { response: CompletionResponse } | { error: unknown };
+
+class FlakyQueueModel {
+  readonly provider = "test";
+  readonly defaultModel = "test";
+  readonly capabilities = {
+    streaming: false,
+    tools: true,
+    toolChoice: true,
+    imageInput: true,
+    documentInput: true,
+    outputSchema: true,
+    reasoning: true,
+  };
+  readonly requests: CompletionRequest[] = [];
+
+  constructor(private readonly outcomes: CompletionOutcome[]) {}
+
+  async completion(request: CompletionRequest): Promise<CompletionResponse> {
+    this.requests.push(request);
+    const outcome = this.outcomes.shift();
+    if (outcome === undefined) {
+      throw new Error("No queued outcome");
+    }
+    if ("error" in outcome) {
+      throw outcome.error;
+    }
+    return outcome.response;
+  }
+}
+
 class StreamingQueueModel implements StreamingCompletionModel {
   readonly provider = "test";
   readonly defaultModel = "test";
@@ -102,7 +133,11 @@ class StreamingQueueModel implements StreamingCompletionModel {
   };
   readonly requests: CompletionRequest[] = [];
 
-  constructor(private readonly responses: CompletionStreamEvent[][]) {}
+  constructor(
+    private readonly responses: Array<
+      Iterable<CompletionStreamEvent> | AsyncIterable<CompletionStreamEvent>
+    >,
+  ) {}
 
   async completion(): Promise<CompletionResponse> {
     throw new Error("completion should not be called");
@@ -123,8 +158,18 @@ class StreamingQueueModel implements StreamingCompletionModel {
     if (response === undefined) {
       throw new Error("No queued stream response");
     }
-    yield* response;
+    for await (const event of response) {
+      yield event;
+    }
   }
+}
+
+async function* streamThenThrow(
+  events: CompletionStreamEvent[],
+  error: unknown,
+): AsyncIterable<CompletionStreamEvent> {
+  yield* events;
+  throw error;
 }
 
 class GatedReasoningModel implements StreamingCompletionModel {
@@ -1668,6 +1713,34 @@ describe("Anvia studio", () => {
     ]);
   });
 
+  it("retries transient completion failures for buffered agent runs", async () => {
+    const error = Object.assign(new Error("temporarily unavailable"), { status: 503 });
+    const model = new FlakyQueueModel([
+      { error },
+      { response: response([AssistantContent.text("recovered")]) },
+    ]);
+    const agent = new AgentBuilder("support", model).build();
+    const runner = new Studio([agent]);
+    const random = vi.spyOn(Math, "random").mockReturnValue(0);
+
+    try {
+      const res = await runner.fetch(
+        new Request("http://runner.test/agents/support/runs", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ message: "hi" }),
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toMatchObject({ output: "recovered" });
+      expect(model.requests).toHaveLength(2);
+      expect(model.requests[1]).toBe(model.requests[0]);
+    } finally {
+      random.mockRestore();
+    }
+  });
+
   it("passes trace options to observed non-streaming runs and preserves trace output", async () => {
     const observer = new TraceObserver();
     const model = new QueueModel([response([AssistantContent.text("traced")])]);
@@ -1724,6 +1797,38 @@ describe("Anvia studio", () => {
       { type: "turn_end", turn: 1 },
       { type: "final", output: "hello" },
     ]);
+  });
+
+  it("retries transient streaming failures before the first provider event", async () => {
+    const error = Object.assign(new Error("temporarily unavailable"), { status: 503 });
+    const model = new StreamingQueueModel([
+      streamThenThrow([], error),
+      [{ type: "text_delta", delta: "recovered" }],
+    ]);
+    const agent = new AgentBuilder("support", model).build();
+    const runner = new Studio([agent]);
+    const random = vi.spyOn(Math, "random").mockReturnValue(0);
+
+    try {
+      const res = await runner.fetch(
+        new Request("http://runner.test/agents/support/runs", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ message: "hi", stream: true }),
+        }),
+      );
+      const events = await readJsonl(res);
+
+      expect(res.status).toBe(200);
+      expect(events).not.toContainEqual(expect.objectContaining({ type: "error" }));
+      expect(events).toContainEqual(
+        expect.objectContaining({ type: "final", output: "recovered" }),
+      );
+      expect(model.requests).toHaveLength(2);
+      expect(model.requests[1]).toBe(model.requests[0]);
+    } finally {
+      random.mockRestore();
+    }
   });
 
   it("accepts shared UI-style agent run requests", async () => {
@@ -3903,6 +4008,7 @@ describe("Anvia studio", () => {
         error: expect.objectContaining({ message: "stream failed" }),
       }),
     );
+    expect(model.requests).toHaveLength(1);
 
     const loaded = await runner.fetch(new Request(`http://runner.test/sessions/${session.id}`));
     await expect(loaded.json()).resolves.toMatchObject({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -776,7 +776,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@8.1.0(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/server:
     dependencies:
@@ -802,6 +802,9 @@ importers:
 
   packages/tool-sandbox:
     dependencies:
+      '@clack/prompts':
+        specifier: ^1.7.0
+        version: 1.7.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -820,7 +823,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@8.1.0(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/tool-studio:
     dependencies:
@@ -1600,8 +1603,16 @@ packages:
     resolution: {integrity: sha512-0Ty/1Gfm+Kb07sXcuESjyKfwEhSy4Ns1AgeEisHb/bDY5fWme0tTeTkU14T1Gmcs17YIjB/teiDe4uaCghbYqQ==}
     engines: {node: '>= 20.12.0'}
 
+  '@clack/core@1.4.3':
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
+    engines: {node: '>= 20.12.0'}
+
   '@clack/prompts@1.6.0':
     resolution: {integrity: sha512-EYlRokl8szrP9Z25qT5aepMdBjzBvHF9ZEhzIiUBc9guz/T31EqRgvD0QSgZcpE93xiwrr+OkB4nz0BZyF6fSA==}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.7.0':
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
 
   '@cloudflare/kv-asset-handler@0.5.0':
@@ -8884,9 +8895,21 @@ snapshots:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
+  '@clack/core@1.4.3':
+    dependencies:
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
   '@clack/prompts@1.6.0':
     dependencies:
       '@clack/core': 1.4.2
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.7.0':
+    dependencies:
+      '@clack/core': 1.4.3
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5


### PR DESCRIPTION
## Summary

- enable completion retries for Studio agent runs through `withCompletionRetries()`
- add `pnpm dlx @anvia/sandbox create-image` for interactive and scripted Docker image creation
- support composable Node.js, Bun, Python, artifact-generation, and Playwright capabilities
- offer curated apt, npm, and uv package selections while preserving `apt`, `npm`, and `uv` manifest groups
- generate Python environments from `pyproject.toml` with `uv sync`

## Impact

Studio runs now use the core completion retry behavior. Sandbox users can generate reproducible local images for document, data, browser, and custom tool workloads without manually authoring Dockerfiles.

## Validation

- `pnpm --filter @anvia/studio typecheck`
- `pnpm --filter @anvia/studio test`
- `pnpm --filter @anvia/studio build`
- `pnpm --filter @anvia/sandbox typecheck`
- `pnpm --filter @anvia/sandbox test`
- `pnpm --filter @anvia/sandbox build`
- `ANVIA_SANDBOX_DOCKER_TESTS=1 pnpm --filter @anvia/sandbox test -- image-builder.integration.test.ts`
- `pnpm --filter www reference-check`
- `pnpm --filter www build`
- manual TTY wizard verification


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an image builder CLI for creating and optionally building custom sandbox Docker images with selected runtimes, features, and packages.
  * Supports interactive and scriptable workflows, dry runs, version pinning, and generated build contexts.

* **Bug Fixes**
  * Studio agent runs now retry transient completion failures, including eligible streaming failures before output begins.

* **Documentation**
  * Added setup and reference documentation for the sandbox image builder and Studio retry behavior.

* **Tests**
  * Added coverage for CLI workflows, image generation, Docker integration, and completion retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->