### PR TITLE
Complete Langfuse tracing coverage

### DIFF
--- a/.changeset/trace-complete-langfuse.md
+++ b/.changeset/trace-complete-langfuse.md
@@ -1,0 +1,14 @@
+---
+"@anvia/core": minor
+"@anvia/langfuse": minor
+"@anvia/openai": patch
+"@anvia/anthropic": patch
+"@anvia/gemini": patch
+"@anvia/mistral": patch
+"@anvia/grok": patch
+---
+
+Trace complete model inputs and nested agent generations in Langfuse with safe and full capture
+modes, consistent redaction, native prompt and time-to-first-token attributes, and reliable score
+queue flushing. Normalize provider token totals and expose mutually exclusive usage detail buckets
+for accurate cache- and reasoning-aware cost inference.

--- a/apps/www/src/content/docs/packages/core/reference/completion.md
+++ b/apps/www/src/content/docs/packages/core/reference/completion.md
@@ -241,6 +241,15 @@ definitions in `tools` and provider-executed definitions in `providerTools`.
 
 Notable errors: providers can reject unsupported tool choice modes.
 
+## UsageDetails
+
+```ts
+type UsageDetails = Record<string, number>;
+```
+
+Purpose: represent mutually exclusive provider pricing buckets. The `total` key is the only
+aggregate and equals the sum of every other bucket.
+
 ## Usage
 
 ```ts
@@ -250,6 +259,7 @@ type Usage = {
   totalTokens: number;
   cachedInputTokens: number;
   cacheCreationInputTokens: number;
+  details?: UsageDetails;
 };
 
 const Usage: {
@@ -258,9 +268,12 @@ const Usage: {
 };
 ```
 
-Purpose: normalized token accounting.
+Purpose: normalized token accounting. Top-level input and output counts are inclusive totals.
+`details`, when present, contains mutually exclusive provider pricing buckets; `total` is its only
+aggregate key.
 
-Return behavior: `empty()` returns zeroed usage; `add(...)` sums matching fields.
+Return behavior: `empty()` returns zeroed usage. `add(...)` sums matching fields and keeps
+`details` only when the resulting breakdown remains complete.
 
 Notable errors: none directly.
 

--- a/apps/www/src/content/docs/packages/core/reference/observability.md
+++ b/apps/www/src/content/docs/packages/core/reference/observability.md
@@ -26,6 +26,7 @@ type AgentTraceOptions = {
   version?: string;
   traceId?: string;
   failOnObserverError?: boolean;
+  promptRef?: AgentRunPromptRef;
 };
 ```
 
@@ -94,7 +95,18 @@ Notable errors: observer errors are ignored unless `failOnObserverError` is enab
 ## Generation and Tool Observer Types
 
 ```ts
-type AgentGenerationStartArgs = { turn: number; request: CompletionRequest };
+type AgentGenerationModelInfo = {
+  provider: string;
+  defaultModel: string;
+  capabilities?: CompletionModelCapabilities;
+};
+
+type AgentGenerationStartArgs = {
+  turn: number;
+  request: CompletionRequest;
+  providerRequest?: JsonObject;
+  modelInfo?: AgentGenerationModelInfo;
+};
 type AgentGenerationEndArgs<RawResponse = unknown> = {
   turn: number;
   response: CompletionResponse<RawResponse>;

--- a/apps/www/src/content/docs/packages/core/reference/request.md
+++ b/apps/www/src/content/docs/packages/core/reference/request.md
@@ -121,6 +121,7 @@ type AgentToolCallDeltaEvent = {
 
 type AgentStreamEvent =
   | { type: "turn_start"; turn: number; prompt: Message; history: Message[] }
+  | { type: "generation_start"; turn: number; request: CompletionRequest; modelInfo: AgentGenerationModelInfo }
   | { type: "text_delta"; turn: number; delta: string }
   | { type: "reasoning_delta"; turn: number; delta: string; id?: string; contentType?: "text" | "summary" | "encrypted" | "redacted"; signature?: string }
   | AgentToolCallDeltaEvent
@@ -129,7 +130,7 @@ type AgentStreamEvent =
   | { type: "provider_tool_call"; turn: number; toolCall: ProviderToolCall }
   | { type: "tool_result"; turn: number; toolName: string; toolCallId?: string; internalCallId: string; args: string; result: string }
   | { type: "agent_tool_event"; turn: number; toolName: string; toolCallId?: string; internalCallId: string; agentId: string; agentName?: string; event: AgentChildStreamEvent }
-  | { type: "turn_end"; turn: number; response: CompletionResponse }
+  | { type: "turn_end"; turn: number; response: CompletionResponse; firstDeltaMs?: number }
   | { type: "final"; runId: string; output: string; usage: Usage; messages: Message[]; trace?: AgentTraceInfo; sources?: CompletionSource[]; providerToolCalls?: ProviderToolCall[] }
   | AgentErrorStreamEvent;
 
@@ -149,6 +150,10 @@ type AgentStreamEventWithToolCallDeltas = AgentStreamEvent;
 Purpose: streaming event union for observing agent execution.
 
 Return behavior: emitted by `PromptRequest.stream()` and `readableStream()`. `agent_tool_event` appears when a child agent is exposed with `asTool({ stream: true })`.
+
+`generation_start` is emitted after request middleware has produced the provider-facing normalized
+request. It exposes model context needed by nested observers but does not include the provider-native
+request summary. `turn_end.firstDeltaMs` carries time to first generation delta when available.
 
 Tool-call deltas are provisional events emitted by default. They are emitted immediately, including
 through streaming child agents, and may precede completion-response middleware. Missing

--- a/apps/www/src/content/docs/packages/langfuse/reference.md
+++ b/apps/www/src/content/docs/packages/langfuse/reference.md
@@ -9,6 +9,16 @@ sidebar:
 ---
 Import from `@anvia/langfuse`.
 
+## LangfuseCaptureMode
+
+```ts
+type LangfuseCaptureMode = "safe" | "full";
+```
+
+Purpose: choose between bounded model input plus request summaries (`"safe"`) and richer request
+capture including documents, tools, schemas, additional parameters, and provider-native requests
+(`"full"`).
+
 ## LangfuseTracingOptions
 
 ```ts
@@ -23,13 +33,17 @@ type LangfuseTracingOptions = {
   scoreBatchSize?: number;
   scoreFlushIntervalMs?: number;
   scoreMaxRetries?: number;
+  captureMode?: "safe" | "full";
+  captureMaxBytes?: number;
   redactInputs?: LangfuseRedactionMode;
   redactOutputs?: LangfuseRedactionMode;
   redaction?: LangfuseRedactionOptions;
 };
 ```
 
-Purpose: configure Langfuse tracing, scoring, batching, and redaction.
+Purpose: configure Langfuse tracing, scoring, request capture, and redaction. `captureMode` defaults
+to `"safe"` and `captureMaxBytes` defaults to 262,144 bytes per captured value, with a minimum of
+96 bytes.
 
 Return behavior: consumed by `langfuse.create(...)`.
 

--- a/packages/core/src/completion/types.ts
+++ b/packages/core/src/completion/types.ts
@@ -477,12 +477,21 @@ export type ProviderToolCall = {
   details?: JsonObject;
 };
 
+/**
+ * Provider-normalized, mutually exclusive usage buckets.
+ *
+ * Every token should appear in exactly one non-total bucket. `total` is the
+ * only aggregate key and should equal the sum of the other buckets.
+ */
+export type UsageDetails = Record<string, number>;
+
 export type Usage = {
   inputTokens: number;
   outputTokens: number;
   totalTokens: number;
   cachedInputTokens: number;
   cacheCreationInputTokens: number;
+  details?: UsageDetails;
 };
 
 export type AssistantGenerationMetadata = {
@@ -504,15 +513,47 @@ export const Usage = {
     };
   },
   add(left: Usage, right: Usage): Usage {
-    return {
+    const result: Usage = {
       inputTokens: left.inputTokens + right.inputTokens,
       outputTokens: left.outputTokens + right.outputTokens,
       totalTokens: left.totalTokens + right.totalTokens,
       cachedInputTokens: left.cachedInputTokens + right.cachedInputTokens,
       cacheCreationInputTokens: left.cacheCreationInputTokens + right.cacheCreationInputTokens,
     };
+    const details = addUsageDetails(left, right);
+    if (details !== undefined) {
+      result.details = details;
+    }
+    return result;
   },
 };
+
+function addUsageDetails(left: Usage, right: Usage): UsageDetails | undefined {
+  if (isEmptyUsage(left) && left.details === undefined) {
+    return right.details === undefined ? undefined : { ...right.details };
+  }
+  if (isEmptyUsage(right) && right.details === undefined) {
+    return left.details === undefined ? undefined : { ...left.details };
+  }
+  if (left.details === undefined || right.details === undefined) {
+    return undefined;
+  }
+  const details: UsageDetails = { ...left.details };
+  for (const [key, value] of Object.entries(right.details)) {
+    details[key] = (details[key] ?? 0) + value;
+  }
+  return details;
+}
+
+function isEmptyUsage(usage: Usage): boolean {
+  return (
+    usage.inputTokens === 0 &&
+    usage.outputTokens === 0 &&
+    usage.totalTokens === 0 &&
+    usage.cachedInputTokens === 0 &&
+    usage.cacheCreationInputTokens === 0
+  );
+}
 
 export function getAssistantGenerationMetadata(
   message: Message,
@@ -536,7 +577,12 @@ export function getAssistantGenerationMetadata(
   const metadata: AssistantGenerationMetadata = {
     provider: generation.provider,
     model: generation.model,
-    usage: { ...generation.usage },
+    usage: {
+      ...generation.usage,
+      ...(generation.usage.details === undefined
+        ? {}
+        : { details: { ...generation.usage.details } }),
+    },
   };
   if (isCompletionSourceArray(generation.sources)) {
     metadata.sources = generation.sources.map((source) => ({ ...source }));
@@ -563,12 +609,23 @@ function isUsageValue(value: JsonValue | undefined): value is JsonObject & Usage
     isNonnegativeFiniteNumber(value.outputTokens) &&
     isNonnegativeFiniteNumber(value.totalTokens) &&
     isNonnegativeFiniteNumber(value.cachedInputTokens) &&
-    isNonnegativeFiniteNumber(value.cacheCreationInputTokens)
+    isNonnegativeFiniteNumber(value.cacheCreationInputTokens) &&
+    isUsageDetailsValue(value.details)
   );
 }
 
 function isNonnegativeFiniteNumber(value: JsonValue | undefined): value is number {
   return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function isUsageDetailsValue(value: JsonValue | undefined): value is JsonObject | undefined {
+  return (
+    value === undefined ||
+    (isJsonObjectValue(value) &&
+      Object.values(value).every(
+        (detail) => detail !== undefined && isNonnegativeFiniteNumber(detail),
+      ))
+  );
 }
 
 function isCompletionSourceArray(value: JsonValue | undefined): value is CompletionSource[] {

--- a/packages/core/src/completion/types.ts
+++ b/packages/core/src/completion/types.ts
@@ -619,13 +619,25 @@ function isNonnegativeFiniteNumber(value: JsonValue | undefined): value is numbe
 }
 
 function isUsageDetailsValue(value: JsonValue | undefined): value is JsonObject | undefined {
-  return (
-    value === undefined ||
-    (isJsonObjectValue(value) &&
-      Object.values(value).every(
-        (detail) => detail !== undefined && isNonnegativeFiniteNumber(detail),
-      ))
-  );
+  if (value === undefined) {
+    return true;
+  }
+  if (!isJsonObjectValue(value)) {
+    return false;
+  }
+  let total: number | undefined;
+  let bucketSum = 0;
+  for (const [key, detail] of Object.entries(value)) {
+    if (detail === undefined || !isNonnegativeFiniteNumber(detail)) {
+      return false;
+    }
+    if (key === "total") {
+      total = detail;
+    } else {
+      bucketSum += detail;
+    }
+  }
+  return total !== undefined && total === bucketSum;
 }
 
 function isCompletionSourceArray(value: JsonValue | undefined): value is CompletionSource[] {

--- a/packages/core/src/observability/index.ts
+++ b/packages/core/src/observability/index.ts
@@ -1,6 +1,7 @@
 export type {
   AgentGenerationEndArgs,
   AgentGenerationErrorArgs,
+  AgentGenerationModelInfo,
   AgentGenerationObserver,
   AgentGenerationStartArgs,
   AgentGenerationUpdateArgs,

--- a/packages/core/src/observability/types.ts
+++ b/packages/core/src/observability/types.ts
@@ -29,6 +29,7 @@ export type AgentTraceOptions = {
   version?: string | undefined;
   traceId?: string | undefined;
   failOnObserverError?: boolean | undefined;
+  promptRef?: AgentRunPromptRef | undefined;
 };
 
 export type AgentRunPromptRef = {
@@ -61,15 +62,17 @@ export type AgentRunErrorArgs = {
   messages: Message[];
 };
 
+export type AgentGenerationModelInfo = {
+  provider: string;
+  defaultModel: string;
+  capabilities?: CompletionModelCapabilities | undefined;
+};
+
 export type AgentGenerationStartArgs = {
   turn: number;
   request: CompletionRequest;
   providerRequest?: JsonObject | undefined;
-  modelInfo?: {
-    provider: string;
-    defaultModel: string;
-    capabilities?: CompletionModelCapabilities | undefined;
-  };
+  modelInfo?: AgentGenerationModelInfo | undefined;
 };
 
 export type AgentGenerationEndArgs<RawResponse = unknown> = {

--- a/packages/core/src/request/prompt-request.ts
+++ b/packages/core/src/request/prompt-request.ts
@@ -52,6 +52,7 @@ import type { MemoryContext } from "../memory/types";
 import { type ActiveAgentRunObservers, startAgentRunObservers } from "../observability/group";
 import type {
   AgentGenerationEndArgs,
+  AgentGenerationModelInfo,
   AgentGenerationStartArgs,
   AgentTraceOptions,
 } from "../observability/types";
@@ -467,9 +468,18 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
 
         assertCompletionRequestSupported(this.agent.model, request, { streaming: true });
         const providerRequest = this.providerTraceRequest(request, { stream: true });
-        const generationObservers = await runObservers.startGeneration(
-          this.generationStartArgs(currentTurns, request, providerRequest),
+        const generationStartArgs = this.generationStartArgs(
+          currentTurns,
+          request,
+          providerRequest,
         );
+        const generationObservers = await runObservers.startGeneration(generationStartArgs);
+        yield await emit({
+          type: "generation_start",
+          turn: currentTurns,
+          request,
+          modelInfo: generationStartArgs.modelInfo,
+        });
         const accumulator = new CompletionStreamAccumulator();
         const generationStartedAt = Date.now();
         let firstDeltaMs: number | undefined;
@@ -561,7 +571,12 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
                 yield await emit(event);
               }
             }
-            yield await emit({ type: "turn_end", turn: currentTurns, response });
+            yield await emit({
+              type: "turn_end",
+              turn: currentTurns,
+              response,
+              firstDeltaMs,
+            });
             emittedTurnEnd = true;
           }
           if (this.steeringMessages.length > 0) {
@@ -608,7 +623,12 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
             }
           }
           if (!emittedTurnEnd) {
-            yield await emit({ type: "turn_end", turn: currentTurns, response });
+            yield await emit({
+              type: "turn_end",
+              turn: currentTurns,
+              response,
+              firstDeltaMs,
+            });
           }
 
           const result: PromptResponse = {
@@ -659,7 +679,12 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
           [assistantMessage],
           pendingTurnMessages,
         );
-        yield await emit({ type: "turn_end", turn: currentTurns, response });
+        yield await emit({
+          type: "turn_end",
+          turn: currentTurns,
+          response,
+          firstDeltaMs,
+        });
 
         const toolResultEvents = createAsyncQueue<ToolExecutionEventPayload>();
         const toolResultsPromise = this.executeToolCalls(
@@ -798,8 +823,8 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
     turn: number,
     request: ReturnType<CompletionRequestBuilder["build"]>,
     providerRequest: JsonObject | undefined,
-  ): AgentGenerationStartArgs {
-    const args: AgentGenerationStartArgs = {
+  ): AgentGenerationStartArgs & { modelInfo: AgentGenerationModelInfo } {
+    const args: AgentGenerationStartArgs & { modelInfo: AgentGenerationModelInfo } = {
       turn,
       request,
       modelInfo: {
@@ -958,6 +983,7 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
         agentDescription: this.agent.description,
         instructions: this.agent.instructions,
         trace: this.traceOptions,
+        promptRef: this.traceOptions?.promptRef,
         prompt: this.promptMessage,
         history: this.chatHistory,
         maxTurns: this.maxTurnCount,

--- a/packages/core/src/request/prompt-request.ts
+++ b/packages/core/src/request/prompt-request.ts
@@ -474,6 +474,7 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
           providerRequest,
         );
         const generationObservers = await runObservers.startGeneration(generationStartArgs);
+        const generationStartedAt = Date.now();
         yield await emit({
           type: "generation_start",
           turn: currentTurns,
@@ -481,7 +482,6 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
           modelInfo: generationStartArgs.modelInfo,
         });
         const accumulator = new CompletionStreamAccumulator();
-        const generationStartedAt = Date.now();
         let firstDeltaMs: number | undefined;
         const bufferResponseEvents = this.shouldBufferStreamResponseEvents();
         const emittedToolCallIds = new Set<string>();

--- a/packages/core/src/request/types.ts
+++ b/packages/core/src/request/types.ts
@@ -1,4 +1,5 @@
 import type {
+  CompletionRequest,
   CompletionResponse,
   CompletionSource,
   Message as MessageType,
@@ -10,7 +11,7 @@ import type {
   Usage,
 } from "../completion/index";
 import type { GuardrailDecisionRecord } from "../guardrails";
-import type { AgentTraceInfo } from "../observability/types";
+import type { AgentGenerationModelInfo, AgentTraceInfo } from "../observability/types";
 
 export type PromptResponse = {
   output: string;
@@ -65,6 +66,12 @@ type AgentChildStreamEventBase<RawResponse = unknown> =
       history: MessageType[];
     }
   | {
+      type: "generation_start";
+      turn: number;
+      request: CompletionRequest;
+      modelInfo: AgentGenerationModelInfo;
+    }
+  | {
       type: "text_delta";
       turn: number;
       delta: string;
@@ -106,6 +113,7 @@ type AgentChildStreamEventBase<RawResponse = unknown> =
       type: "turn_end";
       turn: number;
       response: CompletionResponse<RawResponse>;
+      firstDeltaMs?: number | undefined;
     }
   | {
       type: "guardrail_decision";

--- a/packages/core/test/message-content.test.ts
+++ b/packages/core/test/message-content.test.ts
@@ -271,6 +271,44 @@ describe("message attachment content", () => {
     ).toBeUndefined();
   });
 
+  it("rejects incomplete or inconsistent generation usage details", () => {
+    const messageWithDetails = (details: Record<string, number>) =>
+      Message.assistant("assistant", {
+        metadata: {
+          anvia: {
+            generation: {
+              provider: "test",
+              model: "test-model",
+              usage: {
+                inputTokens: 7,
+                outputTokens: 2,
+                totalTokens: 9,
+                cachedInputTokens: 1,
+                cacheCreationInputTokens: 0,
+                details,
+              },
+            },
+          },
+        },
+      });
+
+    expect(
+      getAssistantGenerationMetadata(
+        messageWithDetails({ input: 6, input_cached_tokens: 1, output: 2 }),
+      ),
+    ).toBeUndefined();
+    expect(
+      getAssistantGenerationMetadata(
+        messageWithDetails({ input: 6, input_cached_tokens: 1, output: 2, total: 10 }),
+      ),
+    ).toBeUndefined();
+    expect(
+      getAssistantGenerationMetadata(
+        messageWithDetails({ input: 6, input_cached_tokens: 1, output: 2, total: 9 }),
+      ),
+    ).toMatchObject({ usage: { details: { total: 9 } } });
+  });
+
   it("validates strict JSON values without accepting lossy structures", () => {
     const shared = { value: 1 };
     expect(isJsonValue({ shared, duplicate: shared, list: [null, true, 1, "ok"] })).toBe(true);

--- a/packages/core/test/observability.test.ts
+++ b/packages/core/test/observability.test.ts
@@ -175,7 +175,12 @@ describe("agent observability", () => {
 
     const result = await agent
       .prompt("hello")
-      .withTrace({ name: "test-run", userId: "user_1", metadata: { case: "text" } })
+      .withTrace({
+        name: "test-run",
+        userId: "user_1",
+        metadata: { case: "text" },
+        promptRef: { name: "support.system", version: 3 },
+      })
       .send();
 
     expect(result.trace).toEqual({ traceId: "trace_1", observationId: "obs_1" });
@@ -191,7 +196,9 @@ describe("agent observability", () => {
           name: "test-run",
           userId: "user_1",
           metadata: { case: "text" },
+          promptRef: { name: "support.system", version: 3 },
         },
+        promptRef: { name: "support.system", version: 3 },
       },
     });
     expect(observer.events).toContainEqual(

--- a/packages/core/test/streaming.test.ts
+++ b/packages/core/test/streaming.test.ts
@@ -131,6 +131,7 @@ describe("PromptRequest streaming", () => {
 
     expect(events.map((event) => event.type)).toEqual([
       "turn_start",
+      "generation_start",
       "text_delta",
       "text_delta",
       "turn_end",
@@ -155,6 +156,7 @@ describe("PromptRequest streaming", () => {
 
     expect(events.map((event) => event.type)).toEqual([
       "turn_start",
+      "generation_start",
       "text_delta",
       "turn_end",
       "final",
@@ -400,6 +402,11 @@ describe("PromptRequest streaming", () => {
       [Symbol.asyncIterator]();
 
     expect(await nextEvent(iterator)).toMatchObject({ type: "turn_start" });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: "generation_start",
+      request: { chatHistory: [Message.user("hi")] },
+      modelInfo: { provider: "test", defaultModel: "test" },
+    });
     expect(await nextEvent(iterator)).toMatchObject({ type: "text_delta", delta: "partial" });
     expect(await nextEvent(iterator)).toEqual({ type: "error", error, usage: Usage.empty() });
     await expect(iterator.next()).rejects.toBe(error);
@@ -420,6 +427,7 @@ describe("PromptRequest streaming", () => {
       [Symbol.asyncIterator]();
 
     expect(await nextEvent(iterator)).toMatchObject({ type: "turn_start" });
+    expect(await nextEvent(iterator)).toMatchObject({ type: "generation_start" });
     expect(await nextEvent(iterator)).toEqual({ type: "error", error, usage: Usage.empty() });
     await expect(iterator.next()).rejects.toBe(error);
     expect(model.requests).toHaveLength(1);
@@ -477,9 +485,11 @@ describe("PromptRequest streaming", () => {
     events.push(await nextEvent(iterator));
     events.push(await nextEvent(iterator));
     events.push(await nextEvent(iterator));
+    events.push(await nextEvent(iterator));
 
     expect(events.map((event) => event.type)).toEqual([
       "turn_start",
+      "generation_start",
       "text_delta",
       "turn_end",
       "error",
@@ -610,6 +620,10 @@ describe("PromptRequest streaming", () => {
       prompt: Message.user("hi"),
     });
     expect(await nextEvent(iterator)).toMatchObject({
+      type: "generation_start",
+      turn: 1,
+    });
+    expect(await nextEvent(iterator)).toMatchObject({
       type: "text_delta",
       turn: 1,
       delta: "first",
@@ -621,6 +635,7 @@ describe("PromptRequest streaming", () => {
     const rest = await collectIterator(iterator);
     expect(rest.map((event) => event.type)).toEqual([
       "turn_start",
+      "generation_start",
       "text_delta",
       "turn_end",
       "final",
@@ -703,6 +718,7 @@ describe("PromptRequest streaming", () => {
     const secondSteer = Message.user("second steer");
 
     expect(await nextEvent(iterator)).toMatchObject({ type: "turn_start", turn: 1 });
+    expect(await nextEvent(iterator)).toMatchObject({ type: "generation_start", turn: 1 });
     expect(await nextEvent(iterator)).toMatchObject({ type: "text_delta", turn: 1 });
     expect(await nextEvent(iterator)).toMatchObject({ type: "turn_end", turn: 1 });
 
@@ -888,6 +904,7 @@ describe("PromptRequest streaming", () => {
     const iterator = agent.prompt("add").stream()[Symbol.asyncIterator]();
 
     expect(await nextEvent(iterator)).toMatchObject({ type: "turn_start", turn: 1 });
+    expect(await nextEvent(iterator)).toMatchObject({ type: "generation_start", turn: 1 });
     expect(await nextEvent(iterator)).toEqual({
       type: "tool_call_delta",
       turn: 1,
@@ -1076,6 +1093,7 @@ describe("PromptRequest streaming", () => {
       [Symbol.asyncIterator]();
 
     expect(await nextEvent(iterator)).toMatchObject({ type: "turn_start" });
+    expect(await nextEvent(iterator)).toMatchObject({ type: "generation_start" });
     expect(await nextEvent(iterator)).toMatchObject({
       type: "tool_call",
       toolCall: AssistantContent.toolCall("call_slow", "slow_tool", {}),
@@ -1157,6 +1175,7 @@ describe("PromptRequest streaming", () => {
 
     expect(childEvents.map((event) => event.event.type)).toEqual([
       "turn_start",
+      "generation_start",
       "text_delta",
       "text_delta",
       "turn_end",

--- a/packages/core/test/streaming.test.ts
+++ b/packages/core/test/streaming.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, expectTypeOf, it } from "vitest";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
 import { z } from "zod";
 import {
   AgentBuilder,
@@ -140,6 +140,28 @@ describe("PromptRequest streaming", () => {
     expect(events.at(-1)).toMatchObject({ type: "final", output: "hello" });
     expect(model.requests[0]?.instructions).toBe("system");
     expect(model.requests[0]?.chatHistory[0]).toEqual(Message.user("hi"));
+  });
+
+  it("measures first-delta latency from before generation_start is emitted", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+    try {
+      const model = new StreamingQueueModel([[{ type: "text_delta", delta: "hello" }]]);
+      const agent = new AgentBuilder("test-agent", model).build();
+      const iterator = agent.prompt("hi").stream()[Symbol.asyncIterator]();
+
+      expect((await iterator.next()).value).toMatchObject({ type: "turn_start" });
+      expect((await iterator.next()).value).toMatchObject({ type: "generation_start" });
+      vi.advanceTimersByTime(50);
+      expect((await iterator.next()).value).toMatchObject({ type: "text_delta" });
+      expect((await iterator.next()).value).toMatchObject({
+        type: "turn_end",
+        firstDeltaMs: 50,
+      });
+      expect((await iterator.next()).value).toMatchObject({ type: "final" });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("retries a transient stream failure before the first provider event", async () => {

--- a/packages/core/test/usage.test.ts
+++ b/packages/core/test/usage.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { Usage } from "../src/completion";
+
+describe("Usage", () => {
+  it("adds complete mutually exclusive details", () => {
+    const left = {
+      inputTokens: 8,
+      outputTokens: 2,
+      totalTokens: 10,
+      cachedInputTokens: 3,
+      cacheCreationInputTokens: 0,
+      details: { input: 5, input_cached_tokens: 3, output: 2, total: 10 },
+    };
+    const right = {
+      inputTokens: 4,
+      outputTokens: 1,
+      totalTokens: 5,
+      cachedInputTokens: 0,
+      cacheCreationInputTokens: 0,
+      details: { input: 4, input_cached_tokens: 0, output: 1, total: 5 },
+    };
+
+    expect(Usage.add(left, right)).toEqual({
+      inputTokens: 12,
+      outputTokens: 3,
+      totalTokens: 15,
+      cachedInputTokens: 3,
+      cacheCreationInputTokens: 0,
+      details: { input: 9, input_cached_tokens: 3, output: 3, total: 15 },
+    });
+  });
+
+  it("omits details when an aggregate contains an incomplete breakdown", () => {
+    expect(
+      Usage.add(
+        {
+          inputTokens: 2,
+          outputTokens: 1,
+          totalTokens: 3,
+          cachedInputTokens: 0,
+          cacheCreationInputTokens: 0,
+          details: { input: 2, output: 1, total: 3 },
+        },
+        {
+          inputTokens: 4,
+          outputTokens: 1,
+          totalTokens: 5,
+          cachedInputTokens: 0,
+          cacheCreationInputTokens: 0,
+        },
+      ),
+    ).not.toHaveProperty("details");
+  });
+
+  it("treats empty usage as an identity for details", () => {
+    const usage = {
+      inputTokens: 2,
+      outputTokens: 1,
+      totalTokens: 3,
+      cachedInputTokens: 0,
+      cacheCreationInputTokens: 0,
+      details: { input: 2, output: 1, total: 3 },
+    };
+    expect(Usage.add(Usage.empty(), usage)).toEqual(usage);
+  });
+});

--- a/packages/observability-langfuse/README.md
+++ b/packages/observability-langfuse/README.md
@@ -63,6 +63,8 @@ explicit options always win.
 | `environment` | `LANGFUSE_TRACING_ENVIRONMENT`| Tag attached to every trace.                               |
 | `release`     | `LANGFUSE_RELEASE`            | Tag attached to every trace.                               |
 | `serviceName` | `LANGFUSE_SERVICE_NAME`       | Recorded on the root observation and as the OTel `service.name` resource attribute. |
+| `captureMode` | —                             | `"safe"` (default) records instructions/messages plus request summaries; `"full"` includes documents, tool definitions, schemas, and additional parameters. |
+| `captureMaxBytes` | —                          | Maximum encoded size per captured value; defaults to 262,144 bytes and must be at least 96. |
 
 ```ts
 const tracing = langfuse.create({
@@ -73,24 +75,26 @@ const tracing = langfuse.create({
 
 ## Observation metadata
 
-The adapter records extra data on Langfuse observations so the UI
-shows everything the agent runtime emits:
+The adapter records structured model and runtime data while keeping
+the default capture surface bounded:
 
-- **Generation observations** carry `providerRequest` and `modelInfo`
-  (with `provider`, `defaultModel`, and `capabilities`) on start, and
-  `firstDeltaMs` on end. `usageDetails` always includes
-  `cachedInputTokens` and `cacheCreationInputTokens`.
+- **Generation observations** carry system instructions, model messages,
+  the resolved model, and `modelInfo`. Full capture also includes the
+  sanitized `providerRequest`.
+  `completionStartTime` and `firstDeltaMs` provide native time-to-first-token data.
+- **Usage details** use mutually exclusive `input`, `output`, cache, and
+  reasoning buckets so Langfuse can infer cost without double counting.
 - **Generation observations** receive a `generation.update({ output: { delta } })`
   call for every streaming delta (`text_delta`, `reasoning_delta`,
   `tool_call`), so the Langfuse UI reflects partial output as the
   model produces it.
-- **Tool observations** carry `toolDefinition` and `toolMetadata` on
-  start, and `structuredResult` on end.
+- **Tool observations** carry arguments on start and structured results on
+  end. Definitions and tool metadata are included when `captureMode: "full"`.
 - **Root run observation** carries `serviceName` and the configured
   `metadata` from `AgentRunStartArgs`.
 
-User-supplied `trace.metadata` always wins over the built-in fields
-above (the spread order preserves it).
+Binary and base64 bodies are replaced with omission markers. Oversized
+values are replaced with deterministic bounded previews.
 
 ## Eval Scores
 
@@ -231,8 +235,8 @@ trace?.addEvent("validation.passed");
 trace?.addAttributes({ quality: "high" });
 ```
 
-`addEvent` creates a Langfuse `event` observation under the active
-root and ends it immediately. `addAttributes` updates the root
+`addEvent` creates an instantaneous Langfuse `event` observation under the active
+root. `addAttributes` updates the root
 observation's metadata. Both calls bubble up to Langfuse via the
 existing OpenTelemetry span processor.
 
@@ -369,13 +373,12 @@ const prompts = createLangfusePromptClient(tracing);
 const prompt = await prompts.getPrompt("support.system");
 console.log(prompt.prompt, prompt.version);
 
-await tracing.startRun({
-  agentName: "support",
-  prompt: { role: "user", content: [{ type: "text", text: "hi" }] },
-  history: [],
-  maxTurns: 3,
-  promptRef: { name: "support.system", version: prompt.version },
-});
+await agent
+  .prompt("hi")
+  .withTrace({
+    promptRef: { name: "support.system", version: prompt.version },
+  })
+  .send();
 ```
 
 `promptRef` is also accepted on `trace.metadata` (keys
@@ -424,9 +427,10 @@ const tracing = langfuse.create({
 });
 ```
 
-- `redactInputs` redacts text on root inputs, chat history, and tool
-  arguments.
-- `redactOutputs` redacts generation output text and tool results.
+- `redactInputs` redacts system instructions, root inputs, chat history,
+  tool arguments, request metadata, and nested-agent inputs.
+- `redactOutputs` redacts streaming/final generation output, errors,
+  tool results, transcripts, and nested-agent outputs.
 - `"deep"` recurses into nested objects and arrays (in addition to
   top-level strings).
 

--- a/packages/observability-langfuse/src/capture.ts
+++ b/packages/observability-langfuse/src/capture.ts
@@ -23,18 +23,17 @@ export function validateCaptureMaxBytes(value: number | undefined): number {
   return resolved;
 }
 
-export function sanitizeTraceValue<T>(value: T, maxBytes: number): T | TruncatedTraceValue {
+export function sanitizeTraceValue<T>(
+  value: T,
+  maxBytes: number,
+): T | TruncatedTraceValue | OmittedTraceValue {
   validateCaptureMaxBytes(maxBytes);
   const sanitized = sanitizeValue(value, 0, new WeakSet<object>()) as T;
   let serialized: string;
   try {
     serialized = JSON.stringify(sanitized) ?? String(sanitized);
   } catch {
-    return {
-      anviaTraceValue: "truncated",
-      originalBytes: maxBytes + 1,
-      preview: "[UNSERIALIZABLE]",
-    };
+    return omitted("unserializable");
   }
   const originalBytes = utf8Bytes(serialized);
   if (originalBytes <= maxBytes) {
@@ -58,17 +57,8 @@ function sanitizeValue(value: unknown, depth: number, seen: WeakSet<object>): un
     }
     return value;
   }
-  if (
-    value instanceof ArrayBuffer ||
-    ArrayBuffer.isView(value) ||
-    (typeof Buffer !== "undefined" && Buffer.isBuffer(value))
-  ) {
-    const byteLength =
-      value instanceof ArrayBuffer
-        ? value.byteLength
-        : ArrayBuffer.isView(value)
-          ? value.byteLength
-          : (value as Buffer).byteLength;
+  if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) {
+    const byteLength = value.byteLength;
     return omitted("binary", byteLength);
   }
   if (value === null || typeof value !== "object") {
@@ -129,5 +119,7 @@ function boundedPreview(value: string, originalBytes: number, maxBytes: number):
 }
 
 function utf8Bytes(value: string): number {
-  return Buffer.byteLength(value, "utf8");
+  return typeof Buffer === "undefined"
+    ? new TextEncoder().encode(value).byteLength
+    : Buffer.byteLength(value, "utf8");
 }

--- a/packages/observability-langfuse/src/capture.ts
+++ b/packages/observability-langfuse/src/capture.ts
@@ -1,0 +1,133 @@
+export const DEFAULT_CAPTURE_MAX_BYTES = 262_144;
+export const MIN_CAPTURE_MAX_BYTES = 96;
+
+type TruncatedTraceValue = {
+  anviaTraceValue: "truncated";
+  originalBytes: number;
+  preview: string;
+};
+
+type OmittedTraceValue = {
+  anviaTraceValue: "omitted";
+  reason: "base64" | "binary" | "circular" | "depth" | "unserializable";
+  originalBytes?: number;
+};
+
+export function validateCaptureMaxBytes(value: number | undefined): number {
+  const resolved = value ?? DEFAULT_CAPTURE_MAX_BYTES;
+  if (!Number.isInteger(resolved) || resolved < MIN_CAPTURE_MAX_BYTES) {
+    throw new TypeError(
+      `Langfuse captureMaxBytes must be an integer of at least ${MIN_CAPTURE_MAX_BYTES}`,
+    );
+  }
+  return resolved;
+}
+
+export function sanitizeTraceValue<T>(value: T, maxBytes: number): T | TruncatedTraceValue {
+  validateCaptureMaxBytes(maxBytes);
+  const sanitized = sanitizeValue(value, 0, new WeakSet<object>()) as T;
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(sanitized) ?? String(sanitized);
+  } catch {
+    return {
+      anviaTraceValue: "truncated",
+      originalBytes: maxBytes + 1,
+      preview: "[UNSERIALIZABLE]",
+    };
+  }
+  const originalBytes = utf8Bytes(serialized);
+  if (originalBytes <= maxBytes) {
+    return sanitized;
+  }
+  const preview = boundedPreview(serialized, originalBytes, maxBytes);
+  return {
+    anviaTraceValue: "truncated",
+    originalBytes,
+    preview,
+  };
+}
+
+function sanitizeValue(value: unknown, depth: number, seen: WeakSet<object>): unknown {
+  if (depth > 16) {
+    return omitted("depth");
+  }
+  if (typeof value === "string") {
+    if (/^data:[^;,]+;base64,/i.test(value)) {
+      return omitted("base64", utf8Bytes(value));
+    }
+    return value;
+  }
+  if (
+    value instanceof ArrayBuffer ||
+    ArrayBuffer.isView(value) ||
+    (typeof Buffer !== "undefined" && Buffer.isBuffer(value))
+  ) {
+    const byteLength =
+      value instanceof ArrayBuffer
+        ? value.byteLength
+        : ArrayBuffer.isView(value)
+          ? value.byteLength
+          : (value as Buffer).byteLength;
+    return omitted("binary", byteLength);
+  }
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  if (seen.has(value)) {
+    return omitted("circular");
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    const result = value.map((entry) => sanitizeValue(entry, depth + 1, seen));
+    seen.delete(value);
+    return result;
+  }
+  const record = value as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(record)) {
+    if (
+      key === "data" &&
+      typeof entry === "string" &&
+      (record.type === "base64" ||
+        (record.type === "image" && typeof record.mediaType === "string"))
+    ) {
+      result[key] = omitted("base64", utf8Bytes(entry));
+      continue;
+    }
+    result[key] = sanitizeValue(entry, depth + 1, seen);
+  }
+  seen.delete(value);
+  return result;
+}
+
+function omitted(reason: OmittedTraceValue["reason"], originalBytes?: number): OmittedTraceValue {
+  return {
+    anviaTraceValue: "omitted",
+    reason,
+    ...(originalBytes === undefined ? {} : { originalBytes }),
+  };
+}
+
+function boundedPreview(value: string, originalBytes: number, maxBytes: number): string {
+  let low = 0;
+  let high = value.length;
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    const candidate = {
+      anviaTraceValue: "truncated" as const,
+      originalBytes,
+      preview: value.slice(0, middle),
+    };
+    if (utf8Bytes(JSON.stringify(candidate)) <= maxBytes) {
+      low = middle;
+    } else {
+      high = middle - 1;
+    }
+  }
+  return value.slice(0, low);
+}
+
+function utf8Bytes(value: string): number {
+  return Buffer.byteLength(value, "utf8");
+}

--- a/packages/observability-langfuse/src/helpers.ts
+++ b/packages/observability-langfuse/src/helpers.ts
@@ -34,7 +34,7 @@ export function modelParameters(
 export function usageDetails(
   usage: AgentGenerationEndArgs["response"]["usage"],
 ): Record<string, number> {
-  if (usage.details !== undefined) {
+  if (usage.details !== undefined && Object.keys(usage.details).length > 0) {
     return { ...usage.details };
   }
   return {

--- a/packages/observability-langfuse/src/helpers.ts
+++ b/packages/observability-langfuse/src/helpers.ts
@@ -34,24 +34,34 @@ export function modelParameters(
 export function usageDetails(
   usage: AgentGenerationEndArgs["response"]["usage"],
 ): Record<string, number> {
+  if (usage.details !== undefined) {
+    return { ...usage.details };
+  }
   return {
-    inputTokens: usage.inputTokens,
-    outputTokens: usage.outputTokens,
-    totalTokens: usage.totalTokens,
-    cachedInputTokens: usage.cachedInputTokens,
-    cacheCreationInputTokens: usage.cacheCreationInputTokens,
+    input: usage.inputTokens,
+    output: usage.outputTokens,
+    total: usage.totalTokens,
   };
 }
 
 export function usageDetailsFromRecord(usage: Record<string, unknown>): Record<string, number> {
+  if (isRecord(usage.details)) {
+    const details = Object.fromEntries(
+      Object.entries(usage.details).filter(
+        (entry): entry is [string, number] =>
+          typeof entry[1] === "number" && Number.isFinite(entry[1]) && entry[1] >= 0,
+      ),
+    );
+    if (Object.keys(details).length > 0) {
+      return details;
+    }
+  }
   return {
-    inputTokens: numberValue(usage.inputTokens) ?? 0,
-    outputTokens: numberValue(usage.outputTokens) ?? 0,
-    totalTokens:
+    input: numberValue(usage.inputTokens) ?? 0,
+    output: numberValue(usage.outputTokens) ?? 0,
+    total:
       numberValue(usage.totalTokens) ??
       (numberValue(usage.inputTokens) ?? 0) + (numberValue(usage.outputTokens) ?? 0),
-    cachedInputTokens: numberValue(usage.cachedInputTokens) ?? 0,
-    cacheCreationInputTokens: numberValue(usage.cacheCreationInputTokens) ?? 0,
   };
 }
 

--- a/packages/observability-langfuse/src/index.ts
+++ b/packages/observability-langfuse/src/index.ts
@@ -15,6 +15,7 @@ export { createPiiRedactor, DEFAULT_PATTERNS } from "./redaction.js";
 export { LangfuseScoreError } from "./scoring.js";
 export { langfuse } from "./tracing.js";
 export type {
+  LangfuseCaptureMode,
   LangfuseChatMessage,
   LangfuseDataset,
   LangfuseDatasetClient,

--- a/packages/observability-langfuse/src/redaction.ts
+++ b/packages/observability-langfuse/src/redaction.ts
@@ -151,13 +151,30 @@ function redactValue(
   redactStringFn: (s: string) => string,
 ): unknown {
   if (depth > MAX_DEPTH) return value;
-  if (typeof value === "string") return redactStringFn(value);
+  if (typeof value === "string") {
+    return isBase64DataUrl(value) ? value : redactStringFn(value);
+  }
   if (Array.isArray(value))
     return value.map((entry) => redactValue(entry, depth + 1, redactStringFn));
   if (value !== null && typeof value === "object") {
+    if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) {
+      return value;
+    }
+    const record = value as Record<string, unknown>;
     const out: Record<string, unknown> = {};
-    for (const [key, entry] of Object.entries(value)) {
-      out[key] = redactValue(entry, depth + 1, redactStringFn);
+    for (const [key, entry] of Object.entries(record)) {
+      if (
+        key === "data" &&
+        typeof entry === "string" &&
+        (record.type === "base64" ||
+          record.type === "image" ||
+          record.type === "encrypted" ||
+          record.type === "redacted")
+      ) {
+        out[key] = entry;
+      } else {
+        out[key] = redactValue(entry, depth + 1, redactStringFn);
+      }
     }
     return out;
   }
@@ -165,14 +182,44 @@ function redactValue(
 }
 
 function redactMessage(message: Message, redactStringFn: (s: string) => string): Message {
-  if (!Array.isArray(message.content)) return message;
-  const newContent = message.content.map((part) => {
-    if (part === null || typeof part !== "object") return part;
-    const rec = part as Record<string, unknown>;
-    if (rec.type === "text" && typeof rec.text === "string") {
-      return { ...part, text: redactStringFn(rec.text) };
+  if (message.role === "system") {
+    return { ...message, content: redactStringFn(message.content) };
+  }
+  return {
+    ...message,
+    content: redactMessageContent(message.content, redactStringFn) as never,
+  };
+}
+
+function redactMessageContent(value: unknown, redactStringFn: (s: string) => string): unknown {
+  if (typeof value === "string") {
+    return isBase64DataUrl(value) ? value : redactStringFn(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactMessageContent(entry, redactStringFn));
+  }
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  const record = value as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(record)) {
+    if (
+      key === "data" &&
+      typeof entry === "string" &&
+      (record.type === "base64" ||
+        record.type === "image" ||
+        record.type === "encrypted" ||
+        record.type === "redacted")
+    ) {
+      result[key] = entry;
+    } else {
+      result[key] = redactMessageContent(entry, redactStringFn);
     }
-    return part;
-  });
-  return { ...message, content: newContent as never };
+  }
+  return result;
+}
+
+function isBase64DataUrl(value: string): boolean {
+  return /^data:[^;,]+;base64,/i.test(value);
 }

--- a/packages/observability-langfuse/src/redaction.ts
+++ b/packages/observability-langfuse/src/redaction.ts
@@ -192,32 +192,7 @@ function redactMessage(message: Message, redactStringFn: (s: string) => string):
 }
 
 function redactMessageContent(value: unknown, redactStringFn: (s: string) => string): unknown {
-  if (typeof value === "string") {
-    return isBase64DataUrl(value) ? value : redactStringFn(value);
-  }
-  if (Array.isArray(value)) {
-    return value.map((entry) => redactMessageContent(entry, redactStringFn));
-  }
-  if (value === null || typeof value !== "object") {
-    return value;
-  }
-  const record = value as Record<string, unknown>;
-  const result: Record<string, unknown> = {};
-  for (const [key, entry] of Object.entries(record)) {
-    if (
-      key === "data" &&
-      typeof entry === "string" &&
-      (record.type === "base64" ||
-        record.type === "image" ||
-        record.type === "encrypted" ||
-        record.type === "redacted")
-    ) {
-      result[key] = entry;
-    } else {
-      result[key] = redactMessageContent(entry, redactStringFn);
-    }
-  }
-  return result;
+  return redactValue(value, 0, redactStringFn);
 }
 
 function isBase64DataUrl(value: string): boolean {

--- a/packages/observability-langfuse/src/scoring.ts
+++ b/packages/observability-langfuse/src/scoring.ts
@@ -14,6 +14,8 @@ export class LangfuseScoreError extends Error {
   }
 }
 
+class RetryableLangfuseScoreError extends LangfuseScoreError {}
+
 export type ScoreQueueOptions = {
   baseUrl: string;
   publicKey: string;
@@ -121,7 +123,11 @@ export class ScoreQueue {
   async shutdown(): Promise<void> {
     this.closed = true;
     this.clearScheduledTimer();
-    await this.flush();
+    try {
+      await this.flush();
+    } catch {
+      // Shutdown is best-effort so a score delivery failure cannot block SDK teardown.
+    }
   }
 
   private scheduleTimer(): void {
@@ -135,11 +141,7 @@ export class ScoreQueue {
   }
 
   private triggerBackgroundFlush(): void {
-    void this.flush().catch(() => {
-      if (!this.closed && this.pending.length > 0) {
-        this.scheduleTimer();
-      }
-    });
+    void this.flush().catch(() => {});
   }
 
   private clearScheduledTimer(): void {
@@ -185,7 +187,7 @@ export class ScoreQueue {
         await this.sleep(computeBackoff(attempt));
       }
     }
-    throw new LangfuseScoreError(
+    throw new RetryableLangfuseScoreError(
       `Langfuse score batch failed after ${this.maxRetries} attempts`,
       scores,
       lastError,
@@ -193,14 +195,26 @@ export class ScoreQueue {
   }
 
   private async drain(): Promise<void> {
+    let permanentError: LangfuseScoreError | undefined;
     while (this.pending.length > 0) {
       const batch = this.pending.splice(0, this.batchSize);
       try {
         await this.sendBatch(batch);
       } catch (error) {
+        if (error instanceof RetryableLangfuseScoreError) {
+          this.pending.unshift(...batch);
+          throw error;
+        }
+        if (error instanceof LangfuseScoreError) {
+          permanentError ??= error;
+          continue;
+        }
         this.pending.unshift(...batch);
         throw error;
       }
+    }
+    if (permanentError !== undefined) {
+      throw permanentError;
     }
   }
 }

--- a/packages/observability-langfuse/src/scoring.ts
+++ b/packages/observability-langfuse/src/scoring.ts
@@ -50,6 +50,7 @@ export class ScoreQueue {
   private readonly pending: LangfuseScoreArgs[] = [];
   private timer: unknown = null;
   private flushing: Promise<void> | null = null;
+  private closed = false;
   private readonly baseUrl: string;
   private readonly publicKey: string;
   private readonly secretKey: string;
@@ -77,9 +78,12 @@ export class ScoreQueue {
   }
 
   enqueue(score: LangfuseScoreArgs): void {
+    if (this.closed) {
+      throw new Error("Langfuse score queue is shut down");
+    }
     this.pending.push(score);
     if (this.pending.length >= this.batchSize) {
-      void this.flush();
+      this.triggerBackgroundFlush();
       return;
     }
     this.scheduleTimer();
@@ -90,23 +94,32 @@ export class ScoreQueue {
   }
 
   async flush(): Promise<void> {
-    if (this.flushing !== null) {
-      await this.flushing;
-      return;
-    }
-    if (this.pending.length === 0) {
-      this.clearScheduledTimer();
-      return;
-    }
-    const batch = this.pending.splice(0, this.pending.length);
     this.clearScheduledTimer();
-    this.flushing = this.sendBatch(batch).finally(() => {
-      this.flushing = null;
-    });
-    await this.flushing;
+    while (true) {
+      if (this.flushing !== null) {
+        await this.flushing;
+        if (this.pending.length === 0) {
+          return;
+        }
+        continue;
+      }
+      if (this.pending.length === 0) {
+        return;
+      }
+      const draining = this.drain();
+      this.flushing = draining;
+      try {
+        await draining;
+      } finally {
+        if (this.flushing === draining) {
+          this.flushing = null;
+        }
+      }
+    }
   }
 
   async shutdown(): Promise<void> {
+    this.closed = true;
     this.clearScheduledTimer();
     await this.flush();
   }
@@ -117,8 +130,16 @@ export class ScoreQueue {
     }
     this.timer = this.setTimer(() => {
       this.timer = null;
-      void this.flush();
+      this.triggerBackgroundFlush();
     }, this.flushIntervalMs);
+  }
+
+  private triggerBackgroundFlush(): void {
+    void this.flush().catch(() => {
+      if (!this.closed && this.pending.length > 0) {
+        this.scheduleTimer();
+      }
+    });
   }
 
   private clearScheduledTimer(): void {
@@ -169,6 +190,18 @@ export class ScoreQueue {
       scores,
       lastError,
     );
+  }
+
+  private async drain(): Promise<void> {
+    while (this.pending.length > 0) {
+      const batch = this.pending.splice(0, this.batchSize);
+      try {
+        await this.sendBatch(batch);
+      } catch (error) {
+        this.pending.unshift(...batch);
+        throw error;
+      }
+    }
   }
 }
 

--- a/packages/observability-langfuse/src/tracing.ts
+++ b/packages/observability-langfuse/src/tracing.ts
@@ -21,7 +21,9 @@ import type {
 import { LangfuseSpanProcessor } from "@langfuse/otel";
 import {
   type LangfuseAgent,
+  type LangfuseEventAttributes,
   type LangfuseGeneration,
+  type LangfuseGenerationAttributes,
   LangfuseOtelSpanAttributes,
   type LangfuseSpan,
   type LangfuseTool,
@@ -30,6 +32,7 @@ import {
 import { resourceFromAttributes } from "@opentelemetry/resources";
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { SEMRESATTRS_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+import { sanitizeTraceValue, validateCaptureMaxBytes } from "./capture.js";
 import {
   type LangfuseResolvedConfig,
   langfuseResolvedConfigSymbol,
@@ -50,6 +53,7 @@ import {
 import { createPiiRedactor, type PiiRedactor } from "./redaction.js";
 import { ScoreQueue } from "./scoring.js";
 import type {
+  LangfuseCaptureMode,
   LangfuseRedactionMode,
   LangfuseScoreArgs,
   LangfuseTraceHandle,
@@ -77,6 +81,8 @@ class LangfuseAgentObserver implements LangfuseTracing {
   private readonly redactor: PiiRedactor | undefined;
   private readonly redactInputs: LangfuseRedactionMode | undefined;
   private readonly redactOutputs: LangfuseRedactionMode | undefined;
+  private readonly captureMode: LangfuseCaptureMode;
+  private readonly captureMaxBytes: number;
 
   constructor(options: LangfuseTracingOptions) {
     const resolvedConfig = resolveLangfuseConfig(options);
@@ -121,6 +127,8 @@ class LangfuseAgentObserver implements LangfuseTracing {
         : null;
     this.redactInputs = options.redactInputs;
     this.redactOutputs = options.redactOutputs;
+    this.captureMode = options.captureMode ?? "safe";
+    this.captureMaxBytes = validateCaptureMaxBytes(options.captureMaxBytes);
     this.redactor =
       options.redactInputs !== undefined || options.redactOutputs !== undefined
         ? createPiiRedactor(options.redaction)
@@ -129,19 +137,25 @@ class LangfuseAgentObserver implements LangfuseTracing {
 
   async startRun(args: AgentRunStartArgs): Promise<AgentRunObserver> {
     const traceId = args.trace?.traceId;
-    const redactedInput = this.maybeRedactInput({
+    const capturedInput = this.captureInput({
+      instructions: args.instructions,
       prompt: args.prompt,
       history: args.history,
     });
+    const capturedTraceMetadata = this.captureInput(args.trace?.metadata ?? {});
     const metadata: Record<string, unknown> = {
       agentName: args.agentName,
       agentDescription: args.agentDescription,
       maxTurns: args.maxTurns,
     };
     if (this.serviceName !== undefined) metadata.serviceName = this.serviceName;
-    Object.assign(metadata, args.trace?.metadata);
+    if (isRecord(capturedTraceMetadata)) {
+      Object.assign(metadata, capturedTraceMetadata);
+    } else {
+      metadata.traceMetadata = capturedTraceMetadata;
+    }
     const rootAttributes: Parameters<typeof startObservation>[1] = {
-      input: redactedInput,
+      input: capturedInput,
       metadata,
     };
     if (args.trace?.version !== undefined) {
@@ -162,7 +176,7 @@ class LangfuseAgentObserver implements LangfuseTracing {
             },
           },
     );
-    applyTraceAttributes(root, args);
+    applyTraceAttributes(root, args, capturedTraceMetadata);
 
     const promptRef = resolvePromptRef(args);
     const runObserver = new LangfuseRunObserver(
@@ -176,6 +190,8 @@ class LangfuseAgentObserver implements LangfuseTracing {
         redactor: this.redactor,
         redactInputs: this.redactInputs,
         redactOutputs: this.redactOutputs,
+        captureMode: this.captureMode,
+        captureMaxBytes: this.captureMaxBytes,
       },
     );
     this.currentHandle = runObserver.getHandle();
@@ -212,14 +228,12 @@ class LangfuseAgentObserver implements LangfuseTracing {
     return this.currentHandle;
   }
 
-  private maybeRedactInput<T>(value: T): T {
-    if (this.redactor === undefined || this.redactInputs === undefined) return value;
-    return applyRedaction(this.redactor, value, this.redactInputs);
-  }
-
-  private maybeRedactOutput<T>(value: T): T {
-    if (this.redactor === undefined || this.redactOutputs === undefined) return value;
-    return applyRedaction(this.redactor, value, this.redactOutputs);
+  private captureInput<T>(value: T): unknown {
+    const redacted =
+      this.redactor === undefined || this.redactInputs === undefined
+        ? value
+        : applyRedaction(this.redactor, value, this.redactInputs);
+    return sanitizeTraceValue(redacted, this.captureMaxBytes);
   }
 
   async score(args: LangfuseScoreArgs): Promise<void> {
@@ -299,7 +313,11 @@ function buildScoreBody(score: LangfuseScoreArgs): Record<string, unknown> {
   return body;
 }
 
-function applyTraceAttributes(root: LangfuseAgent, args: AgentRunStartArgs): void {
+function applyTraceAttributes(
+  root: LangfuseAgent,
+  args: AgentRunStartArgs,
+  capturedMetadata: unknown,
+): void {
   const traceName = args.trace?.name ?? args.agentName;
   if (traceName !== undefined) {
     root.otelSpan.setAttribute(LangfuseOtelSpanAttributes.TRACE_NAME, traceName);
@@ -313,7 +331,9 @@ function applyTraceAttributes(root: LangfuseAgent, args: AgentRunStartArgs): voi
   if (args.trace?.tags !== undefined) {
     root.otelSpan.setAttribute(LangfuseOtelSpanAttributes.TRACE_TAGS, args.trace.tags);
   }
-  for (const [key, value] of Object.entries(args.trace?.metadata ?? {})) {
+  for (const [key, value] of Object.entries(
+    isRecord(capturedMetadata) ? capturedMetadata : { value: capturedMetadata },
+  )) {
     const serialized = serializeMetadataValue(value);
     if (serialized === undefined) {
       continue;
@@ -342,9 +362,6 @@ function applyRedaction<T>(redactor: PiiRedactor, value: T, mode: LangfuseRedact
   if (typeof value === "string") {
     return redactor.redactString(value) as unknown as T;
   }
-  if (Array.isArray(value)) {
-    return redactor.redactMessages(value as never) as unknown as T;
-  }
   if (value !== null && typeof value === "object") {
     return redactor.redactObject(value);
   }
@@ -354,6 +371,9 @@ function applyRedaction<T>(redactor: PiiRedactor, value: T, mode: LangfuseRedact
 function resolvePromptRef(args: AgentRunStartArgs): AgentRunPromptRef | undefined {
   if (args.promptRef !== undefined) {
     return args.promptRef;
+  }
+  if (args.trace?.promptRef !== undefined) {
+    return args.trace.promptRef;
   }
   const metadata = args.trace?.metadata;
   if (metadata === undefined) {
@@ -406,6 +426,21 @@ function serializeMetadataValue(value: unknown): string | undefined {
   }
 }
 
+function asMetadata(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : { value };
+}
+
+function eventStartTime(value: Date | string | undefined): Date | undefined {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? undefined : value;
+  }
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
 class LangfuseRunObserver implements AgentRunObserver {
   private readonly turnSpans = new Map<number, LangfuseSpan>();
   // Assigned by LangfuseAgentObserver.startRun so that the run can
@@ -417,6 +452,8 @@ class LangfuseRunObserver implements AgentRunObserver {
   private readonly redactor: PiiRedactor | undefined;
   private readonly redactInputs: LangfuseRedactionMode | undefined;
   private readonly redactOutputs: LangfuseRedactionMode | undefined;
+  private readonly captureMode: LangfuseCaptureMode;
+  private readonly captureMaxBytes: number;
 
   constructor(
     private readonly root: LangfuseAgent,
@@ -426,6 +463,8 @@ class LangfuseRunObserver implements AgentRunObserver {
       redactor: PiiRedactor | undefined;
       redactInputs: LangfuseRedactionMode | undefined;
       redactOutputs: LangfuseRedactionMode | undefined;
+      captureMode: LangfuseCaptureMode;
+      captureMaxBytes: number;
     },
   ) {
     this.handle = this.buildHandle();
@@ -433,28 +472,53 @@ class LangfuseRunObserver implements AgentRunObserver {
     this.redactor = redaction.redactor;
     this.redactInputs = redaction.redactInputs;
     this.redactOutputs = redaction.redactOutputs;
+    this.captureMode = redaction.captureMode;
+    this.captureMaxBytes = redaction.captureMaxBytes;
   }
 
-  redactInputValue<T>(value: T): T {
-    if (this.redactor === undefined || this.redactInputs === undefined) return value;
-    return applyRedaction(this.redactor, value, this.redactInputs);
+  redactInputValue<T>(value: T): unknown {
+    const redacted =
+      this.redactor === undefined || this.redactInputs === undefined
+        ? value
+        : applyRedaction(this.redactor, value, this.redactInputs);
+    return sanitizeTraceValue(redacted, this.captureMaxBytes);
   }
 
-  redactOutputValue<T>(value: T): T {
-    if (this.redactor === undefined || this.redactOutputs === undefined) return value;
-    return applyRedaction(this.redactor, value, this.redactOutputs);
+  redactOutputValue<T>(value: T): unknown {
+    const redacted =
+      this.redactor === undefined || this.redactOutputs === undefined
+        ? value
+        : applyRedaction(this.redactor, value, this.redactOutputs);
+    return sanitizeTraceValue(redacted, this.captureMaxBytes);
   }
 
   startGeneration(args: AgentGenerationStartArgs): AgentGenerationObserver {
     this.closeEarlierTurns(args.turn);
     const turn = this.turnSpan(args.turn);
-    const redactedChatHistory = this.redactInputValue(modelInputMessages(args.request.chatHistory));
+    const safeInput: Record<string, unknown> = {
+      instructions: args.request.instructions,
+      messages: modelInputMessages(args.request.chatHistory),
+    };
+    if (this.captureMode === "full") {
+      safeInput.documents = args.request.documents;
+      safeInput.tools = args.request.tools;
+      safeInput.providerTools = args.request.providerTools;
+      safeInput.outputSchema = args.request.outputSchema;
+      safeInput.additionalParams = args.request.additionalParams;
+    }
     const metadata: Record<string, unknown> = {
       turn: args.turn,
-      toolCount: args.request.tools.length,
+      documentCount: args.request.documents.length,
+      toolNames: args.request.tools.map((tool) => tool.name),
+      providerToolNames: args.request.providerTools?.map((tool) => tool.name) ?? [],
       hasOutputSchema: args.request.outputSchema !== undefined,
+      additionalParamKeys: isRecord(args.request.additionalParams)
+        ? Object.keys(args.request.additionalParams)
+        : [],
     };
-    if (args.providerRequest !== undefined) metadata.providerRequest = args.providerRequest;
+    if (this.captureMode === "full" && args.providerRequest !== undefined) {
+      metadata.providerRequest = this.redactInputValue(args.providerRequest);
+    }
     if (args.modelInfo !== undefined) {
       const modelInfo: Record<string, unknown> = {
         provider: args.modelInfo.provider,
@@ -466,37 +530,44 @@ class LangfuseRunObserver implements AgentRunObserver {
       metadata.modelInfo = modelInfo;
     }
     Object.assign(metadata, promptMetadata(this.promptRef));
-    const generation = turn.startObservation(
-      `model.turn.${args.turn}`,
-      {
-        input: redactedChatHistory,
-        model: args.request.model ?? "default",
-        modelParameters: modelParameters(args.request),
-        metadata,
-      },
-      { asType: "generation" },
-    );
-    return new LangfuseGenerationObserver(generation, this);
+    const generationAttributes: LangfuseGenerationAttributes = {
+      input: this.redactInputValue(safeInput),
+      model: args.request.model ?? args.modelInfo?.defaultModel ?? "default",
+      modelParameters: modelParameters(args.request),
+      metadata: asMetadata(this.redactInputValue(metadata)),
+    };
+    if (this.promptRef?.version !== undefined) {
+      generationAttributes.prompt = {
+        name: this.promptRef.name,
+        version: this.promptRef.version,
+        isFallback: false,
+      };
+    }
+    const generation = turn.startObservation(`model.turn.${args.turn}`, generationAttributes, {
+      asType: "generation",
+    });
+    return new LangfuseGenerationObserver(generation, this, new Date());
   }
 
   startTool(args: AgentToolStartArgs): AgentToolObserver {
     const turn = this.turnSpan(args.turn);
-    const redactedArgs = this.redactInputValue(args.args);
     const metadata: Record<string, unknown> = {
       turn: args.turn,
       internalCallId: args.internalCallId,
       toolCallId: args.toolCallId,
     };
-    if (args.toolDefinition !== undefined) metadata.toolDefinition = args.toolDefinition;
-    if (args.toolMetadata !== undefined) metadata.toolMetadata = args.toolMetadata;
+    if (this.captureMode === "full") {
+      if (args.toolDefinition !== undefined) metadata.toolDefinition = args.toolDefinition;
+      if (args.toolMetadata !== undefined) metadata.toolMetadata = args.toolMetadata;
+    }
     const tool = turn.startObservation(
       `tool.${args.toolName}`,
       {
-        input: {
-          args: redactedArgs,
+        input: this.redactInputValue({
+          args: args.args,
           toolCall: args.toolCall,
-        },
-        metadata,
+        }),
+        metadata: asMetadata(this.redactInputValue(metadata)),
       },
       { asType: "tool" },
     );
@@ -506,13 +577,19 @@ class LangfuseRunObserver implements AgentRunObserver {
   end(args: AgentRunEndArgs): void {
     this.closeAllTurns();
     const redactedOutput = this.redactOutputValue(args.output);
+    const metadata: Record<string, unknown> = {
+      usage: args.usage,
+      messageCount: args.messages.length,
+      sources: this.redactOutputValue(args.sources),
+      providerToolCalls: this.redactOutputValue(args.providerToolCalls),
+    };
+    if (this.captureMode === "full") {
+      metadata.messages = this.redactTranscript(args.messages);
+    }
     this.root
       .update({
         output: redactedOutput,
-        metadata: {
-          usage: args.usage,
-          messages: args.messages,
-        },
+        metadata,
       })
       .end();
     this.clearCurrentHandle?.();
@@ -520,26 +597,38 @@ class LangfuseRunObserver implements AgentRunObserver {
 
   error(args: AgentRunErrorArgs): void {
     this.closeAllTurns();
+    const redactedError = this.redactOutputValue(errorMessage(args.error));
+    const metadata: Record<string, unknown> = {
+      usage: args.usage,
+      messageCount: args.messages.length,
+    };
+    if (this.captureMode === "full") {
+      metadata.messages = this.redactTranscript(args.messages);
+    }
     this.root
       .update({
         level: "ERROR",
-        statusMessage: errorMessage(args.error),
+        statusMessage: typeof redactedError === "string" ? redactedError : "Agent run failed",
         output: {
-          error: errorMessage(args.error),
+          error: redactedError,
         },
-        metadata: {
-          usage: args.usage,
-          messages: args.messages,
-        },
+        metadata,
       })
       .end();
     this.clearCurrentHandle?.();
   }
 
   event(args: AgentRunEventArgs): void {
-    const metadata: Record<string, unknown> = {};
-    Object.assign(metadata, args.attributes);
-    this.root.startObservation(args.name, { metadata }, { asType: "event" }).end();
+    const metadata = asMetadata(this.redactOutputValue(args.attributes ?? {}));
+    const attributes: LangfuseEventAttributes = { metadata };
+    if (args.level !== undefined) {
+      attributes.level = args.level;
+    }
+    const startTime = eventStartTime(args.timestamp);
+    this.root.startObservation(args.name, attributes, {
+      asType: "event",
+      ...(startTime === undefined ? {} : { startTime }),
+    });
   }
 
   getHandle(): LangfuseTraceHandle {
@@ -551,13 +640,15 @@ class LangfuseRunObserver implements AgentRunObserver {
       traceId: this.trace.traceId ?? "",
       observationId: this.trace.observationId ?? "",
       addAttributes: (attributes) => {
-        this.root.update({ metadata: attributes });
+        this.root.update({ metadata: asMetadata(this.redactOutputValue(attributes)) });
         this.setCurrentHandle?.(this.handle);
       },
       addEvent: (name, attributes) => {
-        const metadata: Record<string, unknown> = {};
-        Object.assign(metadata, attributes);
-        this.root.startObservation(name, { metadata }, { asType: "event" }).end();
+        this.root.startObservation(
+          name,
+          { metadata: asMetadata(this.redactOutputValue(attributes ?? {})) },
+          { asType: "event" },
+        );
         this.setCurrentHandle?.(this.handle);
       },
     };
@@ -595,17 +686,34 @@ class LangfuseRunObserver implements AgentRunObserver {
     }
     this.turnSpans.clear();
   }
+
+  isFullCapture(): boolean {
+    return this.captureMode === "full";
+  }
+
+  redactTranscript(messages: Message[]): unknown {
+    const inputRedacted =
+      this.redactor === undefined || this.redactInputs === undefined
+        ? messages
+        : applyRedaction(this.redactor, messages, this.redactInputs);
+    const outputRedacted =
+      this.redactor === undefined || this.redactOutputs === undefined
+        ? inputRedacted
+        : applyRedaction(this.redactor, inputRedacted, this.redactOutputs);
+    return sanitizeTraceValue(outputRedacted, this.captureMaxBytes);
+  }
 }
 
 class LangfuseGenerationObserver implements AgentGenerationObserver {
   constructor(
     private readonly generation: LangfuseGeneration,
     private readonly run: LangfuseRunObserver,
+    private readonly startedAt: Date,
   ) {}
 
   update(args: AgentGenerationUpdateArgs): void {
     this.generation.update({
-      output: { delta: args.delta },
+      output: this.run.redactOutputValue({ delta: args.delta }),
     });
   }
 
@@ -614,25 +722,35 @@ class LangfuseGenerationObserver implements AgentGenerationObserver {
     const redactedChoice = this.run.redactOutputValue(args.response.choice);
     const metadata: Record<string, unknown> = { turn: args.turn };
     if (args.firstDeltaMs !== undefined) metadata.firstDeltaMs = args.firstDeltaMs;
-    this.generation
-      .update({
-        output: {
-          messageId: args.response.messageId,
-          content: redactedChoice,
-          text: redactedText,
-        },
-        usageDetails: usageDetails(args.response.usage),
-        metadata,
-      })
-      .end();
+    const output: Record<string, unknown> = {
+      messageId: args.response.messageId,
+      content: redactedChoice,
+      text: redactedText,
+      sources: this.run.redactOutputValue(args.response.sources),
+      providerToolCalls: this.run.redactOutputValue(args.response.providerToolCalls),
+    };
+    const completionStartTime =
+      args.firstDeltaMs === undefined
+        ? undefined
+        : new Date(this.startedAt.getTime() + args.firstDeltaMs);
+    const update: LangfuseGenerationAttributes = {
+      output,
+      usageDetails: usageDetails(args.response.usage),
+      metadata,
+    };
+    if (completionStartTime !== undefined) {
+      update.completionStartTime = completionStartTime;
+    }
+    this.generation.update(update).end();
   }
 
   error(args: AgentGenerationErrorArgs): void {
+    const redactedError = this.run.redactOutputValue(errorMessage(args.error));
     this.generation
       .update({
         level: "ERROR",
-        statusMessage: errorMessage(args.error),
-        output: { error: errorMessage(args.error) },
+        statusMessage: typeof redactedError === "string" ? redactedError : "Generation failed",
+        output: { error: redactedError },
         metadata: { turn: args.turn },
       })
       .end();
@@ -641,7 +759,10 @@ class LangfuseGenerationObserver implements AgentGenerationObserver {
 
 class LangfuseToolObserver implements AgentToolObserver {
   private readonly childAgents = new Map<string, LangfuseAgent>();
-  private readonly childGenerations = new Map<string, LangfuseGeneration>();
+  private readonly childGenerations = new Map<
+    string,
+    { generation: LangfuseGeneration; startedAt: Date }
+  >();
   private readonly childTools: Array<{
     agentId: string;
     toolName: string;
@@ -668,38 +789,156 @@ class LangfuseToolObserver implements AgentToolObserver {
     const agent = this.childAgent(agentId, agentName, args);
 
     if (child.type === "turn_start") {
+      agent.startObservation(
+        `${agentLabel(agentId, agentName)}.turn.${childTurn}.start`,
+        {
+          input: this.run.redactInputValue({
+            prompt: modelInputMessage(child.prompt as Message),
+            history: modelInputMessages(child.history as Message[]),
+          }),
+          metadata: asMetadata(
+            this.run.redactInputValue(childMetadata(args, agentId, agentName, childTurn)),
+          ),
+        },
+        { asType: "event" },
+      );
+      return;
+    }
+
+    if (child.type === "generation_start" && isRecord(child.request)) {
+      const request = child.request;
+      const modelInfo = isRecord(child.modelInfo) ? child.modelInfo : undefined;
+      const messages = Array.isArray(request.chatHistory)
+        ? modelInputMessages(request.chatHistory as Message[])
+        : [];
+      const input: Record<string, unknown> = {
+        instructions: typeof request.instructions === "string" ? request.instructions : undefined,
+        messages,
+      };
+      if (this.run.isFullCapture()) {
+        input.documents = request.documents;
+        input.tools = request.tools;
+        input.providerTools = request.providerTools;
+        input.outputSchema = request.outputSchema;
+        input.additionalParams = request.additionalParams;
+      }
+      const toolNames = Array.isArray(request.tools)
+        ? request.tools
+            .filter(isRecord)
+            .map((tool) => tool.name)
+            .filter((name): name is string => typeof name === "string")
+        : [];
+      const providerToolNames = Array.isArray(request.providerTools)
+        ? request.providerTools
+            .filter(isRecord)
+            .map((tool) => tool.name)
+            .filter((name): name is string => typeof name === "string")
+        : [];
       const generation = agent.startObservation(
         `${agentLabel(agentId, agentName)}.model.turn.${childTurn}`,
         {
-          input: {
-            prompt: modelInputMessage(child.prompt as Message),
-            history: modelInputMessages(child.history as Message[]),
-          },
-          metadata: childMetadata(args, agentId, agentName, childTurn),
+          input: this.run.redactInputValue(input),
+          model:
+            typeof request.model === "string"
+              ? request.model
+              : typeof modelInfo?.defaultModel === "string"
+                ? modelInfo.defaultModel
+                : "default",
+          modelParameters: modelParameters(request as AgentGenerationStartArgs["request"]),
+          metadata: asMetadata(
+            this.run.redactInputValue({
+              ...childMetadata(args, agentId, agentName, childTurn),
+              documentCount: Array.isArray(request.documents) ? request.documents.length : 0,
+              toolNames,
+              providerToolNames,
+              hasOutputSchema: request.outputSchema !== undefined,
+              modelInfo,
+            }),
+          ),
         },
         { asType: "generation" },
       );
-      this.childGenerations.set(generationKey(agentId, childTurn), generation);
+      this.childGenerations.set(generationKey(agentId, childTurn), {
+        generation,
+        startedAt: new Date(),
+      });
       return;
     }
 
     if (child.type === "turn_end") {
-      const generation = this.childGenerations.get(generationKey(agentId, childTurn));
-      if (generation !== undefined) {
+      const childGeneration = this.childGenerations.get(generationKey(agentId, childTurn));
+      if (childGeneration !== undefined) {
         const update: Parameters<LangfuseGeneration["update"]>[0] = {
-          output: child.response,
-          metadata: childMetadata(args, agentId, agentName, childTurn),
+          output: this.run.redactOutputValue(child.response),
+          metadata: asMetadata(
+            this.run.redactOutputValue(childMetadata(args, agentId, agentName, childTurn)),
+          ),
         };
         if (isRecord(child.response) && isRecord(child.response.usage)) {
           update.usageDetails = usageDetailsFromRecord(child.response.usage);
         }
-        generation.update(update).end();
+        if (typeof child.firstDeltaMs === "number") {
+          update.completionStartTime = new Date(
+            childGeneration.startedAt.getTime() + child.firstDeltaMs,
+          );
+        }
+        childGeneration.generation.update(update).end();
         this.childGenerations.delete(generationKey(agentId, childTurn));
       }
       return;
     }
 
+    if (
+      child.type === "text_delta" ||
+      child.type === "reasoning_delta" ||
+      child.type === "tool_call_delta"
+    ) {
+      const childGeneration = this.childGenerations.get(generationKey(agentId, childTurn));
+      childGeneration?.generation.update({
+        output: this.run.redactOutputValue({ delta: child }),
+      });
+      return;
+    }
+
+    if (child.type === "source" || child.type === "provider_tool_call") {
+      const childGeneration = this.childGenerations.get(generationKey(agentId, childTurn));
+      const parent = childGeneration?.generation ?? agent;
+      parent.startObservation(
+        `${agentLabel(agentId, agentName)}.${child.type}`,
+        {
+          output: this.run.redactOutputValue(
+            child.type === "source" ? child.source : child.toolCall,
+          ),
+          metadata: asMetadata(
+            this.run.redactOutputValue(childMetadata(args, agentId, agentName, childTurn)),
+          ),
+        },
+        { asType: "event" },
+      );
+      return;
+    }
+
+    if (child.type === "guardrail_decision") {
+      agent
+        .startObservation(
+          `${agentLabel(agentId, agentName)}.guardrail`,
+          {
+            output: this.run.redactOutputValue(child.decision),
+            metadata: asMetadata(
+              this.run.redactOutputValue(childMetadata(args, agentId, agentName, childTurn)),
+            ),
+          },
+          { asType: "guardrail" },
+        )
+        .end();
+      return;
+    }
+
     if (child.type === "tool_call" && isRecord(child.toolCall)) {
+      const childGeneration = this.childGenerations.get(generationKey(agentId, childTurn));
+      childGeneration?.generation.update({
+        output: this.run.redactOutputValue({ toolCall: child.toolCall }),
+      });
       const toolCall = child.toolCall;
       const toolCallFunction = isRecord(toolCall.function) ? toolCall.function : undefined;
       const toolName = typeof toolCallFunction?.name === "string" ? toolCallFunction.name : "tool";
@@ -712,15 +951,17 @@ class LangfuseToolObserver implements AgentToolObserver {
       const childTool = agent.startObservation(
         `${agentLabel(agentId, agentName)}.${toolName}`,
         {
-          input: {
+          input: this.run.redactInputValue({
             args: toolCallFunction?.arguments ?? {},
             toolCall,
-          },
-          metadata: {
-            ...childMetadata(args, agentId, agentName, childTurn),
-            toolName,
-            toolCallId,
-          },
+          }),
+          metadata: asMetadata(
+            this.run.redactInputValue({
+              ...childMetadata(args, agentId, agentName, childTurn),
+              toolName,
+              toolCallId,
+            }),
+          ),
         },
         { asType: "tool" },
       );
@@ -743,15 +984,19 @@ class LangfuseToolObserver implements AgentToolObserver {
         childTool.ended = true;
         childTool.tool
           .update({
-            output: typeof child.result === "string" ? child.result : child,
-            metadata: {
-              ...childMetadata(args, agentId, agentName, childTurn),
-              toolName,
-              toolCallId,
-              internalCallId:
-                typeof child.internalCallId === "string" ? child.internalCallId : undefined,
-              args: typeof child.args === "string" ? child.args : undefined,
-            },
+            output: this.run.redactOutputValue(
+              typeof child.result === "string" ? child.result : child,
+            ),
+            metadata: asMetadata(
+              this.run.redactInputValue({
+                ...childMetadata(args, agentId, agentName, childTurn),
+                toolName,
+                toolCallId,
+                internalCallId:
+                  typeof child.internalCallId === "string" ? child.internalCallId : undefined,
+                args: typeof child.args === "string" ? child.args : undefined,
+              }),
+            ),
           })
           .end();
       }
@@ -759,18 +1004,35 @@ class LangfuseToolObserver implements AgentToolObserver {
     }
 
     if (child.type === "final") {
-      const update: Parameters<LangfuseAgent["update"]>[0] = { output: child.output };
-      if (isRecord(child.usage)) update.metadata = { usage: child.usage };
+      const update: Parameters<LangfuseAgent["update"]>[0] = {
+        output: this.run.redactOutputValue(child.output),
+      };
+      const metadata: Record<string, unknown> = {};
+      if (isRecord(child.usage)) metadata.usage = child.usage;
+      if (this.run.isFullCapture() && Array.isArray(child.messages)) {
+        metadata.messages = this.run.redactTranscript(child.messages as Message[]);
+      }
+      if (Object.keys(metadata).length > 0) update.metadata = metadata;
       agent.update(update).end();
       this.childAgents.delete(agentId);
       return;
     }
 
     if (child.type === "error") {
+      const redactedError = this.run.redactOutputValue(errorMessage(child.error));
+      const childGeneration = this.childGenerations.get(generationKey(agentId, childTurn));
+      childGeneration?.generation
+        .update({
+          level: "ERROR",
+          statusMessage: typeof redactedError === "string" ? redactedError : "Generation failed",
+          output: { error: redactedError },
+        })
+        .end();
+      this.childGenerations.delete(generationKey(agentId, childTurn));
       const update: Parameters<LangfuseAgent["update"]>[0] = {
         level: "ERROR",
-        statusMessage: errorMessage(child.error),
-        output: { error: errorMessage(child.error) },
+        statusMessage: typeof redactedError === "string" ? redactedError : "Child agent failed",
+        output: { error: redactedError },
       };
       if (isRecord(child.usage)) update.metadata = { usage: child.usage };
       agent.update(update).end();
@@ -802,11 +1064,12 @@ class LangfuseToolObserver implements AgentToolObserver {
 
   error(args: AgentToolErrorArgs): void {
     this.endOpenChildren();
+    const redactedError = this.run.redactOutputValue(errorMessage(args.error));
     this.tool
       .update({
         level: "ERROR",
-        statusMessage: errorMessage(args.error),
-        output: { error: errorMessage(args.error) },
+        statusMessage: typeof redactedError === "string" ? redactedError : "Tool failed",
+        output: { error: redactedError },
         metadata: {
           turn: args.turn,
           internalCallId: args.internalCallId,
@@ -828,7 +1091,9 @@ class LangfuseToolObserver implements AgentToolObserver {
     const agent = this.tool.startObservation(
       `${agentLabel(agentId, agentName)}.run`,
       {
-        metadata: childMetadata(args, agentId, agentName, args.turn),
+        metadata: asMetadata(
+          this.run.redactInputValue(childMetadata(args, agentId, agentName, args.turn)),
+        ),
       },
       { asType: "agent" },
     );
@@ -860,7 +1125,7 @@ class LangfuseToolObserver implements AgentToolObserver {
 
   private endOpenChildren(): void {
     for (const generation of this.childGenerations.values()) {
-      generation.end();
+      generation.generation.end();
     }
     this.childGenerations.clear();
     for (const tool of this.childTools) {

--- a/packages/observability-langfuse/src/tracing.ts
+++ b/packages/observability-langfuse/src/tracing.ts
@@ -517,7 +517,7 @@ class LangfuseRunObserver implements AgentRunObserver {
         : [],
     };
     if (this.captureMode === "full" && args.providerRequest !== undefined) {
-      metadata.providerRequest = this.redactInputValue(args.providerRequest);
+      metadata.providerRequest = args.providerRequest;
     }
     if (args.modelInfo !== undefined) {
       const modelInfo: Record<string, unknown> = {
@@ -789,12 +789,16 @@ class LangfuseToolObserver implements AgentToolObserver {
     const agent = this.childAgent(agentId, agentName, args);
 
     if (child.type === "turn_start") {
+      const promptMessage = isRecord(child.prompt) ? (child.prompt as Message) : undefined;
+      const historyMessages = Array.isArray(child.history)
+        ? (child.history.filter(isRecord) as Message[])
+        : [];
       agent.startObservation(
         `${agentLabel(agentId, agentName)}.turn.${childTurn}.start`,
         {
           input: this.run.redactInputValue({
-            prompt: modelInputMessage(child.prompt as Message),
-            history: modelInputMessages(child.history as Message[]),
+            prompt: promptMessage === undefined ? undefined : modelInputMessage(promptMessage),
+            history: modelInputMessages(historyMessages),
           }),
           metadata: asMetadata(
             this.run.redactInputValue(childMetadata(args, agentId, agentName, childTurn)),
@@ -809,7 +813,7 @@ class LangfuseToolObserver implements AgentToolObserver {
       const request = child.request;
       const modelInfo = isRecord(child.modelInfo) ? child.modelInfo : undefined;
       const messages = Array.isArray(request.chatHistory)
-        ? modelInputMessages(request.chatHistory as Message[])
+        ? modelInputMessages(request.chatHistory.filter(isRecord) as Message[])
         : [];
       const input: Record<string, unknown> = {
         instructions: typeof request.instructions === "string" ? request.instructions : undefined,

--- a/packages/observability-langfuse/src/types.ts
+++ b/packages/observability-langfuse/src/types.ts
@@ -2,6 +2,7 @@ import type { JsonValue } from "@anvia/core/completion";
 import type { AgentObserver } from "@anvia/core/observability";
 
 export type LangfuseRedactionMode = boolean | "deep";
+export type LangfuseCaptureMode = "safe" | "full";
 
 export type LangfuseRedactionOptions = {
   patterns?: RedactorPattern[];
@@ -24,6 +25,8 @@ export type LangfuseTracingOptions = {
   scoreBatchSize?: number | undefined;
   scoreFlushIntervalMs?: number | undefined;
   scoreMaxRetries?: number | undefined;
+  captureMode?: LangfuseCaptureMode | undefined;
+  captureMaxBytes?: number | undefined;
   redactInputs?: LangfuseRedactionMode | undefined;
   redactOutputs?: LangfuseRedactionMode | undefined;
   redaction?: LangfuseRedactionOptions | undefined;

--- a/packages/observability-langfuse/test/langfuse.test.ts
+++ b/packages/observability-langfuse/test/langfuse.test.ts
@@ -11,6 +11,7 @@ import type {
   AgentToolObserver,
 } from "@anvia/core/observability";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sanitizeTraceValue } from "../src/capture";
 import { createLangfuseDatasetClient } from "../src/dataset-client";
 import { runEvalAsExperiment } from "../src/experiment-runner";
 import { createLangfuseEvalReporter as createReporter, langfuse } from "../src/index";
@@ -83,6 +84,120 @@ afterEach(() => {
 });
 
 describe("langfuse", () => {
+  it("captures system instructions and falls back to the provider default model", async () => {
+    const root = fakeObservation("root", "trace-system", "obs-root-system");
+    const turn = fakeObservation("turn", "trace-system", "obs-turn-system");
+    const generation = fakeObservation("generation", "trace-system", "obs-generation-system");
+    root.startObservation.mockReturnValueOnce(turn);
+    turn.startObservation.mockReturnValueOnce(generation);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const run = (await tracing.startRun({
+      instructions: "You are a careful support agent.",
+      prompt: userMessage("hello"),
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+
+    expect(mocks.startObservation).toHaveBeenCalledWith(
+      "agent.run",
+      expect.objectContaining({
+        input: expect.objectContaining({
+          instructions: "You are a careful support agent.",
+        }),
+      }),
+      { asType: "agent" },
+    );
+
+    const requestWithoutModel = { ...generationStartArgs().request };
+    delete requestWithoutModel.model;
+    await run.startGeneration?.({
+      ...generationStartArgs(),
+      request: {
+        ...requestWithoutModel,
+        instructions: "You are a careful support agent.",
+      },
+      modelInfo: {
+        provider: "test",
+        defaultModel: "provider-default",
+      },
+    });
+
+    expect(turn.startObservation).toHaveBeenCalledWith(
+      "model.turn.1",
+      expect.objectContaining({
+        model: "provider-default",
+        input: expect.objectContaining({
+          instructions: "You are a careful support agent.",
+        }),
+      }),
+      { asType: "generation" },
+    );
+  });
+
+  it("keeps rich request fields opt-in while retaining safe summaries", async () => {
+    const request: AgentGenerationStartArgs["request"] = {
+      ...generationStartArgs().request,
+      documents: [{ id: "policy", text: "private policy" }],
+      tools: [{ name: "lookup", description: "Lookup", parameters: { type: "object" } }],
+      providerTools: [{ kind: "provider", provider: "test", name: "search" }],
+      outputSchema: { type: "object" },
+      additionalParams: { seed: 7 },
+    };
+
+    for (const [captureMode, includesFullFields] of [
+      ["safe", false],
+      ["full", true],
+    ] as const) {
+      const root = fakeObservation(`root-${captureMode}`, "trace-capture", "obs-root-capture");
+      const turn = fakeObservation(`turn-${captureMode}`, "trace-capture", "obs-turn-capture");
+      const generation = fakeObservation(
+        `generation-${captureMode}`,
+        "trace-capture",
+        "obs-generation-capture",
+      );
+      root.startObservation.mockReturnValueOnce(turn);
+      turn.startObservation.mockReturnValueOnce(generation);
+      mocks.startObservation.mockReturnValueOnce(root);
+
+      const tracing = langfuse.create({
+        publicKey: "pk",
+        secretKey: "sk",
+        captureMode,
+      });
+      const run = (await tracing.startRun({
+        prompt: userMessage("hello"),
+        history: [],
+        maxTurns: 1,
+      })) as AgentRunObserver;
+      await run.startGeneration?.({
+        ...generationStartArgs(),
+        request,
+        providerRequest: {
+          model: "provider-model",
+          messages: [{ role: "user", content: "provider payload" }],
+        },
+      });
+
+      const attributes = turn.startObservation.mock.calls[0]?.[1] as {
+        input: Record<string, unknown>;
+        metadata: Record<string, unknown>;
+      };
+      expect(attributes.metadata).toMatchObject({
+        documentCount: 1,
+        toolNames: ["lookup"],
+        providerToolNames: ["search"],
+        hasOutputSchema: true,
+        additionalParamKeys: ["seed"],
+      });
+      expect("documents" in attributes.input).toBe(includesFullFields);
+      expect("tools" in attributes.input).toBe(includesFullFields);
+      expect("outputSchema" in attributes.input).toBe(includesFullFields);
+      expect("providerRequest" in attributes.metadata).toBe(includesFullFields);
+    }
+  });
+
   it("creates tracing from explicit options and delegates lifecycle methods", async () => {
     const tracing = langfuse.create({
       publicKey: "public",
@@ -243,7 +358,11 @@ describe("langfuse", () => {
     turn.startObservation.mockReturnValueOnce(generation);
     mocks.startObservation.mockReturnValueOnce(root);
 
-    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const tracing = langfuse.create({
+      publicKey: "pk",
+      secretKey: "sk",
+      captureMode: "full",
+    });
     const run = (await tracing.startRun({
       agentName: "support",
       prompt: userMessage("hi"),
@@ -308,7 +427,11 @@ describe("langfuse", () => {
     turn.startObservation.mockReturnValueOnce(generation);
     mocks.startObservation.mockReturnValueOnce(root);
 
-    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const tracing = langfuse.create({
+      publicKey: "pk",
+      secretKey: "sk",
+      captureMode: "full",
+    });
     const run = (await tracing.startRun({
       agentName: "support",
       prompt: userMessage("hi"),
@@ -393,6 +516,7 @@ describe("langfuse", () => {
     expect(generation.update).toHaveBeenCalledWith(
       expect.objectContaining({
         metadata: expect.objectContaining({ firstDeltaMs: 12 }),
+        completionStartTime: expect.any(Date),
       }),
     );
   });
@@ -437,7 +561,11 @@ describe("langfuse", () => {
     turn.startObservation.mockReturnValueOnce(tool);
     mocks.startObservation.mockReturnValueOnce(root);
 
-    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const tracing = langfuse.create({
+      publicKey: "pk",
+      secretKey: "sk",
+      captureMode: "full",
+    });
     const run = (await tracing.startRun({
       agentName: "support",
       prompt: userMessage("hi"),
@@ -575,6 +703,7 @@ describe("langfuse", () => {
       publicKey: "option-public",
       secretKey: "option-secret",
       baseUrl: "https://option.test",
+      captureMode: "full",
     });
     const run = await tracing.startRun({
       agentName: "support",
@@ -595,7 +724,11 @@ describe("langfuse", () => {
     expect(mocks.startObservation).toHaveBeenCalledWith(
       "support",
       expect.objectContaining({
-        input: { prompt: userMessage("Summarize ticket"), history: [] },
+        input: {
+          instructions: undefined,
+          prompt: userMessage("Summarize ticket"),
+          history: [],
+        },
         metadata: expect.objectContaining({
           agentName: "support",
           agentDescription: "Support agent",
@@ -660,14 +793,20 @@ describe("langfuse", () => {
       "model.turn.1",
       expect.objectContaining({
         model: "test-model",
-        metadata: { turn: 1, toolCount: 0, hasOutputSchema: false },
+        metadata: expect.objectContaining({
+          turn: 1,
+          documentCount: 0,
+          toolNames: [],
+          providerToolNames: [],
+          hasOutputSchema: false,
+        }),
       }),
       { asType: "generation" },
     );
     expect(generation.update).toHaveBeenCalledWith(
       expect.objectContaining({
         output: expect.objectContaining({ text: "Done" }),
-        usageDetails: expect.objectContaining({ inputTokens: 2, outputTokens: 3, totalTokens: 5 }),
+        usageDetails: expect.objectContaining({ input: 2, output: 3, total: 5 }),
       }),
     );
     expect(turn.startObservation).toHaveBeenCalledWith(
@@ -699,7 +838,11 @@ describe("langfuse", () => {
     mocks.startObservation.mockReturnValueOnce(root);
     const metadata = { composer: { entities: [{ id: "document-1" }] } };
 
-    const tracing = langfuse.create({ publicKey: "pk", secretKey: "sk" });
+    const tracing = langfuse.create({
+      publicKey: "pk",
+      secretKey: "sk",
+      captureMode: "full",
+    });
     const run = (await tracing.startRun({
       prompt: Message.user("hello", { metadata }),
       history: [Message.user("earlier", { metadata })],
@@ -709,6 +852,7 @@ describe("langfuse", () => {
       "agent.run",
       expect.objectContaining({
         input: {
+          instructions: undefined,
           prompt: expect.objectContaining({ metadata }),
           history: [expect.objectContaining({ metadata })],
         },
@@ -723,8 +867,10 @@ describe("langfuse", () => {
         chatHistory: [Message.user("hello", { metadata })],
       },
     });
-    const generationInput = turn.startObservation.mock.calls[0]?.[1]?.input as MessageType[];
-    expect(generationInput[0]).not.toHaveProperty("metadata");
+    const generationInput = turn.startObservation.mock.calls[0]?.[1]?.input as {
+      messages: MessageType[];
+    };
+    expect(generationInput.messages[0]).not.toHaveProperty("metadata");
 
     await run.end({
       output: "done",
@@ -745,12 +891,16 @@ describe("langfuse", () => {
     const turn = fakeObservation("turn", "trace-1", "obs-turn");
     const parentTool = fakeObservation("parent-tool", "trace-1", "obs-parent-tool");
     const childAgent = fakeObservation("child-agent", "trace-1", "obs-child-agent");
+    const childTurnEvent = fakeObservation("child-turn-event", "trace-1", "obs-child-turn-event");
     const childGeneration = fakeObservation("child-generation", "trace-1", "obs-child-generation");
     const childTool = fakeObservation("child-tool", "trace-1", "obs-child-tool");
     root.startObservation.mockReturnValueOnce(turn);
     turn.startObservation.mockReturnValueOnce(parentTool);
     parentTool.startObservation.mockReturnValueOnce(childAgent);
-    childAgent.startObservation.mockReturnValueOnce(childGeneration).mockReturnValueOnce(childTool);
+    childAgent.startObservation
+      .mockReturnValueOnce(childTurnEvent)
+      .mockReturnValueOnce(childGeneration)
+      .mockReturnValueOnce(childTool);
     mocks.startObservation.mockReturnValueOnce(root);
 
     const tracing = langfuse.create({ publicKey: "public", secretKey: "secret" });
@@ -783,6 +933,19 @@ describe("langfuse", () => {
         agentId: "child",
         agentName: "Child Agent",
         event: { type: "turn_start", turn: 1, prompt: userMessage("inspect"), history: [] },
+      },
+    });
+    await tool?.streamEvent?.({
+      turn: 1,
+      toolName: "ask_child",
+      args: '{"prompt":"inspect"}',
+      toolCall: parentToolCall,
+      internalCallId: "internal-child",
+      toolCallId: "call-child",
+      event: {
+        agentId: "child",
+        agentName: "Child Agent",
+        event: childGenerationStartEvent(),
       },
     });
     await tool?.streamEvent?.({
@@ -1018,12 +1181,16 @@ describe("langfuse", () => {
     const turn = fakeObservation("turn", "trace-1", "obs-turn");
     const parentTool = fakeObservation("parent-tool", "trace-1", "obs-parent-tool");
     const childAgent = fakeObservation("child-agent", "trace-1", "obs-child-agent");
+    const childTurnEvent = fakeObservation("child-turn-event", "trace-1", "obs-child-turn-event");
     const childGeneration = fakeObservation("child-generation", "trace-1", "obs-child-generation");
     const childTool = fakeObservation("child-tool", "trace-1", "obs-child-tool");
     root.startObservation.mockReturnValueOnce(turn);
     turn.startObservation.mockReturnValueOnce(parentTool);
     parentTool.startObservation.mockReturnValueOnce(childAgent);
-    childAgent.startObservation.mockReturnValueOnce(childGeneration).mockReturnValueOnce(childTool);
+    childAgent.startObservation
+      .mockReturnValueOnce(childTurnEvent)
+      .mockReturnValueOnce(childGeneration)
+      .mockReturnValueOnce(childTool);
     mocks.startObservation.mockReturnValueOnce(root);
 
     const tracing = langfuse.create({ publicKey: "public", secretKey: "secret" });
@@ -1053,6 +1220,18 @@ describe("langfuse", () => {
       event: {
         agentId: "child",
         event: { type: "turn_start", turn: 1, prompt: userMessage("inspect"), history: [] },
+      },
+    });
+    await tool?.streamEvent?.({
+      turn: 1,
+      toolName: "ask_child",
+      args: "{}",
+      toolCall,
+      internalCallId: "internal-child",
+      toolCallId: "call-child",
+      event: {
+        agentId: "child",
+        event: childGenerationStartEvent(),
       },
     });
     await tool?.streamEvent?.({
@@ -2025,6 +2204,44 @@ describe("ScoreQueue", () => {
     expect(queue.depth()).toBe(0);
   });
 
+  it("limits every request body to scoreBatchSize", async () => {
+    const { queue, fetchMock } = makeQueue({ batchSize: 2 });
+    for (let index = 0; index < 5; index += 1) {
+      queue.enqueue(scoreArgs({ name: `score-${index}` }));
+    }
+
+    await queue.flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const sizes = fetchMock.mock.calls.map((call) => JSON.parse(String(call[1]?.body)).length);
+    expect(sizes).toEqual([2, 2, 1]);
+  });
+
+  it("drains scores enqueued while a flush is active", async () => {
+    let releaseFirst: (() => void) | undefined;
+    const firstResponse = new Promise<Response>((resolve) => {
+      releaseFirst = () => resolve(new Response(null, { status: 204 }));
+    });
+    const fetchMock = vi
+      .fn()
+      .mockReturnValueOnce(firstResponse)
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    const { queue } = makeQueue({
+      batchSize: 2,
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+    queue.enqueue(scoreArgs({ name: "first" }));
+    queue.enqueue(scoreArgs({ name: "second" }));
+    const flush = queue.flush();
+    queue.enqueue(scoreArgs({ name: "during-flush" }));
+    releaseFirst?.();
+
+    await flush;
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(queue.depth()).toBe(0);
+  });
+
   it("flush returns when the response is 2xx and clears the queue", async () => {
     const { queue, fetchMock } = makeQueue();
     queue.enqueue(scoreArgs());
@@ -2091,6 +2308,7 @@ describe("ScoreQueue", () => {
       ]),
     });
     expect(fetchMock).toHaveBeenCalledOnce();
+    expect(queue.depth()).toBe(2);
   });
 
   it("gives up after maxRetries and throws LangfuseScoreError", async () => {
@@ -2132,6 +2350,7 @@ describe("ScoreQueue", () => {
 
     expect(fetchMock).toHaveBeenCalledOnce();
     expect(queue.depth()).toBe(0);
+    expect(() => queue.enqueue(scoreArgs())).toThrow(/shut down/);
   });
 });
 
@@ -2226,7 +2445,7 @@ describe("score queue integration", () => {
 });
 
 describe("usageDetailsFromRecord", () => {
-  it("includes cache token fields when present", async () => {
+  it("prefers explicit mutually exclusive details", async () => {
     const { usageDetailsFromRecord } = await import("../src/helpers");
     expect(
       usageDetailsFromRecord({
@@ -2235,17 +2454,24 @@ describe("usageDetailsFromRecord", () => {
         totalTokens: 3,
         cachedInputTokens: 4,
         cacheCreationInputTokens: 5,
+        details: {
+          input: 1,
+          cache_read_input_tokens: 4,
+          cache_creation_input_tokens: 5,
+          output: 2,
+          total: 12,
+        },
       }),
     ).toEqual({
-      inputTokens: 1,
-      outputTokens: 2,
-      totalTokens: 3,
-      cachedInputTokens: 4,
-      cacheCreationInputTokens: 5,
+      input: 1,
+      cache_read_input_tokens: 4,
+      cache_creation_input_tokens: 5,
+      output: 2,
+      total: 12,
     });
   });
 
-  it("defaults cache token fields to 0 when absent", async () => {
+  it("falls back to standard totals when details are absent", async () => {
     const { usageDetailsFromRecord } = await import("../src/helpers");
     expect(
       usageDetailsFromRecord({
@@ -2253,22 +2479,18 @@ describe("usageDetailsFromRecord", () => {
         outputTokens: 2,
       }),
     ).toEqual({
-      inputTokens: 1,
-      outputTokens: 2,
-      totalTokens: 3,
-      cachedInputTokens: 0,
-      cacheCreationInputTokens: 0,
+      input: 1,
+      output: 2,
+      total: 3,
     });
   });
 
   it("defaults every field to 0 when given an empty record", async () => {
     const { usageDetailsFromRecord } = await import("../src/helpers");
     expect(usageDetailsFromRecord({})).toEqual({
-      inputTokens: 0,
-      outputTokens: 0,
-      totalTokens: 0,
-      cachedInputTokens: 0,
-      cacheCreationInputTokens: 0,
+      input: 0,
+      output: 0,
+      total: 0,
     });
   });
 });
@@ -2347,7 +2569,7 @@ describe("LangfuseTraceHandle", () => {
     expect(root.update).toHaveBeenCalledWith({ metadata: { quality: "high", score: 0.9 } });
   });
 
-  it("addEvent creates an event observation under the root and ends it", async () => {
+  it("addEvent creates an auto-ended event observation under the root", async () => {
     const root = fakeObservation("root", "trace-10", "obs-root-10");
     const event = fakeObservation("event", "trace-10", "obs-event-1");
     root.startObservation.mockReturnValueOnce(event);
@@ -2367,7 +2589,7 @@ describe("LangfuseTraceHandle", () => {
       { metadata: { docCount: 4 } },
       { asType: "event" },
     );
-    expect(event.end).toHaveBeenCalledOnce();
+    expect(event.end).not.toHaveBeenCalled();
   });
 
   it("event? on the run observer creates an event observation", async () => {
@@ -2394,7 +2616,35 @@ describe("LangfuseTraceHandle", () => {
       { metadata: { checks: 3 } },
       { asType: "event" },
     );
-    expect(event.end).toHaveBeenCalledOnce();
+    expect(event.end).not.toHaveBeenCalled();
+  });
+
+  it("maps runtime event level and timestamp to native event attributes", async () => {
+    const root = fakeObservation("root", "trace-event", "obs-root-event");
+    const event = fakeObservation("event", "trace-event", "obs-event");
+    root.startObservation.mockReturnValueOnce(event);
+    mocks.startObservation.mockReturnValueOnce(root);
+    const timestamp = new Date("2026-01-02T03:04:05.000Z");
+
+    const tracing = langfuse.create({ publicKey: "public", secretKey: "secret" });
+    const runObserver = (await tracing.startRun({
+      prompt: userMessage("hi"),
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+    await runObserver.event?.({
+      name: "guardrail.warning",
+      level: "WARNING",
+      timestamp,
+      attributes: { rule: "pii" },
+    });
+
+    expect(root.startObservation).toHaveBeenCalledWith(
+      "guardrail.warning",
+      { level: "WARNING", metadata: { rule: "pii" } },
+      { asType: "event", startTime: timestamp },
+    );
+    expect(event.end).not.toHaveBeenCalled();
   });
 
   it("multiple addEvent calls within one run all create observations", async () => {
@@ -2429,8 +2679,8 @@ describe("LangfuseTraceHandle", () => {
       { metadata: {} },
       { asType: "event" },
     );
-    expect(eventA.end).toHaveBeenCalledOnce();
-    expect(eventB.end).toHaveBeenCalledOnce();
+    expect(eventA.end).not.toHaveBeenCalled();
+    expect(eventB.end).not.toHaveBeenCalled();
   });
 
   it("sequential runs replace the handle (last-write-wins)", async () => {
@@ -2500,6 +2750,27 @@ function generationStartArgs(): AgentGenerationStartArgs {
       documents: [],
       tools: [],
       additionalParams: {},
+    },
+  };
+}
+
+function childGenerationStartEvent() {
+  return {
+    type: "generation_start" as const,
+    turn: 1,
+    request: generationStartArgs().request,
+    modelInfo: {
+      provider: "test",
+      defaultModel: "test-model",
+      capabilities: {
+        streaming: true,
+        tools: true,
+        toolChoice: true,
+        imageInput: false,
+        documentInput: false,
+        outputSchema: true,
+        reasoning: true,
+      },
     },
   };
 }
@@ -3368,6 +3639,11 @@ describe("Langfuse prompt attribute binding", () => {
     expect(turn.startObservation).toHaveBeenCalledWith(
       "model.turn.1",
       expect.objectContaining({
+        prompt: {
+          name: "support.system",
+          version: 5,
+          isFallback: false,
+        },
         metadata: expect.objectContaining({
           promptName: "support.system",
           promptVersion: 5,
@@ -3489,6 +3765,24 @@ describe("PII redaction", () => {
     });
   });
 
+  it("redactObject redacts arbitrary arrays without scanning binary payloads", async () => {
+    const { createPiiRedactor } = await import("../src/redaction");
+    const r = createPiiRedactor();
+    const binary = new Uint8Array([1, 2, 3]);
+    const out = r.redactObject([
+      { uri: "mailto:alice@example.com" },
+      { type: "image", data: "alice@example.com" },
+      { url: "data:image/png;base64,alice@example.com" },
+      binary,
+    ]);
+    expect(out).toEqual([
+      { uri: "mailto:[REDACTED]" },
+      { type: "image", data: "alice@example.com" },
+      { url: "data:image/png;base64,alice@example.com" },
+      binary,
+    ]);
+  });
+
   it("redactObject returns primitives unchanged", async () => {
     const { createPiiRedactor } = await import("../src/redaction");
     const r = createPiiRedactor();
@@ -3512,6 +3806,36 @@ describe("PII redaction", () => {
     expect(r.redactString("ssn 123-45-6789 not alice@example.com")).toBe(
       "ssn [REDACTED] not alice@example.com",
     );
+  });
+});
+
+describe("Langfuse trace capture", () => {
+  it("rejects limits too small to contain a truncation marker", () => {
+    expect(() => sanitizeTraceValue("hello", 95)).toThrow(/at least 96/);
+  });
+
+  it("omits base64 bodies before capture", () => {
+    expect(
+      sanitizeTraceValue({ type: "image", mediaType: "image/png", data: "a".repeat(200) }, 1_000),
+    ).toEqual({
+      type: "image",
+      mediaType: "image/png",
+      data: {
+        anviaTraceValue: "omitted",
+        reason: "base64",
+        originalBytes: 200,
+      },
+    });
+  });
+
+  it("replaces oversized values with a bounded deterministic envelope", () => {
+    const captured = sanitizeTraceValue({ text: "x".repeat(1_000) }, 160);
+    expect(captured).toMatchObject({
+      anviaTraceValue: "truncated",
+      originalBytes: expect.any(Number),
+      preview: expect.any(String),
+    });
+    expect(Buffer.byteLength(JSON.stringify(captured), "utf8")).toBeLessThanOrEqual(160);
   });
 });
 
@@ -3592,8 +3916,12 @@ describe("Langfuse redaction integration", () => {
     });
 
     const call = turn.startObservation.mock.calls[0];
-    const input = (call?.[1] as { input: Array<{ content: Array<{ text?: string }> }> }).input;
-    expect(input[0]?.content[0]?.text).toBe("hello [REDACTED]");
+    const input = (
+      call?.[1] as {
+        input: { messages: Array<{ content: Array<{ text?: string }> }> };
+      }
+    ).input;
+    expect(input.messages[0]?.content[0]?.text).toBe("hello [REDACTED]");
   });
 
   it("with redactOutputs: true the generation output text is redacted", async () => {

--- a/packages/observability-langfuse/test/langfuse.test.ts
+++ b/packages/observability-langfuse/test/langfuse.test.ts
@@ -1,5 +1,6 @@
 import {
   AssistantContent,
+  type JsonValue,
   Message,
   type Message as MessageType,
   type Usage,
@@ -1064,6 +1065,58 @@ describe("langfuse", () => {
         output: "7",
         metadata: expect.objectContaining({ parentToolName: "ask_child" }),
       }),
+    );
+  });
+
+  it("ignores malformed streamed child turn inputs", async () => {
+    const root = fakeObservation("root", "trace-1", "obs-root");
+    const turn = fakeObservation("turn", "trace-1", "obs-turn");
+    const parentTool = fakeObservation("parent-tool", "trace-1", "obs-parent-tool");
+    const childAgent = fakeObservation("child-agent", "trace-1", "obs-child-agent");
+    const childTurnEvent = fakeObservation("child-turn-event", "trace-1", "obs-child-turn-event");
+    root.startObservation.mockReturnValueOnce(turn);
+    turn.startObservation.mockReturnValueOnce(parentTool);
+    parentTool.startObservation.mockReturnValueOnce(childAgent);
+    childAgent.startObservation.mockReturnValueOnce(childTurnEvent);
+    mocks.startObservation.mockReturnValueOnce(root);
+
+    const tracing = langfuse.create({ publicKey: "public", secretKey: "secret" });
+    const run = (await tracing.startRun({
+      agentName: "support",
+      prompt: userMessage("delegate"),
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+    const toolCall = AssistantContent.toolCall("call-child", "ask_child", {});
+    const tool = await run.startTool?.({
+      turn: 1,
+      toolName: "ask_child",
+      args: "{}",
+      toolCall,
+      internalCallId: "internal-child",
+      toolCallId: "call-child",
+    });
+
+    await tool?.streamEvent?.({
+      turn: 1,
+      toolName: "ask_child",
+      args: "{}",
+      toolCall,
+      internalCallId: "internal-child",
+      toolCallId: "call-child",
+      event: {
+        agentId: "child",
+        agentName: "Child Agent",
+        event: { type: "turn_start", turn: 1, prompt: "invalid", history: null } as never,
+      },
+    });
+
+    expect(childAgent.startObservation).toHaveBeenCalledWith(
+      "Child_Agent.turn.1.start",
+      expect.objectContaining({
+        input: { prompt: undefined, history: [] },
+      }),
+      { asType: "event" },
     );
   });
 
@@ -2308,7 +2361,29 @@ describe("ScoreQueue", () => {
       ]),
     });
     expect(fetchMock).toHaveBeenCalledOnce();
-    expect(queue.depth()).toBe(2);
+    expect(queue.depth()).toBe(0);
+  });
+
+  it("drops a permanent poison batch and continues draining later scores", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("bad", { status: 400 }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+    const { queue } = makeQueue({
+      batchSize: 2,
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    queue.enqueue(scoreArgs({ name: "poison-1" }));
+    queue.enqueue(scoreArgs({ name: "poison-2" }));
+    queue.enqueue(scoreArgs({ name: "later" }));
+
+    await expect(queue.flush()).rejects.toThrow(/HTTP 400/);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body))).toEqual([
+      expect.objectContaining({ name: "later" }),
+    ]);
+    expect(queue.depth()).toBe(0);
   });
 
   it("gives up after maxRetries and throws LangfuseScoreError", async () => {
@@ -2327,6 +2402,24 @@ describe("ScoreQueue", () => {
     });
     expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(sleepMock).toHaveBeenCalledTimes(2);
+    expect(queue.depth()).toBe(1);
+  });
+
+  it("does not start an unbounded background retry loop", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 500 }));
+    const setTimer = vi.fn();
+    const { queue } = makeQueue({
+      batchSize: 1,
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      maxRetries: 2,
+      setTimer,
+    });
+
+    queue.enqueue(scoreArgs());
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    expect(setTimer).not.toHaveBeenCalled();
+    expect(queue.depth()).toBe(1);
   });
 
   it("size threshold triggers an immediate flush without waiting for the timer", async () => {
@@ -2350,6 +2443,21 @@ describe("ScoreQueue", () => {
 
     expect(fetchMock).toHaveBeenCalledOnce();
     expect(queue.depth()).toBe(0);
+    expect(() => queue.enqueue(scoreArgs())).toThrow(/shut down/);
+  });
+
+  it("shutdown remains best-effort when pending scores cannot be delivered", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 500 }));
+    const { queue } = makeQueue({
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      maxRetries: 1,
+    });
+
+    queue.enqueue(scoreArgs());
+    await expect(queue.shutdown()).resolves.toBeUndefined();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(queue.depth()).toBe(1);
     expect(() => queue.enqueue(scoreArgs())).toThrow(/shut down/);
   });
 });
@@ -2445,6 +2553,15 @@ describe("score queue integration", () => {
 });
 
 describe("usageDetailsFromRecord", () => {
+  it("falls back to standard totals when typed details are empty", async () => {
+    const { usageDetails } = await import("../src/helpers");
+    expect(usageDetails({ ...usage(1, 2), details: {} })).toEqual({
+      input: 1,
+      output: 2,
+      total: 3,
+    });
+  });
+
   it("prefers explicit mutually exclusive details", async () => {
     const { usageDetailsFromRecord } = await import("../src/helpers");
     expect(
@@ -3752,6 +3869,24 @@ describe("PII redaction", () => {
     });
   });
 
+  it("redactMessages bounds deeply nested content", async () => {
+    const { createPiiRedactor } = await import("../src/redaction");
+    const r = createPiiRedactor();
+    let nested: Record<string, JsonValue> = { value: "alice@example.com" };
+    for (let depth = 0; depth < 20_000; depth += 1) {
+      nested = { nested };
+    }
+
+    expect(() =>
+      r.redactMessages([
+        {
+          role: "assistant",
+          content: [{ type: "tool_call", id: "c", function: { name: "x", arguments: nested } }],
+        },
+      ]),
+    ).not.toThrow();
+  });
+
   it("redactObject recurses into nested objects and arrays", async () => {
     const { createPiiRedactor } = await import("../src/redaction");
     const r = createPiiRedactor();
@@ -3836,6 +3971,13 @@ describe("Langfuse trace capture", () => {
       preview: expect.any(String),
     });
     expect(Buffer.byteLength(JSON.stringify(captured), "utf8")).toBeLessThanOrEqual(160);
+  });
+
+  it("omits values that remain unserializable after sanitization", () => {
+    expect(sanitizeTraceValue(1n, 1_000)).toEqual({
+      anviaTraceValue: "omitted",
+      reason: "unserializable",
+    });
   });
 });
 

--- a/packages/observability-langfuse/test/lifecycle.test.ts
+++ b/packages/observability-langfuse/test/lifecycle.test.ts
@@ -1,0 +1,14 @@
+import { startObservation } from "@langfuse/tracing";
+import { describe, expect, it } from "vitest";
+
+describe("Langfuse SDK lifecycle", () => {
+  it("creates instantaneous event observations without explicitly ending them", () => {
+    const root = startObservation("agent.run", {}, { asType: "agent" });
+
+    const event = root.startObservation("checkpoint", {}, { asType: "event" });
+
+    expect(event.id).toBeTypeOf("string");
+    expect(event.traceId).toBe(root.traceId);
+    root.end();
+  });
+});

--- a/packages/provider-anthropic/src/anthropic/completion.ts
+++ b/packages/provider-anthropic/src/anthropic/completion.ts
@@ -166,12 +166,16 @@ function applyAnthropicStreamUsage(
   fields: AnthropicStreamUsageFields,
 ): boolean {
   let changed = false;
+  let uncachedInputTokens = Math.max(
+    0,
+    usage.inputTokens - usage.cachedInputTokens - usage.cacheCreationInputTokens,
+  );
 
   if (event.type === "message_start" && isPlainObject(event.message)) {
     const source = isPlainObject(event.message.usage) ? event.message.usage : undefined;
     if (source !== undefined) {
       if ("input_tokens" in source) {
-        usage.inputTokens = numberFrom(source.input_tokens);
+        uncachedInputTokens = numberFrom(source.input_tokens);
         fields.inputTokens = true;
         changed = true;
       }
@@ -198,28 +202,52 @@ function applyAnthropicStreamUsage(
   }
 
   if (changed) {
-    usage.totalTokens = usage.inputTokens + usage.outputTokens;
+    Object.assign(
+      usage,
+      anthropicUsage(
+        uncachedInputTokens,
+        usage.outputTokens,
+        usage.cachedInputTokens,
+        usage.cacheCreationInputTokens,
+      ),
+    );
   }
 
   return changed;
 }
 
 function mergeUsage(base: Usage, stream: Usage, fields: AnthropicStreamUsageFields): Usage {
-  const inputTokens = fields.inputTokens ? stream.inputTokens : base.inputTokens;
+  const baseUncachedInputTokens = Math.max(
+    0,
+    base.inputTokens - base.cachedInputTokens - base.cacheCreationInputTokens,
+  );
+  const streamUncachedInputTokens = Math.max(
+    0,
+    stream.inputTokens - stream.cachedInputTokens - stream.cacheCreationInputTokens,
+  );
+  const uncachedInputTokens = fields.inputTokens
+    ? streamUncachedInputTokens
+    : baseUncachedInputTokens;
   const outputTokens = fields.outputTokens ? stream.outputTokens : base.outputTokens;
-  return {
-    inputTokens,
+  const cachedInputTokens = fields.cachedInputTokens
+    ? stream.cachedInputTokens
+    : base.cachedInputTokens;
+  const cacheCreationInputTokens = fields.cacheCreationInputTokens
+    ? stream.cacheCreationInputTokens
+    : base.cacheCreationInputTokens;
+  return anthropicUsage(
+    uncachedInputTokens,
     outputTokens,
-    totalTokens: inputTokens + outputTokens,
-    cachedInputTokens: fields.cachedInputTokens ? stream.cachedInputTokens : base.cachedInputTokens,
-    cacheCreationInputTokens: fields.cacheCreationInputTokens
-      ? stream.cacheCreationInputTokens
-      : base.cacheCreationInputTokens,
-  };
+    cachedInputTokens,
+    cacheCreationInputTokens,
+  );
 }
 
 function copyUsage(usage: Usage): Usage {
-  return { ...usage };
+  return {
+    ...usage,
+    ...(usage.details === undefined ? {} : { details: { ...usage.details } }),
+  };
 }
 
 export function toAnthropicMessagesParams(
@@ -350,16 +378,15 @@ export function fromAnthropicMessage(response: unknown): CompletionResponse {
   }
 
   const usageSource = isPlainObject(raw.usage) ? raw.usage : {};
+  const usage = anthropicUsage(
+    numberFrom(usageSource.input_tokens),
+    numberFrom(usageSource.output_tokens),
+    numberFrom(usageSource.cache_read_input_tokens),
+    numberFrom(usageSource.cache_creation_input_tokens),
+  );
   const result: CompletionResponse = {
     choice,
-    usage: {
-      ...Usage.empty(),
-      inputTokens: numberFrom(usageSource.input_tokens),
-      outputTokens: numberFrom(usageSource.output_tokens),
-      totalTokens: numberFrom(usageSource.input_tokens) + numberFrom(usageSource.output_tokens),
-      cachedInputTokens: numberFrom(usageSource.cache_read_input_tokens),
-      cacheCreationInputTokens: numberFrom(usageSource.cache_creation_input_tokens),
-    },
+    usage,
     rawResponse: response,
   };
 
@@ -368,6 +395,31 @@ export function fromAnthropicMessage(response: unknown): CompletionResponse {
   }
 
   return result;
+}
+
+function anthropicUsage(
+  uncachedInputTokens: number,
+  outputTokens: number,
+  cachedInputTokens: number,
+  cacheCreationInputTokens: number,
+): Usage {
+  const inputTokens = uncachedInputTokens + cachedInputTokens + cacheCreationInputTokens;
+  const totalTokens = inputTokens + outputTokens;
+  return {
+    ...Usage.empty(),
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    cachedInputTokens,
+    cacheCreationInputTokens,
+    details: {
+      input: uncachedInputTokens,
+      cache_read_input_tokens: cachedInputTokens,
+      cache_creation_input_tokens: cacheCreationInputTokens,
+      output: outputTokens,
+      total: totalTokens,
+    },
+  };
 }
 
 export function fromAnthropicStreamEvent(event: unknown): CompletionStreamEvent[] {

--- a/packages/provider-anthropic/test/anthropic-completion.test.ts
+++ b/packages/provider-anthropic/test/anthropic-completion.test.ts
@@ -268,11 +268,18 @@ describe("Anthropic Messages mapping", () => {
     expect(response.choice).toEqual([AssistantContent.toolCall("toolu_1", "add", { x: 2, y: 5 })]);
     expect(response.usage).toEqual({
       ...Usage.empty(),
-      inputTokens: 10,
+      inputTokens: 15,
       outputTokens: 5,
-      totalTokens: 15,
+      totalTokens: 20,
       cachedInputTokens: 3,
       cacheCreationInputTokens: 2,
+      details: {
+        input: 10,
+        cache_read_input_tokens: 3,
+        cache_creation_input_tokens: 2,
+        output: 5,
+        total: 20,
+      },
     });
     expect(response.messageId).toBe("msg_1");
   });
@@ -447,9 +454,9 @@ describe("Anthropic Messages mapping", () => {
       type: "final",
       output: "Hello",
       usage: {
-        inputTokens: 10,
+        inputTokens: 13,
         outputTokens: 4,
-        totalTokens: 14,
+        totalTokens: 17,
         cachedInputTokens: 3,
       },
     });
@@ -484,11 +491,18 @@ describe("Anthropic Messages mapping", () => {
 
     expect(response.usage).toEqual({
       ...Usage.empty(),
-      inputTokens: 20,
+      inputTokens: 32,
       outputTokens: 6,
-      totalTokens: 26,
+      totalTokens: 38,
       cachedInputTokens: 7,
       cacheCreationInputTokens: 5,
+      details: {
+        input: 20,
+        cache_read_input_tokens: 7,
+        cache_creation_input_tokens: 5,
+        output: 6,
+        total: 38,
+      },
     });
   });
 
@@ -634,11 +648,18 @@ describe("Anthropic Messages mapping", () => {
     expect(response.choice).toEqual([AssistantContent.text("Full final text")]);
     expect(response.usage).toEqual({
       ...Usage.empty(),
-      inputTokens: 10,
+      inputTokens: 13,
       outputTokens: 4,
-      totalTokens: 14,
+      totalTokens: 17,
       cachedInputTokens: 2,
       cacheCreationInputTokens: 1,
+      details: {
+        input: 10,
+        cache_read_input_tokens: 2,
+        cache_creation_input_tokens: 1,
+        output: 4,
+        total: 17,
+      },
     });
   });
 

--- a/packages/provider-gemini/src/gemini/completion.ts
+++ b/packages/provider-gemini/src/gemini/completion.ts
@@ -607,14 +607,28 @@ function candidateParts(response: Record<string, unknown>): Array<Record<string,
 
 function usageFromGemini(usage: unknown): Usage {
   const raw = isPlainObject(usage) ? usage : {};
-  const inputTokens = numberFrom(raw.promptTokenCount);
-  const outputTokens = numberFrom(raw.candidatesTokenCount);
+  const promptInputTokens = numberFrom(raw.promptTokenCount);
+  const toolInputTokens = numberFrom(raw.toolUsePromptTokenCount);
+  const inputTokens = promptInputTokens + toolInputTokens;
+  const candidateOutputTokens = numberFrom(raw.candidatesTokenCount);
+  const reasoningOutputTokens = numberFrom(raw.thoughtsTokenCount);
+  const outputTokens = candidateOutputTokens + reasoningOutputTokens;
+  const cachedInputTokens = Math.min(promptInputTokens, numberFrom(raw.cachedContentTokenCount));
+  const totalTokens = inputTokens + outputTokens;
   return {
     ...Usage.empty(),
     inputTokens,
     outputTokens,
-    totalTokens: numberFrom(raw.totalTokenCount) || inputTokens + outputTokens,
-    cachedInputTokens: numberFrom(raw.cachedContentTokenCount),
+    totalTokens,
+    cachedInputTokens,
+    details: {
+      input: promptInputTokens - cachedInputTokens,
+      input_cached_tokens: cachedInputTokens,
+      input_tool_use_tokens: toolInputTokens,
+      output: candidateOutputTokens,
+      output_reasoning_tokens: reasoningOutputTokens,
+      total: totalTokens,
+    },
   };
 }
 

--- a/packages/provider-gemini/test/completion.test.ts
+++ b/packages/provider-gemini/test/completion.test.ts
@@ -266,7 +266,9 @@ describe("Gemini completion mapping", () => {
       usageMetadata: {
         promptTokenCount: 3,
         candidatesTokenCount: 4,
-        totalTokenCount: 7,
+        thoughtsTokenCount: 2,
+        toolUsePromptTokenCount: 2,
+        totalTokenCount: 11,
         cachedContentTokenCount: 1,
       },
     });
@@ -278,10 +280,18 @@ describe("Gemini completion mapping", () => {
       AssistantContent.toolCall("call-1", "lookup_order", { id: "A1" }, "call-1"),
     ]);
     expect(response.usage).toMatchObject({
-      inputTokens: 3,
-      outputTokens: 4,
-      totalTokens: 7,
+      inputTokens: 5,
+      outputTokens: 6,
+      totalTokens: 11,
       cachedInputTokens: 1,
+      details: {
+        input: 2,
+        input_cached_tokens: 1,
+        input_tool_use_tokens: 2,
+        output: 4,
+        output_reasoning_tokens: 2,
+        total: 11,
+      },
     });
   });
 

--- a/packages/provider-mistral/src/mistral/completion.ts
+++ b/packages/provider-mistral/src/mistral/completion.ts
@@ -259,11 +259,17 @@ function usageFromMistral(usage: unknown): Usage {
   const raw = isPlainObject(usage) ? usage : {};
   const inputTokens = numberFrom(raw.promptTokens) || numberFrom(raw.prompt_tokens);
   const outputTokens = numberFrom(raw.completionTokens) || numberFrom(raw.completion_tokens);
+  const totalTokens = inputTokens + outputTokens;
   return {
     ...Usage.empty(),
     inputTokens,
     outputTokens,
-    totalTokens: numberFrom(raw.totalTokens) || numberFrom(raw.total_tokens),
+    totalTokens,
+    details: {
+      input: inputTokens,
+      output: outputTokens,
+      total: totalTokens,
+    },
   };
 }
 

--- a/packages/provider-mistral/test/completion.test.ts
+++ b/packages/provider-mistral/test/completion.test.ts
@@ -328,6 +328,11 @@ describe("Mistral completion mapping", () => {
       inputTokens: 3,
       outputTokens: 4,
       totalTokens: 7,
+      details: {
+        input: 3,
+        output: 4,
+        total: 7,
+      },
     });
   });
 
@@ -373,6 +378,11 @@ describe("Mistral completion mapping", () => {
             inputTokens: 1,
             outputTokens: 1,
             totalTokens: 2,
+            details: {
+              input: 1,
+              output: 1,
+              total: 2,
+            },
           },
         }),
       },

--- a/packages/provider-openai/src/openai/chat-completion.ts
+++ b/packages/provider-openai/src/openai/chat-completion.ts
@@ -15,12 +15,18 @@ import {
   type ToolChoice,
   type ToolContent,
   type ToolDefinition,
-  Usage,
   type UserContent,
 } from "@anvia/core/completion";
 import type { OpenAI } from "openai";
 import { orderedRequestMessages } from "../request-messages";
-import { isPlainObject, numberFrom, parseToolArguments, schemaName, stringFrom } from "../utils";
+import {
+  isPlainObject,
+  normalizeOpenAIUsage,
+  numberFrom,
+  parseToolArguments,
+  schemaName,
+  stringFrom,
+} from "../utils";
 import type { OpenAICompletionModelName } from "./models";
 
 type ChatCompletionParams = Record<string, unknown>;
@@ -451,7 +457,7 @@ function isTerminalFinishReason(value: unknown): boolean {
   return value !== undefined && value !== null;
 }
 
-function usageFromOpenAIChatCompletion(usage: unknown): Usage {
+function usageFromOpenAIChatCompletion(usage: unknown) {
   const usageSource = isPlainObject(usage) ? usage : {};
   const promptDetails = isPlainObject(usageSource.prompt_tokens_details)
     ? usageSource.prompt_tokens_details
@@ -461,27 +467,12 @@ function usageFromOpenAIChatCompletion(usage: unknown): Usage {
     : {};
   const inputTokens = numberFrom(usageSource.prompt_tokens);
   const outputTokens = numberFrom(usageSource.completion_tokens);
-  const cachedInputTokens = Math.min(inputTokens, numberFrom(promptDetails.cached_tokens));
-  const reasoningOutputTokens = Math.min(
-    outputTokens,
-    numberFrom(completionDetails.reasoning_tokens),
-  );
-  const totalTokens = inputTokens + outputTokens;
-
-  return {
-    ...Usage.empty(),
+  return normalizeOpenAIUsage({
     inputTokens,
     outputTokens,
-    totalTokens,
-    cachedInputTokens,
-    details: {
-      input: inputTokens - cachedInputTokens,
-      input_cached_tokens: cachedInputTokens,
-      output: outputTokens - reasoningOutputTokens,
-      output_reasoning_tokens: reasoningOutputTokens,
-      total: totalTokens,
-    },
-  };
+    cachedInputTokens: numberFrom(promptDetails.cached_tokens),
+    reasoningOutputTokens: numberFrom(completionDetails.reasoning_tokens),
+  });
 }
 
 function messageToChatMessages(message: MessageType): ChatMessage[] {

--- a/packages/provider-openai/src/openai/chat-completion.ts
+++ b/packages/provider-openai/src/openai/chat-completion.ts
@@ -456,13 +456,31 @@ function usageFromOpenAIChatCompletion(usage: unknown): Usage {
   const promptDetails = isPlainObject(usageSource.prompt_tokens_details)
     ? usageSource.prompt_tokens_details
     : {};
+  const completionDetails = isPlainObject(usageSource.completion_tokens_details)
+    ? usageSource.completion_tokens_details
+    : {};
+  const inputTokens = numberFrom(usageSource.prompt_tokens);
+  const outputTokens = numberFrom(usageSource.completion_tokens);
+  const cachedInputTokens = Math.min(inputTokens, numberFrom(promptDetails.cached_tokens));
+  const reasoningOutputTokens = Math.min(
+    outputTokens,
+    numberFrom(completionDetails.reasoning_tokens),
+  );
+  const totalTokens = inputTokens + outputTokens;
 
   return {
     ...Usage.empty(),
-    inputTokens: numberFrom(usageSource.prompt_tokens),
-    outputTokens: numberFrom(usageSource.completion_tokens),
-    totalTokens: numberFrom(usageSource.total_tokens),
-    cachedInputTokens: numberFrom(promptDetails.cached_tokens),
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    cachedInputTokens,
+    details: {
+      input: inputTokens - cachedInputTokens,
+      input_cached_tokens: cachedInputTokens,
+      output: outputTokens - reasoningOutputTokens,
+      output_reasoning_tokens: reasoningOutputTokens,
+      total: totalTokens,
+    },
   };
 }
 

--- a/packages/provider-openai/src/openai/responses.ts
+++ b/packages/provider-openai/src/openai/responses.ts
@@ -396,17 +396,29 @@ function usageFromOpenAIResponse(usage: unknown): Usage {
   const usageSource = isPlainObject(usage) ? usage : {};
   const inputTokens = numberFrom(usageSource.input_tokens);
   const outputTokens = numberFrom(usageSource.output_tokens);
-  const totalTokens = numberFrom(usageSource.total_tokens) || inputTokens + outputTokens;
-  const details = isPlainObject(usageSource.input_tokens_details)
+  const totalTokens = inputTokens + outputTokens;
+  const inputDetails = isPlainObject(usageSource.input_tokens_details)
     ? usageSource.input_tokens_details
     : {};
+  const outputDetails = isPlainObject(usageSource.output_tokens_details)
+    ? usageSource.output_tokens_details
+    : {};
+  const cachedInputTokens = Math.min(inputTokens, numberFrom(inputDetails.cached_tokens));
+  const reasoningOutputTokens = Math.min(outputTokens, numberFrom(outputDetails.reasoning_tokens));
 
   return {
     ...Usage.empty(),
     inputTokens,
     outputTokens,
     totalTokens,
-    cachedInputTokens: numberFrom(details.cached_tokens),
+    cachedInputTokens,
+    details: {
+      input: inputTokens - cachedInputTokens,
+      input_cached_tokens: cachedInputTokens,
+      output: outputTokens - reasoningOutputTokens,
+      output_reasoning_tokens: reasoningOutputTokens,
+      total: totalTokens,
+    },
   };
 }
 

--- a/packages/provider-openai/src/openai/responses.ts
+++ b/packages/provider-openai/src/openai/responses.ts
@@ -21,12 +21,18 @@ import {
   type ToolContent,
   type ToolDefinition,
   type ToolResultContent,
-  Usage,
   type UserContent,
 } from "@anvia/core/completion";
 import type { OpenAI } from "openai";
 import { orderedRequestMessages } from "../request-messages";
-import { isPlainObject, numberFrom, parseToolArguments, schemaName, stringFrom } from "../utils";
+import {
+  isPlainObject,
+  normalizeOpenAIUsage,
+  numberFrom,
+  parseToolArguments,
+  schemaName,
+  stringFrom,
+} from "../utils";
 import type { OpenAICompletionModelName } from "./models";
 
 type ResponsesCreateParams = Record<string, unknown>;
@@ -392,34 +398,22 @@ export function fromOpenAIStreamEvent(event: unknown): CompletionStreamEvent | u
   return undefined;
 }
 
-function usageFromOpenAIResponse(usage: unknown): Usage {
+function usageFromOpenAIResponse(usage: unknown) {
   const usageSource = isPlainObject(usage) ? usage : {};
   const inputTokens = numberFrom(usageSource.input_tokens);
   const outputTokens = numberFrom(usageSource.output_tokens);
-  const totalTokens = inputTokens + outputTokens;
   const inputDetails = isPlainObject(usageSource.input_tokens_details)
     ? usageSource.input_tokens_details
     : {};
   const outputDetails = isPlainObject(usageSource.output_tokens_details)
     ? usageSource.output_tokens_details
     : {};
-  const cachedInputTokens = Math.min(inputTokens, numberFrom(inputDetails.cached_tokens));
-  const reasoningOutputTokens = Math.min(outputTokens, numberFrom(outputDetails.reasoning_tokens));
-
-  return {
-    ...Usage.empty(),
+  return normalizeOpenAIUsage({
     inputTokens,
     outputTokens,
-    totalTokens,
-    cachedInputTokens,
-    details: {
-      input: inputTokens - cachedInputTokens,
-      input_cached_tokens: cachedInputTokens,
-      output: outputTokens - reasoningOutputTokens,
-      output_reasoning_tokens: reasoningOutputTokens,
-      total: totalTokens,
-    },
-  };
+    cachedInputTokens: numberFrom(inputDetails.cached_tokens),
+    reasoningOutputTokens: numberFrom(outputDetails.reasoning_tokens),
+  });
 }
 
 function messageToResponsesInput(message: MessageType): ResponsesInputItem[] {

--- a/packages/provider-openai/src/utils.ts
+++ b/packages/provider-openai/src/utils.ts
@@ -1,4 +1,4 @@
-import type { JsonObject, JsonValue } from "@anvia/core/completion";
+import { type JsonObject, type JsonValue, Usage } from "@anvia/core/completion";
 
 export function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -10,6 +10,33 @@ export function numberFrom(value: unknown): number {
 
 export function stringFrom(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
+}
+
+export function normalizeOpenAIUsage(options: {
+  inputTokens: number;
+  outputTokens: number;
+  cachedInputTokens: number;
+  reasoningOutputTokens: number;
+}): Usage {
+  const inputTokens = Math.max(0, options.inputTokens);
+  const outputTokens = Math.max(0, options.outputTokens);
+  const cachedInputTokens = Math.min(inputTokens, Math.max(0, options.cachedInputTokens));
+  const reasoningOutputTokens = Math.min(outputTokens, Math.max(0, options.reasoningOutputTokens));
+  const totalTokens = inputTokens + outputTokens;
+  return {
+    ...Usage.empty(),
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    cachedInputTokens,
+    details: {
+      input: inputTokens - cachedInputTokens,
+      input_cached_tokens: cachedInputTokens,
+      output: outputTokens - reasoningOutputTokens,
+      output_reasoning_tokens: reasoningOutputTokens,
+      total: totalTokens,
+    },
+  };
 }
 
 export function parseToolArguments(toolCallId: string, text: string): JsonValue {

--- a/packages/provider-openai/test/openai-chat-completion.test.ts
+++ b/packages/provider-openai/test/openai-chat-completion.test.ts
@@ -232,6 +232,33 @@ describe("OpenAI chat-completions client path", () => {
     ]);
   });
 
+  it("normalizes cached and reasoning token usage into exclusive details", () => {
+    const response = fromOpenAIChatCompletionResponse({
+      choices: [{ message: { role: "assistant", content: "done" } }],
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 4,
+        prompt_tokens_details: { cached_tokens: 3 },
+        completion_tokens_details: { reasoning_tokens: 2 },
+      },
+    });
+
+    expect(response.usage).toEqual({
+      inputTokens: 10,
+      outputTokens: 4,
+      totalTokens: 14,
+      cachedInputTokens: 3,
+      cacheCreationInputTokens: 0,
+      details: {
+        input: 7,
+        input_cached_tokens: 3,
+        output: 2,
+        output_reasoning_tokens: 2,
+        total: 14,
+      },
+    });
+  });
+
   it("uses one stable reasoning id for interleaved Chat Completions chunks", async () => {
     const model = openAIChatModelWithStreams([reasoningInterleaveStream()]);
 

--- a/packages/provider-openai/test/openai-responses.test.ts
+++ b/packages/provider-openai/test/openai-responses.test.ts
@@ -269,6 +269,13 @@ describe("OpenAI Responses mapping", () => {
       outputTokens: 5,
       totalTokens: 15,
       cachedInputTokens: 3,
+      details: {
+        input: 7,
+        input_cached_tokens: 3,
+        output: 5,
+        output_reasoning_tokens: 0,
+        total: 15,
+      },
     });
     expect(response.messageId).toBe("resp_1");
   });
@@ -663,6 +670,13 @@ describe("OpenAI Responses mapping", () => {
         outputTokens: 4,
         totalTokens: 15,
         cachedInputTokens: 2,
+        details: {
+          input: 9,
+          input_cached_tokens: 2,
+          output: 4,
+          output_reasoning_tokens: 0,
+          total: 15,
+        },
       },
     });
 
@@ -694,6 +708,13 @@ describe("OpenAI Responses mapping", () => {
           inputTokens: 2,
           outputTokens: 3,
           totalTokens: 5,
+          details: {
+            input: 2,
+            input_cached_tokens: 0,
+            output: 3,
+            output_reasoning_tokens: 0,
+            total: 5,
+          },
         },
         rawResponse: expect.objectContaining({ id: "resp_incomplete" }),
         messageId: "resp_incomplete",

--- a/packages/tool-studio/test/runner.test.ts
+++ b/packages/tool-studio/test/runner.test.ts
@@ -1793,6 +1793,11 @@ describe("Anvia studio", () => {
     expect(res.headers.get("content-type")).toContain("application/x-ndjson");
     expect(await readJsonl(res)).toMatchObject([
       { type: "turn_start", turn: 1 },
+      {
+        type: "generation_start",
+        turn: 1,
+        modelInfo: { provider: "test", defaultModel: "test" },
+      },
       { type: "text_delta", turn: 1, delta: "hello" },
       { type: "turn_end", turn: 1 },
       { type: "final", output: "hello" },


### PR DESCRIPTION
## Summary

- trace system instructions, normalized model inputs, prompt references, TTFT, and nested agent generations in Langfuse
- add safe/full capture modes with bounded payloads, binary omission, and consistent input/output redaction
- normalize cache-, reasoning-, and tool-use-aware token accounting across OpenAI, Grok, Anthropic, Gemini, and Mistral
- make score queue batching, retry, concurrent flushing, and shutdown behavior reliable
- expose the required core generation stream and usage contracts, with Studio compatibility
- document the public APIs and include `.changeset/trace-complete-langfuse.md`

## Why

Langfuse generation observations did not reliably include system instructions or nested-agent model
requests. Usage fields could also overlap cache and reasoning buckets, which made downstream cost
inference inaccurate. The score queue had race and failure-retention gaps during concurrent flushes
and shutdown.

## Validation

- `pnpm check`
- `pnpm --filter @anvia/core build`
- `pnpm --filter './packages/**' --filter '!@anvia/core' build`
- `pnpm --filter './packages/**' typecheck`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter './packages/**' test`
- `pnpm --filter www reference-check`

The package test suite passed. Eight Docker-gated sandbox integration tests remained skipped because
`ANVIA_SANDBOX_DOCKER_TESTS=1` was not enabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safe and full tracing capture modes with configurable size limits and clearer handling of sensitive, oversized, binary, and circular data.
  * Added generation-start events, model metadata, prompt references, and time-to-first-token timing to streaming observability.
  * Added detailed token usage breakdowns for cached, tool-use, and reasoning tokens across providers.
* **Bug Fixes**
  * Improved score delivery reliability during queue flushing and shutdown.
  * Standardized token totals and redaction behavior across integrations.
* **Documentation**
  * Updated tracing, usage, observability, and configuration references with the new capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->