### PR TITLE
feat: add smooth streaming display

### DIFF
--- a/.changeset/smooth-stream-display.md
+++ b/.changeset/smooth-stream-display.md
@@ -1,0 +1,9 @@
+---
+"@anvia/react": minor
+"@anvia/react-ui": minor
+"@anvia/studio": patch
+---
+
+Replace stream animation presets with lifecycle-driven, buffered smoothing for text and ordered
+mixed items. Add stable-block live Markdown rendering and use the pipeline in the Studio Playground
+transcript.

--- a/apps/www/src/components/docs/StreamSmoothingComparison.astro
+++ b/apps/www/src/components/docs/StreamSmoothingComparison.astro
@@ -167,6 +167,15 @@
       setStatus(smoothStatus, "Buffering", "waiting");
       comparison.dataset.playing = "true";
 
+      if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+        setOutput(directOutput, directCount, fullText);
+        setOutput(smoothOutput, smoothCount, fullText);
+        setStatus(directStatus, "Complete", "complete");
+        setStatus(smoothStatus, "Complete", "complete");
+        comparison.dataset.playing = "false";
+        return;
+      }
+
       const startedAt = performance.now();
       let lastFrameAt = startedAt;
       let smoothCursor = 0;

--- a/apps/www/src/components/docs/StreamSmoothingComparison.astro
+++ b/apps/www/src/components/docs/StreamSmoothingComparison.astro
@@ -1,0 +1,494 @@
+<figure class="stream-comparison" data-stream-comparison>
+  <div class="stream-comparison__header">
+    <div>
+      <span class="stream-comparison__eyebrow">Interactive comparison</span>
+      <h4>Same source events, different display</h4>
+    </div>
+
+    <button type="button" class="stream-comparison__replay" data-stream-replay>
+      <svg aria-hidden="true" viewBox="0 0 20 20" fill="none">
+        <path d="M4.5 6.5V2.75m0 0H8.25m-3.75 0 2.02 2.02A6.25 6.25 0 1 1 3.75 10" />
+      </svg>
+      Replay
+    </button>
+  </div>
+
+  <div class="stream-comparison__grid">
+    <section class="stream-panel" aria-label="Without smoothing: source updates">
+      <div class="stream-panel__header">
+        <div>
+          <span class="stream-panel__kicker">Without smoothing</span>
+          <h5>Source updates</h5>
+        </div>
+        <span class="stream-panel__status" data-stream-direct-status>
+          <span aria-hidden="true"></span>
+          Waiting
+        </span>
+      </div>
+
+      <div class="stream-panel__output" aria-label="Direct streamed text">
+        <span data-stream-direct-output></span><span class="stream-panel__cursor" aria-hidden="true"></span>
+      </div>
+
+      <div class="stream-panel__footer">
+        <span>Immediate</span>
+        <span data-stream-direct-count>0 chars</span>
+      </div>
+    </section>
+
+    <section class="stream-panel stream-panel--smooth" aria-label="With smoothing: buffered display">
+      <div class="stream-panel__header">
+        <div>
+          <span class="stream-panel__kicker">With smoothing</span>
+          <h5>Buffered display</h5>
+        </div>
+        <span class="stream-panel__status" data-stream-smooth-status>
+          <span aria-hidden="true"></span>
+          Waiting
+        </span>
+      </div>
+
+      <div class="stream-panel__output" aria-label="Smoothed streamed text">
+        <span data-stream-smooth-output></span><span class="stream-panel__cursor" aria-hidden="true"></span>
+      </div>
+
+      <div class="stream-panel__footer">
+        <span>Paced</span>
+        <span data-stream-smooth-count>0 chars</span>
+      </div>
+    </section>
+  </div>
+
+  <figcaption>
+    Both views receive the same bursty source and finish with identical text. Smoothing changes only
+    the display cadence; the stored message is unchanged.
+  </figcaption>
+</figure>
+
+<script>
+  const sourceChunks = [
+    { atMs: 100, text: "Here’s" },
+    { atMs: 145, text: " the rollout plan:" },
+    { atMs: 500, text: " validate" },
+    { atMs: 540, text: " the schema," },
+    { atMs: 880, text: " stream every response," },
+    { atMs: 920, text: " and keep" },
+    { atMs: 1_260, text: " tool calls in order." },
+  ] as const;
+  const bufferMs = 225;
+  const completionDrainMs = 700;
+
+  const comparisons = document.querySelectorAll<HTMLElement>("[data-stream-comparison]");
+
+  comparisons.forEach((comparison) => {
+    if (comparison.dataset.initialized === "true") {
+      return;
+    }
+
+    comparison.dataset.initialized = "true";
+
+    const directOutput = comparison.querySelector<HTMLElement>("[data-stream-direct-output]");
+    const smoothOutput = comparison.querySelector<HTMLElement>("[data-stream-smooth-output]");
+    const directCount = comparison.querySelector<HTMLElement>("[data-stream-direct-count]");
+    const smoothCount = comparison.querySelector<HTMLElement>("[data-stream-smooth-count]");
+    const directStatus = comparison.querySelector<HTMLElement>("[data-stream-direct-status]");
+    const smoothStatus = comparison.querySelector<HTMLElement>("[data-stream-smooth-status]");
+    const replay = comparison.querySelector<HTMLButtonElement>("[data-stream-replay]");
+
+    if (
+      !directOutput ||
+      !smoothOutput ||
+      !directCount ||
+      !smoothCount ||
+      !directStatus ||
+      !smoothStatus ||
+      !replay
+    ) {
+      return;
+    }
+
+    const fullText = sourceChunks.map((chunk) => chunk.text).join("");
+    const finalSourceAtMs = sourceChunks.at(-1)?.atMs ?? 0;
+    let animationFrame = 0;
+
+    const setStatus = (element: HTMLElement, label: string, state: string) => {
+      element.lastChild?.remove();
+      element.append(document.createTextNode(label));
+      element.dataset.state = state;
+    };
+
+    const setOutput = (element: HTMLElement, countElement: HTMLElement, text: string) => {
+      element.textContent = text;
+      countElement.textContent = `${text.length} ${text.length === 1 ? "char" : "chars"}`;
+    };
+
+    const getDirectText = (elapsedMs: number) =>
+      sourceChunks
+        .filter((chunk) => elapsedMs >= chunk.atMs)
+        .map((chunk) => chunk.text)
+        .join("");
+
+    const getBufferedTargetLength = (elapsedMs: number) => {
+      const playbackAtMs = elapsedMs - bufferMs;
+      const samples = [{ atMs: 0, totalChars: 0 }];
+      let totalChars = 0;
+
+      for (const chunk of sourceChunks) {
+        totalChars += chunk.text.length;
+        samples.push({ atMs: chunk.atMs, totalChars });
+      }
+
+      if (playbackAtMs <= 0) {
+        return 0;
+      }
+
+      for (let index = 1; index < samples.length; index += 1) {
+        const previous = samples[index - 1];
+        const next = samples[index];
+        if (!previous || !next || playbackAtMs > next.atMs) {
+          continue;
+        }
+
+        const progress = Math.min(
+          Math.max((playbackAtMs - previous.atMs) / (next.atMs - previous.atMs), 0),
+          1,
+        );
+        return previous.totalChars + (next.totalChars - previous.totalChars) * progress;
+      }
+
+      return fullText.length;
+    };
+
+    const play = () => {
+      cancelAnimationFrame(animationFrame);
+      setOutput(directOutput, directCount, "");
+      setOutput(smoothOutput, smoothCount, "");
+      setStatus(directStatus, "Waiting", "waiting");
+      setStatus(smoothStatus, "Buffering", "waiting");
+      comparison.dataset.playing = "true";
+
+      const startedAt = performance.now();
+      let lastFrameAt = startedAt;
+      let smoothCursor = 0;
+
+      const tick = (now: number) => {
+        const elapsedMs = now - startedAt;
+        const elapsedSinceFrameMs = Math.min(Math.max(now - lastFrameAt, 0), 64);
+        const directText = getDirectText(elapsedMs);
+        const sourceComplete = elapsedMs >= finalSourceAtMs;
+        const bufferedTarget = getBufferedTargetLength(elapsedMs);
+        const pendingChars = Math.max(0, fullText.length - smoothCursor);
+        const playbackPendingChars = Math.max(0, bufferedTarget - smoothCursor);
+        const streamingRate = Math.min(360, 200 + playbackPendingChars * 4);
+        const drainDeadlineAtMs = finalSourceAtMs + completionDrainMs;
+        const remainingDrainMs = Math.max(drainDeadlineAtMs - elapsedMs, 1);
+        const completionRate = Math.min(1_600, Math.max(140, (pendingChars / remainingDrainMs) * 1_000));
+        const charsPerSecond = sourceComplete ? completionRate : streamingRate;
+        const nextTarget = sourceComplete ? fullText.length : bufferedTarget;
+
+        smoothCursor = Math.min(
+          nextTarget,
+          smoothCursor + (elapsedSinceFrameMs / 1_000) * charsPerSecond,
+        );
+
+        const smoothText = fullText.slice(0, Math.floor(smoothCursor));
+        setOutput(directOutput, directCount, directText);
+        setOutput(smoothOutput, smoothCount, smoothText);
+
+        setStatus(
+          directStatus,
+          sourceComplete ? "Complete" : directText.length === 0 ? "Waiting" : "Receiving",
+          sourceComplete ? "complete" : directText.length === 0 ? "waiting" : "active",
+        );
+        setStatus(
+          smoothStatus,
+          smoothText.length >= fullText.length
+            ? "Complete"
+            : sourceComplete
+              ? "Draining"
+              : smoothText.length === 0
+                ? "Buffering"
+                : "Playing",
+          smoothText.length >= fullText.length
+            ? "complete"
+            : sourceComplete
+              ? "draining"
+              : smoothText.length === 0
+                ? "waiting"
+                : "active",
+        );
+
+        lastFrameAt = now;
+
+        if (smoothText.length < fullText.length) {
+          animationFrame = requestAnimationFrame(tick);
+          return;
+        }
+
+        comparison.dataset.playing = "false";
+      };
+
+      animationFrame = requestAnimationFrame(tick);
+    };
+
+    replay.addEventListener("click", play);
+
+    if ("IntersectionObserver" in window) {
+      const observer = new IntersectionObserver(
+        (entries) => {
+          if (!entries.some((entry) => entry.isIntersecting)) {
+            return;
+          }
+
+          observer.disconnect();
+          play();
+        },
+        { threshold: 0.35 },
+      );
+      observer.observe(comparison);
+    } else {
+      play();
+    }
+  });
+</script>
+
+<style>
+  .stream-comparison {
+    --comparison-accent: #2bf563;
+    --comparison-border: rgba(255, 255, 255, 0.09);
+    --comparison-panel: rgba(255, 255, 255, 0.025);
+    margin: 1.35rem 0 0;
+    overflow: hidden;
+    border: 1px solid var(--comparison-border);
+    border-radius: 0.9rem;
+    background:
+      linear-gradient(135deg, rgba(43, 245, 99, 0.03) 0 1px, transparent 1px 28px),
+      #101011;
+  }
+
+  .stream-comparison__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid var(--comparison-border);
+    padding: 1rem 1.1rem;
+  }
+
+  .stream-comparison__eyebrow,
+  .stream-panel__kicker,
+  .stream-panel__footer,
+  .stream-panel__status {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  }
+
+  .stream-comparison__eyebrow {
+    color: color-mix(in srgb, var(--comparison-accent) 72%, transparent);
+    font-size: 0.65rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .stream-comparison h4,
+  .stream-comparison h5 {
+    margin: 0;
+    color: rgb(244 244 245);
+    font-weight: 650;
+  }
+
+  .stream-comparison h4 {
+    margin-top: 0.25rem;
+    font-size: 1rem;
+  }
+
+  .stream-comparison h5 {
+    margin-top: 0.2rem;
+    font-size: 0.9rem;
+  }
+
+  .stream-comparison__replay {
+    display: inline-flex;
+    flex: none;
+    align-items: center;
+    gap: 0.4rem;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 0.55rem;
+    background: rgba(255, 255, 255, 0.055);
+    padding: 0.5rem 0.7rem;
+    color: rgb(228 228 231);
+    font: inherit;
+    font-size: 0.75rem;
+    font-weight: 700;
+    line-height: 1;
+    cursor: pointer;
+    transition:
+      border-color 150ms ease,
+      background-color 150ms ease,
+      color 150ms ease;
+  }
+
+  .stream-comparison__replay:hover {
+    border-color: rgba(43, 245, 99, 0.32);
+    background: rgba(43, 245, 99, 0.08);
+    color: var(--comparison-accent);
+  }
+
+  .stream-comparison__replay:focus-visible {
+    outline: 2px solid var(--comparison-accent);
+    outline-offset: 2px;
+  }
+
+  .stream-comparison__replay svg {
+    width: 0.9rem;
+    height: 0.9rem;
+    stroke: currentColor;
+    stroke-width: 1.6;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .stream-comparison[data-playing="true"] .stream-comparison__replay svg {
+    animation: stream-comparison-spin 900ms linear infinite;
+  }
+
+  .stream-comparison__grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+    padding: 0.75rem;
+  }
+
+  .stream-panel {
+    min-width: 0;
+    overflow: hidden;
+    border: 1px solid var(--comparison-border);
+    border-radius: 0.7rem;
+    background: var(--comparison-panel);
+  }
+
+  .stream-panel--smooth {
+    border-color: rgba(43, 245, 99, 0.2);
+    background: rgba(43, 245, 99, 0.035);
+  }
+
+  .stream-panel__header,
+  .stream-panel__footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .stream-panel__header {
+    min-height: 3.7rem;
+    border-bottom: 1px solid var(--comparison-border);
+    padding: 0.75rem;
+  }
+
+  .stream-panel__kicker {
+    color: rgb(113 113 122);
+    font-size: 0.62rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .stream-panel--smooth .stream-panel__kicker {
+    color: color-mix(in srgb, var(--comparison-accent) 68%, transparent);
+  }
+
+  .stream-panel__status {
+    display: inline-flex;
+    flex: none;
+    align-items: center;
+    gap: 0.35rem;
+    color: rgb(161 161 170);
+    font-size: 0.62rem;
+  }
+
+  .stream-panel__status > span {
+    width: 0.38rem;
+    height: 0.38rem;
+    border-radius: 999px;
+    background: rgb(82 82 91);
+  }
+
+  .stream-panel__status[data-state="active"] > span,
+  .stream-panel__status[data-state="draining"] > span {
+    background: var(--comparison-accent);
+    box-shadow: 0 0 0 0.2rem rgba(43, 245, 99, 0.1);
+  }
+
+  .stream-panel__status[data-state="complete"] > span {
+    background: rgb(161 161 170);
+  }
+
+  .stream-panel__output {
+    min-height: 8.25rem;
+    padding: 1rem 0.9rem;
+    color: rgb(228 228 231);
+    font-size: 0.88rem;
+    line-height: 1.75;
+  }
+
+  .stream-panel__cursor {
+    display: inline-block;
+    width: 0.42rem;
+    height: 1em;
+    margin-left: 0.16rem;
+    translate: 0 0.12em;
+    background: currentColor;
+    opacity: 0.35;
+    animation: stream-comparison-blink 900ms steps(1, end) infinite;
+  }
+
+  .stream-comparison[data-playing="false"] .stream-panel__cursor {
+    display: none;
+  }
+
+  .stream-panel__footer {
+    border-top: 1px solid var(--comparison-border);
+    padding: 0.55rem 0.75rem;
+    color: rgb(113 113 122);
+    font-size: 0.62rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .stream-comparison figcaption {
+    border-top: 1px solid var(--comparison-border);
+    padding: 0.8rem 1.1rem;
+    color: rgb(161 161 170);
+    font-size: 0.75rem;
+    line-height: 1.6;
+  }
+
+  @keyframes stream-comparison-spin {
+    to {
+      rotate: 360deg;
+    }
+  }
+
+  @keyframes stream-comparison-blink {
+    50% {
+      opacity: 0;
+    }
+  }
+
+  @media (max-width: 42rem) {
+    .stream-comparison__grid {
+      grid-template-columns: 1fr;
+    }
+
+    .stream-panel__output {
+      min-height: 6.75rem;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .stream-comparison__replay svg,
+    .stream-panel__cursor {
+      animation: none !important;
+    }
+  }
+</style>

--- a/apps/www/src/content/docs/packages/react-ui/reference.md
+++ b/apps/www/src/content/docs/packages/react-ui/reference.md
@@ -19,6 +19,8 @@ Subpath entrypoints are also available:
 - `@anvia/react-ui/message`
 - `@anvia/react-ui/selection-toolbar`
 - `@anvia/react-ui/shared`
+- `@anvia/react-ui/stream`
+- `@anvia/react-ui/stream/styles.css`
 - `@anvia/react-ui/thread-list`
 - `@anvia/react-ui/styles.css`
 
@@ -158,22 +160,22 @@ const ThreadListItem: {
 };
 ```
 
-## Streamed text animation
+## Streamed text smoothing
 
-`Message.Text` and `Message.Markdown` accept these optional display props:
+`Message.Parts`, `Message.Text`, and `Message.Markdown` accept an optional `stream` lifecycle:
 
 ```ts
-type MessageStreamAnimationProps = {
-  animate?: boolean;
-  animationMode?: "none" | "smooth" | "fadeIn";
-  isStreaming?: boolean;
-  smoothingPreset?: "realtime" | "balanced" | "silky";
-  reducedMotion?: boolean;
+type MessageStreamOptions = {
+  isStreaming: boolean;
+  resetKey: string | number;
+  flushImmediately?: boolean;
 };
 ```
 
-Animation is disabled by default. When enabled, these renderers pass their existing text through
-`useSmoothStreamText`; the underlying `useChat` controller and `UIMessage[]` remain unchanged.
+Smoothing is disabled by default. Keep `stream` present when `isStreaming` changes to `false` so
+buffered text drains. `Message.Parts` smooths text and reasoning together and delays later opaque
+parts, such as tools, until preceding text is visible. The underlying `useChat` controller and
+`UIMessage[]` remain unchanged.
 
 `Message.Markdown` also accepts `renderEntity?: (entity: ComposerEntity) => ReactNode`. Valid
 entities from `message.metadata.composer.entities` render through `Message.Entity` by default.
@@ -186,6 +188,25 @@ type MessageEntityProps = React.HTMLAttributes<HTMLSpanElement> & {
 
 The default span emits `data-anvia-message-entity`, `data-entity-id`, and `data-trigger-id`. It does
 not serialize `entity.data` into the DOM.
+
+## StreamMarkdown
+
+Import `StreamMarkdown` from `@anvia/react-ui` or `@anvia/react-ui/stream`:
+
+```ts
+type StreamMarkdownProps = React.HTMLAttributes<HTMLDivElement> & {
+  content: string;
+  live?: boolean;
+  components?: Components;
+  remarkPlugins?: ReactMarkdownOptions["remarkPlugins"];
+  remarkRehypeOptions?: ReactMarkdownOptions["remarkRehypeOptions"];
+};
+```
+
+`StreamMarkdown` is context-free and does not pace content itself. It keeps completed top-level
+Markdown blocks stable as `content` grows and applies a two-band reveal only to text in the final
+live block. Preformatted code is excluded. Import `@anvia/react-ui/stream/styles.css` when using the
+subpath by itself.
 
 ## Providers
 
@@ -507,4 +528,5 @@ non-archived threads by default and accepts `archived` for archived lists.
 ## Styling
 
 Import `@anvia/react-ui/styles.css` for functional prototype styling, or target the emitted
-`data-anvia-*` attributes directly. Application CSS owns layout, spacing, colors, and cards.
+`data-anvia-*` attributes directly. Standalone `StreamMarkdown` consumers can import only
+`@anvia/react-ui/stream/styles.css`. Application CSS owns layout, spacing, colors, and cards.

--- a/apps/www/src/content/docs/packages/react-ui/usage-patterns.md
+++ b/apps/www/src/content/docs/packages/react-ui/usage-patterns.md
@@ -118,6 +118,24 @@ application state.
 Use `Message.Markdown` when text parts should render GitHub-flavored Markdown; pass `components` to
 replace code blocks or other Markdown elements with app-owned components.
 
+For a streaming mixed-part response, put the lifecycle on `Message.Parts` so tool cards remain
+behind buffered text:
+
+```tsx
+<Message.Parts
+  stream={{
+    isStreaming: chat.status === "streaming" && chat.messages.at(-1)?.id === message.id,
+    resetKey: message.id,
+    flushImmediately: chat.status === "error",
+  }}
+>
+  {(part) => (part.type === "text" ? <Message.Markdown /> : <Message.Part />)}
+</Message.Parts>
+```
+
+Keep the lifecycle present with `isStreaming: false` at completion to allow the buffered tail to
+drain. Change `resetKey` when the displayed conversation changes.
+
 ## Completion panels
 
 Use `Completion.Root`, `Completion.Output`, `Completion.Form`, `Completion.Input`,

--- a/apps/www/src/content/docs/packages/react/reference.md
+++ b/apps/www/src/content/docs/packages/react/reference.md
@@ -426,35 +426,67 @@ continues tailing live events until `stream_end`. Custom `createRequest` callbac
 ## useSmoothStreamText
 
 ```ts
-type StreamAnimationMode = "none" | "smooth" | "fadeIn";
-type StreamSmoothingPreset = "realtime" | "balanced" | "silky";
-
-type UseSmoothStreamTextOptions = {
-  enabled?: boolean;
-  mode?: StreamAnimationMode;
-  isStreaming?: boolean;
-  preset?: StreamSmoothingPreset;
-  reducedMotion?: boolean;
-  largeAppendChars?: number;
+type StreamSmoothingLifecycle = {
+  isStreaming: boolean;
+  resetKey: string | number;
+  flushImmediately?: boolean;
 };
+
+type UseSmoothStreamTextOptions = StreamSmoothingLifecycle;
 
 type UseSmoothStreamTextResult = {
   text: string;
   isAnimating: boolean;
+  isDraining: boolean;
   flush(): void;
-  reset(nextText?: string): void;
 };
 
 function useSmoothStreamText(
   content: string,
-  options?: UseSmoothStreamTextOptions,
+  options: UseSmoothStreamTextOptions,
 ): UseSmoothStreamTextResult;
 ```
 
-Purpose: progressively reveal append-only display text with `requestAnimationFrame`. It does not
-consume transport events, update `UIMessage[]`, or replace `useChat`. Replacement text, large
-appends over the default 500-character threshold, disabled animation, stopped streaming, and
-reduced motion synchronize immediately.
+Purpose: buffer and pace append-only display text with elapsed-time `requestAnimationFrame`
+updates. It does not consume transport events, update `UIMessage[]`, or replace `useChat`.
+
+Keep the hook mounted when `isStreaming` changes to `false`; it enters a bounded completion drain
+instead of snapping to the target. Change `resetKey` when loading a different conversation so its
+existing content seeds immediately. `flushImmediately` and `flush()` reveal the complete target,
+including for terminal errors, hidden tabs, and non-animation environments. Reveals respect
+grapheme boundaries and the internal backlog is bounded.
+
+## useSmoothStreamItems
+
+```ts
+type SmoothStreamItemAdapter<T> = {
+  getKey(item: T): string;
+  getText(item: T): string | undefined;
+  withText(item: T, text: string): T;
+};
+
+type UseSmoothStreamItemsOptions<T> = StreamSmoothingLifecycle & {
+  adapter: SmoothStreamItemAdapter<T>;
+};
+
+type UseSmoothStreamItemsResult<T> = {
+  items: readonly T[];
+  isAnimating: boolean;
+  isDraining: boolean;
+  liveItemKey: string | null;
+  flush(): void;
+};
+
+function useSmoothStreamItems<T>(
+  items: readonly T[],
+  options: UseSmoothStreamItemsOptions<T>,
+): UseSmoothStreamItemsResult<T>;
+```
+
+Purpose: apply the same smoothing state machine to ordered heterogeneous items. Return text only
+for items that should be paced; return `undefined` for opaque items such as tools. Opaque items are
+held behind preceding buffered text, while updates to an already visible opaque item are applied
+immediately. `liveItemKey` identifies the current growing item for a tail-only visual treatment.
 
 ## useCompletion
 

--- a/apps/www/src/content/docs/react-ui/messages.mdx
+++ b/apps/www/src/content/docs/react-ui/messages.mdx
@@ -9,6 +9,7 @@ sidebar:
 ---
 
 import CodeVariants from "../../../components/docs/CodeVariants.astro";
+import StreamSmoothingComparison from "../../../components/docs/StreamSmoothingComparison.astro";
 import { defaultRendererVariants, messageRowVariants, customRendererVariants, markdownVariants } from "../../../lib/react-ui-code-variants";
 
 `Message.Root` renders one Anvia `UIMessage`. `Message.Parts` renders the message's streamed
@@ -149,34 +150,106 @@ code, fenced code, or link destinations remain literal. Regular Markdown links, 
 plugins, and `components.span` overrides continue to work. Entity `data` is never serialized into
 the DOM.
 
-### Opt-in streaming animation
+### Opt-in stream smoothing
 
-`useChat(...)` continues to own the real message state. Enable display smoothing only on the latest
-assistant message while its response is streaming:
+Stream smoothing changes only what is displayed. `useChat(...)` still receives and stores the
+complete source message immediately.
+
+<StreamSmoothingComparison />
+
+Use these rules:
+
+1. Put `stream` on `Message.Parts` when a response can contain reasoning, text, and tools. This
+   preserves their reveal order.
+2. Keep the `stream` prop mounted when the request finishes. Change `isStreaming` from `true` to
+   `false`; removing `stream` immediately would skip the completion drain.
+3. Use a stable `resetKey` for the displayed response. `message.id` is the normal choice and also
+   prevents loaded history from replaying.
+
+The recommended mixed-part integration is:
 
 ```tsx
 <Thread.Messages>
-  {(message) => (
-    <Message.Root>
-      <Message.Content>
-        <Message.Markdown
-          animate
-          isStreaming={
-            chat.status === "streaming" &&
-            message.role === "assistant" &&
-            chat.messages.at(-1)?.id === message.id
-          }
-          animationMode="smooth"
-          smoothingPreset="balanced"
-        />
-      </Message.Content>
-    </Message.Root>
-  )}
+  {(message) => {
+    const isAssistant = message.role === "assistant";
+    const isLatestAssistant = isAssistant && chat.messages.at(-1)?.id === message.id;
+    const stream = {
+      // true while source events arrive; false starts the final drain
+      isStreaming: isLatestAssistant && chat.status === "streaming",
+      // keep stable for this response; change it when switching responses
+      resetKey: message.id,
+      // errors should show their complete source text immediately
+      flushImmediately: isLatestAssistant && chat.status === "error",
+    };
+
+    return (
+      <Message.Root>
+        <Message.Content>
+          <Message.Parts {...(isAssistant ? { stream } : {})}>
+            {(part) => (part.type === "text" ? <Message.Markdown /> : <Message.Part />)}
+          </Message.Parts>
+        </Message.Content>
+      </Message.Root>
+    );
+  }}
 </Thread.Messages>
 ```
 
-Use `animationMode="fadeIn"` to combine the same progressive reveal with the optional stylesheet's
-entry fade. Reduced-motion preferences and non-streaming content display immediately.
+`Message.Parts` smooths text and reasoning parts. A new tool part waits until preceding buffered
+text is visible, while updates to a tool that is already visible render immediately.
+
+#### Stream lifecycle
+
+| Option | Set it to | What happens |
+| --- | --- | --- |
+| `isStreaming` | `true` only while source events are arriving | The display follows the buffered source timeline. |
+| `isStreaming` | `false` after completion or stop | Remaining buffered text drains smoothly, usually within 700 ms. |
+| `resetKey` | A stable message or session identifier | Existing content seeds immediately when the identifier changes. |
+| `flushImmediately` | `true` for a terminal error or forced completion | The display synchronizes to the complete source without draining. |
+
+Do not conditionally remove `stream` as soon as `chat.status` becomes `"idle"`. Keep it present for
+assistant messages and let `isStreaming: false` finish the drain:
+
+```tsx
+// Avoid: this removes smoothing before its buffered tail can drain.
+{chat.status === "streaming" ? (
+  <Message.Parts stream={{ isStreaming: true, resetKey: message.id }} />
+) : (
+  <Message.Parts />
+)}
+
+// Use: the same lifecycle remains mounted through completion.
+<Message.Parts
+  stream={{
+    isStreaming: chat.status === "streaming",
+    resetKey: message.id,
+  }}
+/>
+```
+
+#### Text-only rendering
+
+If the surface renders one text value and has no later tool parts to order, put the same lifecycle
+directly on `Message.Text` or `Message.Markdown`:
+
+```tsx
+<Message.Markdown
+  stream={{
+    isStreaming: isLatestAssistant && chat.status === "streaming",
+    resetKey: message.id,
+    flushImmediately: isLatestAssistant && chat.status === "error",
+  }}
+/>
+```
+
+This smooths only Markdown text. Use `Message.Parts` instead when tool cards must wait behind text.
+The standalone `StreamMarkdown` component does not perform pacing by itself; it renders whatever
+display string its `content` prop receives.
+
+The fixed pacing adapts to source throughput, preserves grapheme boundaries, bounds its backlog,
+and drains completion without a snap. The Markdown renderer keeps completed blocks stable and
+applies the live-tail opacity treatment only to the growing final block. Pacing works without the
+optional stylesheet; import `@anvia/react-ui/styles.css` to enable the 180 ms opacity settle.
 
 ## Filtering parts
 

--- a/apps/www/src/content/docs/react-ui/reference.md
+++ b/apps/www/src/content/docs/react-ui/reference.md
@@ -219,10 +219,10 @@ provider supplied by that list.
 | --- | --- | --- | --- |
 | `Message.Root` | `article` | child function via parent | Provides one `UIMessage`. |
 | `Message.Content` | `div` | element props | Wraps message body. |
-| `Message.Parts` | `div` | `filter`, child function | Renders message parts. |
+| `Message.Parts` | `div` | `filter`, `stream`, child function | Renders message parts and can preserve text/tool reveal order. |
 | `Message.Part` | `div` | child function | Provides one `UIMessagePart`. |
-| `Message.Text` | `span` | element props | Renders text part as plain text. |
-| `Message.Markdown` | `div` | `components`, `remarkPlugins`, `renderEntity` | Renders text with GitHub-flavored Markdown and validated Composer entities. |
+| `Message.Text` | `span` | `stream`, element props | Renders text part as plain text. |
+| `Message.Markdown` | `div` | `stream`, `components`, `remarkPlugins`, `renderEntity` | Renders stable-block GitHub-flavored Markdown and validated Composer entities. |
 | `Message.Entity` | `span` | `entity`, span props | Renders headless semantic entity markup. |
 | `Message.CodeBlock` | `pre` | `code`, `language` | Markdown code block helper. |
 | `Message.Reasoning` | `details` | element props | Renders reasoning parts. |

--- a/packages/react-ui/README.md
+++ b/packages/react-ui/README.md
@@ -60,18 +60,25 @@ support inline `@`, `/`, `$`, or other entity chips; selected entities are submi
 `metadata.composer.entities`. Use `Composer.TextareaInput` when you need the previous native
 textarea behavior.
 
-Streaming text animation is opt-in and display-only. Keep `useChat` as the owner of transport and
-`UIMessage[]` state, then enable smoothing on the latest streaming assistant message:
+Streaming smoothing is opt-in and display-only. Keep `useChat` as the owner of transport and
+`UIMessage[]` state. Keep the lifecycle mounted after streaming stops so its buffered tail drains;
+`Message.Parts` also keeps later tool parts behind text that has not been revealed yet:
 
 ```tsx
-<Message.Markdown
-  animate
-  isStreaming={
-    chat.status === "streaming" &&
-    message.role === "assistant" &&
-    chat.messages.at(-1)?.id === message.id
-  }
-  animationMode="smooth"
-  smoothingPreset="balanced"
-/>
+<Message.Parts
+  stream={{
+    isStreaming:
+      chat.status === "streaming" &&
+      message.role === "assistant" &&
+      chat.messages.at(-1)?.id === message.id,
+    resetKey: message.id,
+    flushImmediately: chat.status === "error",
+  }}
+>
+  {(part) => (part.type === "text" ? <Message.Markdown /> : <Message.Part />)}
+</Message.Parts>
 ```
+
+For app-owned text state, `StreamMarkdown` is available from `@anvia/react-ui/stream`. It is a
+context-free renderer: pass the already displayed text as `content`, set `live` only for its growing
+tail, and import `@anvia/react-ui/stream/styles.css` for the settle animation.

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -52,6 +52,11 @@
       "types": "./dist/selection-toolbar/index.d.ts",
       "import": "./dist/selection-toolbar/index.js"
     },
+    "./stream": {
+      "types": "./dist/stream/index.d.ts",
+      "import": "./dist/stream/index.js"
+    },
+    "./stream/styles.css": "./dist/stream/styles.css",
     "./shared": {
       "types": "./dist/shared.d.ts",
       "import": "./dist/shared.js"
@@ -63,7 +68,7 @@
     "./styles.css": "./dist/styles.css"
   },
   "scripts": {
-    "build": "tsup src/index.ts src/attachment/index.ts src/chat/index.ts src/completion/index.ts src/human-input/index.ts src/image/index.ts src/message/index.ts src/selection-toolbar/index.ts src/shared.ts src/thread-list/index.ts --format esm --dts --sourcemap --clean --external react --external react-dom && cp src/styles.css dist/styles.css",
+    "build": "tsup src/index.ts src/attachment/index.ts src/chat/index.ts src/completion/index.ts src/human-input/index.ts src/image/index.ts src/message/index.ts src/selection-toolbar/index.ts src/shared.ts src/stream/index.ts src/thread-list/index.ts --format esm --dts --sourcemap --clean --external react --external react-dom && cp src/styles.css dist/styles.css && cp src/stream/styles.css dist/stream/styles.css",
     "coverage": "vitest run --coverage",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
@@ -80,11 +85,12 @@
     "@tiptap/pm": "^3.27.3",
     "@tiptap/react": "^3.27.3",
     "@tiptap/suggestion": "^3.27.3",
+    "marked": "^15.0.12",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1"
   },
   "peerDependencies": {
-    "@anvia/react": ">=0.7.8 <1.0.0",
+    "@anvia/react": ">=0.9.0 <1.0.0",
     "react": ">=18",
     "react-dom": ">=18"
   },

--- a/packages/react-ui/src/chat/thread.tsx
+++ b/packages/react-ui/src/chat/thread.tsx
@@ -84,12 +84,31 @@ const ThreadViewport = forwardRef<HTMLDivElement, ThreadViewportProps>(function 
     }
   }, [autoScroll, messages, thread]);
 
+  useEffect(() => {
+    const viewport = thread.viewportRef.current;
+    if (viewport === null || !autoScroll || typeof ResizeObserver !== "function") {
+      return;
+    }
+    const content = viewport.querySelector<HTMLElement>("[data-anvia-thread-messages]");
+    if (content === null) {
+      return;
+    }
+    const observer = new ResizeObserver(() => {
+      if (thread.atBottom) {
+        thread.scrollToBottom("auto");
+      }
+    });
+    observer.observe(viewport);
+    observer.observe(content);
+    return () => observer.disconnect();
+  }, [autoScroll, thread]);
+
   const handleScroll = useCallback(
     (event: UIEvent<HTMLDivElement>) => {
       onScroll?.(event);
       const node = event.currentTarget;
       const distanceFromBottom = node.scrollHeight - node.scrollTop - node.clientHeight;
-      thread.setAtBottom(distanceFromBottom < 8);
+      thread.setAtBottom(distanceFromBottom < 80);
     },
     [onScroll, thread],
   );

--- a/packages/react-ui/src/contexts/message.tsx
+++ b/packages/react-ui/src/contexts/message.tsx
@@ -6,7 +6,9 @@ export type MessageContextValue = {
 };
 
 export type MessagePartContextValue = {
+  isLive: boolean;
   part: UIMessagePart;
+  streamControlled: boolean;
 };
 
 const MessageContext = createContext<MessageContextValue | undefined>(undefined);
@@ -24,12 +26,20 @@ export function InternalMessageProvider({
 
 export function InternalMessagePartProvider({
   part,
+  isLive = false,
+  streamControlled = false,
   children,
 }: {
   part: UIMessagePart;
+  isLive?: boolean;
+  streamControlled?: boolean;
   children?: ReactNode;
 }): ReactElement {
-  return createElement(MessagePartContext.Provider, { value: { part } }, children);
+  return createElement(
+    MessagePartContext.Provider,
+    { value: { isLive, part, streamControlled } },
+    children,
+  );
 }
 
 export function useMessage(): MessageContextValue {

--- a/packages/react-ui/src/index.ts
+++ b/packages/react-ui/src/index.ts
@@ -26,6 +26,7 @@ export type {
   MessageAttachmentPart,
   MessageEntityProps,
   MessagePartsFilter,
+  MessageStreamOptions,
   MessageToolPart,
   MessageToolRenderWhen,
 } from "./message/index";
@@ -64,6 +65,8 @@ export type {
   SelectionToolbarContextValue,
   ThreadContextValue,
 } from "./shared";
+export type { StreamMarkdownProps } from "./stream/index";
+export { StreamMarkdown } from "./stream/index";
 export type {
   ThreadListController,
   ThreadListItemContextValue,

--- a/packages/react-ui/src/message/index.ts
+++ b/packages/react-ui/src/message/index.ts
@@ -49,6 +49,7 @@ export type { MessageEntityProps } from "./entity";
 export type {
   MessageAttachmentPart,
   MessagePartsFilter,
+  MessageStreamOptions,
   MessageToolPart,
   MessageToolRenderWhen,
 } from "./parts";

--- a/packages/react-ui/src/message/parts.tsx
+++ b/packages/react-ui/src/message/parts.tsx
@@ -1,16 +1,19 @@
 import {
-  type StreamAnimationMode,
-  type StreamSmoothingPreset,
+  type SmoothStreamItemAdapter,
+  type StreamSmoothingLifecycle,
   type UIAttachment,
   type UIMessagePart,
-  type UseSmoothStreamTextOptions,
+  useSmoothStreamItems,
   useSmoothStreamText,
 } from "@anvia/react";
-import { type ComponentPropsWithoutRef, createElement, forwardRef, type ReactNode } from "react";
-import ReactMarkdown, {
-  type Components,
-  type Options as ReactMarkdownOptions,
-} from "react-markdown";
+import {
+  type ComponentPropsWithoutRef,
+  createElement,
+  forwardRef,
+  type ReactNode,
+  useMemo,
+} from "react";
+import type { Components, Options as ReactMarkdownOptions } from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 import { Attachment } from "../attachment/index";
@@ -25,6 +28,7 @@ import {
 import { entitiesForTextSegment, messageTextLayout, validComposerEntities } from "../entities";
 import { stringifyValue } from "../format";
 import { type PrimitiveProps, renderPrimitive } from "../primitives";
+import { StreamMarkdown } from "../stream";
 import { MessageEntity } from "./entity";
 import { createMessageEntityRemarkPlugin, messageEntityRehypeOptions } from "./markdown-entities";
 
@@ -36,40 +40,100 @@ export type MessageToolRenderWhen = "always" | "pending" | "settled";
 export type MessageAttachmentPart = Extract<UIMessagePart, { type: "attachment" }>;
 type MessageAttachmentChildren = ReactNode | ((attachment: UIAttachment) => ReactNode);
 
-type MessageStreamAnimationProps = {
-  animate?: boolean;
-  animationMode?: StreamAnimationMode;
-  isStreaming?: boolean;
-  smoothingPreset?: StreamSmoothingPreset;
-  reducedMotion?: boolean;
+export type MessageStreamOptions = StreamSmoothingLifecycle;
+
+type MessageStreamProps = {
+  stream?: MessageStreamOptions;
+};
+
+const messagePartStreamAdapter: SmoothStreamItemAdapter<UIMessagePart> = {
+  getKey: (part) => part.id,
+  getText: (part) => (part.type === "text" || part.type === "reasoning" ? part.text : undefined),
+  withText: (part, text) => {
+    if (part.type === "text" || part.type === "reasoning") {
+      return part.text === text ? part : { ...part, text };
+    }
+    return part;
+  },
 };
 
 type MessagePartsProps = Omit<PrimitiveProps<"div">, "children"> & {
   children?: MessagePartChildren;
   filter?: MessagePartsFilter;
-};
+} & MessageStreamProps;
 
 const MessageParts = forwardRef<HTMLDivElement, MessagePartsProps>(function MessageParts(
-  { children, filter, ...props },
+  { children, filter, stream, ...props },
   ref,
 ) {
   const { message } = useMessage();
   const parts = filter === undefined ? message.parts : message.parts.filter(filter);
+  if (stream !== undefined) {
+    return (
+      <SmoothedMessageParts {...props} parts={parts} ref={ref} stream={stream}>
+        {children}
+      </SmoothedMessageParts>
+    );
+  }
 
   return renderPrimitive(
     "div",
     {
       ...props,
-      children: parts.map((part) => (
-        <InternalMessagePartProvider key={part.id} part={part}>
-          {typeof children === "function" ? children(part) : (children ?? <MessagePart />)}
-        </InternalMessagePartProvider>
-      )),
+      children: renderMessagePartNodes(parts, children),
       "data-anvia-message-parts": "",
     } as PrimitiveProps<"div">,
     ref,
   );
 });
+
+type SmoothedMessagePartsProps = Omit<PrimitiveProps<"div">, "children"> & {
+  children?: MessagePartChildren;
+  parts: readonly UIMessagePart[];
+  stream: MessageStreamOptions;
+};
+
+const SmoothedMessageParts = forwardRef<HTMLDivElement, SmoothedMessagePartsProps>(
+  function SmoothedMessageParts({ children, parts, stream, ...props }, ref) {
+    const smooth = useSmoothStreamItems(parts, {
+      adapter: messagePartStreamAdapter,
+      isStreaming: stream.isStreaming,
+      resetKey: stream.resetKey,
+      ...(stream.flushImmediately === undefined
+        ? {}
+        : { flushImmediately: stream.flushImmediately }),
+    });
+
+    return renderPrimitive(
+      "div",
+      {
+        ...props,
+        children: renderMessagePartNodes(smooth.items, children, smooth.liveItemKey),
+        "data-anvia-message-parts": "",
+        "data-draining": smooth.isDraining ? "" : undefined,
+        "data-streaming": stream.isStreaming ? "" : undefined,
+      } as PrimitiveProps<"div">,
+      ref,
+    );
+  },
+);
+
+function renderMessagePartNodes(
+  parts: readonly UIMessagePart[],
+  children: MessagePartChildren | undefined,
+  liveItemKey?: string | null,
+): ReactNode[] {
+  return parts.map((part) => (
+    <InternalMessagePartProvider
+      isLive={liveItemKey === part.id}
+      key={part.id}
+      part={part}
+      streamControlled={liveItemKey !== undefined}
+    >
+      {typeof children === "function" ? children(part) : (children ?? <MessagePart />)}
+    </InternalMessagePartProvider>
+  ));
+}
 
 type MessagePartProps = Omit<PrimitiveProps<"div">, "children"> & {
   children?: MessagePartChildren;
@@ -95,59 +159,50 @@ const MessagePart = forwardRef<HTMLDivElement, MessagePartProps>(function Messag
   );
 });
 
-type MessageTextProps = PrimitiveProps<"span"> & MessageStreamAnimationProps;
+type MessageTextProps = PrimitiveProps<"span"> & MessageStreamProps;
 
 const MessageText = forwardRef<HTMLSpanElement, MessageTextProps>(function MessageText(props, ref) {
-  const { part } = useMessagePart();
+  const { part, streamControlled } = useMessagePart();
   if (part.type !== "text") {
     return null;
   }
 
-  return <MessageTextContent {...props} content={part.text} ref={ref} />;
+  return (
+    <MessageTextContent
+      {...props}
+      content={part.text}
+      partId={part.id}
+      ref={ref}
+      streamControlled={streamControlled}
+    />
+  );
 });
 
 type MessageTextContentProps = MessageTextProps & {
   content: string;
+  partId: string;
+  streamControlled: boolean;
 };
 
 const MessageTextContent = forwardRef<HTMLSpanElement, MessageTextContentProps>(
-  function MessageTextContent(
-    {
-      animate = false,
-      animationMode = "smooth",
-      isStreaming,
-      smoothingPreset,
-      reducedMotion,
-      content,
-      ...props
-    },
-    ref,
-  ) {
-    const animationEnabled = animate && props.children === undefined;
-    const smooth = useSmoothStreamText(
-      content,
-      smoothStreamOptions(
-        animationEnabled,
-        animationMode,
-        isStreaming,
-        smoothingPreset,
-        reducedMotion,
-      ),
-    );
-    const animationActive =
-      animationEnabled &&
-      animationMode !== "none" &&
-      isStreaming !== false &&
-      reducedMotion !== true;
+  function MessageTextContent({ content, partId, stream, streamControlled, ...props }, ref) {
+    const ownsStream = stream !== undefined && !streamControlled && props.children === undefined;
+    const smooth = useSmoothStreamText(content, {
+      isStreaming: ownsStream ? stream.isStreaming : false,
+      resetKey: ownsStream ? stream.resetKey : partId,
+      ...(ownsStream && stream.flushImmediately !== undefined
+        ? { flushImmediately: stream.flushImmediately }
+        : {}),
+    });
 
     return renderPrimitive(
       "span",
       {
         ...props,
-        children: props.children ?? (animationEnabled ? smooth.text : content),
+        children: props.children ?? (ownsStream ? smooth.text : content),
         "data-anvia-text": "",
-        "data-anvia-stream-animation": animationEnabled ? animationMode : undefined,
-        "data-streaming": animationActive ? "" : undefined,
+        "data-draining": ownsStream && smooth.isDraining ? "" : undefined,
+        "data-streaming": ownsStream && stream.isStreaming ? "" : undefined,
       } as PrimitiveProps<"span">,
       ref,
     );
@@ -155,7 +210,7 @@ const MessageTextContent = forwardRef<HTMLSpanElement, MessageTextContentProps>(
 );
 
 type MessageMarkdownProps = Omit<PrimitiveProps<"div">, "children"> &
-  MessageStreamAnimationProps & {
+  MessageStreamProps & {
     children?: string;
     components?: Components;
     renderEntity?: ((entity: ComposerEntity) => ReactNode) | undefined;
@@ -186,64 +241,100 @@ const MessageMarkdown = forwardRef<HTMLDivElement, MessageMarkdownProps>(functio
       : undefined;
   const entities =
     segment === undefined ? validEntities : entitiesForTextSegment(validEntities, segment);
+  const lastPart = message.parts.at(-1);
+  const liveEligible = part?.type === "text" ? lastPart?.id === part.id : lastPart?.type === "text";
 
-  return <MessageMarkdownContent {...props} entities={entities} markdown={markdown} ref={ref} />;
+  return (
+    <MessageMarkdownContent
+      {...props}
+      entities={entities}
+      liveEligible={liveEligible}
+      markdown={markdown}
+      ref={ref}
+      resetKey={message.id}
+      streamControlled={partContext?.streamControlled ?? false}
+      streamLive={partContext?.isLive ?? false}
+    />
+  );
 });
 
 type MessageMarkdownContentProps = Omit<MessageMarkdownProps, "children"> & {
   entities: ComposerEntity[];
+  liveEligible: boolean;
   markdown: string;
+  resetKey: string;
+  streamControlled: boolean;
+  streamLive: boolean;
 };
 
 const MessageMarkdownContent = forwardRef<HTMLDivElement, MessageMarkdownContentProps>(
   function MessageMarkdownContent(
     {
-      animate = false,
-      animationMode = "smooth",
-      isStreaming,
-      smoothingPreset,
-      reducedMotion,
       components,
       renderEntity,
       remarkPlugins,
       entities,
+      liveEligible,
       markdown,
+      resetKey,
+      stream,
+      streamControlled,
+      streamLive,
       ...props
     },
     ref,
   ) {
-    const smooth = useSmoothStreamText(
-      markdown,
-      smoothStreamOptions(animate, animationMode, isStreaming, smoothingPreset, reducedMotion),
-    );
-    const animationActive =
-      animate && animationMode !== "none" && isStreaming !== false && reducedMotion !== true;
-    const renderedMarkdown = animate ? smooth.text : markdown;
-    const renderedEntities = validComposerEntities(renderedMarkdown, {
-      composer: { entities },
+    const ownsStream = stream !== undefined && !streamControlled;
+    const smooth = useSmoothStreamText(markdown, {
+      isStreaming: ownsStream ? stream.isStreaming : false,
+      resetKey: ownsStream ? stream.resetKey : resetKey,
+      ...(ownsStream && stream.flushImmediately !== undefined
+        ? { flushImmediately: stream.flushImmediately }
+        : {}),
     });
-
-    return renderPrimitive(
-      "div",
-      {
-        ...props,
-        children: (
-          <ReactMarkdown
-            components={markdownComponents(components, renderedEntities, renderEntity)}
-            remarkPlugins={[
+    const renderedMarkdown = ownsStream ? smooth.text : markdown;
+    const renderedEntities = useMemo(
+      () =>
+        entities.length === 0
+          ? entities
+          : validComposerEntities(renderedMarkdown, {
+              composer: { entities },
+            }),
+      [entities, renderedMarkdown],
+    );
+    const renderedComponents = useMemo(
+      () => markdownComponents(components, renderedEntities, renderEntity),
+      [components, renderEntity, renderedEntities],
+    );
+    const renderedRemarkPlugins = useMemo(
+      () =>
+        renderedEntities.length === 0
+          ? remarkPlugins
+          : [
               createMessageEntityRemarkPlugin(renderedMarkdown, renderedEntities),
               ...(remarkPlugins ?? [remarkGfm]),
-            ]}
-            remarkRehypeOptions={messageEntityRehypeOptions()}
-          >
-            {renderedMarkdown}
-          </ReactMarkdown>
-        ),
-        "data-anvia-markdown": "",
-        "data-anvia-stream-animation": animate ? animationMode : undefined,
-        "data-streaming": animationActive ? "" : undefined,
-      } as PrimitiveProps<"div">,
-      ref,
+            ],
+      [remarkPlugins, renderedEntities, renderedMarkdown],
+    );
+    const live = streamControlled
+      ? streamLive
+      : ownsStream && liveEligible && (stream.isStreaming || smooth.isDraining);
+
+    return (
+      <StreamMarkdown
+        {...props}
+        components={renderedComponents}
+        content={renderedMarkdown}
+        data-anvia-markdown=""
+        data-draining={ownsStream && smooth.isDraining ? "" : undefined}
+        data-streaming={ownsStream && stream.isStreaming ? "" : undefined}
+        live={live}
+        ref={ref}
+        remarkPlugins={renderedRemarkPlugins}
+        remarkRehypeOptions={
+          renderedEntities.length === 0 ? undefined : messageEntityRehypeOptions()
+        }
+      />
     );
   },
 );
@@ -295,20 +386,6 @@ function markdownComponents(
       return <span {...elementProps} />;
     },
   };
-}
-
-function smoothStreamOptions(
-  enabled: boolean,
-  mode: StreamAnimationMode,
-  isStreaming: boolean | undefined,
-  preset: StreamSmoothingPreset | undefined,
-  reducedMotion: boolean | undefined,
-): UseSmoothStreamTextOptions {
-  const options: UseSmoothStreamTextOptions = { enabled, mode };
-  if (isStreaming !== undefined) options.isStreaming = isStreaming;
-  if (preset !== undefined) options.preset = preset;
-  if (reducedMotion !== undefined) options.reducedMotion = reducedMotion;
-  return options;
 }
 
 type MessageCodeBlockProps = Omit<PrimitiveProps<"pre">, "children"> & {

--- a/packages/react-ui/src/stream/index.ts
+++ b/packages/react-ui/src/stream/index.ts
@@ -1,0 +1,2 @@
+export type { StreamMarkdownProps } from "./markdown";
+export { StreamMarkdown } from "./markdown";

--- a/packages/react-ui/src/stream/markdown-blocks.ts
+++ b/packages/react-ui/src/stream/markdown-blocks.ts
@@ -1,0 +1,48 @@
+import { lexer } from "marked";
+
+export type StreamMarkdownBlock = {
+  content: string;
+  startOffset: number;
+};
+
+export function splitStreamMarkdownBlocks(
+  content: string,
+  options: { singleDocument?: boolean } = {},
+): StreamMarkdownBlock[] {
+  if (content.length === 0) {
+    return [];
+  }
+  if (options.singleDocument === true) {
+    return [{ content, startOffset: 0 }];
+  }
+
+  try {
+    const tokens = lexer(content, { gfm: false });
+    if (tokens.some((token) => token.type === "def") || Object.keys(tokens.links).length > 0) {
+      return [{ content, startOffset: 0 }];
+    }
+
+    const rawBlocks: string[] = [];
+    for (const token of tokens) {
+      if (token.type === "space" && rawBlocks.length > 0) {
+        const lastIndex = rawBlocks.length - 1;
+        rawBlocks[lastIndex] = `${rawBlocks[lastIndex] ?? ""}${token.raw}`;
+      } else {
+        rawBlocks.push(token.raw);
+      }
+    }
+
+    if (rawBlocks.length === 0 || rawBlocks.join("") !== content) {
+      return [{ content, startOffset: 0 }];
+    }
+
+    let startOffset = 0;
+    return rawBlocks.map((block) => {
+      const result = { content: block, startOffset };
+      startOffset += block.length;
+      return result;
+    });
+  } catch {
+    return [{ content, startOffset: 0 }];
+  }
+}

--- a/packages/react-ui/src/stream/markdown-reveal.ts
+++ b/packages/react-ui/src/stream/markdown-reveal.ts
@@ -1,0 +1,180 @@
+export const streamRevealConfig = {
+  bandGraphemes: 2,
+  minimumOpacity: 0.12,
+  tailGraphemes: 24,
+} as const;
+
+type MarkdownNode = {
+  type: string;
+  tagName?: string;
+  value?: string;
+  properties?: Record<string, unknown>;
+  children?: MarkdownNode[];
+};
+
+type TextTarget = {
+  endOffset: number;
+  index: number;
+  node: MarkdownNode;
+  parent: MarkdownNode;
+  startOffset: number;
+};
+
+type RevealBand = {
+  endOffset: number;
+  opacity: number;
+  startOffset: number;
+};
+
+export function createStreamGradientRevealPlugin(frameId: number) {
+  return function streamGradientRevealPlugin() {
+    return (tree: MarkdownNode) => {
+      const targets = collectTextTargets(tree);
+      const renderedText = targets.map((target) => target.node.value ?? "").join("");
+      const bands = createRevealBands(renderedText);
+      wrapStreamRevealBands(targets, bands, frameId);
+    };
+  };
+}
+
+function collectTextTargets(tree: MarkdownNode): TextTarget[] {
+  const targets: TextTarget[] = [];
+  let offset = 0;
+
+  function visit(node: MarkdownNode, parent: MarkdownNode | undefined, index: number): void {
+    if (node.type === "element" && node.tagName === "pre") {
+      return;
+    }
+    if (node.type === "text" && node.value !== undefined && parent !== undefined) {
+      if (!/\S/u.test(node.value)) {
+        return;
+      }
+      const startOffset = offset;
+      offset += node.value.length;
+      targets.push({
+        endOffset: offset,
+        index,
+        node,
+        parent,
+        startOffset,
+      });
+      return;
+    }
+    for (const [childIndex, child] of (node.children ?? []).entries()) {
+      visit(child, node, childIndex);
+    }
+  }
+
+  visit(tree, undefined, 0);
+  return targets;
+}
+
+function createRevealBands(content: string): RevealBand[] {
+  const tail = segmentTailGraphemeRanges(content, streamRevealConfig.tailGraphemes);
+  const bands: RevealBand[] = [];
+
+  for (let index = 0; index < tail.length; index += streamRevealConfig.bandGraphemes) {
+    const first = tail[index];
+    const endIndex = Math.min(index + streamRevealConfig.bandGraphemes, tail.length) - 1;
+    const last = tail[endIndex];
+    if (first === undefined || last === undefined) {
+      continue;
+    }
+    const progress = tail.length === 1 ? 1 : endIndex / (tail.length - 1);
+    bands.push({
+      startOffset: first.startOffset,
+      endOffset: last.endOffset,
+      opacity: Math.max(
+        streamRevealConfig.minimumOpacity,
+        1 - progress * (1 - streamRevealConfig.minimumOpacity),
+      ),
+    });
+  }
+  return bands;
+}
+
+function wrapStreamRevealBands(
+  targets: readonly TextTarget[],
+  bands: readonly RevealBand[],
+  frameId: number,
+): void {
+  for (const target of [...targets].reverse()) {
+    const value = target.node.value ?? "";
+    const intersectingBands = bands.filter(
+      (band) => band.endOffset > target.startOffset && band.startOffset < target.endOffset,
+    );
+    if (intersectingBands.length === 0) {
+      continue;
+    }
+
+    const replacement: MarkdownNode[] = [];
+    let cursor = 0;
+    for (const band of intersectingBands) {
+      const start = Math.max(0, band.startOffset - target.startOffset);
+      const end = Math.min(value.length, band.endOffset - target.startOffset);
+      if (start > cursor) {
+        replacement.push({ type: "text", value: value.slice(cursor, start) });
+      }
+      if (end > start) {
+        replacement.push({
+          type: "element",
+          tagName: "span",
+          properties: {
+            "data-anvia-stream-frame-id": `${frameId}:${band.startOffset}`,
+            "data-anvia-stream-opacity": String(band.opacity),
+            "data-anvia-stream-reveal": "",
+          },
+          children: [{ type: "text", value: value.slice(start, end) }],
+        });
+      }
+      cursor = Math.max(cursor, end);
+    }
+    if (cursor < value.length) {
+      replacement.push({ type: "text", value: value.slice(cursor) });
+    }
+    target.parent.children?.splice(target.index, 1, ...replacement);
+  }
+}
+
+function segmentTailGraphemeRanges(
+  content: string,
+  limit: number,
+): Array<{
+  endOffset: number;
+  startOffset: number;
+}> {
+  if (typeof Intl !== "undefined" && typeof Intl.Segmenter === "function") {
+    const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+    const segments = segmenter.segment(content);
+    const ranges: Array<{ endOffset: number; startOffset: number }> = [];
+    let cursor = content.length;
+    while (cursor > 0 && ranges.length < limit) {
+      const segment = segments.containing(cursor - 1);
+      if (segment === undefined) {
+        break;
+      }
+      ranges.unshift({
+        startOffset: segment.index,
+        endOffset: segment.index + segment.segment.length,
+      });
+      cursor = segment.index;
+    }
+    return ranges;
+  }
+
+  const ranges: Array<{ endOffset: number; startOffset: number }> = [];
+  let cursor = content.length;
+  while (cursor > 0 && ranges.length < limit) {
+    let startOffset = cursor - 1;
+    const code = content.charCodeAt(startOffset);
+    if (code >= 0xdc00 && code <= 0xdfff && startOffset > 0) {
+      const previousCode = content.charCodeAt(startOffset - 1);
+      if (previousCode >= 0xd800 && previousCode <= 0xdbff) {
+        startOffset -= 1;
+      }
+    }
+    ranges.unshift({ startOffset, endOffset: cursor });
+    cursor = startOffset;
+  }
+  return ranges;
+}

--- a/packages/react-ui/src/stream/markdown.tsx
+++ b/packages/react-ui/src/stream/markdown.tsx
@@ -1,0 +1,157 @@
+import {
+  type ComponentPropsWithoutRef,
+  createElement,
+  forwardRef,
+  memo,
+  type ReactNode,
+  useMemo,
+  useRef,
+} from "react";
+import ReactMarkdown, {
+  type Components,
+  type Options as ReactMarkdownOptions,
+} from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+import { type PrimitiveProps, renderPrimitive } from "../primitives";
+import { splitStreamMarkdownBlocks } from "./markdown-blocks";
+import { createStreamGradientRevealPlugin } from "./markdown-reveal";
+
+export type StreamMarkdownProps = Omit<PrimitiveProps<"div">, "children"> & {
+  components?: Components;
+  content: string;
+  live?: boolean;
+  remarkPlugins?: ReactMarkdownOptions["remarkPlugins"];
+  remarkRehypeOptions?: ReactMarkdownOptions["remarkRehypeOptions"];
+};
+
+const defaultRemarkPlugins: NonNullable<ReactMarkdownOptions["remarkPlugins"]> = [remarkGfm];
+
+export const StreamMarkdown = forwardRef<HTMLDivElement, StreamMarkdownProps>(
+  function StreamMarkdown(
+    { components, content, live = false, remarkPlugins, remarkRehypeOptions, ...props },
+    ref,
+  ) {
+    const previousContentRef = useRef(content);
+    const frameIdRef = useRef(0);
+    if (previousContentRef.current !== content) {
+      previousContentRef.current = content;
+      frameIdRef.current += 1;
+    }
+
+    const blocks = useMemo(
+      () =>
+        splitStreamMarkdownBlocks(content, {
+          singleDocument: remarkPlugins !== undefined,
+        }),
+      [content, remarkPlugins],
+    );
+    const streamingComponents = useMemo(() => withStreamRevealComponent(components), [components]);
+
+    return renderPrimitive(
+      "div",
+      {
+        ...props,
+        children: blocks.map((block, index) => (
+          <StreamMarkdownBlock
+            components={streamingComponents}
+            content={block.content}
+            frameId={live && index === blocks.length - 1 ? frameIdRef.current : 0}
+            live={live && index === blocks.length - 1}
+            remarkPlugins={remarkPlugins ?? defaultRemarkPlugins}
+            remarkRehypeOptions={remarkRehypeOptions}
+            key={block.startOffset}
+          />
+        )),
+        "data-anvia-stream-markdown": "",
+        "data-live": live ? "" : undefined,
+      } as PrimitiveProps<"div">,
+      ref,
+    );
+  },
+);
+
+const StreamMarkdownBlock = memo(function StreamMarkdownBlock(props: {
+  components: Components;
+  content: string;
+  frameId: number;
+  live: boolean;
+  remarkPlugins: ReactMarkdownOptions["remarkPlugins"];
+  remarkRehypeOptions: ReactMarkdownOptions["remarkRehypeOptions"];
+}) {
+  const revealPlugin = useMemo(
+    () => createStreamGradientRevealPlugin(props.frameId),
+    [props.frameId],
+  );
+  return (
+    <ReactMarkdown
+      components={props.components}
+      rehypePlugins={props.live ? [revealPlugin] : undefined}
+      remarkPlugins={props.remarkPlugins}
+      remarkRehypeOptions={props.remarkRehypeOptions}
+    >
+      {props.content}
+    </ReactMarkdown>
+  );
+});
+
+function withStreamRevealComponent(components: Components | undefined): Components {
+  const consumerSpan = components?.span;
+  return {
+    ...components,
+    span(spanProps) {
+      const safeProps = componentPropsWithoutKey(spanProps);
+      const internalProps = safeProps as typeof safeProps & {
+        "data-anvia-stream-frame-id"?: string | undefined;
+        "data-anvia-stream-opacity"?: string | undefined;
+        "data-anvia-stream-reveal"?: string | undefined;
+      };
+      if (internalProps["data-anvia-stream-reveal"] !== undefined) {
+        return streamRevealSpan(internalProps);
+      }
+      if (consumerSpan !== undefined) {
+        return createElement(consumerSpan, safeProps);
+      }
+      const { node: _node, ...elementProps } = safeProps;
+      return <span {...elementProps} />;
+    },
+  };
+}
+
+function componentPropsWithoutKey<T extends object>(props: T): T {
+  const result: Record<string, unknown> = {};
+  for (const name of Object.keys(props)) {
+    if (name !== "key") {
+      result[name] = (props as Record<string, unknown>)[name];
+    }
+  }
+  return result as T;
+}
+
+function streamRevealSpan(
+  props: ComponentPropsWithoutRef<"span"> & {
+    node?: unknown;
+    "data-anvia-stream-frame-id"?: string | undefined;
+    "data-anvia-stream-opacity"?: string | undefined;
+    "data-anvia-stream-reveal"?: string | undefined;
+  },
+): ReactNode {
+  const {
+    children,
+    node: _node,
+    "data-anvia-stream-frame-id": frameId,
+    "data-anvia-stream-opacity": opacity,
+    ...elementProps
+  } = props;
+  const parsedOpacity = Number(opacity);
+  return (
+    <span
+      {...elementProps}
+      data-anvia-stream-frame-id={frameId}
+      key={frameId ?? "stream-frame"}
+      style={{ opacity: Number.isFinite(parsedOpacity) ? parsedOpacity : 1 }}
+    >
+      {children}
+    </span>
+  );
+}

--- a/packages/react-ui/src/stream/styles.css
+++ b/packages/react-ui/src/stream/styles.css
@@ -1,0 +1,9 @@
+@keyframes anvia-stream-gradient-settle {
+  to {
+    opacity: 1;
+  }
+}
+
+[data-anvia-stream-reveal] {
+  animation: anvia-stream-gradient-settle 180ms linear both;
+}

--- a/packages/react-ui/src/styles.css
+++ b/packages/react-ui/src/styles.css
@@ -1,5 +1,6 @@
 [data-anvia-thread-viewport] {
   overflow: auto;
+  overflow-anchor: none;
   min-height: 0;
 }
 
@@ -88,22 +89,12 @@
   opacity: 0.55;
 }
 
-@keyframes anvia-stream-fade-in {
-  from {
-    opacity: 0.35;
-  }
-
+@keyframes anvia-stream-gradient-settle {
   to {
     opacity: 1;
   }
 }
 
-[data-anvia-stream-animation="fadeIn"][data-streaming] {
-  animation: anvia-stream-fade-in 180ms ease-out;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  [data-anvia-stream-animation="fadeIn"][data-streaming] {
-    animation: none;
-  }
+[data-anvia-stream-reveal] {
+  animation: anvia-stream-gradient-settle 180ms linear both;
 }

--- a/packages/react-ui/src/styles.css
+++ b/packages/react-ui/src/styles.css
@@ -98,3 +98,9 @@
 [data-anvia-stream-reveal] {
   animation: anvia-stream-gradient-settle 180ms linear both;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  [data-anvia-stream-reveal] {
+    animation: none;
+  }
+}

--- a/packages/react-ui/test/message.test.tsx
+++ b/packages/react-ui/test/message.test.tsx
@@ -85,22 +85,22 @@ describe("Message primitives", () => {
 
     const text = container.querySelector("[data-anvia-text]");
     expect(text?.textContent).toBe("Hello world");
-    expect(text?.hasAttribute("data-anvia-stream-animation")).toBe(false);
+    expect(text?.hasAttribute("data-streaming")).toBe(false);
     expect(raf.request).not.toHaveBeenCalled();
   });
 
-  it("uses smoothed text when Message.Text animation is enabled", () => {
+  it("uses smoothed text when Message.Text receives a stream lifecycle", () => {
     const raf = installAnimationFrame();
-    const props = { animate: true, isStreaming: true, reducedMotion: false };
+    const props = { stream: { isStreaming: true, resetKey: "msg_1" } };
     const { container, rerender } = render(textView("Hello", props));
 
     rerender(textView("Hello world", props));
 
     const text = container.querySelector("[data-anvia-text]");
     expect(text?.textContent).toBe("Hello");
-    expect(text?.getAttribute("data-anvia-stream-animation")).toBe("smooth");
+    expect(text?.hasAttribute("data-streaming")).toBe(true);
 
-    actAnimationFrame(raf);
+    act(() => raf.advance(230));
 
     expect(text?.textContent).not.toBe("Hello world");
     expect(text?.textContent?.startsWith("Hello")).toBe(true);
@@ -109,13 +109,11 @@ describe("Message primitives", () => {
     expect(text?.textContent).toBe("Hello world");
   });
 
-  it("preserves custom Message.Text children when animation is enabled", () => {
+  it("preserves custom Message.Text children when streaming is enabled", () => {
     const raf = installAnimationFrame();
     const props = {
-      animate: true,
       children: "Custom content",
-      isStreaming: true,
-      reducedMotion: false,
+      stream: { isStreaming: true, resetKey: "msg_1" },
     };
     const { container, rerender } = render(textView("Hello", props));
 
@@ -123,6 +121,67 @@ describe("Message primitives", () => {
 
     expect(container.querySelector("[data-anvia-text]")?.textContent).toBe("Custom content");
     expect(raf.request).not.toHaveBeenCalled();
+  });
+
+  it("delays a later tool until parent-controlled text finishes", () => {
+    const raf = installAnimationFrame();
+    const stream = { isStreaming: true, resetKey: "msg_1" };
+    const initial = textMessage("msg_1", "assistant", "A");
+    const next: UIMessage = {
+      ...initial,
+      parts: [
+        { id: initial.parts[0]?.id ?? "text_1", type: "text", text: "Text before the tool" },
+        {
+          id: "tool_1",
+          type: "tool",
+          toolCallId: "call_1",
+          toolName: "search",
+          state: "input-available",
+        },
+      ],
+    };
+    const { container, rerender } = render(partsStreamView(initial, stream));
+
+    rerender(partsStreamView(next, stream));
+    expect(container.querySelector("[data-anvia-tool]")).toBeNull();
+
+    act(() => raf.advance(230));
+    expect(container.querySelector("[data-anvia-tool]")).toBeNull();
+
+    drainAnimationFrames(raf);
+    expect(container.querySelector("[data-anvia-tool]")).not.toBeNull();
+    expect(
+      container.querySelector("[data-anvia-message-parts]")?.hasAttribute("data-streaming"),
+    ).toBe(true);
+  });
+
+  it("does not let a filtered reasoning part delay a visible tool", () => {
+    installAnimationFrame();
+    const stream = { isStreaming: true, resetKey: "msg_1" };
+    const initial: UIMessage = {
+      id: "msg_1",
+      role: "assistant",
+      parts: [{ id: "reasoning_1", type: "reasoning", text: "A" }],
+    };
+    const next: UIMessage = {
+      ...initial,
+      parts: [
+        { id: "reasoning_1", type: "reasoning", text: "Reasoning still being revealed" },
+        {
+          id: "tool_1",
+          type: "tool",
+          toolCallId: "call_1",
+          toolName: "search",
+          state: "input-available",
+        },
+      ],
+    };
+    const filter = (part: UIMessage["parts"][number]) => part.type !== "reasoning";
+    const { container, rerender } = render(partsStreamView(initial, stream, filter));
+
+    rerender(partsStreamView(next, stream, filter));
+
+    expect(container.querySelector("[data-anvia-tool]")).not.toBeNull();
   });
 
   it("supports custom tool rendering with input and output in one component", () => {
@@ -586,17 +645,14 @@ describe("Message primitives", () => {
     const markdown = container.querySelector("[data-anvia-markdown]");
     expect(markdown?.textContent).toBe("Hello world");
     expect(markdown?.querySelector("strong")?.textContent).toBe("world");
-    expect(markdown?.hasAttribute("data-anvia-stream-animation")).toBe(false);
+    expect(markdown?.hasAttribute("data-streaming")).toBe(false);
     expect(raf.request).not.toHaveBeenCalled();
   });
 
-  it("uses smoothed markdown text and fade-in attributes when enabled", () => {
+  it("uses smoothed markdown text and a live-tail reveal while streaming", () => {
     const raf = installAnimationFrame();
     const props = {
-      animate: true,
-      animationMode: "fadeIn" as const,
-      isStreaming: true,
-      reducedMotion: false,
+      stream: { isStreaming: true, resetKey: "msg_1" },
     };
     const { container, rerender } = render(markdownView("Hello", props));
 
@@ -604,11 +660,11 @@ describe("Message primitives", () => {
 
     const markdown = container.querySelector("[data-anvia-markdown]");
     expect(markdown?.textContent).toBe("Hello");
-    expect(markdown?.getAttribute("data-anvia-stream-animation")).toBe("fadeIn");
     expect(markdown?.hasAttribute("data-streaming")).toBe(true);
 
-    actAnimationFrame(raf);
+    act(() => raf.advance(250));
     expect(markdown?.textContent).not.toBe("Hello world");
+    expect(markdown?.querySelector("[data-anvia-stream-reveal]")).not.toBeNull();
 
     drainAnimationFrames(raf);
     expect(markdown?.textContent).toBe("Hello world");
@@ -617,7 +673,7 @@ describe("Message primitives", () => {
 
   it("preserves code block behavior after animated markdown completes", () => {
     const raf = installAnimationFrame();
-    const props = { animate: true, isStreaming: true, reducedMotion: false };
+    const props = { stream: { isStreaming: true, resetKey: "msg_1" } };
     const { container, rerender } = render(markdownView("Code:\n\n", props));
 
     rerender(markdownView("Code:\n\n```ts\nconst ok = true;\n```", props));
@@ -828,6 +884,24 @@ function markdownView(
   );
 }
 
+function partsStreamView(
+  message: UIMessage,
+  stream: NonNullable<ComponentProps<typeof Message.Parts>["stream"]>,
+  filter?: ComponentProps<typeof Message.Parts>["filter"],
+): ReactElement {
+  return (
+    <ChatProvider controller={createChatController({ messages: [message] })}>
+      <Thread.Root>
+        <Thread.Messages>
+          <Message.Root>
+            <Message.Parts {...(filter === undefined ? {} : { filter })} stream={stream} />
+          </Message.Root>
+        </Thread.Messages>
+      </Thread.Root>
+    </ChatProvider>
+  );
+}
+
 function markdownEntityView(
   markdown: string,
   entities: ComposerEntity[],
@@ -899,8 +973,10 @@ function literalizeEntityNodes(value: unknown): void {
 }
 
 function installAnimationFrame() {
+  let now = 0;
   let nextId = 0;
   const callbacks = new Map<number, FrameRequestCallback>();
+  vi.spyOn(performance, "now").mockImplementation(() => now);
   const request = vi.fn((callback: FrameRequestCallback) => {
     const id = ++nextId;
     callbacks.set(id, callback);
@@ -917,23 +993,22 @@ function installAnimationFrame() {
     cancel,
     pending: () => callbacks.size,
     request,
-    step() {
-      const pending = [...callbacks.values()];
-      callbacks.clear();
-      for (const callback of pending) {
-        callback(0);
+    advance(durationMs: number) {
+      const target = now + durationMs;
+      while (callbacks.size > 0 && now < target) {
+        now = Math.min(target, now + 1_000 / 60);
+        const pending = [...callbacks.values()];
+        callbacks.clear();
+        for (const callback of pending) {
+          callback(now);
+        }
       }
+      now = target;
     },
   };
 }
 
-function actAnimationFrame(raf: AnimationFrameHarness): void {
-  act(() => raf.step());
-}
-
 function drainAnimationFrames(raf: AnimationFrameHarness): void {
-  for (let frame = 0; frame < 100 && raf.pending() > 0; frame += 1) {
-    actAnimationFrame(raf);
-  }
+  act(() => raf.advance(2_000));
   expect(raf.pending()).toBe(0);
 }

--- a/packages/react-ui/test/stream-markdown.test.tsx
+++ b/packages/react-ui/test/stream-markdown.test.tsx
@@ -1,0 +1,72 @@
+import { render } from "@testing-library/react";
+import type { ComponentPropsWithoutRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { StreamMarkdown } from "../src/stream";
+import { splitStreamMarkdownBlocks } from "../src/stream/markdown-blocks";
+
+describe("StreamMarkdown", () => {
+  it("splits top-level blocks without changing source content", () => {
+    const markdown = "# Heading\n\nFirst paragraph.\n\n- one\n- two\n";
+    const blocks = splitStreamMarkdownBlocks(markdown);
+
+    expect(blocks.length).toBeGreaterThan(1);
+    expect(blocks.map((block) => block.content).join("")).toBe(markdown);
+  });
+
+  it("keeps reference definitions in one document", () => {
+    const markdown = "Read [the guide][guide].\n\n[guide]: https://example.com\n";
+    expect(splitStreamMarkdownBlocks(markdown)).toEqual([{ content: markdown, startOffset: 0 }]);
+  });
+
+  it("wraps only the live rendered tail and excludes preformatted code", () => {
+    const { container } = render(
+      <StreamMarkdown
+        content={"```ts\nconst untouched = true;\n```\n\nVisible **formatted tail**"}
+        live
+      />,
+    );
+
+    const revealNodes = container.querySelectorAll("[data-anvia-stream-reveal]");
+    expect(revealNodes.length).toBeGreaterThan(0);
+    expect(container.querySelector("pre [data-anvia-stream-reveal]")).toBeNull();
+    expect(container.querySelector("strong [data-anvia-stream-reveal]")).not.toBeNull();
+  });
+
+  it("does not wrap whitespace-only nodes between list items", () => {
+    const { container } = render(<StreamMarkdown content={"- first\n- second\n- third"} live />);
+    const list = container.querySelector("ul");
+
+    expect(list?.children).toHaveLength(3);
+    expect(
+      Array.from(list?.childNodes ?? []).filter((node) => node.nodeName === "SPAN"),
+    ).toHaveLength(0);
+  });
+
+  it("does not rerender completed blocks while the live block grows", () => {
+    const paragraph = vi.fn(({ children }: ComponentPropsWithoutRef<"p">) => <p>{children}</p>);
+    const components = { p: paragraph };
+    const { rerender } = render(
+      <StreamMarkdown components={components} content={"Stable paragraph.\n\nGrowing"} live />,
+    );
+
+    paragraph.mockClear();
+    rerender(
+      <StreamMarkdown
+        components={components}
+        content={"Stable paragraph.\n\nGrowing paragraph"}
+        live
+      />,
+    );
+
+    expect(paragraph).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders without reveal wrappers after the live state settles", () => {
+    const { container, rerender } = render(<StreamMarkdown content="Settled text" live />);
+    expect(container.querySelector("[data-anvia-stream-reveal]")).not.toBeNull();
+
+    rerender(<StreamMarkdown content="Settled text" live={false} />);
+    expect(container.querySelector("[data-anvia-stream-reveal]")).toBeNull();
+  });
+});

--- a/packages/react-ui/test/stream-markdown.test.tsx
+++ b/packages/react-ui/test/stream-markdown.test.tsx
@@ -19,6 +19,15 @@ describe("StreamMarkdown", () => {
     expect(splitStreamMarkdownBlocks(markdown)).toEqual([{ content: markdown, startOffset: 0 }]);
   });
 
+  it("keeps a GFM table intact as one rendered block", () => {
+    const markdown = "| Name | Status |\n| --- | --- |\n| Stream | Ready |\n";
+    expect(splitStreamMarkdownBlocks(markdown)).toEqual([{ content: markdown, startOffset: 0 }]);
+
+    const { container } = render(<StreamMarkdown content={markdown} live />);
+    expect(container.querySelector("table")).not.toBeNull();
+    expect(container.querySelector("tbody")?.textContent).toContain("StreamReady");
+  });
+
   it("wraps only the live rendered tail and excludes preformatted code", () => {
     const { container } = render(
       <StreamMarkdown

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -44,7 +44,12 @@ export function Chat() {
 - `createChatTransport(options)` creates the default fetch-backed chat transport.
 - `useChat(options)` manages `UIMessage[]` chat state from any `EventTransport`, including optional human-input approval/question state and opt-in stream resume.
 - `useCompletion(options)` appends completion turns into `UIMessage[]` state and exposes derived `completion` text.
-- `useSmoothStreamText(content, options)` smooths an append-only string for display without changing stream events or message state.
+- `useSmoothStreamText(content, lifecycle)` buffers and paces an append-only display string without changing stream events or message state.
+- `useSmoothStreamItems(items, { adapter, ...lifecycle })` applies the same pacing to mixed text/tool item lists while preserving semantic ordering.
+
+Both smoothing hooks require `{ isStreaming, resetKey }`. Keep the lifecycle mounted when the
+source stops so buffered text can drain; change `resetKey` when switching conversations or loading
+history. Use `flushImmediately` for terminal errors.
 
 Default hook requests use one shared wire shape:
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -8,6 +8,10 @@ export {
   defaultEventToQuestion,
 } from "./human-input";
 export { initialMessagesFromMemory } from "./memory";
+export type {
+  SmoothStreamItemAdapter,
+  StreamSmoothingLifecycle,
+} from "./stream-smoothing";
 export { readJsonlStream, readSseStream } from "./streams";
 export type { CreateFetchTransportOptions } from "./transport";
 export { createChatTransport, createFetchTransport } from "./transport";
@@ -55,8 +59,11 @@ export type {
 } from "./use-completion";
 export { useCompletion } from "./use-completion";
 export type {
-  StreamAnimationMode,
-  StreamSmoothingPreset,
+  UseSmoothStreamItemsOptions,
+  UseSmoothStreamItemsResult,
+} from "./use-smooth-stream-items";
+export { useSmoothStreamItems } from "./use-smooth-stream-items";
+export type {
   UseSmoothStreamTextOptions,
   UseSmoothStreamTextResult,
 } from "./use-smooth-stream-text";

--- a/packages/react/src/stream-smoothing.ts
+++ b/packages/react/src/stream-smoothing.ts
@@ -77,7 +77,7 @@ export function updateStreamSmoothingTarget<T>(
 ): StreamSmoothingState<T> {
   const targetItems = [...items];
 
-  if (!state.isSourceStreaming && !options.isStreaming) {
+  if (!state.isSourceStreaming && !options.isStreaming && !hasPendingContent(state, adapter)) {
     return createStreamSmoothingState(targetItems, options, adapter);
   }
 

--- a/packages/react/src/stream-smoothing.ts
+++ b/packages/react/src/stream-smoothing.ts
@@ -1,0 +1,553 @@
+export type StreamSmoothingLifecycle = {
+  isStreaming: boolean;
+  resetKey: string | number;
+  flushImmediately?: boolean;
+};
+
+export type SmoothStreamItemAdapter<T> = {
+  getKey(item: T): string;
+  getText(item: T): string | undefined;
+  withText(item: T, text: string): T;
+};
+
+export type StreamSourceSample = {
+  atMs: number;
+  totalChars: number;
+};
+
+export type StreamSmoothingState<T> = {
+  displayedItems: T[];
+  drainDeadlineAtMs: number | null;
+  isSourceStreaming: boolean;
+  lastAdvanceAtMs: number;
+  playbackCursorChars: number;
+  sourceSamples: StreamSourceSample[];
+  targetItems: T[];
+};
+
+export type StreamSmoothingSnapshot<T> = {
+  hasPendingContent: boolean;
+  isDraining: boolean;
+  items: readonly T[];
+  liveItemKey: string | null;
+};
+
+export const streamSmoothingConfig = {
+  baseCharsPerSecond: 140,
+  completionDrainMs: 700,
+  initialSampleSpreadMs: 50,
+  maxCommitFps: 60,
+  maxCompletionCharsPerFrame: 30,
+  maxCompletionCharsPerSecond: 1_600,
+  maxElapsedMs: 64,
+  maxPendingChars: 1_000,
+  maxSourceSamples: 64,
+  maxStreamingCharsPerFrame: 6,
+  maxStreamingCharsPerSecond: 360,
+  sourceGapResetMs: 180,
+  sourceInterpolationMs: 100,
+  streamingBaseCharsPerSecond: 200,
+  streamingDrainMs: 250,
+  targetBufferMs: 225,
+} as const;
+
+export function createStreamSmoothingState<T>(
+  items: readonly T[],
+  options: { isStreaming: boolean; nowMs: number },
+  adapter: SmoothStreamItemAdapter<T>,
+): StreamSmoothingState<T> {
+  const targetItems = [...items];
+  const totalChars = getSmoothCharacterCount(targetItems, adapter);
+  return {
+    displayedItems: targetItems,
+    drainDeadlineAtMs: null,
+    isSourceStreaming: options.isStreaming,
+    lastAdvanceAtMs: options.nowMs,
+    playbackCursorChars: totalChars,
+    sourceSamples: [{ atMs: options.nowMs, totalChars }],
+    targetItems,
+  };
+}
+
+export function updateStreamSmoothingTarget<T>(
+  state: StreamSmoothingState<T>,
+  items: readonly T[],
+  options: { isStreaming: boolean; nowMs: number },
+  adapter: SmoothStreamItemAdapter<T>,
+): StreamSmoothingState<T> {
+  const targetItems = [...items];
+
+  if (!state.isSourceStreaming && !options.isStreaming) {
+    return createStreamSmoothingState(targetItems, options, adapter);
+  }
+
+  const previousTargetChars = getSmoothCharacterCount(state.targetItems, adapter);
+  const targetChars = getSmoothCharacterCount(targetItems, adapter);
+  let displayedItems = reconcileDisplayedItems(state.displayedItems, targetItems, adapter);
+  displayedItems = revealWithinBudget(displayedItems, targetItems, 0, adapter);
+
+  let sourceSamples = state.sourceSamples;
+  if (options.isStreaming) {
+    sourceSamples = updateSourceSamples(
+      sourceSamples,
+      previousTargetChars,
+      targetChars,
+      options.nowMs,
+    );
+  }
+
+  let nextState: StreamSmoothingState<T> = {
+    ...state,
+    displayedItems,
+    drainDeadlineAtMs:
+      options.isStreaming || state.drainDeadlineAtMs !== null
+        ? options.isStreaming
+          ? null
+          : state.drainDeadlineAtMs
+        : options.nowMs + streamSmoothingConfig.completionDrainMs,
+    isSourceStreaming: options.isStreaming,
+    sourceSamples,
+    targetItems,
+  };
+
+  nextState = applyBackpressure(nextState, adapter);
+
+  if (!options.isStreaming && !hasPendingContent(nextState, adapter)) {
+    return {
+      ...nextState,
+      displayedItems: targetItems,
+      drainDeadlineAtMs: null,
+      playbackCursorChars: targetChars,
+    };
+  }
+
+  if (!options.isStreaming && nextState.drainDeadlineAtMs === null) {
+    nextState = {
+      ...nextState,
+      drainDeadlineAtMs: options.nowMs + streamSmoothingConfig.completionDrainMs,
+    };
+  }
+
+  return nextState;
+}
+
+export function advanceStreamSmoothing<T>(
+  state: StreamSmoothingState<T>,
+  nowMs: number,
+  adapter: SmoothStreamItemAdapter<T>,
+): StreamSmoothingState<T> {
+  const elapsedMs = Math.min(
+    Math.max(nowMs - state.lastAdvanceAtMs, 0),
+    streamSmoothingConfig.maxElapsedMs,
+  );
+  const displayedChars = getSmoothCharacterCount(state.displayedItems, adapter);
+  const targetChars = getSmoothCharacterCount(state.targetItems, adapter);
+  const pendingChars = Math.max(0, targetChars - displayedChars);
+  const playbackTargetChars = state.isSourceStreaming
+    ? getBufferedPlaybackTarget(state.sourceSamples, nowMs)
+    : targetChars;
+  const playbackPendingChars = Math.max(0, playbackTargetChars - displayedChars);
+  const charsPerSecond = state.isSourceStreaming
+    ? getStreamingCharsPerSecond(playbackPendingChars)
+    : getCompletionCharsPerSecond(pendingChars, state.drainDeadlineAtMs, nowMs);
+  const playbackCursorChars = Math.min(
+    playbackTargetChars,
+    Math.max(state.playbackCursorChars, displayedChars) + (elapsedMs / 1_000) * charsPerSecond,
+  );
+  const requestedBudget = Math.max(0, Math.floor(playbackCursorChars - displayedChars));
+  const frameBudget = Math.min(
+    requestedBudget,
+    state.isSourceStreaming
+      ? streamSmoothingConfig.maxStreamingCharsPerFrame
+      : streamSmoothingConfig.maxCompletionCharsPerFrame,
+  );
+  const revealedItems = revealWithinBudget(
+    state.displayedItems,
+    state.targetItems,
+    frameBudget,
+    adapter,
+  );
+  const nextDisplayedChars = getSmoothCharacterCount(revealedItems, adapter);
+  const pending = hasPendingItems(revealedItems, state.targetItems, adapter);
+
+  return {
+    ...state,
+    displayedItems: pending ? revealedItems : state.targetItems,
+    drainDeadlineAtMs: !state.isSourceStreaming && !pending ? null : state.drainDeadlineAtMs,
+    lastAdvanceAtMs: nowMs,
+    playbackCursorChars: Math.max(playbackCursorChars, nextDisplayedChars),
+  };
+}
+
+export function flushStreamSmoothing<T>(
+  state: StreamSmoothingState<T>,
+  nowMs: number,
+  adapter: SmoothStreamItemAdapter<T>,
+): StreamSmoothingState<T> {
+  const targetChars = getSmoothCharacterCount(state.targetItems, adapter);
+  return {
+    ...state,
+    displayedItems: state.targetItems,
+    drainDeadlineAtMs: null,
+    lastAdvanceAtMs: nowMs,
+    playbackCursorChars: targetChars,
+    sourceSamples: [{ atMs: nowMs, totalChars: targetChars }],
+  };
+}
+
+export function getStreamSmoothingSnapshot<T>(
+  state: StreamSmoothingState<T>,
+  adapter: SmoothStreamItemAdapter<T>,
+): StreamSmoothingSnapshot<T> {
+  const pending = hasPendingContent(state, adapter);
+  const active = state.isSourceStreaming || pending;
+  const lastItem = state.displayedItems.at(-1);
+  const liveItemKey =
+    active && lastItem !== undefined && adapter.getText(lastItem) !== undefined
+      ? adapter.getKey(lastItem)
+      : null;
+
+  return {
+    hasPendingContent: pending,
+    isDraining: !state.isSourceStreaming && pending,
+    items: state.displayedItems,
+    liveItemKey,
+  };
+}
+
+export function getBufferedPlaybackTarget(
+  samples: readonly StreamSourceSample[],
+  nowMs: number,
+): number {
+  const playbackAtMs = nowMs - streamSmoothingConfig.targetBufferMs;
+  const firstSample = samples[0];
+  if (firstSample === undefined) {
+    return 0;
+  }
+  if (playbackAtMs <= firstSample.atMs) {
+    return firstSample.totalChars;
+  }
+
+  for (let index = 1; index < samples.length; index += 1) {
+    const previousSample = samples[index - 1];
+    const nextSample = samples[index];
+    if (
+      previousSample === undefined ||
+      nextSample === undefined ||
+      playbackAtMs > nextSample.atMs
+    ) {
+      continue;
+    }
+
+    const durationMs = Math.max(nextSample.atMs - previousSample.atMs, 1);
+    const progress = Math.min(Math.max((playbackAtMs - previousSample.atMs) / durationMs, 0), 1);
+    return (
+      previousSample.totalChars + (nextSample.totalChars - previousSample.totalChars) * progress
+    );
+  }
+
+  return samples.at(-1)?.totalChars ?? 0;
+}
+
+function updateSourceSamples(
+  samples: readonly StreamSourceSample[],
+  previousTotalChars: number,
+  targetChars: number,
+  nowMs: number,
+): StreamSourceSample[] {
+  if (targetChars === previousTotalChars) {
+    return [...samples];
+  }
+
+  if (targetChars < previousTotalChars) {
+    return [
+      {
+        atMs: nowMs - streamSmoothingConfig.initialSampleSpreadMs,
+        totalChars: Math.min(previousTotalChars, targetChars),
+      },
+      { atMs: nowMs, totalChars: targetChars },
+    ];
+  }
+
+  const nextSamples = [...samples];
+  const lastSample = nextSamples.at(-1);
+  if (lastSample === undefined) {
+    nextSamples.push({
+      atMs: nowMs - streamSmoothingConfig.initialSampleSpreadMs,
+      totalChars: previousTotalChars,
+    });
+  } else if (nowMs - lastSample.atMs > streamSmoothingConfig.sourceGapResetMs) {
+    nextSamples.push({
+      atMs: nowMs - streamSmoothingConfig.sourceInterpolationMs,
+      totalChars: previousTotalChars,
+    });
+  }
+  nextSamples.push({ atMs: nowMs, totalChars: targetChars });
+  return nextSamples.slice(-streamSmoothingConfig.maxSourceSamples);
+}
+
+function applyBackpressure<T>(
+  state: StreamSmoothingState<T>,
+  adapter: SmoothStreamItemAdapter<T>,
+): StreamSmoothingState<T> {
+  const displayedChars = getSmoothCharacterCount(state.displayedItems, adapter);
+  const targetChars = getSmoothCharacterCount(state.targetItems, adapter);
+  const excess = targetChars - displayedChars - streamSmoothingConfig.maxPendingChars;
+  if (excess <= 0) {
+    return state;
+  }
+
+  const revealedItems = revealWithinBudget(
+    state.displayedItems,
+    state.targetItems,
+    excess,
+    adapter,
+    true,
+  );
+  const nextDisplayedChars = getSmoothCharacterCount(revealedItems, adapter);
+  return {
+    ...state,
+    displayedItems: revealedItems,
+    playbackCursorChars: Math.max(state.playbackCursorChars, nextDisplayedChars),
+  };
+}
+
+function revealWithinBudget<T>(
+  displayedItems: readonly T[],
+  targetItems: readonly T[],
+  budget: number,
+  adapter: SmoothStreamItemAdapter<T>,
+  preferSemanticBoundary = false,
+): T[] {
+  const nextItems: T[] = [];
+  let remainingBudget = Math.max(0, budget);
+
+  for (let index = 0; index < targetItems.length; index += 1) {
+    const targetItem = targetItems[index];
+    if (targetItem === undefined) {
+      continue;
+    }
+    const displayedItem = displayedItems[index];
+    const displayedMatches =
+      displayedItem !== undefined && adapter.getKey(displayedItem) === adapter.getKey(targetItem);
+    const targetText = adapter.getText(targetItem);
+
+    if (targetText === undefined) {
+      if (displayedMatches || index === nextItems.length) {
+        nextItems.push(targetItem);
+        continue;
+      }
+      break;
+    }
+
+    const displayedText =
+      displayedMatches && displayedItem !== undefined ? (adapter.getText(displayedItem) ?? "") : "";
+    if (displayedText === targetText) {
+      nextItems.push(targetItem);
+      continue;
+    }
+
+    if (remainingBudget <= 0) {
+      if (displayedMatches || displayedText.length > 0) {
+        nextItems.push(adapter.withText(targetItem, displayedText));
+      }
+      break;
+    }
+
+    const requestedLength = Math.min(targetText.length, displayedText.length + remainingBudget);
+    const nextLength = preferSemanticBoundary
+      ? findSemanticBoundaryAtOrAfter(targetText, requestedLength)
+      : findGraphemeBoundaryAtOrAfter(targetText, requestedLength);
+    const nextText = targetText.slice(0, nextLength);
+    const revealed = Math.max(0, nextText.length - displayedText.length);
+    remainingBudget = Math.max(0, remainingBudget - revealed);
+
+    if (nextLength < targetText.length) {
+      nextItems.push(adapter.withText(targetItem, nextText));
+      break;
+    }
+
+    nextItems.push(targetItem);
+  }
+
+  return nextItems;
+}
+
+function reconcileDisplayedItems<T>(
+  displayedItems: readonly T[],
+  targetItems: readonly T[],
+  adapter: SmoothStreamItemAdapter<T>,
+): T[] {
+  const nextItems: T[] = [];
+
+  for (let index = 0; index < targetItems.length; index += 1) {
+    const targetItem = targetItems[index];
+    const displayedItem = displayedItems[index];
+    if (
+      targetItem === undefined ||
+      displayedItem === undefined ||
+      adapter.getKey(targetItem) !== adapter.getKey(displayedItem)
+    ) {
+      break;
+    }
+
+    const targetText = adapter.getText(targetItem);
+    const displayedText = adapter.getText(displayedItem);
+    if (targetText === undefined) {
+      nextItems.push(targetItem);
+      if (displayedText !== undefined) {
+        continue;
+      }
+      continue;
+    }
+
+    if (displayedText === undefined) {
+      nextItems.push(adapter.withText(targetItem, ""));
+      break;
+    }
+    if (targetText.startsWith(displayedText)) {
+      nextItems.push(
+        displayedText === targetText ? targetItem : adapter.withText(targetItem, displayedText),
+      );
+      continue;
+    }
+
+    const commonPrefixLength = findCommonGraphemePrefixLength(displayedText, targetText);
+    nextItems.push(adapter.withText(targetItem, targetText.slice(0, commonPrefixLength)));
+    break;
+  }
+
+  return nextItems;
+}
+
+function hasPendingContent<T>(
+  state: StreamSmoothingState<T>,
+  adapter: SmoothStreamItemAdapter<T>,
+): boolean {
+  return hasPendingItems(state.displayedItems, state.targetItems, adapter);
+}
+
+function hasPendingItems<T>(
+  displayedItems: readonly T[],
+  targetItems: readonly T[],
+  adapter: SmoothStreamItemAdapter<T>,
+): boolean {
+  if (displayedItems.length !== targetItems.length) {
+    return true;
+  }
+  return targetItems.some((targetItem, index) => {
+    const displayedItem = displayedItems[index];
+    if (
+      displayedItem === undefined ||
+      adapter.getKey(displayedItem) !== adapter.getKey(targetItem)
+    ) {
+      return true;
+    }
+    const targetText = adapter.getText(targetItem);
+    const displayedText = adapter.getText(displayedItem);
+    return targetText === undefined ? displayedItem !== targetItem : displayedText !== targetText;
+  });
+}
+
+function getSmoothCharacterCount<T>(
+  items: readonly T[],
+  adapter: SmoothStreamItemAdapter<T>,
+): number {
+  return items.reduce((total, item) => total + (adapter.getText(item)?.length ?? 0), 0);
+}
+
+function getStreamingCharsPerSecond(pendingChars: number): number {
+  return Math.min(
+    streamSmoothingConfig.maxStreamingCharsPerSecond,
+    Math.max(
+      streamSmoothingConfig.streamingBaseCharsPerSecond,
+      pendingChars / (streamSmoothingConfig.streamingDrainMs / 1_000),
+    ),
+  );
+}
+
+function getCompletionCharsPerSecond(
+  pendingChars: number,
+  deadlineAtMs: number | null,
+  nowMs: number,
+): number {
+  const remainingMs = Math.max((deadlineAtMs ?? nowMs) - nowMs, 1);
+  return Math.min(
+    streamSmoothingConfig.maxCompletionCharsPerSecond,
+    Math.max(streamSmoothingConfig.baseCharsPerSecond, pendingChars / (remainingMs / 1_000)),
+  );
+}
+
+function findCommonGraphemePrefixLength(left: string, right: string): number {
+  const leftSegments = segmentGraphemes(left);
+  const rightSegments = segmentGraphemes(right);
+  const length = Math.min(leftSegments.length, rightSegments.length);
+  let offset = 0;
+  for (let index = 0; index < length; index += 1) {
+    const leftSegment = leftSegments[index];
+    const rightSegment = rightSegments[index];
+    if (leftSegment === undefined || leftSegment !== rightSegment) {
+      break;
+    }
+    offset += leftSegment.length;
+  }
+  return offset;
+}
+
+function findSemanticBoundaryAtOrAfter(content: string, requestedLength: number): number {
+  const safeRequestedLength = findGraphemeBoundaryAtOrAfter(content, requestedLength);
+  const scanEnd = Math.min(content.length, safeRequestedLength + 64);
+  for (let index = safeRequestedLength; index < scanEnd; index += 1) {
+    const character = content[index];
+    if (character === "\n") {
+      return findGraphemeBoundaryAtOrAfter(content, index + 1);
+    }
+    if (
+      (character === "." || character === "!" || character === "?") &&
+      /\s/u.test(content[index + 1] ?? "")
+    ) {
+      return findGraphemeBoundaryAtOrAfter(content, index + 1);
+    }
+    if (/\s/u.test(character ?? "")) {
+      return findGraphemeBoundaryAtOrAfter(content, index + 1);
+    }
+  }
+  return safeRequestedLength;
+}
+
+function findGraphemeBoundaryAtOrAfter(content: string, requestedLength: number): number {
+  const clampedLength = Math.min(Math.max(requestedLength, 0), content.length);
+  if (clampedLength === 0 || clampedLength === content.length) {
+    return clampedLength;
+  }
+
+  const segmenter = createGraphemeSegmenter();
+  if (segmenter !== undefined) {
+    const segment = segmenter.segment(content).containing(clampedLength - 1);
+    if (segment !== undefined) {
+      return segment.index + segment.segment.length;
+    }
+    return content.length;
+  }
+
+  const code = content.charCodeAt(clampedLength - 1);
+  if (code >= 0xd800 && code <= 0xdbff) {
+    return Math.min(content.length, clampedLength + 1);
+  }
+  return clampedLength;
+}
+
+function segmentGraphemes(content: string): string[] {
+  const segmenter = createGraphemeSegmenter();
+  if (segmenter !== undefined) {
+    return [...segmenter.segment(content)].map((segment) => segment.segment);
+  }
+  return [...content];
+}
+
+function createGraphemeSegmenter(): Intl.Segmenter | undefined {
+  if (typeof Intl === "undefined" || typeof Intl.Segmenter !== "function") {
+    return undefined;
+  }
+  return new Intl.Segmenter(undefined, { granularity: "grapheme" });
+}

--- a/packages/react/src/use-smooth-stream-items.ts
+++ b/packages/react/src/use-smooth-stream-items.ts
@@ -1,0 +1,220 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+
+import {
+  advanceStreamSmoothing,
+  createStreamSmoothingState,
+  flushStreamSmoothing,
+  getStreamSmoothingSnapshot,
+  type SmoothStreamItemAdapter,
+  type StreamSmoothingLifecycle,
+  type StreamSmoothingSnapshot,
+  type StreamSmoothingState,
+  streamSmoothingConfig,
+  updateStreamSmoothingTarget,
+} from "./stream-smoothing";
+
+export type UseSmoothStreamItemsOptions<T> = StreamSmoothingLifecycle & {
+  adapter: SmoothStreamItemAdapter<T>;
+};
+
+export type UseSmoothStreamItemsResult<T> = {
+  items: readonly T[];
+  isAnimating: boolean;
+  isDraining: boolean;
+  liveItemKey: string | null;
+  flush(): void;
+};
+
+const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
+
+export function useSmoothStreamItems<T>(
+  items: readonly T[],
+  options: UseSmoothStreamItemsOptions<T>,
+): UseSmoothStreamItemsResult<T> {
+  const adapterRef = useRef(options.adapter);
+  adapterRef.current = options.adapter;
+
+  const initialNowRef = useRef<number | undefined>(undefined);
+  if (initialNowRef.current === undefined) {
+    initialNowRef.current = currentTimeMs();
+  }
+  const stateRef = useRef<StreamSmoothingState<T> | undefined>(undefined);
+  if (stateRef.current === undefined) {
+    stateRef.current = createStreamSmoothingState(
+      items,
+      { isStreaming: options.isStreaming, nowMs: initialNowRef.current },
+      options.adapter,
+    );
+  }
+
+  const resetKeyRef = useRef(options.resetKey);
+  const animationFrameRef = useRef<number | null>(null);
+  const mountedRef = useRef(true);
+  const [snapshot, setSnapshot] = useState<StreamSmoothingSnapshot<T>>(() =>
+    getStreamSmoothingSnapshot(stateRef.current as StreamSmoothingState<T>, options.adapter),
+  );
+
+  const clearAnimationFrame = useCallback(() => {
+    const frame = animationFrameRef.current;
+    animationFrameRef.current = null;
+    if (
+      frame !== null &&
+      typeof window !== "undefined" &&
+      typeof window.cancelAnimationFrame === "function"
+    ) {
+      window.cancelAnimationFrame(frame);
+    }
+  }, []);
+
+  const commitState = useCallback((state: StreamSmoothingState<T>) => {
+    const adapter = adapterRef.current;
+    stateRef.current = state;
+    const nextSnapshot = getStreamSmoothingSnapshot(state, adapter);
+    setSnapshot((current) =>
+      streamSmoothingSnapshotsEqual(current, nextSnapshot, adapter) ? current : nextSnapshot,
+    );
+  }, []);
+
+  const flushToTarget = useCallback(() => {
+    const state = stateRef.current;
+    if (state === undefined) {
+      return;
+    }
+    clearAnimationFrame();
+    commitState(flushStreamSmoothing(state, currentTimeMs(), adapterRef.current));
+  }, [clearAnimationFrame, commitState]);
+
+  const scheduleFrame = useCallback(
+    function scheduleFrame() {
+      if (animationFrameRef.current !== null || !mountedRef.current) {
+        return;
+      }
+      if (typeof window === "undefined" || typeof window.requestAnimationFrame !== "function") {
+        flushToTarget();
+        return;
+      }
+
+      animationFrameRef.current = window.requestAnimationFrame((nowMs) => {
+        animationFrameRef.current = null;
+        const state = stateRef.current;
+        if (!mountedRef.current || state === undefined) {
+          return;
+        }
+        const minimumCommitIntervalMs = 1_000 / streamSmoothingConfig.maxCommitFps;
+        if (nowMs - state.lastAdvanceAtMs + 0.5 < minimumCommitIntervalMs) {
+          scheduleFrame();
+          return;
+        }
+
+        const nextState = advanceStreamSmoothing(state, nowMs, adapterRef.current);
+        const nextSnapshot = getStreamSmoothingSnapshot(nextState, adapterRef.current);
+        commitState(nextState);
+        if (nextSnapshot.hasPendingContent) {
+          scheduleFrame();
+        }
+      });
+    },
+    [commitState, flushToTarget],
+  );
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      clearAnimationFrame();
+    };
+  }, [clearAnimationFrame]);
+
+  useIsomorphicLayoutEffect(() => {
+    const nowMs = currentTimeMs();
+    const reset = resetKeyRef.current !== options.resetKey;
+    resetKeyRef.current = options.resetKey;
+    let nextState = reset
+      ? createStreamSmoothingState(
+          items,
+          { isStreaming: options.isStreaming, nowMs },
+          options.adapter,
+        )
+      : updateStreamSmoothingTarget(
+          stateRef.current as StreamSmoothingState<T>,
+          items,
+          { isStreaming: options.isStreaming, nowMs },
+          options.adapter,
+        );
+
+    const hidden = typeof document !== "undefined" && document.visibilityState === "hidden";
+    if (options.flushImmediately === true || hidden) {
+      nextState = flushStreamSmoothing(nextState, nowMs, options.adapter);
+    }
+
+    const nextSnapshot = getStreamSmoothingSnapshot(nextState, options.adapter);
+    commitState(nextState);
+    if (nextSnapshot.hasPendingContent) {
+      scheduleFrame();
+    } else {
+      clearAnimationFrame();
+    }
+  }, [
+    clearAnimationFrame,
+    commitState,
+    items,
+    options.adapter,
+    options.flushImmediately,
+    options.isStreaming,
+    options.resetKey,
+    scheduleFrame,
+  ]);
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        flushToTarget();
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
+  }, [flushToTarget]);
+
+  return {
+    items: snapshot.items,
+    isAnimating: snapshot.hasPendingContent,
+    isDraining: snapshot.isDraining,
+    liveItemKey: snapshot.liveItemKey,
+    flush: flushToTarget,
+  };
+}
+
+function currentTimeMs(): number {
+  if (typeof performance !== "undefined" && typeof performance.now === "function") {
+    return performance.now();
+  }
+  return Date.now();
+}
+
+function streamSmoothingSnapshotsEqual<T>(
+  left: StreamSmoothingSnapshot<T>,
+  right: StreamSmoothingSnapshot<T>,
+  adapter: SmoothStreamItemAdapter<T>,
+): boolean {
+  if (
+    left.hasPendingContent !== right.hasPendingContent ||
+    left.isDraining !== right.isDraining ||
+    left.liveItemKey !== right.liveItemKey ||
+    left.items.length !== right.items.length
+  ) {
+    return false;
+  }
+
+  return left.items.every((leftItem, index) => {
+    const rightItem = right.items[index];
+    if (rightItem === undefined || adapter.getKey(leftItem) !== adapter.getKey(rightItem)) {
+      return false;
+    }
+    const leftText = adapter.getText(leftItem);
+    const rightText = adapter.getText(rightItem);
+    return leftText === undefined ? leftItem === rightItem : leftText === rightText;
+  });
+}

--- a/packages/react/src/use-smooth-stream-text.ts
+++ b/packages/react/src/use-smooth-stream-text.ts
@@ -1,237 +1,49 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useMemo } from "react";
 
-export type StreamAnimationMode = "none" | "smooth" | "fadeIn";
+import type { SmoothStreamItemAdapter, StreamSmoothingLifecycle } from "./stream-smoothing";
+import { useSmoothStreamItems } from "./use-smooth-stream-items";
 
-export type StreamSmoothingPreset = "realtime" | "balanced" | "silky";
-
-export type UseSmoothStreamTextOptions = {
-  enabled?: boolean;
-  mode?: StreamAnimationMode;
-  isStreaming?: boolean;
-  preset?: StreamSmoothingPreset;
-  reducedMotion?: boolean;
-  largeAppendChars?: number;
-};
+export type UseSmoothStreamTextOptions = StreamSmoothingLifecycle;
 
 export type UseSmoothStreamTextResult = {
   text: string;
   isAnimating: boolean;
+  isDraining: boolean;
   flush(): void;
-  reset(nextText?: string): void;
 };
 
-type SmoothingConfig = {
-  fraction: number;
-  maxChars: number;
+type TextStreamItem = {
+  key: "text";
+  text: string;
 };
 
-const DEFAULT_LARGE_APPEND_CHARS = 500;
-const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
-const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
-const smoothingConfigs: Record<StreamSmoothingPreset, SmoothingConfig> = {
-  realtime: { fraction: 0.5, maxChars: 24 },
-  balanced: { fraction: 0.25, maxChars: 12 },
-  silky: { fraction: 0.125, maxChars: 6 },
+const textStreamAdapter: SmoothStreamItemAdapter<TextStreamItem> = {
+  getKey: (item) => item.key,
+  getText: (item) => item.text,
+  withText: (item, text) => (item.text === text ? item : { ...item, text }),
 };
 
 export function useSmoothStreamText(
   content: string,
-  options: UseSmoothStreamTextOptions = {},
+  options: UseSmoothStreamTextOptions,
 ): UseSmoothStreamTextResult {
-  const enabled = options.enabled ?? true;
-  const mode = options.mode ?? "smooth";
-  const preset = options.preset ?? "balanced";
-  const largeAppendChars = options.largeAppendChars ?? DEFAULT_LARGE_APPEND_CHARS;
-  const observeReducedMotion = enabled && mode !== "none" && options.isStreaming !== false;
-  const systemReducedMotion = useSystemReducedMotion(options.reducedMotion, observeReducedMotion);
-  const reducedMotion = options.reducedMotion ?? systemReducedMotion;
-  const shouldAnimate =
-    enabled && mode !== "none" && options.isStreaming !== false && !reducedMotion;
-
-  const [text, setText] = useState(content);
-  const [isAnimating, setIsAnimating] = useState(false);
-  const targetRef = useRef(content);
-  const targetCharactersRef = useRef([...content]);
-  const displayedLengthRef = useRef(targetCharactersRef.current.length);
-  const frameRef = useRef<number | undefined>(undefined);
-  const mountedRef = useRef(true);
-  const shouldAnimateRef = useRef(shouldAnimate);
-  const presetRef = useRef(preset);
-
-  shouldAnimateRef.current = shouldAnimate;
-  presetRef.current = preset;
-
-  const cancelFrame = useCallback(() => {
-    const frame = frameRef.current;
-    frameRef.current = undefined;
-    if (
-      frame !== undefined &&
-      typeof window !== "undefined" &&
-      typeof window.cancelAnimationFrame === "function"
-    ) {
-      window.cancelAnimationFrame(frame);
-    }
-  }, []);
-
-  const syncToTarget = useCallback(() => {
-    cancelFrame();
-    displayedLengthRef.current = targetCharactersRef.current.length;
-    setText(targetRef.current);
-    setIsAnimating(false);
-  }, [cancelFrame]);
-
-  const scheduleFrame = useCallback(
-    function scheduleFrame() {
-      if (frameRef.current !== undefined || !mountedRef.current) {
-        return;
-      }
-      if (!shouldAnimateRef.current) {
-        syncToTarget();
-        return;
-      }
-      if (typeof window === "undefined" || typeof window.requestAnimationFrame !== "function") {
-        syncToTarget();
-        return;
-      }
-
-      setIsAnimating(true);
-      frameRef.current = window.requestAnimationFrame(() => {
-        frameRef.current = undefined;
-        if (!mountedRef.current) {
-          return;
-        }
-        if (!shouldAnimateRef.current) {
-          syncToTarget();
-          return;
-        }
-
-        const targetCharacters = targetCharactersRef.current;
-        const remaining = targetCharacters.length - displayedLengthRef.current;
-        if (remaining <= 0) {
-          setIsAnimating(false);
-          return;
-        }
-
-        const config = smoothingConfigs[presetRef.current];
-        const revealCount = Math.min(
-          config.maxChars,
-          Math.max(1, Math.ceil(remaining * config.fraction)),
-        );
-        const nextLength = Math.min(
-          targetCharacters.length,
-          displayedLengthRef.current + revealCount,
-        );
-
-        displayedLengthRef.current = nextLength;
-        setText(targetCharacters.slice(0, nextLength).join(""));
-
-        if (nextLength < targetCharacters.length) {
-          scheduleFrame();
-        } else {
-          setIsAnimating(false);
-        }
-      });
-    },
-    [syncToTarget],
+  const items = useMemo<readonly TextStreamItem[]>(
+    () => [{ key: "text", text: content }],
+    [content],
   );
+  const smooth = useSmoothStreamItems(items, {
+    adapter: textStreamAdapter,
+    isStreaming: options.isStreaming,
+    resetKey: options.resetKey,
+    ...(options.flushImmediately === undefined
+      ? {}
+      : { flushImmediately: options.flushImmediately }),
+  });
 
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-      cancelFrame();
-    };
-  }, [cancelFrame]);
-
-  useIsomorphicLayoutEffect(() => {
-    const previousTarget = targetRef.current;
-    const targetCharacters = [...content];
-    targetRef.current = content;
-    targetCharactersRef.current = targetCharacters;
-
-    if (!shouldAnimate) {
-      syncToTarget();
-      return;
-    }
-
-    if (!content.startsWith(previousTarget)) {
-      syncToTarget();
-      return;
-    }
-
-    if (exceedsCharacterLimit(content.slice(previousTarget.length), largeAppendChars)) {
-      syncToTarget();
-      return;
-    }
-
-    if (displayedLengthRef.current < targetCharacters.length) {
-      scheduleFrame();
-    }
-  }, [content, largeAppendChars, scheduleFrame, shouldAnimate, syncToTarget]);
-
-  const flush = useCallback(() => {
-    syncToTarget();
-  }, [syncToTarget]);
-
-  const reset = useCallback(
-    (nextText = "") => {
-      cancelFrame();
-      const nextCharacters = [...nextText];
-      targetRef.current = nextText;
-      targetCharactersRef.current = nextCharacters;
-      displayedLengthRef.current = nextCharacters.length;
-      setText(nextText);
-      setIsAnimating(false);
-    },
-    [cancelFrame],
-  );
-
-  return { text, isAnimating, flush, reset };
-}
-
-function useSystemReducedMotion(override: boolean | undefined, observe: boolean): boolean {
-  const [reducedMotion, setReducedMotion] = useState(false);
-
-  useEffect(() => {
-    if (
-      !observe ||
-      override !== undefined ||
-      typeof window === "undefined" ||
-      typeof window.matchMedia !== "function"
-    ) {
-      return;
-    }
-
-    const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
-    const update = () => {
-      setReducedMotion(mediaQuery.matches);
-    };
-
-    update();
-    if (typeof mediaQuery.addEventListener === "function") {
-      mediaQuery.addEventListener("change", update);
-    } else {
-      mediaQuery.addListener(update);
-    }
-    return () => {
-      if (typeof mediaQuery.removeEventListener === "function") {
-        mediaQuery.removeEventListener("change", update);
-      } else {
-        mediaQuery.removeListener(update);
-      }
-    };
-  }, [observe, override]);
-
-  return reducedMotion;
-}
-
-function exceedsCharacterLimit(value: string, limit: number): boolean {
-  let count = 0;
-  for (const _character of value) {
-    count += 1;
-    if (count > limit) {
-      return true;
-    }
-  }
-  return false;
+  return {
+    text: smooth.items[0]?.text ?? "",
+    isAnimating: smooth.isAnimating,
+    isDraining: smooth.isDraining,
+    flush: smooth.flush,
+  };
 }

--- a/packages/react/test/stream-smoothing.test.ts
+++ b/packages/react/test/stream-smoothing.test.ts
@@ -88,6 +88,25 @@ describe("stream smoothing state", () => {
     expect(snapshot.items).toBe(state.targetItems);
     expect(snapshot.isDraining).toBe(false);
   });
+
+  it("preserves an active drain across repeated non-streaming target updates", () => {
+    const target: Item[] = [{ id: "text", kind: "text", text: "Completion tail" }];
+    let state = createStreamSmoothingState<Item>([], { isStreaming: true, nowMs: 0 }, adapter);
+    state = updateStreamSmoothingTarget(state, target, { isStreaming: true, nowMs: 0 }, adapter);
+    state = updateStreamSmoothingTarget(state, target, { isStreaming: false, nowMs: 100 }, adapter);
+    const displayedBeforeRerender = state.displayedItems;
+
+    state = updateStreamSmoothingTarget(
+      state,
+      [...target],
+      { isStreaming: false, nowMs: 120 },
+      adapter,
+    );
+
+    expect(state.displayedItems).toEqual(displayedBeforeRerender);
+    expect(state.displayedItems).not.toBe(state.targetItems);
+    expect(getStreamSmoothingSnapshot(state, adapter).isDraining).toBe(true);
+  });
 });
 
 function advanceForFrameRate(target: Item[], framesPerSecond: number): number {

--- a/packages/react/test/stream-smoothing.test.ts
+++ b/packages/react/test/stream-smoothing.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  advanceStreamSmoothing,
+  createStreamSmoothingState,
+  flushStreamSmoothing,
+  getBufferedPlaybackTarget,
+  getStreamSmoothingSnapshot,
+  type SmoothStreamItemAdapter,
+  streamSmoothingConfig,
+  updateStreamSmoothingTarget,
+} from "../src/stream-smoothing";
+
+type Item =
+  | { id: string; kind: "text"; text: string }
+  | { id: string; kind: "tool"; status: string };
+
+const adapter: SmoothStreamItemAdapter<Item> = {
+  getKey: (item) => item.id,
+  getText: (item) => (item.kind === "text" ? item.text : undefined),
+  withText: (item, text) => (item.kind === "text" ? { ...item, text } : item),
+};
+
+describe("stream smoothing state", () => {
+  it("interpolates the delayed source timeline", () => {
+    const samples = [
+      { atMs: 0, totalChars: 0 },
+      { atMs: 100, totalChars: 20 },
+    ];
+
+    expect(getBufferedPlaybackTarget(samples, 225)).toBe(0);
+    expect(getBufferedPlaybackTarget(samples, 275)).toBe(10);
+    expect(getBufferedPlaybackTarget(samples, 325)).toBe(20);
+  });
+
+  it("bounds the animated backlog without losing target content", () => {
+    const target: Item[] = [{ id: "text", kind: "text", text: "x".repeat(2_500) }];
+    const initial = createStreamSmoothingState<Item>([], { isStreaming: true, nowMs: 0 }, adapter);
+    const updated = updateStreamSmoothingTarget(
+      initial,
+      target,
+      { isStreaming: true, nowMs: 10 },
+      adapter,
+    );
+    const displayedText =
+      updated.displayedItems[0]?.kind === "text" ? updated.displayedItems[0].text : "";
+
+    expect(
+      target[0]?.kind === "text" ? target[0].text.length - displayedText.length : 0,
+    ).toBeLessThanOrEqual(streamSmoothingConfig.maxPendingChars);
+    expect(flushStreamSmoothing(updated, 20, adapter).displayedItems).toBe(updated.targetItems);
+  });
+
+  it("reconciles replacements at a grapheme-safe common prefix", () => {
+    const initialTarget: Item[] = [{ id: "text", kind: "text", text: "Hello 👨‍👩‍👧‍👦 world" }];
+    let state = createStreamSmoothingState(initialTarget, { isStreaming: true, nowMs: 0 }, adapter);
+    const replacement: Item[] = [{ id: "text", kind: "text", text: "Hello 👨‍👩‍👧‍👦 there" }];
+    state = updateStreamSmoothingTarget(
+      state,
+      replacement,
+      { isStreaming: true, nowMs: 100 },
+      adapter,
+    );
+    const displayed = state.displayedItems[0];
+
+    expect(displayed?.kind === "text" ? displayed.text : "").toBe("Hello 👨‍👩‍👧‍👦 ");
+  });
+
+  it("produces comparable elapsed-time playback across frame rates", () => {
+    const target: Item[] = [{ id: "text", kind: "text", text: "x".repeat(300) }];
+    const at60 = advanceForFrameRate(target, 60);
+    const at120 = advanceForFrameRate(target, 120);
+
+    expect(Math.abs(at60 - at120)).toBeLessThanOrEqual(6);
+  });
+
+  it("reports draining until target and display are identical", () => {
+    const target: Item[] = [{ id: "text", kind: "text", text: "Completion tail" }];
+    let state = createStreamSmoothingState<Item>([], { isStreaming: true, nowMs: 0 }, adapter);
+    state = updateStreamSmoothingTarget(state, target, { isStreaming: true, nowMs: 0 }, adapter);
+    state = updateStreamSmoothingTarget(state, target, { isStreaming: false, nowMs: 100 }, adapter);
+    expect(getStreamSmoothingSnapshot(state, adapter).isDraining).toBe(true);
+
+    for (let now = 117; now <= 900; now += 17) {
+      state = advanceStreamSmoothing(state, now, adapter);
+    }
+    const snapshot = getStreamSmoothingSnapshot(state, adapter);
+    expect(snapshot.items).toBe(state.targetItems);
+    expect(snapshot.isDraining).toBe(false);
+  });
+});
+
+function advanceForFrameRate(target: Item[], framesPerSecond: number): number {
+  let state = createStreamSmoothingState<Item>([], { isStreaming: true, nowMs: 0 }, adapter);
+  state = updateStreamSmoothingTarget(state, target, { isStreaming: true, nowMs: 0 }, adapter);
+  const frameDuration = 1_000 / framesPerSecond;
+  for (let now = frameDuration; now <= 500; now += frameDuration) {
+    if (now - state.lastAdvanceAtMs + 0.5 < 1_000 / streamSmoothingConfig.maxCommitFps) {
+      continue;
+    }
+    state = advanceStreamSmoothing(state, now, adapter);
+  }
+  const first = state.displayedItems[0];
+  return first?.kind === "text" ? first.text.length : 0;
+}

--- a/packages/react/test/use-smooth-stream-text.test.ts
+++ b/packages/react/test/use-smooth-stream-text.test.ts
@@ -1,250 +1,230 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-
-import type { StreamSmoothingPreset } from "../src";
-import { useSmoothStreamText } from "../src";
+import type { SmoothStreamItemAdapter } from "../src";
+import { useSmoothStreamItems, useSmoothStreamText } from "../src";
 
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
 
-describe("@anvia/react useSmoothStreamText", () => {
-  it("returns full content when disabled", () => {
-    const raf = installAnimationFrame();
-    const { result, rerender } = renderHook(
-      ({ content }) => useSmoothStreamText(content, { enabled: false }),
-      { initialProps: { content: "Hello" } },
+describe("@anvia/react stream smoothing hooks", () => {
+  it("seeds initial content without replaying it", () => {
+    const clock = installAnimationFrame();
+    const { result } = renderHook(() =>
+      useSmoothStreamText("Loaded history", {
+        isStreaming: false,
+        resetKey: "session-1",
+      }),
     );
 
-    rerender({ content: "Hello world" });
-
-    expect(result.current.text).toBe("Hello world");
+    expect(result.current.text).toBe("Loaded history");
     expect(result.current.isAnimating).toBe(false);
-    expect(raf.request).not.toHaveBeenCalled();
+    expect(clock.request).not.toHaveBeenCalled();
   });
 
-  it("returns full content in none mode", () => {
-    const raf = installAnimationFrame();
+  it("buffers an append before revealing it at an elapsed-time rate", () => {
+    const clock = installAnimationFrame();
     const { result, rerender } = renderHook(
-      ({ content }) => useSmoothStreamText(content, { mode: "none" }),
-      { initialProps: { content: "Hello" } },
-    );
-
-    rerender({ content: "Hello world" });
-
-    expect(result.current.text).toBe("Hello world");
-    expect(result.current.isAnimating).toBe(false);
-    expect(raf.request).not.toHaveBeenCalled();
-  });
-
-  it("progressively reveals appended Unicode characters while streaming", () => {
-    const raf = installAnimationFrame();
-    const { result, rerender } = renderHook(
-      ({ content }) => useSmoothStreamText(content, { reducedMotion: false }),
+      ({ content }) =>
+        useSmoothStreamText(content, {
+          isStreaming: true,
+          resetKey: "message-1",
+        }),
       { initialProps: { content: "A" } },
     );
 
-    rerender({ content: "A🙂🙃😉😊" });
-
+    rerender({ content: "ABCDEFGHIJKLMNO" });
     expect(result.current.text).toBe("A");
     expect(result.current.isAnimating).toBe(true);
 
-    act(() => raf.step());
-
-    expect(result.current.text).toBe("A🙂");
-    expect(result.current.isAnimating).toBe(true);
-
-    drainAnimationFrames(raf);
-
-    expect(result.current.text).toBe("A🙂🙃😉😊");
-    expect(result.current.isAnimating).toBe(false);
-  });
-
-  it.each([
-    ["realtime", 20],
-    ["balanced", 10],
-    ["silky", 5],
-  ] as const)("uses adaptive %s preset pacing", (preset, expectedLength) => {
-    const raf = installAnimationFrame();
-    const content = "x".repeat(40);
-    const { result, rerender } = renderHook(
-      ({ value, smoothingPreset }: { value: string; smoothingPreset: StreamSmoothingPreset }) =>
-        useSmoothStreamText(value, { preset: smoothingPreset, reducedMotion: false }),
-      { initialProps: { value: "", smoothingPreset: preset } },
-    );
-
-    rerender({ value: content, smoothingPreset: preset });
-    act(() => raf.step());
-
-    expect(result.current.text).toBe("x".repeat(expectedLength));
-  });
-
-  it("flushes queued text immediately", () => {
-    const raf = installAnimationFrame();
-    const { result, rerender } = renderHook(
-      ({ content }) => useSmoothStreamText(content, { reducedMotion: false }),
-      { initialProps: { content: "A" } },
-    );
-
-    rerender({ content: "ABCDE" });
-    expect(result.current.isAnimating).toBe(true);
-
-    act(() => result.current.flush());
-
-    expect(result.current.text).toBe("ABCDE");
-    expect(result.current.isAnimating).toBe(false);
-    expect(raf.cancel).toHaveBeenCalled();
-  });
-
-  it("resets its internal target and displayed text", () => {
-    installAnimationFrame();
-    const { result } = renderHook(() => useSmoothStreamText("Original", { reducedMotion: false }));
-
-    act(() => result.current.reset("Replacement"));
-    expect(result.current.text).toBe("Replacement");
-    expect(result.current.isAnimating).toBe(false);
-
-    act(() => result.current.reset());
-    expect(result.current.text).toBe("");
-  });
-
-  it("synchronizes replacement text immediately", () => {
-    const raf = installAnimationFrame();
-    const { result, rerender } = renderHook(
-      ({ content }) => useSmoothStreamText(content, { reducedMotion: false }),
-      { initialProps: { content: "Hello" } },
-    );
-
-    rerender({ content: "Goodbye" });
-
-    expect(result.current.text).toBe("Goodbye");
-    expect(result.current.isAnimating).toBe(false);
-    expect(raf.request).not.toHaveBeenCalled();
-  });
-
-  it("synchronizes appends larger than the configured threshold", () => {
-    const raf = installAnimationFrame();
-    const { result, rerender } = renderHook(
-      ({ content }) => useSmoothStreamText(content, { largeAppendChars: 2, reducedMotion: false }),
-      { initialProps: { content: "A" } },
-    );
-
-    rerender({ content: "ABCDE" });
-
-    expect(result.current.text).toBe("ABCDE");
-    expect(result.current.isAnimating).toBe(false);
-    expect(raf.request).not.toHaveBeenCalled();
-  });
-
-  it("counts Unicode code points for the large append threshold", () => {
-    const raf = installAnimationFrame();
-    const { result, rerender } = renderHook(
-      ({ content }) => useSmoothStreamText(content, { largeAppendChars: 1, reducedMotion: false }),
-      { initialProps: { content: "A" } },
-    );
-
-    rerender({ content: "A🙂" });
-
+    act(() => clock.advance(200));
     expect(result.current.text).toBe("A");
-    expect(result.current.isAnimating).toBe(true);
-    expect(raf.request).toHaveBeenCalledTimes(1);
+
+    act(() => clock.advance(50));
+    expect(result.current.text.startsWith("A")).toBe(true);
+    expect(result.current.text.length).toBeGreaterThan(1);
+    expect(result.current.text).not.toBe("ABCDEFGHIJKLMNO");
   });
 
-  it("synchronizes appends larger than the default 500-character threshold", () => {
-    const raf = installAnimationFrame();
-    const { result, rerender } = renderHook(
-      ({ content }) => useSmoothStreamText(content, { reducedMotion: false }),
-      { initialProps: { content: "A" } },
-    );
-
-    rerender({ content: `A${"x".repeat(501)}` });
-
-    expect(result.current.text).toBe(`A${"x".repeat(501)}`);
-    expect(result.current.isAnimating).toBe(false);
-    expect(raf.request).not.toHaveBeenCalled();
-  });
-
-  it("synchronizes immediately when streaming stops", () => {
-    const raf = installAnimationFrame();
+  it("drains buffered text instead of snapping when streaming completes", () => {
+    const clock = installAnimationFrame();
     const { result, rerender } = renderHook(
       ({ content, isStreaming }) =>
-        useSmoothStreamText(content, { isStreaming, reducedMotion: false }),
-      { initialProps: { content: "A", isStreaming: true } },
+        useSmoothStreamText(content, {
+          isStreaming,
+          resetKey: "message-1",
+        }),
+      { initialProps: { content: "", isStreaming: true } },
     );
 
-    rerender({ content: "ABCDE", isStreaming: true });
-    expect(result.current.text).toBe("A");
+    rerender({ content: "A response that still has buffered text", isStreaming: true });
+    act(() => clock.advance(250));
+    expect(result.current.text).not.toBe("A response that still has buffered text");
 
-    rerender({ content: "ABCDE", isStreaming: false });
+    rerender({ content: "A response that still has buffered text", isStreaming: false });
+    expect(result.current.isDraining).toBe(true);
+    expect(result.current.text).not.toBe("A response that still has buffered text");
 
-    expect(result.current.text).toBe("ABCDE");
-    expect(result.current.isAnimating).toBe(false);
-    expect(raf.cancel).toHaveBeenCalled();
+    drainAnimationFrames(clock, 1_000);
+    expect(result.current.text).toBe("A response that still has buffered text");
+    expect(result.current.isDraining).toBe(false);
   });
 
-  it("follows the system reduced motion preference by default", () => {
-    const raf = installAnimationFrame();
-    installMatchMedia(true);
-    const { result, rerender } = renderHook(({ content }) => useSmoothStreamText(content), {
-      initialProps: { content: "A" },
-    });
-
-    rerender({ content: "ABCDE" });
-
-    expect(result.current.text).toBe("ABCDE");
-    expect(result.current.isAnimating).toBe(false);
-    expect(raf.request).not.toHaveBeenCalled();
-  });
-
-  it("lets an explicit reduced motion value override the system preference", () => {
-    const raf = installAnimationFrame();
-    installMatchMedia(true);
+  it("flushes immediately for fatal source errors", () => {
+    const clock = installAnimationFrame();
     const { result, rerender } = renderHook(
-      ({ content }) => useSmoothStreamText(content, { reducedMotion: false }),
-      { initialProps: { content: "A" } },
+      ({ content, flushImmediately }) =>
+        useSmoothStreamText(content, {
+          flushImmediately,
+          isStreaming: true,
+          resetKey: "message-1",
+        }),
+      { initialProps: { content: "", flushImmediately: false } },
     );
 
-    rerender({ content: "ABCDE" });
+    rerender({ content: "Partial response", flushImmediately: false });
+    expect(result.current.text).toBe("");
 
-    expect(result.current.text).toBe("A");
-    expect(result.current.isAnimating).toBe(true);
-    expect(raf.request).toHaveBeenCalledTimes(1);
+    rerender({ content: "Partial response", flushImmediately: true });
+    expect(result.current.text).toBe("Partial response");
+    expect(result.current.isAnimating).toBe(false);
+    expect(clock.cancel).toHaveBeenCalled();
   });
 
-  it("synchronizes immediately when requestAnimationFrame is unavailable", () => {
-    installMatchMedia(false);
+  it("uses resetKey to seed a newly selected stream", () => {
+    const clock = installAnimationFrame();
+    const { result, rerender } = renderHook(
+      ({ content, resetKey }) =>
+        useSmoothStreamText(content, {
+          isStreaming: true,
+          resetKey,
+        }),
+      { initialProps: { content: "First", resetKey: "session-1" } },
+    );
+
+    rerender({ content: "First response continues", resetKey: "session-1" });
+    expect(result.current.text).toBe("First");
+
+    rerender({ content: "Loaded second session", resetKey: "session-2" });
+    expect(result.current.text).toBe("Loaded second session");
+    expect(result.current.isAnimating).toBe(false);
+    expect(clock.cancel).toHaveBeenCalled();
+  });
+
+  it("keeps composed graphemes intact", () => {
+    const clock = installAnimationFrame();
+    const family = "👨‍👩‍👧‍👦";
+    const target = family.repeat(10);
+    const { result, rerender } = renderHook(
+      ({ content }) =>
+        useSmoothStreamText(content, {
+          isStreaming: true,
+          resetKey: "message-1",
+        }),
+      { initialProps: { content: "" } },
+    );
+
+    rerender({ content: target });
+    act(() => clock.advance(250));
+
+    expect(result.current.text.length).toBeGreaterThan(0);
+    expect(target.startsWith(result.current.text)).toBe(true);
+    const revealedGraphemes = [
+      ...new Intl.Segmenter(undefined, { granularity: "grapheme" }).segment(result.current.text),
+    ];
+    expect(revealedGraphemes.length).toBeLessThan(10);
+    expect(revealedGraphemes.every((segment) => segment.segment === family)).toBe(true);
+  });
+
+  it("preserves item ordering and applies visible opaque updates immediately", () => {
+    const clock = installAnimationFrame();
+    const adapter: SmoothStreamItemAdapter<TestItem> = {
+      getKey: (item) => item.id,
+      getText: (item) => (item.kind === "text" ? item.text : undefined),
+      withText: (item, text) => (item.kind === "text" ? { ...item, text } : item),
+    };
+    const { result, rerender } = renderHook(
+      ({ items, isStreaming }) =>
+        useSmoothStreamItems(items, {
+          adapter,
+          isStreaming,
+          resetKey: "turn-1",
+        }),
+      { initialProps: { items: [] as TestItem[], isStreaming: true } },
+    );
+
+    rerender({
+      items: [
+        { id: "text-1", kind: "text", text: "Text before a tool call" },
+        { id: "tool-1", kind: "tool", status: "running" },
+      ],
+      isStreaming: true,
+    });
+    act(() => clock.advance(250));
+    expect(result.current.items.map((item) => item.id)).toEqual(["text-1"]);
+    expect(result.current.liveItemKey).toBe("text-1");
+
+    drainAnimationFrames(clock, 1_000);
+    expect(result.current.items.map((item) => item.id)).toEqual(["text-1", "tool-1"]);
+    expect(result.current.liveItemKey).toBeNull();
+
+    rerender({
+      items: [
+        { id: "text-1", kind: "text", text: "Text before a tool call" },
+        { id: "tool-1", kind: "tool", status: "done" },
+      ],
+      isStreaming: true,
+    });
+    expect(result.current.items[1]).toEqual({ id: "tool-1", kind: "tool", status: "done" });
+  });
+
+  it("flushes when animation frames are unavailable", () => {
+    const clock = installAnimationFrame();
     vi.stubGlobal("requestAnimationFrame", undefined);
     const { result, rerender } = renderHook(
-      ({ content }) => useSmoothStreamText(content, { reducedMotion: false }),
-      { initialProps: { content: "A" } },
+      ({ content }) =>
+        useSmoothStreamText(content, {
+          isStreaming: true,
+          resetKey: "message-1",
+        }),
+      { initialProps: { content: "" } },
     );
 
-    rerender({ content: "ABCDE" });
-
-    expect(result.current.text).toBe("ABCDE");
+    rerender({ content: "No animation frame support" });
+    expect(result.current.text).toBe("No animation frame support");
     expect(result.current.isAnimating).toBe(false);
+    expect(clock.request).not.toHaveBeenCalled();
   });
 
-  it("cancels a scheduled animation frame on unmount", () => {
-    const raf = installAnimationFrame();
+  it("cancels a scheduled frame on unmount", () => {
+    const clock = installAnimationFrame();
     const { rerender, unmount } = renderHook(
-      ({ content }) => useSmoothStreamText(content, { reducedMotion: false }),
-      { initialProps: { content: "A" } },
+      ({ content }) =>
+        useSmoothStreamText(content, {
+          isStreaming: true,
+          resetKey: "message-1",
+        }),
+      { initialProps: { content: "" } },
     );
 
-    rerender({ content: "ABCDE" });
+    rerender({ content: "Pending" });
     unmount();
-
-    expect(raf.cancel).toHaveBeenCalledTimes(1);
+    expect(clock.cancel).toHaveBeenCalledTimes(1);
   });
 });
+
+type TestItem =
+  | { id: string; kind: "text"; text: string }
+  | { id: string; kind: "tool"; status: string };
 
 type AnimationFrameHarness = ReturnType<typeof installAnimationFrame>;
 
 function installAnimationFrame() {
+  let now = 0;
   let nextId = 0;
   const callbacks = new Map<number, FrameRequestCallback>();
+  vi.spyOn(performance, "now").mockImplementation(() => now);
   const request = vi.fn((callback: FrameRequestCallback) => {
     const id = ++nextId;
     callbacks.set(id, callback);
@@ -253,44 +233,29 @@ function installAnimationFrame() {
   const cancel = vi.fn((id: number) => {
     callbacks.delete(id);
   });
-
   vi.stubGlobal("requestAnimationFrame", request);
   vi.stubGlobal("cancelAnimationFrame", cancel);
-  installMatchMedia(false);
 
   return {
     cancel,
     pending: () => callbacks.size,
     request,
-    step() {
-      const pending = [...callbacks.values()];
-      callbacks.clear();
-      for (const callback of pending) {
-        callback(0);
+    advance(durationMs: number) {
+      const target = now + durationMs;
+      while (callbacks.size > 0 && now < target) {
+        now = Math.min(target, now + 1_000 / 60);
+        const pending = [...callbacks.values()];
+        callbacks.clear();
+        for (const callback of pending) {
+          callback(now);
+        }
       }
+      now = target;
     },
   };
 }
 
-function drainAnimationFrames(raf: AnimationFrameHarness): void {
-  for (let frame = 0; frame < 100 && raf.pending() > 0; frame += 1) {
-    act(() => raf.step());
-  }
-  expect(raf.pending()).toBe(0);
-}
-
-function installMatchMedia(matches: boolean): void {
-  const mediaQuery = {
-    matches,
-    media: "(prefers-reduced-motion: reduce)",
-    onchange: null,
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    dispatchEvent: vi.fn(() => true),
-  } as unknown as MediaQueryList;
-
-  vi.stubGlobal(
-    "matchMedia",
-    vi.fn(() => mediaQuery),
-  );
+function drainAnimationFrames(clock: AnimationFrameHarness, durationMs: number): void {
+  act(() => clock.advance(durationMs));
+  expect(clock.pending()).toBe(0);
 }

--- a/packages/tool-studio/package.json
+++ b/packages/tool-studio/package.json
@@ -27,13 +27,14 @@
   },
   "scripts": {
     "build": "pnpm run build:deps && tsup && vite build --config vite.config.ts",
-    "build:deps": "(test -f ../core/dist/index.d.ts || pnpm --filter @anvia/core build) && pnpm --filter @anvia/server --filter @anvia/react build",
+    "build:deps": "(test -f ../core/dist/index.d.ts || pnpm --filter @anvia/core build) && pnpm --filter @anvia/server --filter @anvia/react --filter @anvia/react-ui build",
     "coverage": "pnpm run build:deps && vitest run --coverage",
     "test": "pnpm run build:deps && vitest run",
     "typecheck": "pnpm run build:deps && tsc --noEmit"
   },
   "dependencies": {
     "@anvia/react": "workspace:*",
+    "@anvia/react-ui": "workspace:*",
     "@anvia/server": "workspace:*",
     "@hono/node-server": "^2.0.8",
     "@hugeicons/core-free-icons": "^4.2.2",
@@ -51,7 +52,6 @@
     "hono": "^4.12.27",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "react-markdown": "^10.1.0",
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
@@ -62,7 +62,6 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "remark-gfm": "^4.0.1",
     "tailwindcss": "^4.2.4",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",

--- a/packages/tool-studio/src/ui/app/app.tsx
+++ b/packages/tool-studio/src/ui/app/app.tsx
@@ -59,6 +59,7 @@ export function StudioConsole() {
   const [status, setStatus] = useState("Loading");
   const [, setError] = useState("");
   const [runState, setRunState] = useState<RunState>("idle");
+  const [transcriptResetKey, setTranscriptResetKey] = useState(0);
   const promptRef = useRef<HTMLTextAreaElement | null>(null);
   const attachmentInputRef = useRef<HTMLInputElement | null>(null);
   const transcriptScrollerRef = useRef<HTMLElement | null>(null);
@@ -90,6 +91,27 @@ export function StudioConsole() {
     });
     return () => window.cancelAnimationFrame(frame);
   }, [activePage, messages]);
+
+  useEffect(() => {
+    if (activePage !== "playground" || typeof ResizeObserver === "undefined") {
+      return;
+    }
+    const scroller = transcriptScrollerRef.current;
+    if (scroller === null) {
+      return;
+    }
+    const content = scroller.querySelector<HTMLElement>("[data-studio-transcript-content]");
+    if (content === null) {
+      return;
+    }
+    const observer = new ResizeObserver(() => {
+      if (transcriptStickToBottomRef.current) {
+        scroller.scrollTop = scroller.scrollHeight;
+      }
+    });
+    observer.observe(content);
+    return () => observer.disconnect();
+  }, [activePage]);
 
   const loadConfig = useCallback(async () => {
     setStatus("Loading");
@@ -215,6 +237,7 @@ export function StudioConsole() {
       traceSummaries: StudioTraceSummary[],
       options: { updatePath?: boolean },
     ) => {
+      setTranscriptResetKey((current) => current + 1);
       setTranscriptSequence(nextSequence(session.transcript));
       setSelectedAgentId(session.agentId);
       setSelectedModelRef(sessionModelRef(session));
@@ -235,6 +258,7 @@ export function StudioConsole() {
         return;
       }
       resetTranscriptSequence();
+      setTranscriptResetKey((current) => current + 1);
       setMessages([]);
       setSessionTraceSummaries([]);
       setPrompt("");
@@ -298,6 +322,7 @@ export function StudioConsole() {
         return;
       }
       resetTranscriptSequence();
+      setTranscriptResetKey((current) => current + 1);
       sessions.clearSelectedSession();
       setMessages([]);
       setSessionTraceSummaries([]);
@@ -322,6 +347,7 @@ export function StudioConsole() {
       setSelectedAgentId(agentId);
       setSelectedModelRef("");
       resetTranscriptSequence();
+      setTranscriptResetKey((current) => current + 1);
       sessions.clearSelectedSession();
       setMessages([]);
       setSessionTraceSummaries([]);
@@ -476,6 +502,7 @@ export function StudioConsole() {
     attachmentInputRef,
     promptRef,
     transcriptScrollerRef,
+    transcriptResetKey,
     activateRoute,
     navigateFallback,
     navigatePage,

--- a/packages/tool-studio/src/ui/app/main.tsx
+++ b/packages/tool-studio/src/ui/app/main.tsx
@@ -1,4 +1,5 @@
 import { createRoot } from "react-dom/client";
+import "@anvia/react-ui/stream/styles.css";
 import { StudioConsole } from "./app";
 import "./styles.css";
 

--- a/packages/tool-studio/src/ui/app/modules/playground/playground-page.tsx
+++ b/packages/tool-studio/src/ui/app/modules/playground/playground-page.tsx
@@ -6,14 +6,7 @@ import {
   ChatIcon,
   StopIcon,
 } from "@hugeicons/core-free-icons";
-import {
-  type ChangeEvent,
-  type KeyboardEvent,
-  lazy,
-  type RefObject,
-  Suspense,
-  useMemo,
-} from "react";
+import type { ChangeEvent, KeyboardEvent, RefObject } from "react";
 import type {
   StudioConfig,
   StudioModelSummary,
@@ -39,14 +32,7 @@ import { StudioPageShell } from "../../components/ui/studio";
 import { Textarea } from "../../components/ui/textarea";
 import { cn } from "../../lib/utils";
 import type { RunState, TranscriptEntry } from "../shared/types";
-import { assistantResponseMetricsByEntryId } from "./response-metrics";
-import { WorkingDuration } from "./working-duration";
-
-const TranscriptItem = lazy(() =>
-  import("./transcript-item").then((module) => ({
-    default: module.TranscriptItem,
-  })),
-);
+import { SmoothedTranscript } from "./smoothed-transcript";
 
 export function PlaygroundPage(props: {
   agents: StudioConfig["agents"];
@@ -56,6 +42,7 @@ export function PlaygroundPage(props: {
   decidingApprovals: Set<string>;
   hasMessages: boolean;
   isStreaming: boolean;
+  transcriptResetKey: string | number;
   workingStartedAt?: number | undefined;
   messages: TranscriptEntry[];
   prompt: string;
@@ -89,28 +76,19 @@ export function PlaygroundPage(props: {
   onSelectModel: (modelRef: string) => void;
   onTranscriptScroll: () => void;
 }) {
-  const responseMetricsByEntryId = useMemo(
-    () =>
-      assistantResponseMetricsByEntryId({
-        entries: props.messages,
-        traceSummaries: props.sessionTraceSummaries,
-        logs: props.sessionLogs,
-      }),
-    [props.messages, props.sessionLogs, props.sessionTraceSummaries],
-  );
-  const workingResponseEntryId =
-    props.workingStartedAt === undefined ? undefined : currentTurnAssistantEntryId(props.messages);
-
   return (
     <StudioPageShell className="grid-cols-[minmax(0,1fr)_minmax(0,460px)] max-xl:grid-cols-1">
       <div className="grid min-h-0 min-w-0">
         <div className="grid h-full min-h-0 min-w-0 grid-rows-[minmax(0,1fr)_auto]">
           <section
-            className="min-h-0 overflow-y-auto overflow-x-hidden px-4 py-4 [scrollbar-gutter:stable]"
+            className="min-h-0 overflow-y-auto overflow-x-hidden px-4 py-4 [overflow-anchor:none] [scrollbar-gutter:stable]"
             ref={props.transcriptScrollerRef}
             onScroll={props.onTranscriptScroll}
           >
-            <div className="mx-auto grid min-h-full w-full max-w-235 content-start items-start gap-6 pb-8">
+            <div
+              className="mx-auto grid min-h-full w-full max-w-235 content-start items-start gap-6 pb-8"
+              data-studio-transcript-content=""
+            >
               {!props.hasMessages ? (
                 <div className="grid min-h-96 place-items-center text-sm font-medium text-muted-foreground">
                   <div className="grid max-w-xl gap-4 text-center">
@@ -125,30 +103,19 @@ export function PlaygroundPage(props: {
                   </div>
                 </div>
               ) : null}
-              <Suspense fallback={null}>
-                {props.messages.map((message) => (
-                  <TranscriptItem
-                    key={message.entryId}
-                    entry={message}
-                    metrics={responseMetricsByEntryId.get(message.entryId)}
-                    workingStartedAt={
-                      message.entryId === workingResponseEntryId
-                        ? props.workingStartedAt
-                        : undefined
-                    }
-                    decidingApprovals={props.decidingApprovals}
-                    answeringQuestions={props.answeringQuestions}
-                    onApprovalDecision={props.onApprovalDecision}
-                    onQuestionAnswer={props.onQuestionAnswer}
-                    onOpenTrace={props.onOpenTrace}
-                  />
-                ))}
-              </Suspense>
-              {props.workingStartedAt !== undefined && workingResponseEntryId === undefined ? (
-                <article className="max-w-[min(82ch,100%)] justify-self-start text-foreground">
-                  <WorkingDuration startedAt={props.workingStartedAt} />
-                </article>
-              ) : null}
+              <SmoothedTranscript
+                answeringQuestions={props.answeringQuestions}
+                decidingApprovals={props.decidingApprovals}
+                isStreaming={props.isStreaming}
+                messages={props.messages}
+                resetKey={props.transcriptResetKey}
+                sessionLogs={props.sessionLogs}
+                sessionTraceSummaries={props.sessionTraceSummaries}
+                workingStartedAt={props.workingStartedAt}
+                onApprovalDecision={props.onApprovalDecision}
+                onOpenTrace={props.onOpenTrace}
+                onQuestionAnswer={props.onQuestionAnswer}
+              />
             </div>
           </section>
           <form
@@ -312,19 +279,6 @@ export function PlaygroundPage(props: {
       />
     </StudioPageShell>
   );
-}
-
-function currentTurnAssistantEntryId(entries: TranscriptEntry[]): number | undefined {
-  for (let index = entries.length - 1; index >= 0; index -= 1) {
-    const entry = entries[index];
-    if (entry?.kind === "message" && entry.role === "assistant") {
-      return entry.entryId;
-    }
-    if (entry?.kind === "message" && entry.role === "user") {
-      return undefined;
-    }
-  }
-  return undefined;
 }
 
 function PlaygroundSessionsPanel(props: {

--- a/packages/tool-studio/src/ui/app/modules/playground/smoothed-transcript.tsx
+++ b/packages/tool-studio/src/ui/app/modules/playground/smoothed-transcript.tsx
@@ -52,9 +52,6 @@ export function SmoothedTranscript(props: {
     [props.messages, props.sessionLogs, props.sessionTraceSummaries],
   );
   const retainedWorkingStartedAtRef = useRef(props.workingStartedAt);
-  if (props.workingStartedAt !== undefined) {
-    retainedWorkingStartedAtRef.current = props.workingStartedAt;
-  }
   const visibleWorkingStartedAt =
     props.workingStartedAt ??
     (smoothed.isDraining ? retainedWorkingStartedAtRef.current : undefined);
@@ -67,6 +64,9 @@ export function SmoothedTranscript(props: {
     : undefined;
 
   useEffect(() => {
+    if (props.workingStartedAt !== undefined) {
+      retainedWorkingStartedAtRef.current = props.workingStartedAt;
+    }
     if (!smoothed.isDraining && props.workingStartedAt === undefined) {
       retainedWorkingStartedAtRef.current = undefined;
     }

--- a/packages/tool-studio/src/ui/app/modules/playground/smoothed-transcript.tsx
+++ b/packages/tool-studio/src/ui/app/modules/playground/smoothed-transcript.tsx
@@ -1,0 +1,108 @@
+import { useSmoothStreamItems } from "@anvia/react";
+import { lazy, Suspense, useEffect, useMemo, useRef } from "react";
+import type { StudioSessionLogEntry, StudioTraceSummary } from "../../../../types";
+import type { TranscriptEntry } from "../shared/types";
+import { assistantResponseMetricsByEntryId } from "./response-metrics";
+import {
+  currentTurnAssistantEntryId,
+  hasTerminalTranscriptError,
+  transcriptStreamAdapter,
+} from "./transcript-stream";
+import { WorkingDuration } from "./working-duration";
+
+const TranscriptItem = lazy(() =>
+  import("./transcript-item").then((module) => ({
+    default: module.TranscriptItem,
+  })),
+);
+
+export function SmoothedTranscript(props: {
+  answeringQuestions: Set<string>;
+  decidingApprovals: Set<string>;
+  isStreaming: boolean;
+  messages: TranscriptEntry[];
+  resetKey: string | number;
+  sessionLogs: StudioSessionLogEntry[];
+  sessionTraceSummaries: StudioTraceSummary[];
+  workingStartedAt?: number | undefined;
+  onApprovalDecision: (approvalId: string, approved: boolean) => void;
+  onOpenTrace: (traceId: string) => void;
+  onQuestionAnswer: (
+    questionId: string,
+    answers: Array<{ questionId: string; answer: string; choice?: string; custom?: boolean }>,
+  ) => void;
+}) {
+  const smoothed = useSmoothStreamItems(props.messages, {
+    adapter: transcriptStreamAdapter,
+    flushImmediately: hasTerminalTranscriptError(props.messages),
+    isStreaming: props.isStreaming,
+    resetKey: props.resetKey,
+  });
+  const sourceEntriesById = useMemo(
+    () => new Map(props.messages.map((entry) => [entry.entryId, entry])),
+    [props.messages],
+  );
+  const responseMetricsByEntryId = useMemo(
+    () =>
+      assistantResponseMetricsByEntryId({
+        entries: props.messages,
+        traceSummaries: props.sessionTraceSummaries,
+        logs: props.sessionLogs,
+      }),
+    [props.messages, props.sessionLogs, props.sessionTraceSummaries],
+  );
+  const retainedWorkingStartedAtRef = useRef(props.workingStartedAt);
+  if (props.workingStartedAt !== undefined) {
+    retainedWorkingStartedAtRef.current = props.workingStartedAt;
+  }
+  const visibleWorkingStartedAt =
+    props.workingStartedAt ??
+    (smoothed.isDraining ? retainedWorkingStartedAtRef.current : undefined);
+  const workingResponseEntryId =
+    visibleWorkingStartedAt === undefined ? undefined : currentTurnAssistantEntryId(props.messages);
+  const visibleWorkingResponseEntryId = smoothed.items.some(
+    (entry) => entry.entryId === workingResponseEntryId,
+  )
+    ? workingResponseEntryId
+    : undefined;
+
+  useEffect(() => {
+    if (!smoothed.isDraining && props.workingStartedAt === undefined) {
+      retainedWorkingStartedAtRef.current = undefined;
+    }
+  }, [props.workingStartedAt, smoothed.isDraining]);
+
+  return (
+    <>
+      <Suspense fallback={null}>
+        {smoothed.items.map((displayEntry) => {
+          const sourceEntry = sourceEntriesById.get(displayEntry.entryId) ?? displayEntry;
+          return (
+            <TranscriptItem
+              key={displayEntry.entryId}
+              entry={sourceEntry}
+              displayText={transcriptStreamAdapter.getText(displayEntry)}
+              live={smoothed.liveItemKey === String(displayEntry.entryId)}
+              metrics={responseMetricsByEntryId.get(displayEntry.entryId)}
+              workingStartedAt={
+                displayEntry.entryId === visibleWorkingResponseEntryId
+                  ? visibleWorkingStartedAt
+                  : undefined
+              }
+              decidingApprovals={props.decidingApprovals}
+              answeringQuestions={props.answeringQuestions}
+              onApprovalDecision={props.onApprovalDecision}
+              onQuestionAnswer={props.onQuestionAnswer}
+              onOpenTrace={props.onOpenTrace}
+            />
+          );
+        })}
+      </Suspense>
+      {visibleWorkingStartedAt !== undefined && visibleWorkingResponseEntryId === undefined ? (
+        <article className="max-w-[min(82ch,100%)] justify-self-start text-foreground">
+          <WorkingDuration startedAt={visibleWorkingStartedAt} />
+        </article>
+      ) : null}
+    </>
+  );
+}

--- a/packages/tool-studio/src/ui/app/modules/playground/transcript-item.tsx
+++ b/packages/tool-studio/src/ui/app/modules/playground/transcript-item.tsx
@@ -5,7 +5,7 @@ import {
   PathIcon,
   Wrench01Icon,
 } from "@hugeicons/core-free-icons";
-import { useState } from "react";
+import { memo, useState } from "react";
 import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
 import { StudioIcon } from "../../components/ui/icon";
@@ -17,8 +17,10 @@ import type { ToolApproval, ToolMessage, ToolQuestion, TranscriptEntry } from ".
 import type { AssistantResponseMetrics, ResponseUsageMetrics } from "./response-metrics";
 import { WorkingDuration } from "./working-duration";
 
-export function TranscriptItem(props: {
+export const TranscriptItem = memo(function TranscriptItem(props: {
   entry: TranscriptEntry;
+  displayText?: string | undefined;
+  live?: boolean | undefined;
   metrics?: AssistantResponseMetrics | undefined;
   workingStartedAt?: number | undefined;
   decidingApprovals: Set<string>;
@@ -30,6 +32,7 @@ export function TranscriptItem(props: {
   ) => void;
   onOpenTrace: (traceId: string) => void;
 }) {
+  const displayText = props.displayText ?? ("text" in props.entry ? props.entry.text : "");
   if (props.entry.kind === "reasoning") {
     return (
       <article
@@ -37,7 +40,7 @@ export function TranscriptItem(props: {
         data-entry-id={String(props.entry.entryId)}
       >
         <div className="mb-1 text-xs font-semibold uppercase text-muted-foreground">Reasoning</div>
-        <MarkdownText size="base" text={props.entry.text} />
+        <MarkdownText live={props.live} size="base" text={displayText} />
       </article>
     );
   }
@@ -55,7 +58,7 @@ export function TranscriptItem(props: {
   }
 
   const traceId = props.entry.role === "assistant" ? props.entry.traceId : undefined;
-  const hasTable = props.entry.role === "assistant" && hasMarkdownTable(props.entry.text);
+  const hasTable = props.entry.role === "assistant" && hasMarkdownTable(displayText);
   const isError =
     props.entry.role === "assistant" && "tone" in props.entry && props.entry.tone === "error";
   const isPending =
@@ -97,8 +100,8 @@ export function TranscriptItem(props: {
       data-entry-id={String(props.entry.entryId)}
     >
       {isPending ? <AssistantLoadingIndicator /> : null}
-      {props.entry.text.trim().length === 0 ? null : (
-        <MarkdownText size="base" text={props.entry.text} />
+      {displayText.trim().length === 0 ? null : (
+        <MarkdownText live={props.live} size="base" text={displayText} />
       )}
       {showAssistantFooter ? (
         <AssistantResponseFooter
@@ -113,7 +116,7 @@ export function TranscriptItem(props: {
       ) : null}
     </article>
   );
-}
+});
 
 function AssistantResponseFooter(props: {
   durationMs?: number | undefined;

--- a/packages/tool-studio/src/ui/app/modules/playground/transcript-stream.ts
+++ b/packages/tool-studio/src/ui/app/modules/playground/transcript-stream.ts
@@ -1,0 +1,52 @@
+import type { SmoothStreamItemAdapter } from "@anvia/react";
+import type { TranscriptEntry } from "../shared/types";
+
+export const transcriptStreamAdapter: SmoothStreamItemAdapter<TranscriptEntry> = {
+  getKey(entry) {
+    return String(entry.entryId);
+  },
+  getText(entry) {
+    if (entry.kind === "reasoning") {
+      return entry.text;
+    }
+    if (entry.kind === "message" && entry.role === "assistant") {
+      return entry.text;
+    }
+    return undefined;
+  },
+  withText(entry, text) {
+    if (entry.kind === "reasoning") {
+      return { ...entry, text };
+    }
+    if (entry.kind === "message" && entry.role === "assistant") {
+      if ("tone" in entry && entry.tone === "pending") {
+        return entry;
+      }
+      return { ...entry, text };
+    }
+    return entry;
+  },
+};
+
+export function currentTurnAssistantEntryId(entries: TranscriptEntry[]): number | undefined {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (entry?.kind === "message" && entry.role === "assistant") {
+      return entry.entryId;
+    }
+    if (entry?.kind === "message" && entry.role === "user") {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+export function hasTerminalTranscriptError(entries: TranscriptEntry[]): boolean {
+  const entry = entries.at(-1);
+  return (
+    entry?.kind === "message" &&
+    entry.role === "assistant" &&
+    "tone" in entry &&
+    entry.tone === "error"
+  );
+}

--- a/packages/tool-studio/src/ui/app/modules/shared/renderers.tsx
+++ b/packages/tool-studio/src/ui/app/modules/shared/renderers.tsx
@@ -1,75 +1,87 @@
+import { StreamMarkdown, type StreamMarkdownProps } from "@anvia/react-ui/stream";
 import type React from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import { cn } from "../../lib/utils";
 import { parseToolDisplayValue } from "./format";
 import { isRecord } from "./object";
 
-export function MarkdownText(props: { text: string; size?: "sm" | "base" }) {
+type MarkdownComponents = NonNullable<StreamMarkdownProps["components"]>;
+type MarkdownSize = "sm" | "base";
+
+const markdownComponents: Record<MarkdownSize, MarkdownComponents> = {
+  base: createMarkdownComponents("base"),
+  sm: createMarkdownComponents("sm"),
+};
+
+export function MarkdownText(props: {
+  live?: boolean | undefined;
+  text: string;
+  size?: MarkdownSize;
+}) {
+  const size = props.size ?? "sm";
   return (
-    <div
+    <StreamMarkdown
       className={cn(
         "prose max-w-none text-current [overflow-wrap:anywhere] prose-headings:text-current prose-headings:font-semibold prose-p:text-current prose-p:leading-7 prose-a:text-current prose-a:decoration-muted-foreground prose-a:underline-offset-2 prose-strong:text-current prose-code:rounded-lg prose-code:border prose-code:border-border/80 prose-code:bg-muted/80 prose-code:px-1 prose-code:py-0.5 prose-code:text-sm prose-code:font-semibold prose-code:text-current prose-code:before:content-none prose-code:after:content-none prose-pre:overflow-auto prose-pre:rounded-lg prose-pre:border prose-pre:border-border/80 prose-pre:bg-card/90 prose-pre:text-current prose-blockquote:border-border prose-blockquote:text-muted-foreground prose-li:marker:text-muted-foreground prose-hr:border-border prose-table:m-0 prose-thead:border-0 prose-tr:border-0 prose-th:p-0 prose-td:p-0 dark:prose-invert dark:prose-headings:text-current dark:prose-p:text-current dark:prose-strong:text-current dark:prose-code:text-current dark:prose-pre:bg-card dark:prose-pre:text-current",
-        props.size === "base" ? "text-base" : "prose-sm",
+        size === "base" ? "text-base" : "prose-sm",
       )}
-    >
-      <ReactMarkdown
-        components={{
-          table({ children }) {
-            return (
-              <div className="my-4 w-full min-w-0 overflow-hidden rounded-lg border border-border/80 bg-card/90 shadow-sm">
-                <div className="min-w-0 overflow-x-auto">
-                  <table
-                    className={cn(
-                      "m-0 w-full min-w-full border-separate border-spacing-0 text-left",
-                      props.size === "base" ? "text-base" : "text-sm",
-                    )}
-                  >
-                    {children}
-                  </table>
-                </div>
-              </div>
-            );
-          },
-          thead({ children }) {
-            return <thead className="bg-muted/45">{children}</thead>;
-          },
-          tbody({ children }) {
-            return <tbody>{children}</tbody>;
-          },
-          tr({ children }) {
-            return <tr className="group/row align-top">{children}</tr>;
-          },
-          th({ children }) {
-            return (
-              <th
-                className="border-b border-border px-4 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground first:pl-5 last:pr-5"
-                style={{ paddingBottom: "0.625rem", paddingTop: "0.625rem" }}
-              >
-                {children}
-              </th>
-            );
-          },
-          td({ children }) {
-            return (
-              <td
-                className={cn(
-                  "border-b border-border/70 px-4 leading-6 text-foreground [overflow-wrap:anywhere] first:pl-5 last:pr-5 group-last/row:border-b-0",
-                  props.size === "base" ? "text-base" : "text-sm",
-                )}
-                style={{ paddingBottom: "0.75rem", paddingTop: "0.75rem" }}
-              >
-                {children}
-              </td>
-            );
-          },
-        }}
-        remarkPlugins={[remarkGfm]}
-      >
-        {props.text}
-      </ReactMarkdown>
-    </div>
+      components={markdownComponents[size]}
+      content={props.text}
+      live={props.live === true}
+    />
   );
+}
+
+function createMarkdownComponents(size: MarkdownSize): MarkdownComponents {
+  return {
+    table({ children }) {
+      return (
+        <div className="my-4 w-full min-w-0 overflow-hidden rounded-lg border border-border/80 bg-card/90 shadow-sm">
+          <div className="min-w-0 overflow-x-auto">
+            <table
+              className={cn(
+                "m-0 w-full min-w-full border-separate border-spacing-0 text-left",
+                size === "base" ? "text-base" : "text-sm",
+              )}
+            >
+              {children}
+            </table>
+          </div>
+        </div>
+      );
+    },
+    thead({ children }) {
+      return <thead className="bg-muted/45">{children}</thead>;
+    },
+    tbody({ children }) {
+      return <tbody>{children}</tbody>;
+    },
+    tr({ children }) {
+      return <tr className="group/row align-top">{children}</tr>;
+    },
+    th({ children }) {
+      return (
+        <th
+          className="border-b border-border px-4 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground first:pl-5 last:pr-5"
+          style={{ paddingBottom: "0.625rem", paddingTop: "0.625rem" }}
+        >
+          {children}
+        </th>
+      );
+    },
+    td({ children }) {
+      return (
+        <td
+          className={cn(
+            "border-b border-border/70 px-4 leading-6 text-foreground [overflow-wrap:anywhere] first:pl-5 last:pr-5 group-last/row:border-b-0",
+            size === "base" ? "text-base" : "text-sm",
+          )}
+          style={{ paddingBottom: "0.75rem", paddingTop: "0.75rem" }}
+        >
+          {children}
+        </td>
+      );
+    },
+  };
 }
 
 export function ToolPayload(props: { title: string; value: string }) {

--- a/packages/tool-studio/src/ui/app/routes/playground-route.tsx
+++ b/packages/tool-studio/src/ui/app/routes/playground-route.tsx
@@ -58,6 +58,7 @@ export function PlaygroundRoute() {
       attachmentInputRef={studio.attachmentInputRef}
       promptRef={studio.promptRef}
       transcriptScrollerRef={studio.transcriptScrollerRef}
+      transcriptResetKey={studio.transcriptResetKey}
       onAddPromptAttachments={studio.addPromptAttachments}
       onApprovalDecision={studio.decideToolApproval}
       onDeleteSession={studio.setDeleteCandidate}

--- a/packages/tool-studio/src/ui/app/studio-console-context.tsx
+++ b/packages/tool-studio/src/ui/app/studio-console-context.tsx
@@ -56,6 +56,7 @@ export type StudioConsoleContextValue = {
   attachmentInputRef: RefObject<HTMLInputElement | null>;
   promptRef: RefObject<HTMLTextAreaElement | null>;
   transcriptScrollerRef: RefObject<HTMLElement | null>;
+  transcriptResetKey: string | number;
   activateRoute: (page: ActivePage) => void;
   navigateFallback: (preferred: ActivePage) => void;
   navigatePage: (page: ActivePage) => void;

--- a/packages/tool-studio/test/markdown-text.test.tsx
+++ b/packages/tool-studio/test/markdown-text.test.tsx
@@ -1,0 +1,19 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { MarkdownText } from "../src/ui/app/modules/shared/renderers";
+
+describe("Studio MarkdownText", () => {
+  it("uses the stream renderer and marks only live content for tail reveal", () => {
+    const live = renderToStaticMarkup(
+      <MarkdownText live size="base" text={"First paragraph.\n\nLive tail"} />,
+    );
+    const settled = renderToStaticMarkup(<MarkdownText text="Settled response" />);
+
+    expect(live).toContain("data-anvia-stream-markdown");
+    expect(live).toContain("data-anvia-stream-reveal");
+    expect(live).toContain("First paragraph.");
+    expect(live.replace(/<[^>]+>/g, "")).toContain("Live tail");
+    expect(settled).toContain("data-anvia-stream-markdown");
+    expect(settled).not.toContain("data-anvia-stream-reveal");
+  });
+});

--- a/packages/tool-studio/test/playground-page-render.test.tsx
+++ b/packages/tool-studio/test/playground-page-render.test.tsx
@@ -64,6 +64,7 @@ function render(overrides: Partial<Parameters<typeof PlaygroundPage>[0]> = {}): 
       attachmentInputRef={createRef<HTMLInputElement>()}
       promptRef={createRef<HTMLTextAreaElement>()}
       transcriptScrollerRef={createRef<HTMLElement>()}
+      transcriptResetKey={0}
       onAddPromptAttachments={vi.fn()}
       onApprovalDecision={vi.fn()}
       onDeleteSession={vi.fn()}

--- a/packages/tool-studio/test/transcript-stream.test.ts
+++ b/packages/tool-studio/test/transcript-stream.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  currentTurnAssistantEntryId,
+  hasTerminalTranscriptError,
+  transcriptStreamAdapter,
+} from "../src/ui/app/modules/playground/transcript-stream";
+import type { TranscriptEntry } from "../src/ui/app/modules/shared/types";
+
+describe("Studio transcript stream smoothing", () => {
+  it("smooths assistant and reasoning text while keeping other entries opaque", () => {
+    const assistant: TranscriptEntry = {
+      entryId: 1,
+      kind: "message",
+      role: "assistant",
+      text: "Complete response",
+    };
+    const reasoning: TranscriptEntry = { entryId: 2, kind: "reasoning", text: "Thinking" };
+    const tool: TranscriptEntry = { entryId: 3, kind: "tool", toolName: "search" };
+    const user: TranscriptEntry = {
+      entryId: 4,
+      kind: "message",
+      role: "user",
+      text: "Question",
+    };
+
+    expect(transcriptStreamAdapter.getText(assistant)).toBe("Complete response");
+    expect(transcriptStreamAdapter.getText(reasoning)).toBe("Thinking");
+    expect(transcriptStreamAdapter.getText(tool)).toBeUndefined();
+    expect(transcriptStreamAdapter.getText(user)).toBeUndefined();
+    expect(transcriptStreamAdapter.withText(assistant, "Partial")).toMatchObject({
+      role: "assistant",
+      text: "Partial",
+    });
+    expect(transcriptStreamAdapter.withText(reasoning, "Think")).toMatchObject({
+      kind: "reasoning",
+      text: "Think",
+    });
+    expect(transcriptStreamAdapter.withText(tool, "ignored")).toBe(tool);
+  });
+
+  it("does not turn a pending assistant placeholder into an invalid transcript entry", () => {
+    const pending: TranscriptEntry = {
+      entryId: 1,
+      kind: "message",
+      role: "assistant",
+      text: "",
+      tone: "pending",
+    };
+
+    expect(transcriptStreamAdapter.withText(pending, "")).toBe(pending);
+  });
+
+  it("finds the current turn assistant without crossing the preceding user entry", () => {
+    expect(
+      currentTurnAssistantEntryId([
+        { entryId: 1, kind: "message", role: "assistant", text: "Old" },
+        { entryId: 2, kind: "message", role: "user", text: "New question" },
+        { entryId: 3, kind: "reasoning", text: "Thinking" },
+      ]),
+    ).toBeUndefined();
+    expect(
+      currentTurnAssistantEntryId([
+        { entryId: 1, kind: "message", role: "user", text: "Question" },
+        { entryId: 2, kind: "message", role: "assistant", text: "Answer" },
+        { entryId: 3, kind: "tool", toolName: "search" },
+      ]),
+    ).toBe(2);
+  });
+
+  it("requests an immediate flush only for a terminal assistant error", () => {
+    expect(
+      hasTerminalTranscriptError([
+        { entryId: 1, kind: "message", role: "assistant", text: "Partial" },
+      ]),
+    ).toBe(false);
+    expect(
+      hasTerminalTranscriptError([
+        {
+          entryId: 1,
+          kind: "message",
+          role: "assistant",
+          text: "Request failed",
+          tone: "error",
+        },
+      ]),
+    ).toBe(true);
+  });
+});

--- a/packages/tool-studio/vitest.config.ts
+++ b/packages/tool-studio/vitest.config.ts
@@ -2,7 +2,11 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
+    dedupe: ["react", "react-dom"],
     alias: {
+      "@anvia/react-ui/stream": new URL("../react-ui/src/stream/index.ts", import.meta.url)
+        .pathname,
+      "@anvia/react": new URL("../react/src/index.ts", import.meta.url).pathname,
       "@anvia/core/agent": new URL("../core/src/agent/index.ts", import.meta.url).pathname,
       "@anvia/core/completion": new URL("../core/src/completion/index.ts", import.meta.url)
         .pathname,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -734,6 +734,9 @@ importers:
       '@tiptap/suggestion':
         specifier: ^3.27.3
         version: 3.27.3(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.3(@tiptap/pm@3.27.3))(@tiptap/pm@3.27.3)
+      marked:
+        specifier: ^15.0.12
+        version: 15.0.12
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.6)
@@ -823,13 +826,16 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@8.1.0(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/tool-studio:
     dependencies:
       '@anvia/react':
         specifier: workspace:*
         version: link:../react
+      '@anvia/react-ui':
+        specifier: workspace:*
+        version: link:../react-ui
       '@anvia/server':
         specifier: workspace:*
         version: link:../server
@@ -881,9 +887,6 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
-      react-markdown:
-        specifier: ^10.1.0
-        version: 10.1.0(@types/react@19.2.14)(react@19.2.7)
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -896,7 +899,7 @@ importers:
         version: 0.5.19(tailwindcss@4.2.4)
       '@tailwindcss/vite':
         specifier: ^4.2.4
-        version: 4.2.4(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.2.4(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@types/node':
         specifier: ^24.9.1
         version: 24.12.2
@@ -908,10 +911,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
-      remark-gfm:
-        specifier: ^4.0.1
-        version: 4.0.1
+        version: 6.0.1(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       tailwindcss:
         specifier: ^4.2.4
         version: 4.2.4
@@ -923,10 +923,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.10
-        version: 8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.0.8
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -11056,12 +11056,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.2.4
 
-  '@tailwindcss/vite@4.2.4(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.2.4(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.2.4
       '@tailwindcss/oxide': 4.2.4
       tailwindcss: 4.2.4
-      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@tailwindcss/vite@4.3.1(vite@8.1.0(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -11357,10 +11357,10 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitejs/plugin-react@6.0.1(vite@8.1.0(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -11379,7 +11379,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -11390,21 +11390,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
-
-  '@vitest/mocker@4.1.5(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.5
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.5(vite@8.1.0(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -14430,24 +14422,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.7):
-    dependencies:
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
-      '@types/react': 19.2.14
-      devlop: 1.1.0
-      hast-util-to-jsx-runtime: 2.3.6
-      html-url-attributes: 3.0.1
-      mdast-util-to-hast: 13.2.1
-      react: 19.2.7
-      remark-parse: 11.0.0
-      remark-rehype: 11.1.2
-      unified: 11.0.5
-      unist-util-visit: 5.1.0
-      vfile: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
   react-reconciler@0.33.0(react@19.2.5):
     dependencies:
       react: 19.2.5
@@ -15430,28 +15404,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0):
+  vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.12
       rolldown: 1.0.0-rc.17
       tinyglobby: 0.2.16
-    optionalDependencies:
-      '@types/node': 24.12.2
-      esbuild: 0.28.0
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      tsx: 4.21.0
-      yaml: 2.9.0
-
-  vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rolldown: 1.1.3
-      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.12.2
       esbuild: 0.27.7
@@ -15494,10 +15453,10 @@ snapshots:
     optionalDependencies:
       vite: 8.1.0(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -15514,37 +15473,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 24.12.2
-      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
-      happy-dom: 20.9.0
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/runner': 4.1.5
-      '@vitest/snapshot': 4.1.5
-      '@vitest/spy': 4.1.5
-      '@vitest/utils': 4.1.5
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.1
-      tinyglobby: 0.2.16
-      tinyrainbow: 3.1.0
-      vite: 8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1


### PR DESCRIPTION
## Summary

- add lifecycle-driven, grapheme-safe stream smoothing primitives to `@anvia/react`
- integrate ordered text, reasoning, tool, and stable-block Markdown streaming in `@anvia/react-ui`
- use the shared smoothing pipeline in the Studio Playground transcript
- document the opt-in lifecycle with an interactive direct-versus-smoothed replay

## Why

Provider token events can arrive in uneven bursts, which makes otherwise-correct streamed responses
look jumpy. Keeping the pacing at the app layer also duplicates lifecycle handling and makes it
harder to preserve text and tool reveal order consistently.

This moves display pacing into the React and React UI packages while leaving the source message and
chat state untouched.

## Impact

- smoothing remains opt-in through the `stream` lifecycle props
- buffered content drains after source completion instead of snapping to the final response
- mixed message parts preserve their source order while text and reasoning are paced
- Studio uses the same behavior consumers receive from the published packages

## Validation

- `pnpm --filter @anvia/react test`
- `pnpm --filter @anvia/react-ui test`
- `pnpm --filter @anvia/studio test`
- `pnpm --filter @anvia/studio build`
- `pnpm --filter www reference-check`
- `pnpm --filter www build`
- staged Biome check and `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lifecycle-based stream smoothing for text and mixed message content, preserving reveal order while buffering and draining updates.
  * Added live Markdown rendering with stable completed blocks and subtle tail-reveal effects.
  * Added `StreamMarkdown` and new smoothing hooks for streamed text and ordered items.
  * Improved transcript rendering, auto-scroll behavior, and reset handling in Studio.

* **Bug Fixes**
  * Reduced unwanted scroll anchoring and kept views at the bottom as content grows.

* **Documentation**
  * Updated streaming APIs, lifecycle guidance, usage examples, and package exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->