### PR TITLE
fix failed streaming agent usage accounting

### DIFF
--- a/.changeset/failed-stream-usage.md
+++ b/.changeset/failed-stream-usage.md
@@ -1,0 +1,12 @@
+---
+"@anvia/core": minor
+"@anvia/openai": patch
+"@anvia/langfuse": patch
+"@anvia/otel": patch
+"@anvia/studio": patch
+---
+
+Expose cumulative authoritative usage on failed agent stream events, include provider-reported usage
+from failed OpenAI Responses requests, and retain failed child-agent usage in built-in observability
+and Studio traces. Agent error event producers must now provide `usage`; unavailable provider usage
+remains empty rather than estimated.

--- a/apps/www/src/content/docs/advanced/streaming-events.md
+++ b/apps/www/src/content/docs/advanced/streaming-events.md
@@ -30,7 +30,7 @@ for await (const event of request.stream()) {
       await ui.finish(event.output, event.usage);
       break;
     case "error":
-      await ui.fail(event.error);
+      await ui.fail(event.error, event.usage);
       break;
   }
 }
@@ -50,7 +50,7 @@ Agent streams can emit:
 - `"turn_end"` with the provider response for a turn
 - `"agent_tool_event"` for events from a nested agent used as a tool
 - `"final"` with output, usage, messages, run id, and trace metadata
-- `"error"` when the run fails
+- `"error"` with cumulative authoritative usage when the run fails
 
 Do not send every event directly to a browser. Tool arguments, tool results, reasoning content, and provider metadata can contain private data. Filter the stream for each surface.
 
@@ -67,7 +67,11 @@ function toClientEvent(event: AgentStreamEvent) {
     return { type: "done", output: event.output, usage: event.usage };
   }
   if (event.type === "error") {
-    return { type: "error", message: "The assistant could not complete the request." };
+    return {
+      type: "error",
+      message: "The assistant could not complete the request.",
+      usage: event.usage,
+    };
   }
   if (event.type === "tool_call") {
     return { type: "status", label: "Checking data" };
@@ -76,6 +80,16 @@ function toClientEvent(event: AgentStreamEvent) {
 ```
 
 Internal tools can receive richer events. User-facing streams should usually expose text, status, final output, and safe error messages only.
+
+## Error Usage Compatibility
+
+`AgentStreamEvent` error records require `usage`. Code that constructs agent events in tests, mocks,
+or custom runtimes must now include it. Use the cumulative authoritative usage received by the run,
+or `Usage.empty()` when no provider has reported usage yet.
+
+Provider-level `CompletionStreamEvent` errors keep usage optional. Network interruptions, provider
+failures without usage, and Chat Completions streams that end before their usage chunk cannot be
+accounted exactly. Anvia does not estimate those tokens from text or request contents.
 
 ## Nested Agent Events
 

--- a/apps/www/src/content/docs/examples/streaming-events.md
+++ b/apps/www/src/content/docs/examples/streaming-events.md
@@ -26,13 +26,13 @@ A support UI needs to show "looking up order", stream the answer, persist the fi
 ## Server Runner
 
 ```ts
-import type { AgentStreamEvent } from "@anvia/core";
+import type { AgentStreamEvent, Usage } from "@anvia/core";
 
 type SupportUiEvent =
   | { type: "activity"; label: string }
   | { type: "text"; delta: string }
   | { type: "final"; output: string; runId: string }
-  | { type: "error"; message: string };
+  | { type: "error"; message: string; usage: Usage };
 
 export async function* runSupportTurnStream(input: SupportStreamInput) {
   const user = await input.auth.requireUser();
@@ -109,7 +109,7 @@ function toSupportUiEvent(event: AgentStreamEvent): SupportUiEvent | undefined {
   }
 
   if (event.type === "error") {
-    return { type: "error", message: "The run failed." };
+    return { type: "error", message: "The run failed.", usage: event.usage };
   }
 }
 ```

--- a/apps/www/src/content/docs/examples/streaming-events.md
+++ b/apps/www/src/content/docs/examples/streaming-events.md
@@ -136,6 +136,15 @@ The session memory store records conversation messages as the stream is consumed
 ## Browser State
 
 ```ts
+type SupportUiState = {
+  activity: string[];
+  text: string;
+  runId?: string;
+  error?: string;
+  usage?: Usage;
+  done: boolean;
+};
+
 export function reduceSupportEvent(state: SupportUiState, event: SupportUiEvent) {
   if (event.type === "activity") {
     return { ...state, activity: [...state.activity, event.label] };
@@ -147,7 +156,7 @@ export function reduceSupportEvent(state: SupportUiState, event: SupportUiEvent)
     return { ...state, text: event.output, runId: event.runId, done: true };
   }
   if (event.type === "error") {
-    return { ...state, error: event.message, done: true };
+    return { ...state, error: event.message, usage: event.usage, done: true };
   }
   return state;
 }

--- a/apps/www/src/content/docs/packages/core/reference/completion.md
+++ b/apps/www/src/content/docs/packages/core/reference/completion.md
@@ -305,7 +305,7 @@ type CompletionStreamEvent<RawResponse = unknown> =
   | { type: "tool_call"; toolCall: ToolCall }
   | { type: "message_id"; id: string }
   | { type: "final"; response: CompletionResponse<RawResponse> }
-  | { type: "error"; error: unknown };
+  | { type: "error"; error: unknown; usage?: Usage };
 
 interface StreamingCompletionModel<RawResponse = unknown> extends CompletionModel<RawResponse> {
   streamCompletion(request: CompletionRequest): AsyncIterable<CompletionStreamEvent<RawResponse>>;
@@ -314,7 +314,9 @@ interface StreamingCompletionModel<RawResponse = unknown> extends CompletionMode
 
 Purpose: provider adapter interfaces. The metadata fields identify the adapter, its default model name, and the normalized request features the adapter supports.
 
-Return behavior: streaming models yield deltas and finish with a `final` event.
+Return behavior: streaming models yield deltas and finish with a `final` event. Provider error events
+may include authoritative usage for the failed request; adapters omit it when the provider does not
+report usage.
 
 Notable errors: provider adapters can throw transport, authentication, provider validation, stream, or capability validation errors.
 

--- a/apps/www/src/content/docs/packages/core/reference/request.md
+++ b/apps/www/src/content/docs/packages/core/reference/request.md
@@ -90,6 +90,12 @@ Return behavior: `messages` contains the new run messages, not the full prior hi
 ```ts
 type AgentChildStreamEvent = Exclude<AgentStreamEvent, { type: "agent_tool_event" }>;
 
+type AgentErrorStreamEvent = {
+  type: "error";
+  error: unknown;
+  usage: Usage;
+};
+
 type AgentStreamEvent =
   | { type: "turn_start"; turn: number; prompt: Message; history: Message[] }
   | { type: "text_delta"; turn: number; delta: string }
@@ -99,12 +105,16 @@ type AgentStreamEvent =
   | { type: "agent_tool_event"; turn: number; toolName: string; toolCallId?: string; internalCallId: string; agentId: string; agentName?: string; event: AgentChildStreamEvent }
   | { type: "turn_end"; turn: number; response: CompletionResponse }
   | { type: "final"; runId: string; output: string; usage: Usage; messages: Message[]; trace?: AgentTraceInfo }
-  | { type: "error"; error: unknown };
+  | AgentErrorStreamEvent;
 ```
 
 Purpose: streaming event union for observing agent execution.
 
 Return behavior: emitted by `PromptRequest.stream()` and `readableStream()`. `agent_tool_event` appears when a child agent is exposed with `asTool({ stream: true })`.
+
+Agent error usage is cumulative across completed turns and any failed provider attempts that report
+authoritative usage. It is `Usage.empty()` when the runtime has not received authoritative usage.
+After yielding an error event, the async iterator rejects its next read with the same error.
 
 ## Errors
 

--- a/apps/www/src/content/docs/packages/openai/reference.md
+++ b/apps/www/src/content/docs/packages/openai/reference.md
@@ -110,7 +110,7 @@ class OpenAIResponsesCompletionModel implements StreamingCompletionModel {
 
 Purpose: completion adapter for OpenAI Responses API.
 
-Return behavior: non-streaming calls return normalized `CompletionResponse`; streaming calls yield normalized completion events.
+Return behavior: non-streaming calls return normalized `CompletionResponse`; streaming calls yield normalized completion events. A Responses API `response.failed` event includes normalized usage when the failed response supplies it. Network errors and failures without provider usage omit it.
 
 Notable errors: rejects or yields errors from OpenAI Responses API calls.
 

--- a/packages/core/src/completion/types.ts
+++ b/packages/core/src/completion/types.ts
@@ -585,6 +585,7 @@ export type CompletionStreamEvent<RawResponse = unknown> =
   | {
       type: "error";
       error: unknown;
+      usage?: Usage;
     };
 
 export interface StreamingCompletionModel<RawResponse = unknown, ModelName extends string = string>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -84,6 +84,7 @@ export { MaxTurnsError, PromptCancelledError, ToolApprovalRequiredError } from "
 export type { CompletionRetryContext, CompletionRetryOptions } from "./request/retry";
 export type {
   AgentChildStreamEvent,
+  AgentErrorStreamEvent,
   AgentStreamEvent,
   PromptResponse,
 } from "./request/types";

--- a/packages/core/src/request/index.ts
+++ b/packages/core/src/request/index.ts
@@ -4,6 +4,7 @@ export type { CompletionRetryContext, CompletionRetryOptions } from "./retry";
 export type {
   AgentChildStreamEvent,
   AgentDeltaEvent,
+  AgentErrorStreamEvent,
   AgentStreamEvent,
   PromptResponse,
 } from "./types";

--- a/packages/core/src/request/prompt-request.ts
+++ b/packages/core/src/request/prompt-request.ts
@@ -462,6 +462,9 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
             try {
               for await (const event of this.agent.model.streamCompletion(request)) {
                 if (event.type === "error") {
+                  if (event.usage !== undefined) {
+                    usage = Usage.add(usage, event.usage);
+                  }
                   throw event.error;
                 }
                 hasProviderProgress = true;
@@ -669,9 +672,14 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
     } catch (error) {
       const finalError = await this.runRunErrorHook(error, usage, newMessages);
       this.runState = finalError instanceof PromptCancelledError ? "cancelled" : "errored";
-      await runObservers.error({ error: finalError, usage, messages: [...newMessages] });
+      const finalUsage = usage;
+      await runObservers.error({
+        error: finalError,
+        usage: finalUsage,
+        messages: [...newMessages],
+      });
       await this.memoryRecorder.recordError(runId, finalError, newMessages);
-      yield await emit({ type: "error", error: finalError });
+      yield await emit({ type: "error", error: finalError, usage: finalUsage });
       throw finalError;
     }
   }

--- a/packages/core/src/request/types.ts
+++ b/packages/core/src/request/types.ts
@@ -28,6 +28,12 @@ export type AgentDeltaEvent =
     }
   | { type: "tool_call"; toolCall: ToolCall };
 
+export type AgentErrorStreamEvent = {
+  type: "error";
+  error: unknown;
+  usage: Usage;
+};
+
 export type AgentChildStreamEvent<RawResponse = unknown> =
   | {
       type: "turn_start";
@@ -82,10 +88,7 @@ export type AgentChildStreamEvent<RawResponse = unknown> =
       trace?: AgentTraceInfo | undefined;
       guardrails?: GuardrailDecisionRecord[] | undefined;
     }
-  | {
-      type: "error";
-      error: unknown;
-    };
+  | AgentErrorStreamEvent;
 
 export type AgentStreamEvent<RawResponse = unknown> =
   | AgentChildStreamEvent<RawResponse>

--- a/packages/core/test/public-exports.test.ts
+++ b/packages/core/test/public-exports.test.ts
@@ -15,12 +15,13 @@ import * as guardrails from "../src/guardrails";
 import * as hooks from "../src/hooks";
 import * as imageGeneration from "../src/image-generation";
 import type {
+  AgentErrorStreamEvent as RootAgentErrorStreamEvent,
   CompletionRetryContext as RootCompletionRetryContext,
   CompletionRetryOptions as RootCompletionRetryOptions,
   ToolContent as RootToolContentType,
 } from "../src/index";
 import * as publicCore from "../src/index";
-import { Message as RootMessage, ToolContent as RootToolContent } from "../src/index";
+import { Message as RootMessage, ToolContent as RootToolContent, Usage } from "../src/index";
 import * as internalAgent from "../src/internal/agent";
 import * as loaders from "../src/loaders";
 import * as mcp from "../src/mcp";
@@ -28,6 +29,8 @@ import * as modelListing from "../src/model-listing";
 import * as observability from "../src/observability";
 import * as pipeline from "../src/pipeline";
 import type {
+  AgentErrorStreamEvent as RequestAgentErrorStreamEvent,
+  AgentStreamEvent as RequestAgentStreamEvent,
   CompletionRetryContext as RequestCompletionRetryContext,
   CompletionRetryOptions as RequestCompletionRetryOptions,
 } from "../src/request";
@@ -92,6 +95,21 @@ describe("public exports", () => {
     expect("ToolApprovalRequiredError" in request).toBe(true);
     expectTypeOf<RootCompletionRetryContext>().toEqualTypeOf<RequestCompletionRetryContext>();
     expectTypeOf<RootCompletionRetryOptions>().toEqualTypeOf<RequestCompletionRetryOptions>();
+    expectTypeOf<RootAgentErrorStreamEvent>().toEqualTypeOf<RequestAgentErrorStreamEvent>();
+    expectTypeOf<
+      Extract<RequestAgentStreamEvent, { type: "error" }>
+    >().toEqualTypeOf<RequestAgentErrorStreamEvent>();
+
+    const errorEvent: RequestAgentErrorStreamEvent = {
+      type: "error",
+      error: new Error("failed"),
+      usage: Usage.empty(),
+    };
+    expect(errorEvent.usage).toEqual(Usage.empty());
+
+    // @ts-expect-error Agent runtime error events require cumulative usage.
+    const missingUsage: RequestAgentErrorStreamEvent = { type: "error", error: "failed" };
+    void missingUsage;
   });
 
   it("does not expose removed experimental UI stream creators", () => {

--- a/packages/core/test/streaming.test.ts
+++ b/packages/core/test/streaming.test.ts
@@ -5,6 +5,7 @@ import {
   type AgentEventAppendInput,
   type AgentEventRecord,
   type AgentEventStore,
+  type AgentRunErrorArgs,
   type AgentStreamEvent,
   AssistantContent,
   type CompletionRequest,
@@ -13,14 +14,18 @@ import {
   cancelPrompt,
   createHook,
   createMiddleware,
+  createObserver,
   createTool,
   createToolMiddleware,
+  defineGuardrailPolicy,
+  defineOutputGuardrail,
   getAssistantGenerationMetadata,
   Message,
   PromptCancelledError,
   type StreamingCompletionModel,
   ToolOutput,
   toReadableStream,
+  Usage,
 } from "./helpers/imports";
 
 class StreamingQueueModel implements StreamingCompletionModel {
@@ -160,6 +165,152 @@ describe("PromptRequest streaming", () => {
     expect(model.requests).toHaveLength(2);
   });
 
+  it("includes authoritative failed-attempt usage exactly once after a retry succeeds", async () => {
+    const error = Object.assign(new Error("temporarily unavailable"), { status: 503 });
+    const failedUsage = usage(4, 1);
+    const successfulUsage = usage(6, 3);
+    const model = new StreamingQueueModel([
+      [{ type: "error", error, usage: failedUsage }],
+      [
+        {
+          type: "final",
+          response: completionResponse([AssistantContent.text("ready")], successfulUsage),
+        },
+      ],
+    ]);
+    const agent = new AgentBuilder("test-agent", model).build();
+
+    const events = await collect(
+      agent.prompt("hi").withCompletionRetries({ initialDelayMs: 0, maxDelayMs: 0 }).stream(),
+    );
+
+    expect(events.at(-1)).toMatchObject({
+      type: "final",
+      output: "ready",
+      usage: Usage.add(failedUsage, successfulUsage),
+    });
+    expect(model.requests).toHaveLength(2);
+  });
+
+  it("keeps successful final-event usage unchanged", async () => {
+    const finalUsage = usage(5, 4);
+    const model = new StreamingQueueModel([
+      [
+        {
+          type: "final",
+          response: completionResponse([AssistantContent.text("done")], finalUsage),
+        },
+      ],
+    ]);
+    const agent = new AgentBuilder("test-agent", model).build();
+
+    const events = await collect(agent.prompt("hi").stream());
+
+    expect(events.at(-1)).toMatchObject({ type: "final", output: "done", usage: finalUsage });
+  });
+
+  it("includes authoritative provider failure usage exactly once", async () => {
+    const error = new Error("provider failed");
+    const providerUsage = usage(7, 2);
+    const model = new StreamingQueueModel([[{ type: "error", error, usage: providerUsage }]]);
+    const agent = new AgentBuilder("test-agent", model).build();
+    const iterator = agent.prompt("hi").stream()[Symbol.asyncIterator]();
+
+    const errorEvent = await nextAgentError(iterator);
+
+    expect(errorEvent).toEqual({ type: "error", error, usage: providerUsage });
+    await expect(iterator.next()).rejects.toBe(error);
+  });
+
+  it("uses empty usage when the first provider failure has no authoritative usage", async () => {
+    const error = new Error("provider failed before usage");
+    const model = new StreamingQueueModel([[{ type: "error", error }]]);
+    const agent = new AgentBuilder("test-agent", model).build();
+    const iterator = agent.prompt("hi").stream()[Symbol.asyncIterator]();
+
+    const errorEvent = await nextAgentError(iterator);
+
+    expect(errorEvent).toEqual({ type: "error", error, usage: Usage.empty() });
+    await expect(iterator.next()).rejects.toBe(error);
+  });
+
+  it("retains completed turn usage when a later provider call fails before usage", async () => {
+    const firstUsage = usage(8, 2);
+    const error = new Error("second turn failed");
+    const model = new StreamingQueueModel([
+      [
+        {
+          type: "final",
+          response: completionResponse(
+            [AssistantContent.toolCall("call_1", "add", { x: 2, y: 5 })],
+            firstUsage,
+          ),
+        },
+      ],
+      [{ type: "error", error }],
+    ]);
+    const agent = new AgentBuilder("test-agent", model).tool(addTool).build();
+    const iterator = agent.prompt("add").stream()[Symbol.asyncIterator]();
+
+    const errorEvent = await nextAgentError(iterator);
+
+    expect(errorEvent.usage).toEqual(firstUsage);
+    await expect(iterator.next()).rejects.toBe(error);
+  });
+
+  it("shares completed tool-turn usage with the observer and terminal error event", async () => {
+    const turnUsage = usage(9, 3);
+    let observedError: AgentRunErrorArgs | undefined;
+    const observer = createObserver({
+      startRun() {
+        return {
+          end() {},
+          error(args) {
+            observedError = args;
+          },
+        };
+      },
+    });
+    const failingTool = createTool({
+      name: "fail",
+      description: "Fail",
+      input: z.object({}),
+      output: z.string(),
+      execute() {
+        throw new Error("tool failed");
+      },
+    });
+    const model = new StreamingQueueModel([
+      [
+        {
+          type: "final",
+          response: completionResponse(
+            [AssistantContent.toolCall("call_1", "fail", {})],
+            turnUsage,
+          ),
+        },
+      ],
+    ]);
+    const agent = new AgentBuilder("test-agent", model)
+      .observe(observer)
+      .tool(failingTool)
+      .hook(
+        createHook({
+          onToolError() {
+            return cancelPrompt("stop after tool failure");
+          },
+        }),
+      )
+      .build();
+    const iterator = agent.prompt("fail").stream()[Symbol.asyncIterator]();
+
+    const errorEvent = await nextAgentError(iterator);
+
+    expect(errorEvent.usage).toEqual(turnUsage);
+    expect(observedError?.usage).toBe(errorEvent.usage);
+    await expect(iterator.next()).rejects.toBe(errorEvent.error);
+  });
+
   it("applies completion retries through PromptRequest readable streams", async () => {
     const error = Object.assign(new Error("temporarily unavailable"), { status: 503 });
     const model = new StreamingQueueModel([
@@ -199,7 +350,7 @@ describe("PromptRequest streaming", () => {
 
     expect(await nextEvent(iterator)).toMatchObject({ type: "turn_start" });
     expect(await nextEvent(iterator)).toMatchObject({ type: "text_delta", delta: "partial" });
-    expect(await nextEvent(iterator)).toEqual({ type: "error", error });
+    expect(await nextEvent(iterator)).toEqual({ type: "error", error, usage: Usage.empty() });
     await expect(iterator.next()).rejects.toBe(error);
     expect(model.requests).toHaveLength(1);
   });
@@ -218,7 +369,7 @@ describe("PromptRequest streaming", () => {
       [Symbol.asyncIterator]();
 
     expect(await nextEvent(iterator)).toMatchObject({ type: "turn_start" });
-    expect(await nextEvent(iterator)).toEqual({ type: "error", error });
+    expect(await nextEvent(iterator)).toEqual({ type: "error", error, usage: Usage.empty() });
     await expect(iterator.next()).rejects.toBe(error);
     expect(model.requests).toHaveLength(1);
   });
@@ -251,8 +402,14 @@ describe("PromptRequest streaming", () => {
     expect(events.at(-1)).toMatchObject({ type: "final", output: "safe" });
   });
 
-  it("does not emit final before the run end hook succeeds", async () => {
-    const model = new StreamingQueueModel([[{ type: "text_delta", delta: "done" }]]);
+  it("retains completed usage when the run end hook cancels before final", async () => {
+    const finalUsage = usage(5, 2);
+    const model = new StreamingQueueModel([
+      [
+        { type: "text_delta", delta: "done" },
+        { type: "final", response: completionResponse([], finalUsage) },
+      ],
+    ]);
     const agent = new AgentBuilder("test-agent", model)
       .hook(
         createHook({
@@ -276,7 +433,102 @@ describe("PromptRequest streaming", () => {
       "turn_end",
       "error",
     ]);
+    expect(events.at(-1)).toMatchObject({ type: "error", usage: finalUsage });
     await expect(iterator.next()).rejects.toBeInstanceOf(PromptCancelledError);
+  });
+
+  it("retains completed usage when an output guardrail fails", async () => {
+    const finalUsage = usage(4, 2);
+    const guardrailError = new Error("guardrail failed");
+    const model = new StreamingQueueModel([
+      [
+        {
+          type: "final",
+          response: completionResponse([AssistantContent.text("done")], finalUsage),
+        },
+      ],
+    ]);
+    const outputGuardrail = defineOutputGuardrail({
+      id: "failing-output",
+      check() {
+        throw guardrailError;
+      },
+    });
+    const agent = new AgentBuilder("test-agent", model)
+      .guardrails(defineGuardrailPolicy({ id: "policy", output: [outputGuardrail] }))
+      .build();
+    const iterator = agent.prompt("hi").stream()[Symbol.asyncIterator]();
+
+    const errorEvent = await nextAgentError(iterator);
+
+    expect(errorEvent).toEqual({ type: "error", error: guardrailError, usage: finalUsage });
+    await expect(iterator.next()).rejects.toBe(guardrailError);
+  });
+
+  it("retains completed usage when event persistence fails", async () => {
+    const finalUsage = usage(7, 3);
+    const persistenceError = new Error("event persistence failed");
+    let failed = false;
+    const eventStore: AgentEventStore = {
+      async append(input) {
+        if (!failed && eventType(input.event) === "turn_end") {
+          failed = true;
+          throw persistenceError;
+        }
+      },
+      async load() {
+        return [];
+      },
+    };
+    const model = new StreamingQueueModel([
+      [
+        {
+          type: "final",
+          response: completionResponse([AssistantContent.text("done")], finalUsage),
+        },
+      ],
+    ]);
+    const agent = new AgentBuilder("test-agent", model)
+      .eventStore(eventStore, { include: "all" })
+      .build();
+    const iterator = agent.prompt("hi").stream()[Symbol.asyncIterator]();
+
+    const errorEvent = await nextAgentError(iterator);
+
+    expect(errorEvent).toEqual({ type: "error", error: persistenceError, usage: finalUsage });
+    await expect(iterator.next()).rejects.toBe(persistenceError);
+  });
+
+  it("retains every completed turn usage when the max-turn limit fails the run", async () => {
+    const firstUsage = usage(3, 1);
+    const secondUsage = usage(6, 2);
+    const model = new StreamingQueueModel([
+      [
+        {
+          type: "final",
+          response: completionResponse(
+            [AssistantContent.toolCall("call_1", "add", { x: 1, y: 2 })],
+            firstUsage,
+          ),
+        },
+      ],
+      [
+        {
+          type: "final",
+          response: completionResponse(
+            [AssistantContent.toolCall("call_2", "add", { x: 3, y: 4 })],
+            secondUsage,
+          ),
+        },
+      ],
+    ]);
+    const agent = new AgentBuilder("test-agent", model).tool(addTool).defaultMaxTurns(0).build();
+    const iterator = agent.prompt("loop").stream()[Symbol.asyncIterator]();
+
+    const errorEvent = await nextAgentError(iterator);
+
+    expect(errorEvent.usage).toEqual(Usage.add(firstUsage, secondUsage));
+    await expect(iterator.next()).rejects.toBe(errorEvent.error);
   });
 
   it("rejects concurrent stream execution on the same prompt request", async () => {
@@ -1089,6 +1341,37 @@ async function nextEvent<T>(iterator: AsyncIterator<T>): Promise<T> {
     throw new Error("Expected another stream event");
   }
   return next.value;
+}
+
+async function nextAgentError(
+  iterator: AsyncIterator<AgentStreamEvent>,
+): Promise<Extract<AgentStreamEvent, { type: "error" }>> {
+  while (true) {
+    const event = await nextEvent(iterator);
+    if (event.type === "error") {
+      return event;
+    }
+  }
+}
+
+function usage(inputTokens: number, outputTokens: number): ReturnType<typeof Usage.empty> {
+  return {
+    ...Usage.empty(),
+    inputTokens,
+    outputTokens,
+    totalTokens: inputTokens + outputTokens,
+  };
+}
+
+function completionResponse(
+  choice: CompletionResponse["choice"],
+  responseUsage: CompletionResponse["usage"],
+): CompletionResponse {
+  return {
+    choice,
+    usage: responseUsage,
+    rawResponse: {},
+  };
 }
 
 function deferred<T>(): {

--- a/packages/observability-langfuse/src/tracing.ts
+++ b/packages/observability-langfuse/src/tracing.ts
@@ -767,13 +767,13 @@ class LangfuseToolObserver implements AgentToolObserver {
     }
 
     if (child.type === "error") {
-      agent
-        .update({
-          level: "ERROR",
-          statusMessage: errorMessage(child.error),
-          output: { error: errorMessage(child.error) },
-        })
-        .end();
+      const update: Parameters<LangfuseAgent["update"]>[0] = {
+        level: "ERROR",
+        statusMessage: errorMessage(child.error),
+        output: { error: errorMessage(child.error) },
+      };
+      if (isRecord(child.usage)) update.metadata = { usage: child.usage };
+      agent.update(update).end();
       this.childAgents.delete(agentId);
     }
   }

--- a/packages/observability-langfuse/test/langfuse.test.ts
+++ b/packages/observability-langfuse/test/langfuse.test.ts
@@ -983,7 +983,7 @@ describe("langfuse", () => {
       toolCallId: "call-child",
       event: {
         agentId: "child",
-        event: { type: "error", error: new Error("child failed") },
+        event: { type: "error", error: new Error("child failed"), usage: usage(3, 1) },
       },
     });
     await tool?.error?.({
@@ -1001,6 +1001,7 @@ describe("langfuse", () => {
         level: "ERROR",
         statusMessage: "child failed",
         output: { error: "child failed" },
+        metadata: { usage: usage(3, 1) },
       }),
     );
     expect(parentTool.update).toHaveBeenCalledWith(

--- a/packages/observability-otel/src/tracing.ts
+++ b/packages/observability-otel/src/tracing.ts
@@ -310,6 +310,9 @@ class OtelToolObserver implements AgentToolObserver {
     }
 
     if (child.type === "error") {
+      if (isRecord(child.usage)) {
+        agent.setAttributes(compactAttributes(usageAttributesFromRecord(child.usage)));
+      }
       recordSpanError(agent, child.error);
       agent.end();
       this.childAgents.delete(agentId);

--- a/packages/observability-otel/test/otel.test.ts
+++ b/packages/observability-otel/test/otel.test.ts
@@ -507,7 +507,7 @@ describe("otel", () => {
       event: {
         agentId: "child",
         agentName: "Child Agent",
-        event: { type: "error", error: "child failed" },
+        event: { type: "error", error: "child failed", usage: usage(3, 1) },
       },
     });
 
@@ -516,6 +516,10 @@ describe("otel", () => {
     expect(childAgent?.status).toEqual({
       code: SpanStatusCode.ERROR,
       message: "child failed",
+    });
+    expect(childAgent?.attributes).toMatchObject({
+      "anvia.usage.input_tokens": 3,
+      "anvia.usage.output_tokens": 1,
     });
     expect(childAgent?.ended).toBe(true);
   });

--- a/packages/provider-openai/src/openai/responses.ts
+++ b/packages/provider-openai/src/openai/responses.ts
@@ -222,23 +222,9 @@ export function fromOpenAIResponse(response: unknown): CompletionResponse {
     }
   }
 
-  const usageSource = isPlainObject(raw.usage) ? raw.usage : {};
-  const inputTokens = numberFrom(usageSource.input_tokens);
-  const outputTokens = numberFrom(usageSource.output_tokens);
-  const totalTokens = numberFrom(usageSource.total_tokens) || inputTokens + outputTokens;
-  const details = isPlainObject(usageSource.input_tokens_details)
-    ? usageSource.input_tokens_details
-    : {};
-
   const result: CompletionResponse = {
     choice,
-    usage: {
-      ...Usage.empty(),
-      inputTokens,
-      outputTokens,
-      totalTokens,
-      cachedInputTokens: numberFrom(details.cached_tokens),
-    },
+    usage: usageFromOpenAIResponse(raw.usage),
     rawResponse: response,
   };
 
@@ -339,7 +325,14 @@ export function fromOpenAIStreamEvent(event: unknown): CompletionStreamEvent | u
   }
 
   if (event.type === "response.failed" && isPlainObject(event.response)) {
-    return { type: "error", error: event.response.error ?? event.response };
+    const mapped: CompletionStreamEvent = {
+      type: "error",
+      error: event.response.error ?? event.response,
+    };
+    if (isPlainObject(event.response.usage)) {
+      mapped.usage = usageFromOpenAIResponse(event.response.usage);
+    }
+    return mapped;
   }
 
   if (event.type === "error" || event.type === "response.error") {
@@ -347,6 +340,24 @@ export function fromOpenAIStreamEvent(event: unknown): CompletionStreamEvent | u
   }
 
   return undefined;
+}
+
+function usageFromOpenAIResponse(usage: unknown): Usage {
+  const usageSource = isPlainObject(usage) ? usage : {};
+  const inputTokens = numberFrom(usageSource.input_tokens);
+  const outputTokens = numberFrom(usageSource.output_tokens);
+  const totalTokens = numberFrom(usageSource.total_tokens) || inputTokens + outputTokens;
+  const details = isPlainObject(usageSource.input_tokens_details)
+    ? usageSource.input_tokens_details
+    : {};
+
+  return {
+    ...Usage.empty(),
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    cachedInputTokens: numberFrom(details.cached_tokens),
+  };
 }
 
 function messageToResponsesInput(message: MessageType): ResponsesInputItem[] {

--- a/packages/provider-openai/test/openai-chat-completion.test.ts
+++ b/packages/provider-openai/test/openai-chat-completion.test.ts
@@ -317,6 +317,19 @@ describe("OpenAI chat-completions client path", () => {
     ]);
   });
 
+  it("does not fabricate usage before a Chat Completions usage chunk", () => {
+    const events = fromOpenAIChatCompletionStreamChunk({
+      id: "cmpl_without_usage",
+      choices: [{ index: 0, finish_reason: "stop", delta: { content: "done" } }],
+    });
+
+    expect(events).toEqual([
+      { type: "text_delta", delta: "done" },
+      { type: "message_id", id: "cmpl_without_usage" },
+    ]);
+    expect(events.some((event) => event.type === "final")).toBe(false);
+  });
+
   it("assembles Devscale-style streamed tool fragments into one valid call", async () => {
     const calls: unknown[] = [];
     const model = openAIChatModelWithStreams([

--- a/packages/provider-openai/test/openai-responses.test.ts
+++ b/packages/provider-openai/test/openai-responses.test.ts
@@ -479,6 +479,33 @@ describe("OpenAI Responses mapping", () => {
 
     expect(
       fromOpenAIStreamEvent({
+        type: "response.failed",
+        response: {
+          id: "resp_failed_with_usage",
+          error: { code: "server_error", message: "The billed response failed." },
+          usage: {
+            input_tokens: 11,
+            output_tokens: 4,
+            total_tokens: 15,
+            input_tokens_details: { cached_tokens: 2 },
+          },
+        },
+        sequence_number: 3,
+      }),
+    ).toEqual({
+      type: "error",
+      error: { code: "server_error", message: "The billed response failed." },
+      usage: {
+        ...Usage.empty(),
+        inputTokens: 11,
+        outputTokens: 4,
+        totalTokens: 15,
+        cachedInputTokens: 2,
+      },
+    });
+
+    expect(
+      fromOpenAIStreamEvent({
         type: "response.incomplete",
         response: {
           id: "resp_incomplete",
@@ -494,7 +521,7 @@ describe("OpenAI Responses mapping", () => {
             total_tokens: 5,
           },
         },
-        sequence_number: 3,
+        sequence_number: 4,
       }),
     ).toEqual({
       type: "final",

--- a/packages/tool-studio/src/runtime/pipelines.ts
+++ b/packages/tool-studio/src/runtime/pipelines.ts
@@ -1,4 +1,4 @@
-import type { JsonObject, JsonValue } from "@anvia/core/completion";
+import { type JsonObject, type JsonValue, Usage } from "@anvia/core/completion";
 import type { PipelineRunEvent } from "@anvia/core/pipeline";
 import type { Context, Hono } from "hono";
 import type {
@@ -378,7 +378,7 @@ async function* pipelineRunEvents(props: {
       if (log !== undefined) {
         events.push({ type: "pipeline_log", log });
       }
-      events.push({ type: "error", error: serializeError(error) } as AgentRunStreamEvent);
+      events.push({ type: "error", error: serializeError(error), usage: Usage.empty() });
     })
     .finally(() => events.close());
 

--- a/packages/tool-studio/src/traces/trace-observer.ts
+++ b/packages/tool-studio/src/traces/trace-observer.ts
@@ -333,6 +333,8 @@ class ChildAgentToolTraceAccumulator {
     }
 
     if (child.type === "error") {
+      const metadata = this.childMetadata(agentId, agentName, childTurn);
+      if (isRecord(child.usage)) metadata.usage = toJsonValue(child.usage);
       this.completedObservations.push(
         traceObservation({
           kind: "tool",
@@ -341,7 +343,7 @@ class ChildAgentToolTraceAccumulator {
           turn: this.parent.turn,
           startedAt: new Date(),
           error: serializeError(child.error),
-          metadata: this.childMetadata(agentId, agentName, childTurn),
+          metadata,
         }),
       );
     }

--- a/packages/tool-studio/test/runner.test.ts
+++ b/packages/tool-studio/test/runner.test.ts
@@ -2737,6 +2737,7 @@ describe("Anvia studio", () => {
       expect.objectContaining({
         type: "error",
         error: expect.objectContaining({ reason: "Blocked by existing hook." }),
+        usage: Usage.empty(),
       }),
     );
   });
@@ -4002,7 +4003,14 @@ describe("Anvia studio", () => {
 
     expect(run.status).toBe(200);
     expect(run.headers.get("content-type")).toContain("application/x-ndjson");
-    expect(await readJsonl(run)).toContainEqual(
+    const events = await readJsonl(run);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "error",
+        usage: Usage.empty(),
+      }),
+    );
+    expect(events).toContainEqual(
       expect.objectContaining({
         type: "error",
         error: expect.objectContaining({ message: "stream failed" }),


### PR DESCRIPTION
## Summary

- require cumulative `Usage` on agent runtime error stream events and emit the same usage object passed to `AgentRunObserver.error()`
- accept optional authoritative usage on provider completion errors, including OpenAI Responses `response.failed` events
- count billed failed attempts exactly once across retries while retaining completed-turn usage for later failures
- update downstream observability and Studio consumers, API documentation, tests, and package changesets

## Root cause

`PromptRequest.stream()` accumulated run usage and reported it to observers, but the terminal agent error event only contained the error. The OpenAI Responses mapper also discarded usage supplied on failed responses, so consumers could not account for billed work after a failed run.

## Compatibility

Agent error event producers must now include a `usage` property. Use cumulative authoritative usage or `Usage.empty()` when none is available. Provider-level completion error usage remains optional; network interruptions, failures without usage, and Chat Completions streams ending before a usage chunk are never estimated.

## Validation

- `pnpm --filter @anvia/core test` — 352 tests passed
- `pnpm --filter @anvia/openai test` — 78 tests passed
- `pnpm --filter @anvia/langfuse test` — 139 tests passed
- `pnpm --filter @anvia/otel test` — 12 tests passed
- `pnpm --filter @anvia/studio test` — 137 tests passed
- `pnpm --filter './packages/**' typecheck`
- `pnpm check`
- core, OpenAI, Langfuse, OpenTelemetry, and Studio builds
- `pnpm --filter www reference-check`
- `pnpm --filter www build`

The root aggregate `pnpm typecheck` also encountered an unrelated existing `rows` prop error in `examples/fullstack-agent/src/App.tsx:146`; all publishable packages typecheck successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming error events now include cumulative, authoritative usage details.
  * Provider-reported usage from failed OpenAI Responses requests is preserved.
  * Failed child-agent usage appears in observability traces and Studio records.
  * Public stream event types now expose usage information for error handling.

* **Bug Fixes**
  * Prevented fabricated usage totals when provider usage is unavailable.
  * Improved usage retention across retries, failed turns, guardrail failures, and cancellations.

* **Documentation**
  * Updated streaming, completion, request, and provider references with the new error-usage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->