### PR TITLE
Fix interleaved Chat Completions reasoning

### DIFF
--- a/.changeset/stable-chat-reasoning.md
+++ b/.changeset/stable-chat-reasoning.md
@@ -1,0 +1,6 @@
+---
+"@anvia/openai": patch
+---
+
+Ensure OpenAI-compatible Chat Completions reasoning chunks retain a stable per-response identity and
+appear before visible answer content.

--- a/packages/provider-openai/src/openai/chat-completion.ts
+++ b/packages/provider-openai/src/openai/chat-completion.ts
@@ -100,10 +100,9 @@ export class OpenAIChatCompletionModel
     const streamOptions = isPlainObject(params.stream_options) ? params.stream_options : {};
     params.stream_options = { ...streamOptions, include_usage: true };
     const stream = await this.client.chat.completions.create(params as never);
-    const streamState = new OpenAIChatCompletionToolStreamState();
+    const streamState = new OpenAIChatCompletionStreamState();
     for await (const chunk of stream as unknown as AsyncIterable<unknown>) {
-      const mapping = mapOpenAIChatCompletionStreamChunk(chunk);
-      streamState.accept(mapping);
+      const mapping = streamState.mapChunk(chunk);
       for (const event of mapping.events) {
         yield event;
       }
@@ -228,17 +227,17 @@ export function fromOpenAIChatCompletionResponse(response: unknown): CompletionR
   const message = isPlainObject(firstChoice?.message) ? firstChoice.message : {};
   const choice: AssistantContentType[] = [];
 
+  const reasoning = stringFrom(message.reasoning) ?? stringFrom(message.reasoning_content);
+  if (reasoning !== undefined && reasoning.length > 0) {
+    choice.push(AssistantContent.reasoning(reasoning));
+  }
+
   if (typeof message.content === "string" && message.content.length > 0) {
     choice.push(AssistantContent.text(message.content));
   }
 
   if (typeof message.refusal === "string" && message.refusal.length > 0) {
     choice.push(AssistantContent.text(message.refusal));
-  }
-
-  const reasoning = stringFrom(message.reasoning) ?? stringFrom(message.reasoning_content);
-  if (reasoning !== undefined && reasoning.length > 0) {
-    choice.push(AssistantContent.reasoning(reasoning));
   }
 
   const toolCalls = Array.isArray(message.tool_calls) ? message.tool_calls : [];
@@ -271,7 +270,10 @@ export function fromOpenAIChatCompletionStreamChunk(chunk: unknown): CompletionS
   return mapOpenAIChatCompletionStreamChunk(chunk).events;
 }
 
-function mapOpenAIChatCompletionStreamChunk(chunk: unknown): ChatCompletionStreamChunkMapping {
+function mapOpenAIChatCompletionStreamChunk(
+  chunk: unknown,
+  reasoningId?: string,
+): ChatCompletionStreamChunkMapping {
   if (!isPlainObject(chunk)) {
     return { events: [], hasToolCalls: false, hasFinishReason: false };
   }
@@ -282,17 +284,21 @@ function mapOpenAIChatCompletionStreamChunk(chunk: unknown): ChatCompletionStrea
 
   if (choice !== undefined && isPlainObject(choice.delta)) {
     const delta = choice.delta;
+    const reasoning = stringFrom(delta.reasoning) ?? stringFrom(delta.reasoning_content);
+    if (reasoning !== undefined && reasoning.length > 0) {
+      const event: CompletionStreamEvent = { type: "reasoning_delta", delta: reasoning };
+      if (reasoningId !== undefined) {
+        event.id = reasoningId;
+      }
+      events.push(event);
+    }
+
     if (typeof delta.content === "string" && delta.content.length > 0) {
       events.push({ type: "text_delta", delta: delta.content });
     }
 
     if (typeof delta.refusal === "string" && delta.refusal.length > 0) {
       events.push({ type: "text_delta", delta: delta.refusal });
-    }
-
-    const reasoning = stringFrom(delta.reasoning) ?? stringFrom(delta.reasoning_content);
-    if (reasoning !== undefined && reasoning.length > 0) {
-      events.push({ type: "reasoning_delta", delta: reasoning });
     }
 
     const toolCalls = Array.isArray(delta.tool_calls) ? delta.tool_calls : [];
@@ -341,12 +347,19 @@ function mapOpenAIChatCompletionStreamChunk(chunk: unknown): ChatCompletionStrea
   return mapping;
 }
 
-class OpenAIChatCompletionToolStreamState {
+class OpenAIChatCompletionStreamState {
+  private readonly reasoningId = crypto.randomUUID();
   private hasToolCalls = false;
   private hasFinishReason = false;
   private finishReason: unknown;
 
-  accept(mapping: ChatCompletionStreamChunkMapping): void {
+  mapChunk(chunk: unknown): ChatCompletionStreamChunkMapping {
+    const mapping = mapOpenAIChatCompletionStreamChunk(chunk, this.reasoningId);
+    this.accept(mapping);
+    return mapping;
+  }
+
+  private accept(mapping: ChatCompletionStreamChunkMapping): void {
     this.hasToolCalls ||= mapping.hasToolCalls;
     if (!mapping.hasFinishReason) {
       return;

--- a/packages/provider-openai/test/openai-chat-completion.test.ts
+++ b/packages/provider-openai/test/openai-chat-completion.test.ts
@@ -227,9 +227,106 @@ describe("OpenAI chat-completions client path", () => {
     });
 
     expect(response.choice).toEqual([
-      AssistantContent.text("created"),
       AssistantContent.reasoning("provider reasoning text"),
+      AssistantContent.text("created"),
     ]);
+  });
+
+  it("uses one stable reasoning id for interleaved Chat Completions chunks", async () => {
+    const model = openAIChatModelWithStreams([reasoningInterleaveStream()]);
+
+    const events = await collectStreamEvents(model);
+    const reasoningEvents = streamedReasoningEvents(events);
+
+    expect(reasoningEvents).toHaveLength(2);
+    expect(reasoningEvents[0]?.id).toEqual(expect.any(String));
+    expect(reasoningEvents[0]?.id).not.toBe("");
+    expect(reasoningEvents[1]?.id).toBe(reasoningEvents[0]?.id);
+  });
+
+  it("uses a different reasoning id for each streamCompletion invocation", async () => {
+    const model = openAIChatModelWithStreams([
+      reasoningInterleaveStream(),
+      reasoningInterleaveStream(),
+    ]);
+
+    const firstId = streamedReasoningEvents(await collectStreamEvents(model))[0]?.id;
+    const secondId = streamedReasoningEvents(await collectStreamEvents(model))[0]?.id;
+
+    expect(firstId).toEqual(expect.any(String));
+    expect(secondId).toEqual(expect.any(String));
+    expect(secondId).not.toBe(firstId);
+  });
+
+  it("assembles interleaved reasoning and text into one ordered Agent response", async () => {
+    const model = openAIChatModelWithStreams([reasoningInterleaveStream()]);
+    const agent = new AgentBuilder("test-agent", model).build();
+
+    const events = await collect(agent.prompt("introduce yourself").stream());
+    const turnEnd = events.find((event) => event.type === "turn_end");
+
+    expect(turnEnd?.type).toBe("turn_end");
+    if (turnEnd?.type !== "turn_end") {
+      throw new Error("Expected AgentBuilder to emit a turn_end event");
+    }
+    expect(turnEnd.response.choice).toEqual([
+      {
+        type: "reasoning",
+        id: expect.any(String),
+        text: "Let me provide a straightforward introduction.",
+      },
+      AssistantContent.text("Hello, Indra Zulfi! I'm DeepSeek V4 Pro"),
+    ]);
+  });
+
+  it("maps reasoning before visible text within the same chunk", () => {
+    expect(
+      fromOpenAIChatCompletionStreamChunk({
+        choices: [
+          {
+            index: 0,
+            finish_reason: null,
+            delta: {
+              content: "answer",
+              reasoning_content: "think",
+            },
+          },
+        ],
+      }),
+    ).toEqual([
+      { type: "reasoning_delta", delta: "think" },
+      { type: "text_delta", delta: "answer" },
+    ]);
+  });
+
+  it("emits text-only Chat Completions deltas incrementally and unchanged", async () => {
+    const model = openAIChatModelWithStreams([
+      [
+        {
+          choices: [{ index: 0, finish_reason: null, delta: { content: "hello" } }],
+        },
+        {
+          choices: [{ index: 0, finish_reason: "stop", delta: { content: " world" } }],
+        },
+      ],
+    ]);
+    const iterator = model
+      .streamCompletion({
+        chatHistory: [Message.user("say hello")],
+        documents: [],
+        tools: [],
+      })
+      [Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: "text_delta", delta: "hello" },
+    });
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: "text_delta", delta: " world" },
+    });
+    await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined });
   });
 
   it("rejects malformed non-streaming tool arguments", () => {
@@ -695,6 +792,51 @@ function finalTextStream(): unknown[] {
   ];
 }
 
+function reasoningInterleaveStream(): unknown[] {
+  return [
+    {
+      id: "chatcmpl-repro",
+      choices: [
+        {
+          index: 0,
+          finish_reason: null,
+          delta: { reasoning_content: "Let me provide a straightfo" },
+        },
+      ],
+    },
+    {
+      id: "chatcmpl-repro",
+      choices: [
+        {
+          index: 0,
+          finish_reason: null,
+          delta: { content: "Hello, Indra Z" },
+        },
+      ],
+    },
+    {
+      id: "chatcmpl-repro",
+      choices: [
+        {
+          index: 0,
+          finish_reason: null,
+          delta: { reasoning_content: "rward introduction." },
+        },
+      ],
+    },
+    {
+      id: "chatcmpl-repro",
+      choices: [
+        {
+          index: 0,
+          finish_reason: "stop",
+          delta: { content: "ulfi! I'm DeepSeek V4 Pro" },
+        },
+      ],
+    },
+  ];
+}
+
 async function collectStreamEvents(
   model: OpenAIChatCompletionModel,
 ): Promise<CompletionStreamEvent[]> {
@@ -719,4 +861,13 @@ async function collect<T>(events: AsyncIterable<T>): Promise<T[]> {
     result.push(event);
   }
   return result;
+}
+
+function streamedReasoningEvents(
+  events: CompletionStreamEvent[],
+): Array<Extract<CompletionStreamEvent, { type: "reasoning_delta" }>> {
+  return events.filter(
+    (event): event is Extract<CompletionStreamEvent, { type: "reasoning_delta" }> =>
+      event.type === "reasoning_delta",
+  );
 }

--- a/packages/react/test/ui-messages.test.ts
+++ b/packages/react/test/ui-messages.test.ts
@@ -7,6 +7,31 @@ import { applyAnviaStreamEvent } from "../src/ui-messages";
 type UIToolPart = Extract<UIMessagePart, { type: "tool" }>;
 
 describe("@anvia/react UI message reducer", () => {
+  it("merges interleaved reasoning deltas with the same id at their first position", () => {
+    const messages = reduceEvents([
+      {
+        type: "reasoning_delta",
+        id: "stable-r",
+        delta: "Let me provide a straightfo",
+      },
+      { type: "text_delta", delta: "Hello, Indra Z" },
+      {
+        type: "reasoning_delta",
+        id: "stable-r",
+        delta: "rward introduction.",
+      },
+      { type: "text_delta", delta: "ulfi! I'm DeepSeek V4 Pro" },
+    ]);
+
+    expect(partSummary(messages)).toEqual([
+      {
+        type: "reasoning",
+        text: "Let me provide a straightforward introduction.",
+      },
+      { type: "text", text: "Hello, Indra Zulfi! I'm DeepSeek V4 Pro" },
+    ]);
+  });
+
   it("keeps reused provider tool ids isolated across turns", () => {
     let messages: UIMessage[] = [];
     const events = [


### PR DESCRIPTION
## Summary

- assign one stable synthetic reasoning ID to scalar `reasoning` and `reasoning_content` deltas for each OpenAI-compatible Chat Completions stream
- emit reasoning before visible content, refusals, and tool-call deltas, including matching non-streaming response ordering
- add provider and React reducer regressions plus a patch changeset for `@anvia/openai`

## Root cause

The Chat Completions adapter emitted scalar reasoning deltas without IDs. Core and React intentionally treat an ID-less reasoning delta that resumes after another content part as a new reasoning part, so providers alternating reasoning and visible text produced fragmented final output.

The adapter now supplies a per-stream UUID. Core and React can therefore merge all reasoning chunks from that response at the first reasoning position without changing generic ID-less behavior, text/tool boundaries, or the OpenAI Responses API, which already uses provider item IDs.

## User impact

OpenAI-compatible providers that alternate reasoning and visible answer chunks now produce one complete reasoning part followed by one complete text part when reasoning appears first. If visible text arrives before the first-ever reasoning delta, existing first-seen ordering still preserves that earlier text rather than reordering already-emitted content.

## Validation

- `pnpm --filter @anvia/core test`
- `pnpm --filter @anvia/openai test`
- `pnpm --filter @anvia/react test`
- `pnpm --filter @anvia/core typecheck`
- `pnpm --filter @anvia/openai typecheck`
- `pnpm --filter @anvia/react typecheck`
- `pnpm check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved streaming responses so reasoning content is emitted before visible answer text.
  - Reasoning updates now maintain a stable identity throughout each response.
  - Interleaved reasoning and answer content are assembled in the correct order.

- **Bug Fixes**
  - Fixed merging of reasoning updates separated by visible text during streaming.
  - Ensured separate responses receive distinct reasoning identities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->