### PR TITLE
fix(mistral): harden tool-call argument and id handling

### DIFF
--- a/.changeset/misty-mistral-tool-calls.md
+++ b/.changeset/misty-mistral-tool-calls.md
@@ -1,0 +1,8 @@
+---
+"@anvia/mistral": patch
+---
+
+Fix Mistral tool-call handling: malformed tool-call JSON arguments now throw instead of being
+silently coerced to a raw string, tool calls missing an id get a deterministic response-derived id
+instead of a random UUID, tool result messages map the function name into the Mistral `name` field,
+and `additionalParams` can no longer override the request `model` or `messages`.

--- a/packages/provider-mistral/src/mistral/completion.ts
+++ b/packages/provider-mistral/src/mistral/completion.ts
@@ -19,7 +19,7 @@ import {
 } from "@anvia/core/completion";
 import type { Mistral } from "@mistralai/mistralai";
 import { orderedRequestMessages } from "../request-messages";
-import { isPlainObject, numberFrom, parseJsonValue, schemaName, stringFrom } from "../utils";
+import { isPlainObject, numberFrom, parseToolArguments, schemaName, stringFrom } from "../utils";
 import type { MistralCompletionModelName } from "./models";
 
 type MistralChatParams = Record<string, unknown>;
@@ -112,7 +112,11 @@ export function toMistralChatParams(
   }
 
   if (request.additionalParams !== undefined && isPlainObject(request.additionalParams)) {
-    Object.assign(params, request.additionalParams);
+    const additionalParams = { ...request.additionalParams };
+    // Model and messages define the request identity; keep them aligned with traceRequest.
+    delete additionalParams.model;
+    delete additionalParams.messages;
+    Object.assign(params, additionalParams);
   }
 
   return params;
@@ -177,11 +181,11 @@ export function fromMistralChatResponse(response: unknown): CompletionResponse {
   }
 
   const toolCalls = toolCallsFrom(message);
-  for (const toolCall of toolCalls) {
+  for (const [index, toolCall] of toolCalls.entries()) {
     const fn = isPlainObject(toolCall.function) ? toolCall.function : {};
-    const id = stringFrom(toolCall.id) ?? crypto.randomUUID();
+    const id = stringFrom(toolCall.id) ?? deterministicToolCallId(raw.id, index);
     const name = stringFrom(fn.name) ?? "";
-    const args = parseToolArguments(fn.arguments);
+    const args = parseToolArgumentsValue(id, fn.arguments);
     choice.push(AssistantContent.toolCall(id, name, args));
   }
 
@@ -322,7 +326,7 @@ function toolContentToMistralMessage(content: ToolContent): MistralChatMessage {
   return {
     role: "tool",
     toolCallId: content.callId ?? content.id,
-    name: content.id,
+    name: content.toolName ?? content.id,
     content: content.content
       .map((item) =>
         item.type === "text" ? item.text : `[image:${item.mediaType ?? "image/png"}]`,
@@ -408,11 +412,16 @@ function stringContent(content: unknown): string | undefined {
   return undefined;
 }
 
-function parseToolArguments(args: unknown): JsonValue {
+function parseToolArgumentsValue(toolCallId: string, args: unknown): JsonValue {
   if (typeof args === "string") {
-    return parseJsonValue(args);
+    return parseToolArguments(toolCallId, args);
   }
   return toJsonValue(args);
+}
+
+function deterministicToolCallId(responseId: unknown, index: number): string {
+  const prefix = typeof responseId === "string" && responseId.length > 0 ? responseId : "mistral";
+  return `${prefix}-tool-${index.toString()}`;
 }
 
 function toJsonValue(value: unknown): JsonValue {

--- a/packages/provider-mistral/src/utils.ts
+++ b/packages/provider-mistral/src/utils.ts
@@ -12,11 +12,16 @@ export function stringFrom(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
-export function parseJsonValue(text: string): JsonValue {
+export function parseToolArguments(toolCallId: string, text: string): JsonValue {
+  if (text.trim().length === 0) {
+    return {};
+  }
   try {
     return JSON.parse(text) as JsonValue;
   } catch {
-    return text;
+    throw new Error(
+      `Mistral returned tool call "${toolCallId}" with malformed JSON arguments; this indicates invalid provider output.`,
+    );
   }
 }
 

--- a/packages/provider-mistral/test/completion.test.ts
+++ b/packages/provider-mistral/test/completion.test.ts
@@ -114,7 +114,7 @@ describe("Mistral completion mapping", () => {
           metadata: { composer: { entities: [] } },
         }),
         Message.assistant([AssistantContent.toolCall("call_1", "lookup_order", { id: "A1" })]),
-        Message.tool(ToolContent.toolResult("call_1", "shipped")),
+        Message.tool(ToolContent.toolResult("call_1", "shipped", { toolName: "lookup_order" })),
       ],
       documents: [{ id: "policy", text: "Refunds take 5 days." }],
       tools: [
@@ -153,7 +153,7 @@ describe("Mistral completion mapping", () => {
         {
           role: "tool",
           toolCallId: "call_1",
-          name: "call_1",
+          name: "lookup_order",
           content: "shipped",
         },
       ],
@@ -194,6 +194,80 @@ describe("Mistral completion mapping", () => {
       type: "function",
       function: { name: "lookup" },
     });
+  });
+
+  it("does not allow additional params to override model or messages", () => {
+    const params = toMistralChatParams("mistral-large-latest", {
+      chatHistory: [Message.user("hi")],
+      documents: [],
+      tools: [],
+      additionalParams: {
+        model: "unsafe-model",
+        messages: [{ role: "user", content: "injected" }],
+        topP: 0.9,
+      },
+    });
+
+    expect(params).toEqual({
+      model: "mistral-large-latest",
+      messages: [{ role: "user", content: "hi" }],
+      topP: 0.9,
+    });
+  });
+
+  it("falls back to the tool call id for the tool message name when no tool name is set", () => {
+    expect(
+      mistralMessageHelpers.messageToMistralMessages(
+        Message.tool(ToolContent.toolResult("call_1", "shipped")),
+      ),
+    ).toEqual([
+      {
+        role: "tool",
+        toolCallId: "call_1",
+        name: "call_1",
+        content: "shipped",
+      },
+    ]);
+  });
+
+  it("throws on malformed tool call arguments instead of coercing them", () => {
+    expect(() =>
+      fromMistralChatResponse({
+        choices: [
+          {
+            message: {
+              toolCalls: [
+                {
+                  id: "call_1",
+                  function: { name: "lookup_order", arguments: '{"id":' },
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    ).toThrow('Mistral returned tool call "call_1" with malformed JSON arguments');
+  });
+
+  it("derives deterministic ids for tool calls missing an id", () => {
+    const response = fromMistralChatResponse({
+      id: "cmpl_9",
+      choices: [
+        {
+          message: {
+            toolCalls: [
+              { function: { name: "first", arguments: "{}" } },
+              { function: { name: "second", arguments: "{}" } },
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(response.choice).toEqual([
+      AssistantContent.toolCall("cmpl_9-tool-0", "first", {}),
+      AssistantContent.toolCall("cmpl_9-tool-1", "second", {}),
+    ]);
   });
 
   it("exposes helper conversion for assistant tool-use history", () => {


### PR DESCRIPTION
## Summary

Deep-review fixes for the Mistral provider adapter's tool-call handling:

- **Malformed tool-call JSON now throws** instead of being silently coerced to a raw string. Previously a truncated/invalid `arguments` payload would reach tool dispatch as a string; now it fails fast with the tool-call id, matching core's stream accumulator and the OpenAI adapter.
- **Deterministic fallback ids** for tool calls missing an `id`: derived from the response id and position (`cmpl_9-tool-0`) instead of `crypto.randomUUID()`, keeping traces and snapshot tests reproducible.
- **Tool result messages now map `ToolContent.toolName`** into the Mistral `name` field instead of the internal tool-call id. Mistral expects the function name there (matching the assistant `toolCalls[].function.name`).
- **`additionalParams` can no longer override `model` or `messages`**, keeping the executed request coherent with `traceRequest` output — mirroring the protection the OCR adapter already had.

## Test plan

- [x] `pnpm --filter @anvia/mistral typecheck`
- [x] `pnpm --filter @anvia/mistral test` — 32/32 passing (4 new tests: malformed-JSON throw, deterministic ids, tool-name fallback, additionalParams protection)
- [x] `npx biome check packages/provider-mistral` — clean
- [x] `pnpm --filter @anvia/mistral build`

Changeset included (`@anvia/mistral` patch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid tool-call arguments now produce a clear error instead of being treated as plain text.
  * Tool calls without IDs now receive stable, response-derived IDs.
  * Tool result messages now correctly preserve the tool function name.
  * Request overrides can no longer replace the selected model or generated messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->