### PR TITLE
Add Vertex authentication support

### DIFF
--- a/.changeset/bright-vertex-clients.md
+++ b/.changeset/bright-vertex-clients.md
@@ -1,0 +1,7 @@
+---
+"@anvia/anthropic": minor
+"@anvia/gemini": minor
+---
+
+Add first-class Google Vertex authentication options for Gemini and a dedicated Anthropic Vertex
+client with Application Default Credentials and custom Google authentication support.

--- a/apps/www/scripts/generate-models-dev-snapshot.mjs
+++ b/apps/www/scripts/generate-models-dev-snapshot.mjs
@@ -199,6 +199,25 @@ function anviaUsageMarkdown(provider) {
   const modelId = provider.models[0]?.id ?? "provider/model";
   const envName = provider.env?.[0] ?? "PROVIDER_API_KEY";
 
+  if (provider.id === "google-vertex-anthropic") {
+    return [
+      "## Anvia Usage",
+      "",
+      "This provider maps to `AnthropicVertexClient` in the Anvia Anthropic provider. Use the [Anthropic provider](/docs/providers/anthropic#vertex-ai) guide for authentication and production setup.",
+      "",
+      "```ts",
+      'import { AnthropicVertexClient } from "@anvia/anthropic";',
+      "",
+      "const client = new AnthropicVertexClient({",
+      "  projectId: process.env.GOOGLE_VERTEX_PROJECT,",
+      '  region: process.env.GOOGLE_VERTEX_LOCATION ?? "global",',
+      "});",
+      "",
+      `const model = client.completionModel(${JSON.stringify(modelId)});`,
+      "```",
+    ].join("\n");
+  }
+
   if (provider.category === "openai-compatible" && provider.api !== undefined) {
     return [
       "## Anvia Usage",
@@ -338,6 +357,9 @@ function anviaSdkLabel(provider) {
   if (provider.id === "anthropic") {
     return "@anvia/anthropic";
   }
+  if (provider.id === "google-vertex-anthropic") {
+    return "@anvia/anthropic";
+  }
   if (provider.id === "google" || provider.id === "google-vertex") {
     return "@anvia/gemini";
   }
@@ -351,6 +373,7 @@ function anviaSdkLabel(provider) {
 function compatibilityLabel(provider) {
   if (provider.id === "openai") return "First-party OpenAI endpoint";
   if (provider.id === "anthropic") return "First-party Anthropic endpoint";
+  if (provider.id === "google-vertex-anthropic") return "Anthropic on Vertex AI";
   if (provider.id === "google") return "Gemini API provider";
   if (provider.id === "google-vertex") return "Vertex AI provider";
   if (provider.id === "mistral") return "First-party Mistral endpoint";

--- a/apps/www/src/content/docs/packages/anthropic/getting-started.md
+++ b/apps/www/src/content/docs/packages/anthropic/getting-started.md
@@ -16,6 +16,10 @@ pnpm add @anvia/anthropic @anvia/core
 
 Set `ANTHROPIC_API_KEY` in the server environment. Keep provider keys on the server side; browser clients should call an application route that owns the model request.
 
+For Vertex AI, use `AnthropicVertexClient` with Google Application Default Credentials. Set
+`GOOGLE_APPLICATION_CREDENTIALS`, `ANTHROPIC_VERTEX_PROJECT_ID`, and `CLOUD_ML_REGION`, or pass the
+official Vertex SDK authentication options explicitly.
+
 ## Minimum setup
 
 ```ts
@@ -35,6 +39,22 @@ const agent = new AgentBuilder("assistant", model)
 const response = await agent.prompt("Summarize this ticket.").send();
 console.log(response.output);
 ```
+
+## Vertex AI setup
+
+```ts
+import { AnthropicVertexClient } from "@anvia/anthropic";
+
+const client = new AnthropicVertexClient({
+  projectId: process.env.ANTHROPIC_VERTEX_PROJECT_ID,
+  region: process.env.CLOUD_ML_REGION ?? "global",
+});
+
+const model = client.completionModel("claude-sonnet-5");
+```
+
+`AnthropicVertexClient` supports completions and streaming, but not model listing because Vertex AI
+does not expose Anthropic's Models API.
 
 ## Next step
 

--- a/apps/www/src/content/docs/packages/anthropic/overview.md
+++ b/apps/www/src/content/docs/packages/anthropic/overview.md
@@ -21,7 +21,9 @@ The package owns mapping Anvia completion requests, tools, multimodal content, a
 
 ## Public surface
 
-The main documented exports are `AnthropicClient`, `AnthropicCompletionModel`, `Helper Namespaces`. The reference page lists the package entrypoint and public symbols that are checked by the docs reference coverage script.
+The main documented exports are `AnthropicClient`, `AnthropicVertexClient`,
+`AnthropicCompletionModel`, and the helper namespace. The reference page lists the package
+entrypoint and public symbols that are checked by the docs reference coverage script.
 
 ## Next pages
 

--- a/apps/www/src/content/docs/packages/anthropic/reference.md
+++ b/apps/www/src/content/docs/packages/anthropic/reference.md
@@ -32,6 +32,33 @@ Return behavior: `completionModel(...)` returns a streaming Anvia completion mod
 
 Notable errors: constructor throws when neither `client` nor `apiKey` is supplied; `listModels()` rejects with `ModelListingError` when the provider request fails.
 
+## AnthropicVertexClient
+
+```ts
+type AnthropicVertexClientOptions = AnthropicVertexSdkOptions & {
+  client?: AnthropicVertex;
+};
+
+class AnthropicVertexClient {
+  readonly client: AnthropicVertex;
+  constructor(options?: AnthropicVertexClientOptions);
+  completionModel(model?: AnthropicCompletionModelName): AnthropicCompletionModel;
+}
+```
+
+Purpose: factory for Claude completion models through Google Vertex AI.
+
+Configuration behavior: accepts the official SDK's `projectId`, `region`, `googleAuth`,
+`authClient`, `accessToken`, and transport options. The SDK can resolve project, region, and Google
+Application Default Credentials from the environment.
+
+Return behavior: `completionModel(...)` returns the shared streaming Anthropic completion adapter
+and defaults to `claude-sonnet-5`.
+
+Notable errors: construction fails when no region is passed and `CLOUD_ML_REGION` is unset.
+Credential and provider failures are surfaced by the official Vertex SDK. Model listing is not
+available on this client.
+
 ## Model Name Types
 
 ```ts
@@ -46,7 +73,10 @@ Purpose: typed model identifiers for autocomplete while preserving support for c
 
 ```ts
 class AnthropicCompletionModel implements StreamingCompletionModel {
-  constructor(client: Anthropic, defaultModel?: AnthropicCompletionModelName);
+  constructor(
+    client: Anthropic | AnthropicVertex,
+    defaultModel?: AnthropicCompletionModelName,
+  );
   completion(request: CompletionRequest): Promise<CompletionResponse>;
   streamCompletion(request: CompletionRequest): AsyncIterable<CompletionStreamEvent>;
 }
@@ -63,6 +93,7 @@ Notable errors: rejects or yields SDK/provider errors.
 ```ts
 namespace anthropic {
   AnthropicClient;
+  AnthropicVertexClient;
   AnthropicCompletionModel;
 }
 ```

--- a/apps/www/src/content/docs/packages/gemini/getting-started.md
+++ b/apps/www/src/content/docs/packages/gemini/getting-started.md
@@ -16,6 +16,8 @@ pnpm add @anvia/gemini @anvia/core
 
 Set `GEMINI_API_KEY` in the server environment. Keep provider keys on the server side; browser clients should call an application route that owns the model request.
 For Vertex AI, construct `GeminiClient` with `vertexai: true`, `project`, and `location` instead of an API key.
+Vertex mode uses Google Application Default Credentials. Set `GOOGLE_APPLICATION_CREDENTIALS` for a
+service-account JSON file, or pass trusted credentials through `googleAuthOptions`.
 
 ## Minimum setup
 
@@ -35,6 +37,19 @@ const agent = new AgentBuilder("assistant", model)
 
 const response = await agent.prompt("Summarize this ticket.").send();
 console.log(response.output);
+```
+
+## Vertex AI setup
+
+```ts
+const client = new GeminiClient({
+  vertexai: true,
+  project: process.env.GOOGLE_CLOUD_PROJECT,
+  location: "us-central1",
+  googleAuthOptions: {
+    credentials: serviceAccountJson,
+  },
+});
 ```
 
 

--- a/apps/www/src/content/docs/packages/gemini/reference.md
+++ b/apps/www/src/content/docs/packages/gemini/reference.md
@@ -14,7 +14,13 @@ Import from `@anvia/gemini`.
 ```ts
 type GeminiClientOptions =
   | { apiKey?: string; vertexai?: false; client?: GoogleGenAI }
-  | { vertexai: true; project?: string; location?: string; client?: GoogleGenAI };
+  | {
+      vertexai: true;
+      project?: string;
+      location?: string;
+      googleAuthOptions?: GoogleGenAIOptions["googleAuthOptions"];
+      client?: GoogleGenAI;
+    };
 
 class GeminiClient {
   readonly client: GoogleGenAI;
@@ -34,6 +40,10 @@ class GeminiClient {
 Purpose: factory for Gemini API or Vertex AI-backed completion, embedding, image generation, transcription, and model listing.
 
 Return behavior: creates or uses a `GoogleGenAI` client, then returns Gemini completion and embedding models. `listModels()` fetches the Gemini model list and returns a normalized `ModelList`.
+
+Authentication behavior: Vertex mode forwards `googleAuthOptions` to the Google SDK, supporting
+trusted credential objects, preconfigured auth clients, and other `GoogleAuthOptions`. When omitted,
+the SDK uses Google Application Default Credentials.
 
 Notable errors: underlying SDK calls can fail for missing credentials, invalid project/location, or API errors; `listModels()` rejects with `ModelListingError` when the provider request fails.
 

--- a/apps/www/src/content/docs/providers/anthropic.md
+++ b/apps/www/src/content/docs/providers/anthropic.md
@@ -1,13 +1,13 @@
 ---
 title: Anthropic provider
-description: Use @anvia/anthropic for Claude completion models.
+description: Use @anvia/anthropic for Claude through Anthropic or Google Vertex AI.
 section: providers
 sidebar:
   group: Provider guides
   order: 20
 ---
 
-`@anvia/anthropic` adapts Anthropic's SDK to Anvia completion and model-listing contracts. Use it when agents, extractors, or pipelines should run on Claude models through Anthropic.
+`@anvia/anthropic` adapts Anthropic's direct and Vertex AI SDKs to Anvia completion contracts. Use it when agents, extractors, or pipelines should run on Claude through Anthropic or Google Vertex AI.
 
 ## Install
 
@@ -28,6 +28,38 @@ export const anthropic = new AnthropicClient({
 `AnthropicClient` accepts `apiKey`, `baseUrl`, or an already-created Anthropic SDK `client`.
 
 Use [Anthropic-Compatible](/docs/providers/anthropic-compatible) when you want to target a non-Anthropic endpoint through the Anvia Anthropic adapter.
+
+## Vertex AI
+
+Use `AnthropicVertexClient` for Claude on Google Vertex AI:
+
+```ts
+import { AnthropicVertexClient } from "@anvia/anthropic";
+
+const vertexAnthropic = new AnthropicVertexClient({
+  projectId: process.env.ANTHROPIC_VERTEX_PROJECT_ID,
+  region: process.env.CLOUD_ML_REGION ?? "global",
+});
+
+const model = vertexAnthropic.completionModel("claude-sonnet-5");
+```
+
+The client follows Google Application Default Credentials. For a service-account JSON file, set
+`GOOGLE_APPLICATION_CREDENTIALS` in the server environment:
+
+```sh
+export GOOGLE_APPLICATION_CREDENTIALS="/absolute/path/service-account.json"
+export ANTHROPIC_VERTEX_PROJECT_ID="my-gcp-project"
+export CLOUD_ML_REGION="global"
+```
+
+`AnthropicVertexClientOptions` also accepts the official SDK's `googleAuth`, `authClient`,
+`accessToken`, and transport options. Use a preconfigured `GoogleAuth` or `AuthClient` when the
+application needs explicit credentials or service-account impersonation. Validate externally
+supplied credential configuration before using it, and never commit credential JSON.
+
+Vertex AI does not expose Anthropic's Models API, so `AnthropicVertexClient` intentionally has no
+`listModels()` method.
 
 ## Completion Models
 
@@ -64,8 +96,9 @@ The adapter preserves structured thinking and reasoning content in assistant his
 const models = await anthropic.listModels();
 ```
 
-Listing returns normalized model inventory when the upstream API supports it. Use it for admin visibility, not capability proof.
+Listing returns normalized model inventory from the direct Anthropic API. Use it for admin visibility, not capability proof.
 
 ## Exports
 
-The root package exports `AnthropicClient`, `AnthropicCompletionModel`, `AnthropicClientOptions`, and the `anthropic` namespace.
+The root package exports `AnthropicClient`, `AnthropicVertexClient`, `AnthropicCompletionModel`,
+their option and model-name types, and the `anthropic` namespace.

--- a/apps/www/src/content/docs/providers/gateway/google-vertex-anthropic.md
+++ b/apps/www/src/content/docs/providers/gateway/google-vertex-anthropic.md
@@ -12,8 +12,8 @@ sidebar:
 
 | Field | Value |
 | --- | --- |
-| Anvia SDK | No dedicated package |
-| Compatibility | Anthropic-compatible metadata |
+| Anvia SDK | @anvia/anthropic |
+| Compatibility | Anthropic on Vertex AI |
 | API URL | Not listed in models.dev |
 | Environment | `GOOGLE_APPLICATION_CREDENTIALS`, `GOOGLE_VERTEX_LOCATION`, `GOOGLE_VERTEX_PROJECT` |
 | Provider docs | [https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude) |
@@ -21,7 +21,18 @@ sidebar:
 
 ## Anvia Usage
 
-Anvia does not currently ship a dedicated provider package for this endpoint. Use the connection details here for evaluation, then build a custom integration against `@anvia/core` completion contracts if you need to run it today.
+This provider maps to `AnthropicVertexClient` in the Anvia Anthropic provider. Use the [Anthropic provider](/docs/providers/anthropic#vertex-ai) guide for authentication and production setup.
+
+```ts
+import { AnthropicVertexClient } from "@anvia/anthropic";
+
+const client = new AnthropicVertexClient({
+  projectId: process.env.GOOGLE_VERTEX_PROJECT,
+  region: process.env.GOOGLE_VERTEX_LOCATION ?? "global",
+});
+
+const model = client.completionModel("claude-3-5-haiku@20241022");
+```
 
 ## Capabilities
 
@@ -53,4 +64,3 @@ Anvia does not currently ship a dedicated provider package for this endpoint. Us
 | `claude-sonnet-4@20250514`<br />Claude Sonnet 4 | claude-sonnet | image, pdf, text | text | tools, reasoning, temperature | context: 200000 / output: 64000 | input: 3 / output: 15 / cache_read: 0.3 / cache_write: 3.75 | 2025-05-22 |
 
 Read [Gateway caveats](/docs/providers/gateway-caveats) before enabling this provider in production.
-

--- a/apps/www/src/content/docs/providers/gemini.md
+++ b/apps/www/src/content/docs/providers/gemini.md
@@ -37,6 +37,32 @@ const vertexGemini = new GeminiClient({
 
 `GeminiClient` requires either `apiKey` for Gemini API mode or `vertexai: true` with `project` and `location` for Vertex AI mode. You can also pass an already-created `GoogleGenAI` `client`.
 
+### Vertex authentication
+
+Vertex mode uses Google Application Default Credentials. Point ADC at a service-account JSON file
+with `GOOGLE_APPLICATION_CREDENTIALS`:
+
+```sh
+export GOOGLE_APPLICATION_CREDENTIALS="/absolute/path/service-account.json"
+```
+
+For trusted credential objects or a preconfigured auth client, pass the Google SDK's
+`googleAuthOptions`:
+
+```ts
+const vertexGemini = new GeminiClient({
+  vertexai: true,
+  project: process.env.GOOGLE_CLOUD_PROJECT,
+  location: "us-central1",
+  googleAuthOptions: {
+    credentials: serviceAccountJson,
+  },
+});
+```
+
+Validate externally supplied credential configuration before using it, and never commit credential
+JSON or service-account keys.
+
 ## Completion Models
 
 ```ts

--- a/apps/www/src/content/docs/providers/overview.md
+++ b/apps/www/src/content/docs/providers/overview.md
@@ -14,7 +14,7 @@ The current provider packages are:
 | Package | Main client | Primary use |
 | --- | --- | --- |
 | `@anvia/openai` | `OpenAIClient` | OpenAI completions, embeddings, image generation, audio generation, transcription, and model listing |
-| `@anvia/anthropic` | `AnthropicClient` | Claude completions through Anthropic |
+| `@anvia/anthropic` | `AnthropicClient`, `AnthropicVertexClient` | Claude completions through Anthropic or Google Vertex AI |
 | `@anvia/gemini` | `GeminiClient` | Gemini API and Vertex AI completions, embeddings, image generation, transcription, and model listing |
 | `@anvia/mistral` | `MistralClient` | Mistral completions, embeddings, OCR, and model listing |
 | `@anvia/grok` | `GrokClient` | xAI Grok completions, image generation, and model listing |

--- a/packages/provider-anthropic/README.md
+++ b/packages/provider-anthropic/README.md
@@ -52,9 +52,62 @@ const client = new AnthropicClient({
 const model = client.completionModel("provider/model-name");
 ```
 
+## Vertex AI
+
+Use Anthropic's official Vertex SDK through `AnthropicVertexClient`:
+
+```ts
+import { AnthropicVertexClient } from "@anvia/anthropic";
+
+const client = new AnthropicVertexClient({
+  projectId: "my-gcp-project",
+  region: "global",
+});
+
+const model = client.completionModel("claude-sonnet-5");
+```
+
+The client follows the standard Google authentication flow. It reads
+`ANTHROPIC_VERTEX_PROJECT_ID` and `CLOUD_ML_REGION` when project and region are omitted, and supports
+Application Default Credentials such as `GOOGLE_APPLICATION_CREDENTIALS`:
+
+```sh
+export ANTHROPIC_VERTEX_PROJECT_ID="my-gcp-project"
+export CLOUD_ML_REGION="global"
+export GOOGLE_APPLICATION_CREDENTIALS="/absolute/path/service-account.json"
+```
+
+For custom authentication, pass the official SDK's `googleAuth`, `authClient`, or `accessToken`
+options:
+
+```sh
+pnpm add google-auth-library
+```
+
+```ts
+import { GoogleAuth } from "google-auth-library";
+
+const client = new AnthropicVertexClient({
+  projectId: "my-gcp-project",
+  region: "global",
+  googleAuth: new GoogleAuth({
+    credentials: serviceAccountJson,
+    scopes: "https://www.googleapis.com/auth/cloud-platform",
+  }),
+});
+```
+
+You can also pass a preconfigured `authClient`, including impersonated credentials. Validate
+externally supplied credential configurations before using them, and never commit credential JSON
+or service-account keys.
+
+Vertex AI does not expose Anthropic's Models API, so `AnthropicVertexClient` intentionally does not
+provide `listModels()`.
+
 ## Exports
 
 - `AnthropicClient`
+- `AnthropicVertexClient`
 - `AnthropicCompletionModel`
 - `anthropic`
 

--- a/packages/provider-anthropic/package.json
+++ b/packages/provider-anthropic/package.json
@@ -33,7 +33,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.112.4"
+    "@anthropic-ai/sdk": "^0.112.4",
+    "@anthropic-ai/vertex-sdk": "^0.19.0"
   },
   "devDependencies": {
     "@anvia/core": "workspace:*",

--- a/packages/provider-anthropic/src/anthropic/completion.ts
+++ b/packages/provider-anthropic/src/anthropic/completion.ts
@@ -1,4 +1,5 @@
 import type { Anthropic } from "@anthropic-ai/sdk";
+import type { AnthropicVertex } from "@anthropic-ai/vertex-sdk";
 import {
   AssistantContent,
   type AssistantContent as AssistantContentType,
@@ -46,7 +47,7 @@ export class AnthropicCompletionModel
   };
 
   constructor(
-    private readonly client: Anthropic,
+    private readonly client: Anthropic | AnthropicVertex,
     readonly defaultModel: AnthropicCompletionModelName = "claude-sonnet-4-20250514",
   ) {}
 

--- a/packages/provider-anthropic/src/anthropic/index.ts
+++ b/packages/provider-anthropic/src/anthropic/index.ts
@@ -4,3 +4,7 @@ export type {
   AnthropicCompletionModelName,
   KnownAnthropicCompletionModelName,
 } from "./models";
+export {
+  AnthropicVertexClient,
+  type AnthropicVertexClientOptions,
+} from "./vertex-client";

--- a/packages/provider-anthropic/src/anthropic/models.ts
+++ b/packages/provider-anthropic/src/anthropic/models.ts
@@ -23,6 +23,7 @@ export type KnownAnthropicCompletionModelName =
   | "claude-sonnet-4-20250514"
   | "claude-sonnet-4-5"
   | "claude-sonnet-4-5-20250929"
-  | "claude-sonnet-4-6";
+  | "claude-sonnet-4-6"
+  | "claude-sonnet-5";
 
 export type AnthropicCompletionModelName = ModelId<KnownAnthropicCompletionModelName>;

--- a/packages/provider-anthropic/src/anthropic/vertex-client.ts
+++ b/packages/provider-anthropic/src/anthropic/vertex-client.ts
@@ -1,0 +1,25 @@
+import {
+  AnthropicVertex,
+  type ClientOptions as AnthropicVertexSdkOptions,
+} from "@anthropic-ai/vertex-sdk";
+import { AnthropicCompletionModel } from "./completion";
+import type { AnthropicCompletionModelName } from "./models";
+
+export type AnthropicVertexClientOptions = AnthropicVertexSdkOptions & {
+  client?: AnthropicVertex | undefined;
+};
+
+export class AnthropicVertexClient {
+  readonly client: AnthropicVertex;
+
+  constructor(options: AnthropicVertexClientOptions = {}) {
+    const { client, ...clientOptions } = options;
+    this.client = client ?? new AnthropicVertex(clientOptions);
+  }
+
+  completionModel(
+    model: AnthropicCompletionModelName = "claude-sonnet-5",
+  ): AnthropicCompletionModel {
+    return new AnthropicCompletionModel(this.client, model);
+  }
+}

--- a/packages/provider-anthropic/src/index.ts
+++ b/packages/provider-anthropic/src/index.ts
@@ -4,5 +4,7 @@ export {
   type AnthropicClientOptions,
   AnthropicCompletionModel,
   type AnthropicCompletionModelName,
+  AnthropicVertexClient,
+  type AnthropicVertexClientOptions,
   type KnownAnthropicCompletionModelName,
 } from "./anthropic/index";

--- a/packages/provider-anthropic/test/client.test.ts
+++ b/packages/provider-anthropic/test/client.test.ts
@@ -1,12 +1,17 @@
 import { Message } from "@anvia/core/completion";
-import { describe, expect, expectTypeOf, it } from "vitest";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import {
   AnthropicClient,
   AnthropicCompletionModel,
   type AnthropicCompletionModelName,
+  AnthropicVertexClient,
 } from "../src/index";
 
 describe("Anthropic client", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("types known Anthropic models while accepting custom model strings", () => {
     const anthropic = new AnthropicClient({
       client: { messages: { create: async () => ({}) } } as never,
@@ -50,6 +55,89 @@ describe("Anthropic client", () => {
         max_tokens: 1024,
         messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
       },
+    ]);
+  });
+
+  it("creates an Anthropic Vertex client with explicit routing and authentication", () => {
+    const anthropic = new AnthropicVertexClient({
+      projectId: "project",
+      region: "global",
+      authClient: {} as never,
+    });
+
+    expect(anthropic.client.projectId).toBe("project");
+    expect(anthropic.client.region).toBe("global");
+    expect(anthropic.completionModel().defaultModel).toBe("claude-sonnet-5");
+    anthropic.completionModel("claude-sonnet-4-5@20250929");
+  });
+
+  it("allows the Anthropic Vertex SDK to resolve project and region from the environment", () => {
+    vi.stubEnv("ANTHROPIC_VERTEX_PROJECT_ID", "environment-project");
+    vi.stubEnv("CLOUD_ML_REGION", "us");
+
+    const anthropic = new AnthropicVertexClient({
+      authClient: {} as never,
+    });
+
+    expect(anthropic.client.projectId).toBe("environment-project");
+    expect(anthropic.client.region).toBe("us");
+  });
+
+  it("uses an injected Anthropic Vertex Messages client for completions and streams", async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const anthropic = new AnthropicVertexClient({
+      client: {
+        messages: {
+          create: async (params: Record<string, unknown>) => {
+            calls.push(params);
+            if (params.stream === true) {
+              return asyncIterable([
+                { type: "message_start", message: { id: "msg_stream" } },
+                {
+                  type: "content_block_delta",
+                  index: 0,
+                  delta: { type: "text_delta", text: "streamed" },
+                },
+                {
+                  type: "message_stop",
+                  message: {
+                    id: "msg_stream",
+                    content: [{ type: "text", text: "streamed" }],
+                  },
+                },
+              ]);
+            }
+            return {
+              id: "msg_completion",
+              content: [{ type: "text", text: "completed" }],
+              usage: {},
+            };
+          },
+        },
+      } as never,
+    });
+    const model = anthropic.completionModel();
+    const request = {
+      chatHistory: [Message.user("hello")],
+      documents: [],
+      tools: [],
+    };
+
+    await expect(model.completion(request)).resolves.toMatchObject({
+      messageId: "msg_completion",
+    });
+    const events = [];
+    for await (const event of model.streamCompletion(request)) {
+      events.push(event);
+    }
+
+    expect(events.at(-1)).toMatchObject({
+      type: "final",
+      response: { messageId: "msg_stream" },
+    });
+    expect(calls).toEqual([
+      expect.objectContaining({ model: "claude-sonnet-5" }),
+      expect.objectContaining({ model: "claude-sonnet-5", stream: true }),
     ]);
   });
 

--- a/packages/provider-gemini/README.md
+++ b/packages/provider-gemini/README.md
@@ -53,6 +53,29 @@ const client = new GeminiClient({
 const model = client.completionModel("gemini-2.5-flash");
 ```
 
+The Google SDK uses Application Default Credentials. For a service-account JSON file, set
+`GOOGLE_APPLICATION_CREDENTIALS` before starting the application:
+
+```sh
+export GOOGLE_APPLICATION_CREDENTIALS="/absolute/path/service-account.json"
+```
+
+Trusted credential objects can also be passed explicitly:
+
+```ts
+const client = new GeminiClient({
+  vertexai: true,
+  project: "my-gcp-project",
+  location: "us-central1",
+  googleAuthOptions: {
+    credentials: serviceAccountJson,
+  },
+});
+```
+
+Validate externally supplied credential configurations before using them. Never commit credential
+JSON or service-account keys.
+
 ## Embeddings
 
 ```ts

--- a/packages/provider-gemini/src/gemini/client.ts
+++ b/packages/provider-gemini/src/gemini/client.ts
@@ -3,7 +3,7 @@ import {
   type ModelListingClient,
   ModelListingError,
 } from "@anvia/core/model-listing";
-import { GoogleGenAI } from "@google/genai";
+import { GoogleGenAI, type GoogleGenAIOptions } from "@google/genai";
 import { GeminiCompletionModel } from "./completion";
 import { GeminiEmbeddingModel, type GeminiEmbeddingModelOptions } from "./embedding";
 import {
@@ -31,6 +31,7 @@ type VertexClientOptions = {
   vertexai: true;
   project?: string | undefined;
   location?: string | undefined;
+  googleAuthOptions?: GoogleGenAIOptions["googleAuthOptions"];
   apiKey?: never;
 };
 
@@ -87,12 +88,15 @@ export class GeminiClient implements ModelListingClient {
   }
 }
 
-export function toGoogleGenAIOptions(options: GeminiClientOptions): Record<string, unknown> {
+export function toGoogleGenAIOptions(options: GeminiClientOptions): GoogleGenAIOptions {
   if (options.vertexai === true) {
     return {
       vertexai: true,
       project: requireOption(options.project, "project", "Vertex Gemini"),
       location: requireOption(options.location, "location", "Vertex Gemini"),
+      ...(options.googleAuthOptions === undefined
+        ? {}
+        : { googleAuthOptions: options.googleAuthOptions }),
     };
   }
 

--- a/packages/provider-gemini/test/client.test.ts
+++ b/packages/provider-gemini/test/client.test.ts
@@ -47,6 +47,27 @@ describe("GeminiClient", () => {
     });
   });
 
+  it("forwards explicit Google authentication options to Vertex AI", () => {
+    const credentials = {
+      client_email: "service-account@example.iam.gserviceaccount.com",
+      private_key: "private-key",
+    };
+
+    expect(
+      toGoogleGenAIOptions({
+        vertexai: true,
+        project: "project",
+        location: "us-central1",
+        googleAuthOptions: { credentials },
+      }),
+    ).toEqual({
+      vertexai: true,
+      project: "project",
+      location: "us-central1",
+      googleAuthOptions: { credentials },
+    });
+  });
+
   it("validates explicit Gemini and Vertex credentials", () => {
     expect(() => new GeminiClient()).toThrow("Missing Gemini apiKey");
     expect(() => new GeminiClient({ vertexai: true, project: "project" })).toThrow(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -551,6 +551,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.112.4
         version: 0.112.4(zod@4.4.3)
+      '@anthropic-ai/vertex-sdk':
+        specifier: ^0.19.0
+        version: 0.19.0(zod@4.4.3)
     devDependencies:
       '@anvia/core':
         specifier: workspace:*
@@ -1127,6 +1130,9 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  '@anthropic-ai/vertex-sdk@0.19.0':
+    resolution: {integrity: sha512-Ja5NkDAmdCcvCJCvkY/6uJ+9krOiXFN56dzb+8n5apElHrYpUMlOCHCVRuLLsJCVWTsN8w60sgN9RSXZ+LPqNA==}
 
   '@anush008/tokenizers-darwin-universal@0.0.0':
     resolution: {integrity: sha512-SACpWEooTjFX89dFKRVUhivMxxcZRtA3nJGVepdLyrwTkQ1TZQ8581B5JoXp0TcTMHfgnDaagifvVoBiFEdNCQ==}
@@ -8238,6 +8244,14 @@ snapshots:
       standardwebhooks: 1.0.0
     optionalDependencies:
       zod: 4.4.3
+
+  '@anthropic-ai/vertex-sdk@0.19.0(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.112.4(zod@4.4.3)
+      google-auth-library: 10.6.2
+    transitivePeerDependencies:
+      - supports-color
+      - zod
 
   '@anush008/tokenizers-darwin-universal@0.0.0':
     optional: true


### PR DESCRIPTION
## Summary

- forward Google authentication options from `GeminiClient` to Vertex AI
- add `AnthropicVertexClient` using the official Anthropic Vertex SDK, ADC, and custom Google auth
- document both Vertex flows across package READMEs, provider guides, package references, and generated gateway docs

## Why

Gemini Vertex mode previously relied only on implicit credentials, while the Anthropic adapter had no first-class path for Claude on Vertex AI. This adds explicit credential support and a dedicated Vertex client without changing direct Anthropic behavior.

## Validation

- `pnpm --filter @anvia/gemini typecheck`
- `pnpm --filter @anvia/gemini test` (29 tests)
- `pnpm --filter @anvia/gemini build`
- `pnpm --filter @anvia/anthropic typecheck`
- `pnpm --filter @anvia/anthropic test` (30 tests)
- `pnpm --filter @anvia/anthropic build`
- `pnpm --filter www reference-check`
- `pnpm --filter www build` (521 pages, 518 indexed)
- `pnpm check`
- `pnpm install --frozen-lockfile`
- rendered Anthropic and Gemini provider guides visually verified at desktop width

## Notes

The workspace audit still reports pre-existing advisories in unrelated dependency paths; none involve the new Anthropic Vertex or Google authentication dependency path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Vertex AI support for Anthropic through a dedicated client.
  * Added configurable Google authentication for Gemini Vertex mode.
  * Added support for the `claude-sonnet-5` model.
  * Anthropic Vertex completions and streaming are supported.

* **Documentation**
  * Added setup, authentication, usage, and export documentation for Vertex AI integrations.
  * Clarified credential configuration and model-listing limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->