### PR TITLE
feat: stream tool call deltas by default

### DIFF
--- a/.changeset/stream-tool-call-deltas.md
+++ b/.changeset/stream-tool-call-deltas.md
@@ -1,0 +1,10 @@
+---
+"@anvia/core": minor
+"@anvia/gemini": patch
+"@anvia/openai": patch
+"@anvia/react": patch
+---
+
+Emit public tool-call deltas by default for responsive application status, provide an explicit
+legacy opt-out, propagate the setting through streaming agent tools, and handle append-versus-replace
+argument snapshots consistently in React clients.

--- a/apps/www/src/content/docs/advanced/streaming-events.md
+++ b/apps/www/src/content/docs/advanced/streaming-events.md
@@ -23,6 +23,9 @@ for await (const event of request.stream()) {
     case "text_delta":
       await ui.writeText(event.delta);
       break;
+    case "tool_call_delta":
+      if (event.name) await ui.showToolPreparing(event.name);
+      break;
     case "tool_call":
       await ui.showToolPending(event.toolCall.function.name);
       break;
@@ -45,6 +48,7 @@ Agent streams can emit:
 - `"turn_start"` with the current prompt and history for the turn
 - `"text_delta"` for incremental assistant text
 - `"reasoning_delta"` when the provider emits reasoning content
+- `"tool_call_delta"` for provisional tool metadata and argument fragments
 - `"tool_call"` when the model asks for a tool
 - `"tool_result"` after a tool returns or is skipped
 - `"turn_end"` with the provider response for a turn
@@ -53,6 +57,14 @@ Agent streams can emit:
 - `"error"` with cumulative authoritative usage when the run fails
 
 Do not send every event directly to a browser. Tool arguments, tool results, reasoning content, and provider metadata can contain private data. Filter the stream for each surface.
+
+`tool_call_delta` availability depends on the provider. Treat its arguments as opaque text: fragments
+can be incomplete, and `argumentsMode: "replace"` indicates a full snapshot. The completed
+`tool_call` remains authoritative and is the only event used for execution.
+
+Tool-call deltas are emitted by default. Pass `{ includeToolCallDeltas: false }` to `stream()` or
+`readableStream()` only when integrating with a strict legacy consumer that cannot ignore new event
+types.
 
 ## Client-Safe Projection
 

--- a/apps/www/src/content/docs/advanced/streaming-events.md
+++ b/apps/www/src/content/docs/advanced/streaming-events.md
@@ -17,6 +17,7 @@ Use streaming when a UI needs progressive text, when an operations surface needs
 ```ts
 const session = agent.session(threadId);
 const request = session.prompt(message);
+const preparedToolIds = new Set<string>();
 
 for await (const event of request.stream()) {
   switch (event.type) {
@@ -24,7 +25,10 @@ for await (const event of request.stream()) {
       await ui.writeText(event.delta);
       break;
     case "tool_call_delta":
-      if (event.name) await ui.showToolPreparing(event.name);
+      if (event.name && !preparedToolIds.has(event.id)) {
+        preparedToolIds.add(event.id);
+        await ui.showToolPreparing(event.name);
+      }
       break;
     case "tool_call":
       await ui.showToolPending(event.toolCall.function.name);

--- a/apps/www/src/content/docs/packages/core/reference/completion.md
+++ b/apps/www/src/content/docs/packages/core/reference/completion.md
@@ -301,7 +301,7 @@ interface CompletionModel<RawResponse = unknown> {
 type CompletionStreamEvent<RawResponse = unknown> =
   | { type: "text_delta"; delta: string }
   | { type: "reasoning_delta"; delta: string; id?: string; contentType?: ReasoningContent["type"]; signature?: string }
-  | { type: "tool_call_delta"; id: string; callId?: string; name?: string; argumentsDelta?: string; signature?: string }
+  | { type: "tool_call_delta"; id: string; callId?: string; name?: string; argumentsDelta?: string; argumentsMode?: ToolCallArgumentsMode; signature?: string }
   | { type: "tool_call"; toolCall: ToolCall }
   | { type: "message_id"; id: string }
   | { type: "final"; response: CompletionResponse<RawResponse> }
@@ -313,6 +313,9 @@ interface StreamingCompletionModel<RawResponse = unknown> extends CompletionMode
 ```
 
 Purpose: provider adapter interfaces. The metadata fields identify the adapter, its default model name, and the normalized request features the adapter supports.
+
+`ToolCallArgumentsMode` is `"append" | "replace"`. An omitted mode means append. Providers use
+`"replace"` when a completion event contains a full argument snapshot rather than the next fragment.
 
 Return behavior: streaming models yield deltas and finish with a `final` event. Provider error events
 may include authoritative usage for the failed request; adapters omit it when the provider does not

--- a/apps/www/src/content/docs/packages/core/reference/request.md
+++ b/apps/www/src/content/docs/packages/core/reference/request.md
@@ -29,7 +29,8 @@ class PromptRequest<M extends CompletionModel = CompletionModel> {
   approvals(options: ToolApprovalsOptions): this;
   send(): Promise<PromptResponse>;
   stream(): AsyncIterable<AgentStreamEvent>;
-  readableStream(options?: ReadableStreamOptions): ReadableStream<AgentStreamEvent>;
+  stream(options: { includeToolCallDeltas: false }): AsyncIterable<AgentStreamEventWithoutToolCallDeltas>;
+  readableStream(options?: AgentStreamOptions): ReadableStream<Uint8Array>;
 }
 ```
 
@@ -96,21 +97,55 @@ type AgentErrorStreamEvent = {
   usage: Usage;
 };
 
+type AgentStreamOptions = {
+  includeToolCallDeltas?: boolean;
+};
+
+type AgentToolCallDeltaEvent = {
+  type: "tool_call_delta";
+  turn: number;
+  id: string;
+  callId?: string;
+  name?: string;
+  argumentsDelta?: string;
+  argumentsMode?: "append" | "replace";
+  signature?: string;
+};
+
 type AgentStreamEvent =
   | { type: "turn_start"; turn: number; prompt: Message; history: Message[] }
   | { type: "text_delta"; turn: number; delta: string }
   | { type: "reasoning_delta"; turn: number; delta: string; id?: string; contentType?: "text" | "summary" | "encrypted" | "redacted"; signature?: string }
+  | AgentToolCallDeltaEvent
   | { type: "tool_call"; turn: number; toolCall: ToolCall }
   | { type: "tool_result"; turn: number; toolName: string; toolCallId?: string; internalCallId: string; args: string; result: string }
   | { type: "agent_tool_event"; turn: number; toolName: string; toolCallId?: string; internalCallId: string; agentId: string; agentName?: string; event: AgentChildStreamEvent }
   | { type: "turn_end"; turn: number; response: CompletionResponse }
   | { type: "final"; runId: string; output: string; usage: Usage; messages: Message[]; trace?: AgentTraceInfo }
   | AgentErrorStreamEvent;
+
+type AgentChildStreamEventWithoutToolCallDeltas = Exclude<
+  AgentChildStreamEvent,
+  { type: "tool_call_delta" }
+>;
+
+type AgentStreamEventWithoutToolCallDeltas =
+  | AgentChildStreamEventWithoutToolCallDeltas
+  | { type: "agent_tool_event"; turn: number; toolName: string; toolCallId?: string; internalCallId: string; agentId: string; agentName?: string; event: AgentChildStreamEventWithoutToolCallDeltas };
+
+type AgentChildStreamEventWithToolCallDeltas = AgentChildStreamEvent;
+type AgentStreamEventWithToolCallDeltas = AgentStreamEvent;
 ```
 
 Purpose: streaming event union for observing agent execution.
 
 Return behavior: emitted by `PromptRequest.stream()` and `readableStream()`. `agent_tool_event` appears when a child agent is exposed with `asTool({ stream: true })`.
+
+Tool-call deltas are provisional events emitted by default. They are emitted immediately, including
+through streaming child agents, and may precede completion-response middleware. Missing
+`argumentsMode` means append; `"replace"` means the fragment is a full snapshot. Only a completed
+`tool_call` is safe to execute. Pass `{ includeToolCallDeltas: false }` for strict legacy consumers;
+the returned stream then narrows to `AgentStreamEventWithoutToolCallDeltas`.
 
 Agent error usage is cumulative across completed turns and any failed provider attempts that report
 authoritative usage. It is `Usage.empty()` when the runtime has not received authoritative usage.

--- a/apps/www/src/content/docs/packages/core/reference/request.md
+++ b/apps/www/src/content/docs/packages/core/reference/request.md
@@ -30,6 +30,8 @@ class PromptRequest<M extends CompletionModel = CompletionModel> {
   send(): Promise<PromptResponse>;
   stream(): AsyncIterable<AgentStreamEvent>;
   stream(options: { includeToolCallDeltas: false }): AsyncIterable<AgentStreamEventWithoutToolCallDeltas>;
+  stream(options: { includeToolCallDeltas?: true }): AsyncIterable<AgentStreamEvent>;
+  stream(options: AgentStreamOptions): AsyncIterable<AgentStreamEvent>;
   readableStream(options?: AgentStreamOptions): ReadableStream<Uint8Array>;
 }
 ```

--- a/apps/www/src/content/docs/packages/react-ui/usage-patterns.md
+++ b/apps/www/src/content/docs/packages/react-ui/usage-patterns.md
@@ -81,6 +81,10 @@ or filter tool parts before wrappers are created:
 />
 ```
 
+`renderWhen="pending"` includes both provisional `input-streaming` parts created from
+`tool_call_delta` events and completed `input-available` tool calls. This lets an application show a
+“Preparing tool…” state as soon as the provider identifies the tool.
+
 ## Human input
 
 `HumanInput.Approvals` and `HumanInput.Questions` read `useChat` human-input state and call the

--- a/apps/www/src/content/docs/packages/react/reference.md
+++ b/apps/www/src/content/docs/packages/react/reference.md
@@ -413,7 +413,7 @@ function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(options?: {
 
 Purpose: React chat state machine that sends `UIStreamRequest` by default and accumulates response events into `UIMessage[]`.
 
-Passing `endpoint` creates a default JSONL fetch transport. Passing `transport` makes the hook independent of HTTP. `sendMessage(...)` appends a user message, keeps the full UI message history in state, and sends the converted core message history. Custom request factories receive the UI array as `messages` for compatibility and the converted array as `coreMessages`. The hook applies raw `CompletionStreamEvent`, raw `AgentStreamEvent`, or `UIStreamEvent` records as the assistant response arrives.
+Passing `endpoint` creates a default JSONL fetch transport. Passing `transport` makes the hook independent of HTTP. `sendMessage(...)` appends a user message, keeps the full UI message history in state, and sends the converted core message history. Custom request factories receive the UI array as `messages` for compatibility and the converted array as `coreMessages`. The hook applies raw `CompletionStreamEvent`, raw `AgentStreamEvent`, or `UIStreamEvent` records as the assistant response arrives. Tool-call deltas produce an `input-streaming` tool part automatically; append fragments are concatenated and replacement snapshots overwrite the provisional input.
 
 Passing `humanInput` tracks streamed tool approval and question events in `humanInput.approvals` and `humanInput.questions`. The action helpers submit approval decisions and question answers through custom handlers or the default `/approvals/:id/decision` and `/questions/:id/answer` endpoint paths.
 

--- a/examples/cookbook/02_tools/02-tool-stream-events.ts
+++ b/examples/cookbook/02_tools/02-tool-stream-events.ts
@@ -33,8 +33,12 @@ const agent = new AgentBuilder("agent", agentModel)
   .defaultMaxTurns(2)
   .build();
 
-// Tool streaming exposes the model request, local tool result, and final text.
+// Provisional deltas let the UI show a tool as soon as the model names it.
 for await (const event of agent.prompt("What is the weather in Jakarta?").stream()) {
+  if (event.type === "tool_call_delta" && event.name) {
+    console.log(`Preparing ${event.name} tool...`);
+  }
+
   if (event.type === "tool_call") {
     console.log("tool call:", event.toolCall.function.name, event.toolCall.function.arguments);
   }

--- a/examples/cookbook/02_tools/02-tool-stream-events.ts
+++ b/examples/cookbook/02_tools/02-tool-stream-events.ts
@@ -34,8 +34,11 @@ const agent = new AgentBuilder("agent", agentModel)
   .build();
 
 // Provisional deltas let the UI show a tool as soon as the model names it.
+const preparedToolIds = new Set<string>();
+
 for await (const event of agent.prompt("What is the weather in Jakarta?").stream()) {
-  if (event.type === "tool_call_delta" && event.name) {
+  if (event.type === "tool_call_delta" && event.name && !preparedToolIds.has(event.id)) {
+    preparedToolIds.add(event.id);
     console.log(`Preparing ${event.name} tool...`);
   }
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -138,7 +138,11 @@ export class Agent<M extends CompletionModel = CompletionModel> {
           isStreamingCompletionModel(this.model)
         ) {
           let output = "";
-          for await (const event of childRequest.stream()) {
+          const childStream =
+            context.includeToolCallDeltas === false
+              ? childRequest.stream({ includeToolCallDeltas: false })
+              : childRequest.stream();
+          for await (const event of childStream) {
             const streamEvent: ToolCallStreamEvent = {
               agentId: this.id,
               event,

--- a/packages/core/src/completion/types.ts
+++ b/packages/core/src/completion/types.ts
@@ -550,6 +550,8 @@ export interface CompletionModel<RawResponse = unknown, ModelName extends string
   completion(request: CompletionRequest<ModelName>): Promise<CompletionResponse<RawResponse>>;
 }
 
+export type ToolCallArgumentsMode = "append" | "replace";
+
 export type CompletionStreamEvent<RawResponse = unknown> =
   | {
       type: "text_delta";
@@ -568,6 +570,7 @@ export type CompletionStreamEvent<RawResponse = unknown> =
       callId?: string;
       name?: string;
       argumentsDelta?: string;
+      argumentsMode?: ToolCallArgumentsMode;
       signature?: string;
     }
   | {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -84,8 +84,14 @@ export { MaxTurnsError, PromptCancelledError, ToolApprovalRequiredError } from "
 export type { CompletionRetryContext, CompletionRetryOptions } from "./request/retry";
 export type {
   AgentChildStreamEvent,
+  AgentChildStreamEventWithoutToolCallDeltas,
+  AgentChildStreamEventWithToolCallDeltas,
   AgentErrorStreamEvent,
   AgentStreamEvent,
+  AgentStreamEventWithoutToolCallDeltas,
+  AgentStreamEventWithToolCallDeltas,
+  AgentStreamOptions,
+  AgentToolCallDeltaEvent,
   PromptResponse,
 } from "./request/types";
 export type { ZodSchema } from "./schema";

--- a/packages/core/src/internal/prompt-runtime/stream-accumulator.ts
+++ b/packages/core/src/internal/prompt-runtime/stream-accumulator.ts
@@ -58,7 +58,11 @@ export class CompletionStreamAccumulator<RawResponse = unknown> {
       if (event.name !== undefined && event.name.length > 0) toolCall.name = event.name;
       if (event.signature !== undefined) toolCall.signature = event.signature;
       if (event.argumentsDelta !== undefined) {
-        toolCall.argumentsText += event.argumentsDelta;
+        if (event.argumentsMode === "replace") {
+          toolCall.argumentsText = event.argumentsDelta;
+        } else {
+          toolCall.argumentsText += event.argumentsDelta;
+        }
       }
       return undefined;
     }

--- a/packages/core/src/internal/prompt-runtime/stream-events.ts
+++ b/packages/core/src/internal/prompt-runtime/stream-events.ts
@@ -1,4 +1,9 @@
-import type { AgentDeltaEvent, AgentStreamEvent } from "../../request/types";
+import type { CompletionStreamEvent } from "../../completion/types";
+import type {
+  AgentDeltaEvent,
+  AgentStreamEvent,
+  AgentToolCallDeltaEvent,
+} from "../../request/types";
 
 export function addTurn(turn: number, event: AgentDeltaEvent): AgentStreamEvent {
   if (event.type === "text_delta") {
@@ -12,6 +17,23 @@ export function addTurn(turn: number, event: AgentDeltaEvent): AgentStreamEvent 
     return mapped;
   }
   return { type: "tool_call", turn, toolCall: event.toolCall };
+}
+
+export function addTurnToToolCallDelta(
+  turn: number,
+  event: Extract<CompletionStreamEvent, { type: "tool_call_delta" }>,
+): AgentToolCallDeltaEvent {
+  const mapped: AgentToolCallDeltaEvent = {
+    type: "tool_call_delta",
+    turn,
+    id: event.id,
+  };
+  if (event.callId !== undefined) mapped.callId = event.callId;
+  if (event.name !== undefined) mapped.name = event.name;
+  if (event.argumentsDelta !== undefined) mapped.argumentsDelta = event.argumentsDelta;
+  if (event.argumentsMode !== undefined) mapped.argumentsMode = event.argumentsMode;
+  if (event.signature !== undefined) mapped.signature = event.signature;
+  return mapped;
 }
 
 export function isGenerationDeltaEvent(type: string): boolean {

--- a/packages/core/src/internal/prompt-runtime/tool-execution.ts
+++ b/packages/core/src/internal/prompt-runtime/tool-execution.ts
@@ -26,6 +26,7 @@ import type {
   ToolApprovalRequest,
   ToolApprovalRunContext,
   ToolApprovalsOptions,
+  ToolCallContext,
   ToolCallStreamEvent,
 } from "../../tool";
 import { parseToolArgs, toolResultContentToText } from "../../tool";
@@ -64,6 +65,7 @@ export type ToolExecutionObservation = {
   turn: number;
   runObservers: ActiveAgentRunObservers;
   toolDefinitions?: ToolDefinition[];
+  includeToolCallDeltas?: boolean;
 };
 
 export type ToolExecutionRunContext = {
@@ -80,6 +82,7 @@ export class ToolCallExecutor {
     private readonly runContext: ToolExecutionRunContext,
     private readonly concurrency: number,
     private readonly requestMiddlewares: AgentMiddleware[],
+    private readonly includeToolCallDeltas: boolean,
     private readonly cancel: (reason: string) => Error,
   ) {}
 
@@ -277,7 +280,7 @@ export class ToolCallExecutor {
       : effectiveArgs;
     hookArgs.args = middlewareArgs;
     try {
-      return await this.agent.callTool(toolCall.function.name, middlewareArgs, {
+      const toolContext: ToolCallContext = {
         emitStreamEvent: async (event) => {
           const streamEventArgs: AgentToolStreamEventArgs = {
             turn: observation?.turn ?? 0,
@@ -296,7 +299,9 @@ export class ToolCallExecutor {
             onStreamEvent?.(payload);
           }
         },
-      });
+      };
+      toolContext.includeToolCallDeltas = this.includeToolCallDeltas;
+      return await this.agent.callTool(toolCall.function.name, middlewareArgs, toolContext);
     } catch (error) {
       const errorAction = await this.activeHook?.onToolError?.({
         ...hookArgs,

--- a/packages/core/src/request/index.ts
+++ b/packages/core/src/request/index.ts
@@ -3,8 +3,14 @@ export { PromptRequest } from "./prompt-request";
 export type { CompletionRetryContext, CompletionRetryOptions } from "./retry";
 export type {
   AgentChildStreamEvent,
+  AgentChildStreamEventWithoutToolCallDeltas,
+  AgentChildStreamEventWithToolCallDeltas,
   AgentDeltaEvent,
   AgentErrorStreamEvent,
   AgentStreamEvent,
+  AgentStreamEventWithoutToolCallDeltas,
+  AgentStreamEventWithToolCallDeltas,
+  AgentStreamOptions,
+  AgentToolCallDeltaEvent,
   PromptResponse,
 } from "./types";

--- a/packages/core/src/request/prompt-request.ts
+++ b/packages/core/src/request/prompt-request.ts
@@ -12,7 +12,6 @@ import {
   Message,
   type Message as MessageType,
   type ToolCall,
-  type ToolDefinition,
   type ToolResult,
   textFromAssistantContent,
   Usage,
@@ -33,11 +32,16 @@ import { createAsyncQueue } from "../internal/async-queue";
 import { PromptRequestMemory } from "../internal/prompt-runtime/memory";
 import { fetchDynamicContext, fetchToolDefinitions } from "../internal/prompt-runtime/retrieval";
 import { CompletionStreamAccumulator } from "../internal/prompt-runtime/stream-accumulator";
-import { addTurn, isGenerationDeltaEvent } from "../internal/prompt-runtime/stream-events";
+import {
+  addTurn,
+  addTurnToToolCallDelta,
+  isGenerationDeltaEvent,
+} from "../internal/prompt-runtime/stream-events";
 import {
   type AgentToolEventPayload,
   ToolCallExecutor,
   type ToolExecutionEventPayload,
+  type ToolExecutionObservation,
   type ToolResultEventPayload,
 } from "../internal/prompt-runtime/tool-execution";
 import { extractRagText } from "../internal/rag-text";
@@ -60,7 +64,12 @@ import {
   resolveCompletionRetryOptions,
   waitForCompletionRetry,
 } from "./retry";
-import type { AgentStreamEvent, PromptResponse } from "./types";
+import type {
+  AgentStreamEvent,
+  AgentStreamEventWithoutToolCallDeltas,
+  AgentStreamOptions,
+  PromptResponse,
+} from "./types";
 
 export class PromptRequest<M extends CompletionModel = CompletionModel> {
   private chatHistory: MessageType[];
@@ -352,12 +361,19 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
     }
   }
 
-  async *stream(): AsyncIterable<AgentStreamEvent> {
+  stream(): AsyncIterable<AgentStreamEvent>;
+  stream(options: {
+    includeToolCallDeltas: false;
+  }): AsyncIterable<AgentStreamEventWithoutToolCallDeltas>;
+  stream(options: { includeToolCallDeltas?: true }): AsyncIterable<AgentStreamEvent>;
+  stream(options: AgentStreamOptions): AsyncIterable<AgentStreamEvent>;
+  async *stream(options: AgentStreamOptions = {}): AsyncIterable<AgentStreamEvent> {
     if (!this.agent.model.capabilities.streaming || !isStreamingCompletionModel(this.agent.model)) {
       throw new Error("This completion model does not support streaming");
     }
 
     this.startRun();
+    const includeToolCallDeltas = options.includeToolCallDeltas !== false;
     const runId = globalThis.crypto.randomUUID();
     const emit = async (event: AgentStreamEvent): Promise<AgentStreamEvent> => {
       await this.recordAgentEvent(runId, event);
@@ -472,6 +488,9 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
                   firstDeltaMs = Date.now() - generationStartedAt;
                 }
                 const mapped = accumulator.accept(event);
+                if (includeToolCallDeltas && event.type === "tool_call_delta") {
+                  yield await emit(addTurnToToolCallDelta(currentTurns, event));
+                }
                 if (mapped !== undefined) {
                   await generationObservers.update?.({ turn: currentTurns, delta: mapped });
                   if (mapped.type === "tool_call") {
@@ -646,6 +665,7 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
             turn: currentTurns,
             runObservers,
             toolDefinitions: request.tools,
+            includeToolCallDeltas,
           },
         );
         toolResultsPromise.then(
@@ -684,8 +704,8 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
     }
   }
 
-  readableStream(): ReadableStream<Uint8Array> {
-    return toReadableStream(this.stream());
+  readableStream(options: AgentStreamOptions = {}): ReadableStream<Uint8Array> {
+    return toReadableStream(this.stream(options));
   }
 
   private async runCompletion(
@@ -830,11 +850,7 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
     newMessages: MessageType[],
     onResult?: (result: ToolResultEventPayload) => void,
     onStreamEvent?: (event: AgentToolEventPayload) => void,
-    observation?: {
-      turn: number;
-      runObservers: ActiveAgentRunObservers;
-      toolDefinitions?: ToolDefinition[];
-    },
+    observation?: ToolExecutionObservation,
   ): Promise<ToolResult[]> {
     const executor = new ToolCallExecutor(
       this.agent,
@@ -847,6 +863,7 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
       },
       this.concurrency,
       this.requestMiddlewares,
+      observation?.includeToolCallDeltas ?? false,
       (reason) => this.cancelled(newMessages, reason),
     );
     return executor.execute(toolCalls, onResult, onStreamEvent, observation);

--- a/packages/core/src/request/types.ts
+++ b/packages/core/src/request/types.ts
@@ -3,6 +3,7 @@ import type {
   Message as MessageType,
   ReasoningContentType,
   ToolCall,
+  ToolCallArgumentsMode,
   ToolResultContent,
   Usage,
 } from "../completion/index";
@@ -34,7 +35,23 @@ export type AgentErrorStreamEvent = {
   usage: Usage;
 };
 
-export type AgentChildStreamEvent<RawResponse = unknown> =
+export type AgentStreamOptions = {
+  /** @default true */
+  includeToolCallDeltas?: boolean;
+};
+
+export type AgentToolCallDeltaEvent = {
+  type: "tool_call_delta";
+  turn: number;
+  id: string;
+  callId?: string;
+  name?: string;
+  argumentsDelta?: string;
+  argumentsMode?: ToolCallArgumentsMode;
+  signature?: string;
+};
+
+type AgentChildStreamEventBase<RawResponse = unknown> =
   | {
       type: "turn_start";
       turn: number;
@@ -90,15 +107,34 @@ export type AgentChildStreamEvent<RawResponse = unknown> =
     }
   | AgentErrorStreamEvent;
 
+export type AgentChildStreamEventWithoutToolCallDeltas<RawResponse = unknown> =
+  AgentChildStreamEventBase<RawResponse>;
+
+export type AgentChildStreamEvent<RawResponse = unknown> =
+  | AgentChildStreamEventBase<RawResponse>
+  | AgentToolCallDeltaEvent;
+
+export type AgentChildStreamEventWithToolCallDeltas<RawResponse = unknown> =
+  AgentChildStreamEvent<RawResponse>;
+
+type AgentToolStreamEvent<ChildEvent> = {
+  type: "agent_tool_event";
+  turn: number;
+  toolName: string;
+  toolCallId?: string;
+  internalCallId: string;
+  agentId: string;
+  agentName?: string;
+  event: ChildEvent;
+};
+
+export type AgentStreamEventWithoutToolCallDeltas<RawResponse = unknown> =
+  | AgentChildStreamEventWithoutToolCallDeltas<RawResponse>
+  | AgentToolStreamEvent<AgentChildStreamEventWithoutToolCallDeltas<RawResponse>>;
+
 export type AgentStreamEvent<RawResponse = unknown> =
   | AgentChildStreamEvent<RawResponse>
-  | {
-      type: "agent_tool_event";
-      turn: number;
-      toolName: string;
-      toolCallId?: string;
-      internalCallId: string;
-      agentId: string;
-      agentName?: string;
-      event: AgentChildStreamEvent<RawResponse>;
-    };
+  | AgentToolStreamEvent<AgentChildStreamEvent<RawResponse>>;
+
+export type AgentStreamEventWithToolCallDeltas<RawResponse = unknown> =
+  AgentStreamEvent<RawResponse>;

--- a/packages/core/src/tool/tool.ts
+++ b/packages/core/src/tool/tool.ts
@@ -48,6 +48,7 @@ export type ToolCallStreamEvent = {
 
 export type ToolCallContext = {
   emitStreamEvent?(event: ToolCallStreamEvent): void | Promise<void>;
+  includeToolCallDeltas?: boolean;
 };
 
 export interface Tool<Args = unknown, Output = unknown> {

--- a/packages/core/test/public-exports.test.ts
+++ b/packages/core/test/public-exports.test.ts
@@ -16,6 +16,11 @@ import * as hooks from "../src/hooks";
 import * as imageGeneration from "../src/image-generation";
 import type {
   AgentErrorStreamEvent as RootAgentErrorStreamEvent,
+  AgentStreamEvent as RootAgentStreamEvent,
+  AgentStreamEventWithoutToolCallDeltas as RootAgentStreamEventWithoutToolCallDeltas,
+  AgentStreamEventWithToolCallDeltas as RootAgentStreamEventWithToolCallDeltas,
+  AgentStreamOptions as RootAgentStreamOptions,
+  AgentToolCallDeltaEvent as RootAgentToolCallDeltaEvent,
   CompletionRetryContext as RootCompletionRetryContext,
   CompletionRetryOptions as RootCompletionRetryOptions,
   ToolContent as RootToolContentType,
@@ -31,6 +36,10 @@ import * as pipeline from "../src/pipeline";
 import type {
   AgentErrorStreamEvent as RequestAgentErrorStreamEvent,
   AgentStreamEvent as RequestAgentStreamEvent,
+  AgentStreamEventWithoutToolCallDeltas as RequestAgentStreamEventWithoutToolCallDeltas,
+  AgentStreamEventWithToolCallDeltas as RequestAgentStreamEventWithToolCallDeltas,
+  AgentStreamOptions as RequestAgentStreamOptions,
+  AgentToolCallDeltaEvent as RequestAgentToolCallDeltaEvent,
   CompletionRetryContext as RequestCompletionRetryContext,
   CompletionRetryOptions as RequestCompletionRetryOptions,
 } from "../src/request";
@@ -96,6 +105,18 @@ describe("public exports", () => {
     expectTypeOf<RootCompletionRetryContext>().toEqualTypeOf<RequestCompletionRetryContext>();
     expectTypeOf<RootCompletionRetryOptions>().toEqualTypeOf<RequestCompletionRetryOptions>();
     expectTypeOf<RootAgentErrorStreamEvent>().toEqualTypeOf<RequestAgentErrorStreamEvent>();
+    expectTypeOf<RootAgentStreamOptions>().toEqualTypeOf<RequestAgentStreamOptions>();
+    expectTypeOf<RootAgentToolCallDeltaEvent>().toEqualTypeOf<RequestAgentToolCallDeltaEvent>();
+    expectTypeOf<RootAgentStreamEvent>().toEqualTypeOf<RequestAgentStreamEvent>();
+    expectTypeOf<RootAgentStreamEventWithoutToolCallDeltas>().toEqualTypeOf<RequestAgentStreamEventWithoutToolCallDeltas>();
+    expectTypeOf<RootAgentStreamEventWithToolCallDeltas>().toEqualTypeOf<RequestAgentStreamEventWithToolCallDeltas>();
+    expectTypeOf<
+      Extract<RequestAgentStreamEvent, { type: "tool_call_delta" }>
+    >().toEqualTypeOf<RequestAgentToolCallDeltaEvent>();
+    expectTypeOf<
+      Extract<RequestAgentStreamEventWithoutToolCallDeltas, { type: "tool_call_delta" }>
+    >().toBeNever();
+    expectTypeOf<RequestAgentStreamEventWithToolCallDeltas>().toEqualTypeOf<RequestAgentStreamEvent>();
     expectTypeOf<
       Extract<RequestAgentStreamEvent, { type: "error" }>
     >().toEqualTypeOf<RequestAgentErrorStreamEvent>();

--- a/packages/core/test/stream-accumulator.test.ts
+++ b/packages/core/test/stream-accumulator.test.ts
@@ -138,6 +138,27 @@ describe("CompletionStreamAccumulator", () => {
     ]);
   });
 
+  it("replaces accumulated tool arguments with a completed snapshot", () => {
+    const accumulator = new CompletionStreamAccumulator();
+
+    accumulator.accept({
+      type: "tool_call_delta",
+      id: "tool_0",
+      name: "ExecCommand",
+      argumentsDelta: '{"command":',
+    });
+    accumulator.accept({
+      type: "tool_call_delta",
+      id: "tool_0",
+      argumentsDelta: '{"command":"pwd"}',
+      argumentsMode: "replace",
+    });
+
+    expect(accumulator.response().choice).toEqual([
+      AssistantContent.toolCall("tool_0", "ExecCommand", { command: "pwd" }),
+    ]);
+  });
+
   it("preserves valid scalar JSON tool arguments", () => {
     const accumulator = new CompletionStreamAccumulator();
 

--- a/packages/core/test/streaming.test.ts
+++ b/packages/core/test/streaming.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import { z } from "zod";
 import {
   AgentBuilder,
@@ -7,6 +7,8 @@ import {
   type AgentEventStore,
   type AgentRunErrorArgs,
   type AgentStreamEvent,
+  type AgentStreamEventWithoutToolCallDeltas,
+  type AgentStreamEventWithToolCallDeltas,
   AssistantContent,
   type CompletionRequest,
   type CompletionResponse,
@@ -102,6 +104,20 @@ const addTool = createTool({
 });
 
 describe("PromptRequest streaming", () => {
+  it("types tool call deltas by default and narrows explicit opt-out streams", () => {
+    const model = new StreamingQueueModel([]);
+    const agent = new AgentBuilder("test-agent", model).build();
+
+    expectTypeOf(agent.prompt("hi").stream()).toEqualTypeOf<AsyncIterable<AgentStreamEvent>>();
+    expectTypeOf(agent.prompt("hi").stream({ includeToolCallDeltas: false })).toEqualTypeOf<
+      AsyncIterable<AgentStreamEventWithoutToolCallDeltas>
+    >();
+    expectTypeOf(agent.prompt("hi").stream({ includeToolCallDeltas: true })).toEqualTypeOf<
+      AsyncIterable<AgentStreamEvent>
+    >();
+    expectTypeOf<AgentStreamEventWithToolCallDeltas>().toEqualTypeOf<AgentStreamEvent>();
+  });
+
   it("streams text deltas and final response", async () => {
     const model = new StreamingQueueModel([
       [
@@ -333,6 +349,41 @@ describe("PromptRequest streaming", () => {
     expect(events.some((event) => event.type === "error")).toBe(false);
     expect(events.at(-1)).toMatchObject({ type: "final", output: "ready" });
     expect(model.requests).toHaveLength(2);
+  });
+
+  it("serializes tool call deltas through PromptRequest readable streams by default", async () => {
+    const model = new StreamingQueueModel([
+      [
+        {
+          type: "tool_call_delta",
+          id: "call_1",
+          name: "add",
+          argumentsDelta: '{"x":2,"y":5}',
+          argumentsMode: "replace",
+        },
+      ],
+      [{ type: "text_delta", delta: "7" }],
+    ]);
+    const agent = new AgentBuilder("test-agent", model).tool(addTool).build();
+
+    const text = await readAll(agent.prompt("add").readableStream());
+    const events = text
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+
+    expect(events).toContainEqual({
+      type: "tool_call_delta",
+      turn: 1,
+      id: "call_1",
+      name: "add",
+      argumentsDelta: '{"x":2,"y":5}',
+      argumentsMode: "replace",
+    });
+    expect(events.findIndex((event) => event.type === "tool_call_delta")).toBeLessThan(
+      events.findIndex((event) => event.type === "tool_call"),
+    );
+    expect(events.at(-1)).toMatchObject({ type: "final", output: "7" });
   });
 
   it("does not retry after a provider delta has been observed", async () => {
@@ -751,6 +802,13 @@ describe("PromptRequest streaming", () => {
     const events = await collect(agent.prompt("add").stream());
 
     expect(events).toContainEqual({
+      type: "tool_call_delta",
+      turn: 1,
+      id: "call_1",
+      name: "add",
+      argumentsDelta: '{"x":2,"y":5}',
+    });
+    expect(events).toContainEqual({
       type: "tool_call",
       turn: 1,
       toolCall: AssistantContent.toolCall("call_1", "add", { x: 2, y: 5 }),
@@ -764,8 +822,108 @@ describe("PromptRequest streaming", () => {
         result: "7",
       }),
     );
+    expect(events.findIndex((event) => event.type === "tool_call_delta")).toBeLessThan(
+      events.findIndex((event) => event.type === "tool_call"),
+    );
     expect(events.at(-1)).toMatchObject({ type: "final", output: "7" });
     expect(model.requests).toHaveLength(2);
+  });
+
+  it("supports explicitly disabling tool call deltas", async () => {
+    const model = new StreamingQueueModel([
+      [
+        {
+          type: "tool_call_delta",
+          id: "call_1",
+          name: "add",
+          argumentsDelta: '{"x":2,"y":5}',
+        },
+      ],
+      [{ type: "text_delta", delta: "7" }],
+    ]);
+    const agent = new AgentBuilder("test-agent", model).tool(addTool).build();
+
+    const events = await collect(agent.prompt("add").stream({ includeToolCallDeltas: false }));
+
+    expect(events).not.toContainEqual(expect.objectContaining({ type: "tool_call_delta" }));
+    expect(events).toContainEqual({
+      type: "tool_call",
+      turn: 1,
+      toolCall: AssistantContent.toolCall("call_1", "add", { x: 2, y: 5 }),
+    });
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: "tool_result", toolName: "add", result: "7" }),
+    );
+    expect(events.at(-1)).toMatchObject({ type: "final", output: "7" });
+  });
+
+  it("emits tool call deltas by default before response middleware completes", async () => {
+    let providerFinished = false;
+    const firstTurn = (async function* (): AsyncIterable<CompletionStreamEvent> {
+      yield {
+        type: "tool_call_delta",
+        id: "tool_1",
+        callId: "call_1",
+        name: "add",
+        argumentsDelta: '{"x":2,"y":5}',
+        signature: "signed",
+      };
+      providerFinished = true;
+    })();
+    const middlewareStarted = deferred<void>();
+    const releaseMiddleware = deferred<void>();
+    const model = new StreamingQueueModel([firstTurn, [{ type: "text_delta", delta: "7" }]]);
+    const agent = new AgentBuilder("test-agent", model)
+      .tool(addTool)
+      .middleware(
+        createMiddleware({
+          async onCompletionResponse({ response }) {
+            middlewareStarted.resolve();
+            await releaseMiddleware.promise;
+            return { response };
+          },
+        }),
+      )
+      .build();
+    const iterator = agent.prompt("add").stream()[Symbol.asyncIterator]();
+
+    expect(await nextEvent(iterator)).toMatchObject({ type: "turn_start", turn: 1 });
+    expect(await nextEvent(iterator)).toEqual({
+      type: "tool_call_delta",
+      turn: 1,
+      id: "tool_1",
+      callId: "call_1",
+      name: "add",
+      argumentsDelta: '{"x":2,"y":5}',
+      signature: "signed",
+    });
+    expect(providerFinished).toBe(false);
+
+    const completedToolCall = iterator.next();
+    await middlewareStarted.promise;
+    let completedToolCallSettled = false;
+    void completedToolCall.then(() => {
+      completedToolCallSettled = true;
+    });
+    await Promise.resolve();
+    expect(completedToolCallSettled).toBe(false);
+
+    releaseMiddleware.resolve();
+    await expect(completedToolCall).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "tool_call",
+        turn: 1,
+        toolCall: AssistantContent.toolCall("tool_1", "add", { x: 2, y: 5 }, "call_1"),
+      },
+    });
+    expect(providerFinished).toBe(true);
+
+    const remaining = await collectIterator(iterator);
+    expect(remaining).toContainEqual(
+      expect.objectContaining({ type: "tool_result", toolName: "add", result: "7" }),
+    );
+    expect(remaining.at(-1)).toMatchObject({ type: "final", output: "7" });
   });
 
   it("streams transformed tool results from middleware", async () => {
@@ -1025,7 +1183,7 @@ describe("PromptRequest streaming", () => {
     expect(events.at(-1)).toMatchObject({ type: "final", output: "parent done" });
   });
 
-  it("streams child tool calls and child tool results from streaming agent tools", async () => {
+  it("suppresses child tool call deltas when the parent stream explicitly opts out", async () => {
     const parentModel = new StreamingQueueModel([
       [
         {
@@ -1038,8 +1196,10 @@ describe("PromptRequest streaming", () => {
     const childModel = new StreamingQueueModel([
       [
         {
-          type: "tool_call",
-          toolCall: AssistantContent.toolCall("call_add", "add", { x: 2, y: 5 }),
+          type: "tool_call_delta",
+          id: "call_add",
+          name: "add",
+          argumentsDelta: '{"x":2,"y":5}',
         },
       ],
       [{ type: "text_delta", delta: "7" }],
@@ -1052,9 +1212,12 @@ describe("PromptRequest streaming", () => {
       .tool(childAgent.asTool({ name: "ask_child", stream: true }))
       .build();
 
-    const events = await collect(parentAgent.prompt("delegate").stream());
+    const events = await collect(
+      parentAgent.prompt("delegate").stream({ includeToolCallDeltas: false }),
+    );
     const childEvents = events.filter((event) => event.type === "agent_tool_event");
 
+    expect(childEvents.map((event) => eventType(event.event))).not.toContain("tool_call_delta");
     expect(childEvents).toContainEqual(
       expect.objectContaining({
         type: "agent_tool_event",
@@ -1079,6 +1242,71 @@ describe("PromptRequest streaming", () => {
         type: "tool_result",
         toolName: "ask_child",
         result: "7",
+      }),
+    );
+  });
+
+  it("propagates tool call deltas through streaming agent tools by default", async () => {
+    const eventStore = new RecordingEventStore();
+    const parentModel = new StreamingQueueModel([
+      [
+        {
+          type: "tool_call",
+          toolCall: AssistantContent.toolCall("call_child", "ask_child", { prompt: "add" }),
+        },
+      ],
+      [{ type: "text_delta", delta: "parent done" }],
+    ]);
+    const childModel = new StreamingQueueModel([
+      [
+        {
+          type: "tool_call_delta",
+          id: "call_add",
+          name: "add",
+          argumentsDelta: '{"x":2,"y":5}',
+        },
+      ],
+      [{ type: "text_delta", delta: "7" }],
+    ]);
+    const childAgent = new AgentBuilder("child", childModel)
+      .tool(addTool)
+      .defaultMaxTurns(2)
+      .build();
+    const parentAgent = new AgentBuilder("parent", parentModel)
+      .tool(childAgent.asTool({ name: "ask_child", stream: true }))
+      .eventStore(eventStore)
+      .build();
+
+    const events = await collect(parentAgent.prompt("delegate").stream());
+    const childEvents = events.filter((event) => event.type === "agent_tool_event");
+
+    expect(childEvents).toContainEqual(
+      expect.objectContaining({
+        type: "agent_tool_event",
+        event: {
+          type: "tool_call_delta",
+          turn: 1,
+          id: "call_add",
+          name: "add",
+          argumentsDelta: '{"x":2,"y":5}',
+        },
+      }),
+    );
+    expect(childEvents).toContainEqual(
+      expect.objectContaining({
+        type: "agent_tool_event",
+        event: expect.objectContaining({
+          type: "tool_call",
+          toolCall: AssistantContent.toolCall("call_add", "add", { x: 2, y: 5 }),
+        }),
+      }),
+    );
+    expect(eventStore.appendCalls).toContainEqual(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          type: "agent_tool_event",
+          event: expect.objectContaining({ type: "tool_call_delta", id: "call_add" }),
+        }),
       }),
     );
   });

--- a/packages/provider-gemini/src/gemini/completion.ts
+++ b/packages/provider-gemini/src/gemini/completion.ts
@@ -10,6 +10,7 @@ import {
   type JsonValue,
   type Message as MessageType,
   type StreamingCompletionModel,
+  type ToolCallArgumentsMode,
   type ToolChoice,
   type ToolContent,
   type ToolDefinition,
@@ -467,6 +468,7 @@ export function fromGeminiGenerateContentStreamChunk(chunk: unknown): Completion
       toolCallDelta(call.id ?? call.name, {
         callId: call.id,
         argumentsDelta: JSON.stringify(call.args ?? {}),
+        argumentsMode: "replace",
       }),
     );
   }
@@ -653,6 +655,7 @@ function toolCallDelta(
     callId?: string | undefined;
     name?: string | undefined;
     argumentsDelta?: string | undefined;
+    argumentsMode?: ToolCallArgumentsMode | undefined;
     signature?: string | undefined;
   },
 ): CompletionStreamEvent {
@@ -660,6 +663,7 @@ function toolCallDelta(
   if (values.callId !== undefined) event.callId = values.callId;
   if (values.name !== undefined) event.name = values.name;
   if (values.argumentsDelta !== undefined) event.argumentsDelta = values.argumentsDelta;
+  if (values.argumentsMode !== undefined) event.argumentsMode = values.argumentsMode;
   if (values.signature !== undefined) event.signature = values.signature;
   return event;
 }

--- a/packages/provider-gemini/test/completion.test.ts
+++ b/packages/provider-gemini/test/completion.test.ts
@@ -305,6 +305,44 @@ describe("Gemini completion mapping", () => {
     ]);
   });
 
+  it("marks streamed Gemini tool arguments as replacement snapshots", () => {
+    expect(
+      fromGeminiGenerateContentStreamChunk({
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    id: "call-1",
+                    name: "write_file",
+                    args: { path: "README.md" },
+                  },
+                  thoughtSignature: "tool_sig",
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        type: "tool_call_delta",
+        id: "call-1",
+        callId: "call-1",
+        name: "write_file",
+        signature: "tool_sig",
+      },
+      {
+        type: "tool_call_delta",
+        id: "call-1",
+        callId: "call-1",
+        argumentsDelta: '{"path":"README.md"}',
+        argumentsMode: "replace",
+      },
+    ]);
+  });
+
   it("maps Gemini thought summaries and thought signatures", () => {
     expect(
       fromGeminiGenerateContentResponse({

--- a/packages/provider-grok/test/completion.test.ts
+++ b/packages/provider-grok/test/completion.test.ts
@@ -1,4 +1,8 @@
-import { type CompletionRequest, Message } from "@anvia/core/completion";
+import {
+  type CompletionRequest,
+  type CompletionStreamEvent,
+  Message,
+} from "@anvia/core/completion";
 import { describe, expect, it } from "vitest";
 import { GrokChatCompletionModel, GrokResponsesCompletionModel } from "../src/index";
 
@@ -49,6 +53,56 @@ describe("Grok completion models", () => {
         reasoning: { effort: "high" },
       },
     ]);
+  });
+
+  it("forwards Responses tool call deltas through the OpenAI-compatible adapter", async () => {
+    const model = new GrokResponsesCompletionModel(
+      {
+        responses: {
+          create: async () =>
+            streamFrom([
+              {
+                type: "response.output_item.added",
+                item: {
+                  type: "function_call",
+                  id: "tool_1",
+                  call_id: "call_1",
+                  name: "write_file",
+                  arguments: "",
+                },
+              },
+              {
+                type: "response.function_call_arguments.delta",
+                item_id: "tool_1",
+                delta: '{"path":',
+              },
+              {
+                type: "response.function_call_arguments.done",
+                item_id: "tool_1",
+                name: "write_file",
+                arguments: '{"path":"README.md"}',
+              },
+            ]),
+        },
+      } as never,
+      "grok-test",
+    );
+
+    const events = await collect(
+      model.streamCompletion({
+        chatHistory: [Message.user("write a file")],
+        documents: [],
+        tools: [],
+      }),
+    );
+
+    expect(events).toContainEqual({
+      type: "tool_call_delta",
+      id: "tool_1",
+      name: "write_file",
+      argumentsDelta: '{"path":"README.md"}',
+      argumentsMode: "replace",
+    });
   });
 
   it("summarizes Responses traces with Grok provider identity", () => {
@@ -128,4 +182,86 @@ describe("Grok completion models", () => {
       },
     ]);
   });
+
+  it("forwards Chat tool call deltas through the OpenAI-compatible adapter", async () => {
+    const model = new GrokChatCompletionModel(
+      {
+        chat: {
+          completions: {
+            create: async () =>
+              streamFrom([
+                {
+                  id: "chatcmpl_1",
+                  choices: [
+                    {
+                      index: 0,
+                      finish_reason: null,
+                      delta: {
+                        tool_calls: [
+                          {
+                            index: 0,
+                            id: "call_1",
+                            function: { name: "write_file", arguments: '{"path":' },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+                {
+                  id: "chatcmpl_1",
+                  choices: [
+                    {
+                      index: 0,
+                      finish_reason: "tool_calls",
+                      delta: {
+                        tool_calls: [{ index: 0, function: { arguments: '"README.md"}' } }],
+                      },
+                    },
+                  ],
+                },
+              ]),
+          },
+        },
+      } as never,
+      "grok-chat-test",
+    );
+
+    const events = await collect(
+      model.streamCompletion({
+        chatHistory: [Message.user("write a file")],
+        documents: [],
+        tools: [],
+      }),
+    );
+
+    expect(events.filter((event) => event.type === "tool_call_delta")).toEqual([
+      {
+        type: "tool_call_delta",
+        id: "tool_0",
+        callId: "call_1",
+        name: "write_file",
+        argumentsDelta: '{"path":',
+      },
+      {
+        type: "tool_call_delta",
+        id: "tool_0",
+        argumentsDelta: '"README.md"}',
+      },
+    ]);
+  });
 });
+
+async function* streamFrom(events: unknown[]): AsyncIterable<unknown> {
+  yield* events;
+}
+
+async function collect(
+  events: AsyncIterable<CompletionStreamEvent>,
+): Promise<CompletionStreamEvent[]> {
+  const result: CompletionStreamEvent[] = [];
+  for await (const event of events) {
+    result.push(event);
+  }
+  return result;
+}

--- a/packages/provider-openai/src/openai/responses.ts
+++ b/packages/provider-openai/src/openai/responses.ts
@@ -281,19 +281,22 @@ export function fromOpenAIStreamEvent(event: unknown): CompletionStreamEvent | u
     }
   }
 
-  if (
-    event.type === "response.function_call_arguments.delta" ||
-    event.type === "response.function_call_arguments.done"
-  ) {
+  if (event.type === "response.function_call_arguments.delta") {
     return toolCallDelta(
       stringFrom(event.item_id) ?? stringFrom(event.output_item_id) ?? crypto.randomUUID(),
       {
-        argumentsDelta:
-          typeof event.delta === "string"
-            ? event.delta
-            : typeof event.arguments === "string"
-              ? event.arguments
-              : undefined,
+        argumentsDelta: typeof event.delta === "string" ? event.delta : undefined,
+      },
+    );
+  }
+
+  if (event.type === "response.function_call_arguments.done") {
+    return toolCallDelta(
+      stringFrom(event.item_id) ?? stringFrom(event.output_item_id) ?? crypto.randomUUID(),
+      {
+        name: stringFrom(event.name),
+        argumentsDelta: typeof event.arguments === "string" ? event.arguments : undefined,
+        argumentsMode: "replace",
       },
     );
   }
@@ -604,12 +607,14 @@ function toolCallDelta(
     callId?: string | undefined;
     name?: string | undefined;
     argumentsDelta?: string | undefined;
+    argumentsMode?: "append" | "replace" | undefined;
   },
 ): CompletionStreamEvent {
   const event: CompletionStreamEvent = { type: "tool_call_delta", id };
   if (values.callId !== undefined) event.callId = values.callId;
   if (values.name !== undefined) event.name = values.name;
   if (values.argumentsDelta !== undefined) event.argumentsDelta = values.argumentsDelta;
+  if (values.argumentsMode !== undefined) event.argumentsMode = values.argumentsMode;
   return event;
 }
 

--- a/packages/provider-openai/test/openai-responses.test.ts
+++ b/packages/provider-openai/test/openai-responses.test.ts
@@ -417,6 +417,33 @@ describe("OpenAI Responses mapping", () => {
 
     expect(
       fromOpenAIStreamEvent({
+        type: "response.function_call_arguments.delta",
+        item_id: "tool_1",
+        delta: '{"query":',
+      }),
+    ).toEqual({
+      type: "tool_call_delta",
+      id: "tool_1",
+      argumentsDelta: '{"query":',
+    });
+
+    expect(
+      fromOpenAIStreamEvent({
+        type: "response.function_call_arguments.done",
+        item_id: "tool_1",
+        name: "lookup",
+        arguments: '{"query":"x"}',
+      }),
+    ).toEqual({
+      type: "tool_call_delta",
+      id: "tool_1",
+      name: "lookup",
+      argumentsDelta: '{"query":"x"}',
+      argumentsMode: "replace",
+    });
+
+    expect(
+      fromOpenAIStreamEvent({
         type: "response.output_item.done",
         item: {
           type: "function_call",

--- a/packages/react-ui/test/message.test.tsx
+++ b/packages/react-ui/test/message.test.tsx
@@ -241,6 +241,51 @@ describe("Message primitives", () => {
     expect(screen.getByText('Output: {"status":"blocked"}')).toBeTruthy();
   });
 
+  it("renders provisional tool call deltas as pending tool UI", () => {
+    const messages: UIMessage[] = [
+      {
+        id: "assistant_1",
+        role: "assistant",
+        parts: [
+          {
+            id: "tool_1",
+            type: "tool",
+            toolName: "write_file",
+            toolCallId: "call_1",
+            state: "input-streaming",
+            input: '{"path":',
+          },
+        ],
+      },
+    ];
+
+    const { container } = render(
+      <ChatProvider controller={createChatController({ messages, status: "streaming" })}>
+        <Thread.Root>
+          <Thread.Messages>
+            <Message.Root>
+              <Message.Parts>
+                <Message.Part>
+                  <Message.Tool renderWhen="pending">
+                    <Message.ToolName />
+                    <Message.ToolStatus />
+                    <Message.ToolInput />
+                  </Message.Tool>
+                </Message.Part>
+              </Message.Parts>
+            </Message.Root>
+          </Thread.Messages>
+        </Thread.Root>
+      </ChatProvider>,
+    );
+
+    const tool = container.querySelector("[data-anvia-tool]");
+    expect(tool?.getAttribute("data-state")).toBe("input-streaming");
+    expect(screen.getByText("write_file")).toBeTruthy();
+    expect(screen.getByText("Running")).toBeTruthy();
+    expect(screen.getByText('{"path":')).toBeTruthy();
+  });
+
   it("filters message parts and gates tool rendering by state", () => {
     const messages: UIMessage[] = [
       {

--- a/packages/react/src/ui-messages.ts
+++ b/packages/react/src/ui-messages.ts
@@ -12,6 +12,12 @@ import type { SendMessageInput } from "./types";
 
 type UIToolMessagePart = Extract<UIMessagePart, { type: "tool" }>;
 
+type AssistantToolPartUpdateOptions = {
+  aliases?: Array<string | undefined>;
+  inputMatch?: JsonValue;
+  replaceInput?: boolean;
+};
+
 export function createUserMessage(input: SendMessageInput): UIMessage | undefined {
   if (isUIMessage(input)) {
     return input;
@@ -148,7 +154,9 @@ export function applyAnviaStreamEvent(
     if (typeof event.callId === "string") part.callId = event.callId;
     if (turn !== undefined) part.turn = turn;
     if (typeof event.argumentsDelta === "string") part.input = event.argumentsDelta;
-    return updateAssistantToolPart(messages, part);
+    return updateAssistantToolPart(messages, part, {
+      replaceInput: event.argumentsMode === "replace",
+    });
   }
 
   if (event.type === "tool_call" && isToolCall(event.toolCall)) {
@@ -188,12 +196,12 @@ export function applyAnviaStreamEvent(
     };
     if (providerCallId !== undefined) part.callId = providerCallId;
     if (turn !== undefined) part.turn = turn;
-    return updateAssistantToolPart(
-      messages,
-      part,
-      [providerCallId, internalCallId],
-      parseJsonValue(event.args),
-    );
+    const updateOptions: AssistantToolPartUpdateOptions = {
+      aliases: [providerCallId, internalCallId],
+    };
+    const inputMatch = parseJsonValue(event.args);
+    if (inputMatch !== undefined) updateOptions.inputMatch = inputMatch;
+    return updateAssistantToolPart(messages, part, updateOptions);
   }
 
   if (event.type === "message_id" && typeof event.id === "string") {
@@ -358,6 +366,7 @@ function updateMessagePart(
   messages: UIMessage[],
   messageId: string,
   part: UIMessagePart,
+  options: { replaceToolInput?: boolean } = {},
 ): UIMessage[] {
   const existingMessage = messages.find((message) => message.id === messageId);
   const current =
@@ -383,7 +392,7 @@ function updateMessagePart(
     ) {
       parts[partIndex] = { ...currentPart, text: `${currentPart.text}${part.text}` };
     } else if (currentPart?.type === "tool" && part.type === "tool") {
-      parts[partIndex] = mergeToolPart(currentPart, part);
+      parts[partIndex] = mergeToolPart(currentPart, part, options);
     } else {
       parts[partIndex] = part;
     }
@@ -394,8 +403,7 @@ function updateMessagePart(
 function updateAssistantToolPart(
   messages: UIMessage[],
   part: UIToolMessagePart,
-  aliases: Array<string | undefined> = [],
-  inputMatch?: JsonValue,
+  options: AssistantToolPartUpdateOptions = {},
 ): UIMessage[] {
   const current = ensureAssistantMessage(messages);
   const assistant = current[current.length - 1];
@@ -403,7 +411,12 @@ function updateAssistantToolPart(
     return current;
   }
 
-  const existingPart = findMatchingToolPart(assistant, part, aliases, inputMatch);
+  const existingPart = findMatchingToolPart(
+    assistant,
+    part,
+    options.aliases ?? [],
+    options.inputMatch,
+  );
   let nextPart = part;
   if (existingPart !== undefined) {
     nextPart = {
@@ -415,7 +428,9 @@ function updateAssistantToolPart(
     if (callId !== undefined) nextPart.callId = callId;
   }
 
-  return updateMessagePart(current, assistant.id, nextPart);
+  return options.replaceInput === true
+    ? updateMessagePart(current, assistant.id, nextPart, { replaceToolInput: true })
+    : updateMessagePart(current, assistant.id, nextPart);
 }
 
 function findMatchingToolPart(
@@ -457,6 +472,7 @@ function findMatchingToolPart(
 function mergeToolPart(
   currentPart: UIToolMessagePart,
   nextPart: UIToolMessagePart,
+  options: { replaceToolInput?: boolean } = {},
 ): UIToolMessagePart {
   const merged: UIToolMessagePart = { ...currentPart, ...nextPart };
 
@@ -468,7 +484,11 @@ function mergeToolPart(
   }
   if (nextPart.input === undefined && currentPart.input !== undefined) {
     merged.input = currentPart.input;
-  } else if (typeof currentPart.input === "string" && typeof nextPart.input === "string") {
+  } else if (
+    options.replaceToolInput !== true &&
+    typeof currentPart.input === "string" &&
+    typeof nextPart.input === "string"
+  ) {
     merged.input = `${currentPart.input}${nextPart.input}`;
   }
   if (nextPart.output === undefined && currentPart.output !== undefined) {

--- a/packages/react/test/transport.test.ts
+++ b/packages/react/test/transport.test.ts
@@ -809,9 +809,52 @@ describe("@anvia/react useChat", () => {
     ]);
   });
 
+  it("replaces streamed tool input when a provider sends a completed snapshot", async () => {
+    const transport: EventTransport<UIStreamRequest, CompletionStreamEvent> = {
+      send: async function* () {
+        yield {
+          type: "tool_call_delta",
+          id: "tool_1",
+          name: "lookup",
+          argumentsDelta: '{"query":',
+        };
+        yield {
+          type: "tool_call_delta",
+          id: "tool_1",
+          name: "lookup",
+          argumentsDelta: '{"query":"Anvia"}',
+          argumentsMode: "replace",
+        };
+      },
+    };
+    const { result } = renderHook(() => useChat({ transport }));
+
+    await act(async () => {
+      await result.current.send("lookup");
+    });
+
+    expect(result.current.messages[1]?.parts).toEqual([
+      expect.objectContaining({
+        type: "tool",
+        toolName: "lookup",
+        toolCallId: "tool_1",
+        state: "input-streaming",
+        input: '{"query":"Anvia"}',
+      }),
+    ]);
+  });
+
   it("applies raw agent stream events", async () => {
     const transport: EventTransport<UIStreamRequest, AgentStreamEvent> = {
       send: async function* () {
+        yield {
+          type: "tool_call_delta",
+          turn: 1,
+          id: "fc_1",
+          callId: "call_1",
+          name: "add",
+          argumentsDelta: '{"x":2,"y":5}',
+        };
         yield {
           type: "tool_call",
           turn: 1,
@@ -844,6 +887,14 @@ describe("@anvia/react useChat", () => {
     });
 
     expect(result.current.text).toBe("7");
+    expect(result.current.events[0]).toEqual({
+      type: "tool_call_delta",
+      turn: 1,
+      id: "fc_1",
+      callId: "call_1",
+      name: "add",
+      argumentsDelta: '{"x":2,"y":5}',
+    });
     expect(result.current.messages).toMatchObject([
       { role: "user", parts: [{ type: "text", text: "add" }] },
       {


### PR DESCRIPTION
## Summary

- emit normalized `tool_call_delta` events by default from agent streams, with an explicit legacy opt-out
- propagate deltas through nested agents and event storage, and normalize append-versus-replace provider arguments
- update React handling, provider coverage, React UI tests, docs, cookbook example, and package changesets

## Why

Agent tool calls previously became visible only after their arguments were fully accumulated, delaying application feedback. Publishing provider deltas lets apps show status such as “Preparing write tool…” immediately while completed tool calls remain authoritative for execution.

## Compatibility

This intentionally adds `tool_call_delta` to the default `AgentStreamEvent` contract. Consumers that need the legacy event union can call `stream({ includeToolCallDeltas: false })`. Consumers that ignore unknown events require no changes.

## Validation

- `pnpm check`
- `pnpm --filter ./packages/** typecheck`
- `pnpm --filter ./packages/** test`
- `pnpm --filter @anvia/core build`
- `pnpm --filter ./packages/** --filter !@anvia/core build`
- `pnpm --filter www reference-check`
- `pnpm --filter www build`

The eight Docker-gated sandbox integration tests remained skipped as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool-call argument deltas are now emitted by default during streaming, enabling responsive “preparing tool” states.
  * Added support for incremental and replacement argument snapshots across providers and React interfaces.
  * Tool-call delta settings now propagate through streaming agent tools, with an opt-out for legacy integrations.

* **Bug Fixes**
  * Corrected streamed tool arguments so replacement snapshots overwrite partial input instead of being concatenated.

* **Documentation**
  * Added event handling guidance, compatibility details, and updated streaming API references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->