### PR TITLE
Remove deprecated middleware and hook aliases from core

### DIFF
--- a/.changeset/remove-deprecated-middleware-aliases.md
+++ b/.changeset/remove-deprecated-middleware-aliases.md
@@ -1,0 +1,7 @@
+---
+"@anvia/core": minor
+---
+
+**Breaking:** Remove deprecated middleware and hook aliases.
+
+Use `createMiddleware`, `AgentMiddleware`, `.middleware(...)` / `.middlewares(...)`, `.withMiddleware(...)` / `.withMiddlewares(...)`, `.withHook(...)`, and `onToolOutput` instead of `createToolMiddleware`, `ToolMiddleware`, `.toolMiddleware(...)` / `.toolMiddlewares(...)`, `.withToolMiddleware(...)` / `.withToolMiddlewares(...)`, `.requestHook(...)`, and `onResult`.

--- a/apps/www/src/content/docs/advanced/tool-middleware.md
+++ b/apps/www/src/content/docs/advanced/tool-middleware.md
@@ -143,11 +143,11 @@ const requireSmallResponses = createMiddleware({
 
 Use this for cross-cutting request policy. Avoid large hidden prompt rewrites; stable behavior belongs in instructions, tools, or the runner.
 
-## Deprecations
+## Removed aliases
 
-Use `createMiddleware`, `.middleware(...)`, `.middlewares(...)`, `.withMiddleware(...)`, and `onToolOutput`.
+Prefer `createMiddleware`, `.middleware(...)`, `.middlewares(...)`, `.withMiddleware(...)` / `.withMiddlewares(...)`, `.withHook(...)`, and `onToolOutput`.
 
-Older names such as `createToolMiddleware`, `.toolMiddleware(...)`, `.toolMiddlewares(...)`, `.withToolMiddleware(...)`, and `onResult` are still present for compatibility, but new docs and application code should use the middleware names.
+The older aliases (`createToolMiddleware`, `ToolMiddleware`, `.toolMiddleware(...)`, `.toolMiddlewares(...)`, `.withToolMiddleware(...)`, `.withToolMiddlewares(...)`, `.requestHook(...)`, and `onResult`) have been removed.
 
 ## Middleware Checklist
 

--- a/apps/www/src/content/docs/packages/core/reference/agent.md
+++ b/apps/www/src/content/docs/packages/core/reference/agent.md
@@ -35,10 +35,6 @@ class AgentBuilder<M extends CompletionModel = CompletionModel> {
   hook(hook: PromptHook): this;
   middleware(middleware: AgentMiddleware): this;
   middlewares(middlewares: AgentMiddleware[]): this;
-  /** @deprecated Use middleware instead. */
-  toolMiddleware(middleware: ToolMiddleware): this;
-  /** @deprecated Use middlewares instead. */
-  toolMiddlewares(middlewares: ToolMiddleware[]): this;
   observe(observer: AgentObserver, options?: ObserveOptions): this;
   approvals(options: ToolApprovalsOptions): this;
   guardrails(policies: GuardrailPolicy | GuardrailPolicy[]): this;

--- a/apps/www/src/content/docs/packages/core/reference/request.md
+++ b/apps/www/src/content/docs/packages/core/reference/request.md
@@ -16,15 +16,9 @@ class PromptRequest<M extends CompletionModel = CompletionModel> {
   maxTurns(maxTurns: number): this;
   withCompletionRetries(options?: CompletionRetryOptions): this;
   withHook(hook: PromptHook): this;
-  /** @deprecated Use withHook instead. */
-  requestHook(hook: PromptHook): this;
   withToolConcurrency(concurrency: number): this;
   withMiddleware(middleware: AgentMiddleware): this;
   withMiddlewares(middlewares: AgentMiddleware[]): this;
-  /** @deprecated Use withMiddleware instead. */
-  withToolMiddleware(middleware: ToolMiddleware): this;
-  /** @deprecated Use withMiddlewares instead. */
-  withToolMiddlewares(middlewares: ToolMiddleware[]): this;
   withTrace(trace: AgentTraceOptions): this;
   approvals(options: ToolApprovalsOptions): this;
   send(): Promise<PromptResponse>;

--- a/apps/www/src/content/docs/packages/core/reference/tools.md
+++ b/apps/www/src/content/docs/packages/core/reference/tools.md
@@ -169,17 +169,9 @@ interface AgentMiddleware {
   onCompletionResponse?(args: CompletionResponseMiddlewareArgs): CompletionResponseMiddlewareResult | Promise<CompletionResponseMiddlewareResult>;
   onToolInput?(args: ToolInputMiddlewareArgs): ToolInputMiddlewareResult | Promise<ToolInputMiddlewareResult>;
   onToolOutput?(args: ToolOutputMiddlewareArgs): ToolOutputMiddlewareResult | Promise<ToolOutputMiddlewareResult>;
-  /** @deprecated Use onToolOutput instead. */
-  onResult?(args: ToolResultMiddlewareArgs): string | undefined | Promise<string | undefined>;
 }
 
 function createMiddleware(middleware: AgentMiddleware): AgentMiddleware;
-
-/** @deprecated Use AgentMiddleware instead. */
-type ToolMiddleware = AgentMiddleware;
-
-/** @deprecated Use createMiddleware instead. */
-function createToolMiddleware(middleware: ToolMiddleware): ToolMiddleware;
 ```
 
 Purpose: transform model requests, model responses, tool inputs, and tool outputs during agent runs.

--- a/examples/cookbook/02_tools/10-tool-result-middleware.ts
+++ b/examples/cookbook/02_tools/10-tool-result-middleware.ts
@@ -2,7 +2,7 @@ import { writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { AgentBuilder } from "@anvia/core/agent";
-import { createTool, createToolMiddleware } from "@anvia/core/tool";
+import { createMiddleware, createTool } from "@anvia/core/tool";
 import { OpenAIClient } from "@anvia/openai";
 import { z } from "zod";
 
@@ -24,8 +24,8 @@ const longReportTool = createTool({
       .repeat(20),
 });
 
-const outputGate = createToolMiddleware({
-  async onResult({ toolName, result, internalCallId }) {
+const outputGate = createMiddleware({
+  async onToolOutput({ toolName, result, internalCallId }) {
     if (result.length <= 1_000) {
       return undefined;
     }
@@ -50,7 +50,7 @@ const agentModel = client.completionModel("gpt-5.5");
 const agent = new AgentBuilder("agent", agentModel)
   .instructions("Use tools when useful. Summarize tool results briefly.")
   .tool(longReportTool)
-  .toolMiddleware(outputGate)
+  .middleware(outputGate)
   .defaultMaxTurns(2)
   .build();
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -61,10 +61,6 @@ export class Agent<M extends CompletionModel = CompletionModel> {
   readonly dynamicContexts: DynamicContextRegistration[];
   readonly dynamicTools: DynamicToolRegistration[];
   readonly middlewares: AgentMiddleware[];
-  /**
-   * @deprecated Use `middlewares` instead.
-   */
-  readonly toolMiddlewares: AgentMiddleware[];
   readonly memory: MemoryRegistration | undefined;
   readonly eventStore: AgentEventStoreRegistration | undefined;
 
@@ -89,8 +85,7 @@ export class Agent<M extends CompletionModel = CompletionModel> {
     this.guardrails = [...(options.guardrails ?? [])];
     this.dynamicContexts = [...(options.dynamicContexts ?? [])];
     this.dynamicTools = [...(options.dynamicTools ?? [])];
-    this.middlewares = [...(options.middlewares ?? options.toolMiddlewares ?? [])];
-    this.toolMiddlewares = this.middlewares;
+    this.middlewares = [...(options.middlewares ?? [])];
     this.memory = options.memory;
     this.eventStore = options.eventStore;
   }

--- a/packages/core/src/agent/builder.ts
+++ b/packages/core/src/agent/builder.ts
@@ -17,7 +17,7 @@ import type { AgentObserver, AgentObserverRegistration, ObserveOptions } from ".
 import { toProviderJsonSchema, type ZodSchema } from "../schema/zod-schema";
 import type { SkillSet } from "../skills";
 import type { ToolSearchDocument } from "../tool/dynamic-tools";
-import type { AgentMiddleware, ToolMiddleware } from "../tool/middleware";
+import type { AgentMiddleware } from "../tool/middleware";
 import type { AnyTool, ToolApprovalsOptions } from "../tool/tool";
 import { ToolSet } from "../tool/tool-set";
 import type { VectorSearchIndex } from "../vector-store";
@@ -172,20 +172,6 @@ export class AgentBuilder<M extends CompletionModel = CompletionModel> {
   middlewares(middlewares: AgentMiddleware[]): this {
     this.middlewareRegistrations.push(...middlewares);
     return this;
-  }
-
-  /**
-   * @deprecated Use `middleware` instead.
-   */
-  toolMiddleware(middleware: ToolMiddleware): this {
-    return this.middleware(middleware);
-  }
-
-  /**
-   * @deprecated Use `middlewares` instead.
-   */
-  toolMiddlewares(middlewares: ToolMiddleware[]): this {
-    return this.middlewares(middlewares);
   }
 
   observe(observer: AgentObserver, options: ObserveOptions = {}): this {

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -38,10 +38,6 @@ export type AgentOptions<M extends CompletionModel = CompletionModel> = {
   dynamicContexts?: DynamicContextRegistration[] | undefined;
   dynamicTools?: DynamicToolRegistration[] | undefined;
   middlewares?: AgentMiddleware[] | undefined;
-  /**
-   * @deprecated Use `middlewares` instead.
-   */
-  toolMiddlewares?: AgentMiddleware[] | undefined;
   memory?: MemoryRegistration | undefined;
   eventStore?: AgentEventStoreRegistration | undefined;
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -138,12 +138,11 @@ export type {
   CompletionResponseMiddlewareResult,
   ToolInputMiddlewareArgs,
   ToolInputMiddlewareResult,
-  ToolMiddleware,
   ToolOutputMiddlewareArgs,
   ToolOutputMiddlewareResult,
   ToolResultMiddlewareArgs,
 } from "./tool/middleware";
-export { createMiddleware, createToolMiddleware } from "./tool/middleware";
+export { createMiddleware } from "./tool/middleware";
 export type {
   CreateUIAttachment,
   UIAttachment,

--- a/packages/core/src/internal/prompt-runtime/tool-execution.ts
+++ b/packages/core/src/internal/prompt-runtime/tool-execution.ts
@@ -349,16 +349,6 @@ export class ToolCallExecutor {
         }
         replaced = true;
       }
-      const legacyReplacement = await middleware.onResult?.({
-        ...args,
-        result,
-        structuredResult,
-      });
-      if (legacyReplacement !== undefined) {
-        result = legacyReplacement;
-        structuredResult = undefined;
-        replaced = true;
-      }
     }
     return replaced ? (structuredResult ?? result) : undefined;
   }

--- a/packages/core/src/request/prompt-request.ts
+++ b/packages/core/src/request/prompt-request.ts
@@ -59,7 +59,7 @@ import type {
 } from "../observability/types";
 import { toReadableStream } from "../streaming";
 import type { ToolApprovalsOptions } from "../tool";
-import type { AgentMiddleware, ToolMiddleware } from "../tool/middleware";
+import type { AgentMiddleware } from "../tool/middleware";
 import { MaxTurnsError, PromptCancelledError } from "./errors";
 import {
   type CompletionRetryOptions,
@@ -139,13 +139,6 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
     return this;
   }
 
-  /**
-   * @deprecated Use `withHook` instead.
-   */
-  requestHook(hook: PromptHook): this {
-    return this.withHook(hook);
-  }
-
   withToolConcurrency(concurrency: number): this {
     this.concurrency = Math.max(1, concurrency);
     return this;
@@ -159,20 +152,6 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
   withMiddlewares(middlewares: AgentMiddleware[]): this {
     this.requestMiddlewares.push(...middlewares);
     return this;
-  }
-
-  /**
-   * @deprecated Use `withMiddleware` instead.
-   */
-  withToolMiddleware(middleware: ToolMiddleware): this {
-    return this.withMiddleware(middleware);
-  }
-
-  /**
-   * @deprecated Use `withMiddlewares` instead.
-   */
-  withToolMiddlewares(middlewares: ToolMiddleware[]): this {
-    return this.withMiddlewares(middlewares);
   }
 
   withTrace(trace: AgentTraceOptions): this {

--- a/packages/core/src/tool/middleware.ts
+++ b/packages/core/src/tool/middleware.ts
@@ -78,28 +78,10 @@ export interface AgentMiddleware<RawResponse = unknown> {
   ): MaybePromise<CompletionResponseMiddlewareResult<RawResponse>>;
   onToolInput?(args: ToolInputMiddlewareArgs): MaybePromise<ToolInputMiddlewareResult>;
   onToolOutput?(args: ToolOutputMiddlewareArgs): MaybePromise<ToolOutputMiddlewareResult>;
-  /**
-   * @deprecated Use `onToolOutput` instead.
-   */
-  onResult?(args: ToolResultMiddlewareArgs): string | undefined | Promise<string | undefined>;
 }
-
-/**
- * @deprecated Use `AgentMiddleware` instead.
- */
-export type ToolMiddleware<RawResponse = unknown> = AgentMiddleware<RawResponse>;
 
 export function createMiddleware<RawResponse = unknown>(
   middleware: AgentMiddleware<RawResponse>,
 ): AgentMiddleware<RawResponse> {
-  return middleware;
-}
-
-/**
- * @deprecated Use `createMiddleware` instead.
- */
-export function createToolMiddleware<RawResponse = unknown>(
-  middleware: ToolMiddleware<RawResponse>,
-): ToolMiddleware<RawResponse> {
   return middleware;
 }

--- a/packages/core/test/agent-tool.test.ts
+++ b/packages/core/test/agent-tool.test.ts
@@ -221,7 +221,6 @@ describe("Agent.asTool", () => {
 
     expect(agent.staticContext).toEqual([{ id: "static_doc_0", text: "initial context" }]);
     expect(agent.middlewares).toHaveLength(0);
-    expect(agent.toolMiddlewares).toBe(agent.middlewares);
     expect(agent.observers).toHaveLength(0);
     expect(agent.guardrails).toHaveLength(0);
     expect(agent.dynamicContexts).toHaveLength(0);

--- a/packages/core/test/mcp.test.ts
+++ b/packages/core/test/mcp.test.ts
@@ -9,8 +9,8 @@ import {
   type CompletionStreamEvent,
   connectMcp,
   createHook,
+  createMiddleware,
   createTool,
-  createToolMiddleware,
   type McpClient,
   type McpConnection,
   type McpServer,
@@ -330,9 +330,9 @@ describe("MCP tools", () => {
     ]);
     const agent = new AgentBuilder("test-agent", model)
       .mcp([fakeMcpServer()])
-      .toolMiddleware(
-        createToolMiddleware({
-          onResult({ result }) {
+      .middleware(
+        createMiddleware({
+          onToolOutput({ result }) {
             return `mcp:${result}`;
           },
         }),

--- a/packages/core/test/prompt-request.test.ts
+++ b/packages/core/test/prompt-request.test.ts
@@ -10,7 +10,6 @@ import {
   createHook,
   createMiddleware,
   createTool,
-  createToolMiddleware,
   MaxTurnsError,
   Message,
   PromptCancelledError,
@@ -438,8 +437,8 @@ describe("PromptRequest", () => {
       response([AssistantContent.text("done")]),
     ]);
     const events: string[] = [];
-    const outputGate = createToolMiddleware({
-      onResult({ toolName, result, originalResult, toolCallId }) {
+    const outputGate = createMiddleware({
+      onToolOutput({ toolName, result, originalResult, toolCallId }) {
         events.push(`${toolName}:${toolCallId}:${originalResult}`);
         return `stored:${result}`;
       },
@@ -451,7 +450,7 @@ describe("PromptRequest", () => {
     });
     const agent = new AgentBuilder("test-agent", model)
       .tool(addTool)
-      .toolMiddleware(outputGate)
+      .middleware(outputGate)
       .hook(hook)
       .build();
 
@@ -528,9 +527,9 @@ describe("PromptRequest", () => {
     const seen: string[] = [];
     const agent = new AgentBuilder("test-agent", model)
       .tool(screenshotTool)
-      .toolMiddleware(
-        createToolMiddleware({
-          onResult({ result, structuredResult, originalStructuredResult }) {
+      .middleware(
+        createMiddleware({
+          onToolOutput({ result, structuredResult, originalStructuredResult }) {
             seen.push(
               `${result}:${structuredResult?.length ?? 0}:${originalStructuredResult?.length ?? 0}`,
             );
@@ -561,32 +560,32 @@ describe("PromptRequest", () => {
       response([AssistantContent.text("done")]),
     ]);
     const events: string[] = [];
-    const keep = createToolMiddleware({
-      onResult({ result, originalResult }) {
+    const keep = createMiddleware({
+      onToolOutput({ result, originalResult }) {
         events.push(`keep:${result}:${originalResult}`);
         return undefined;
       },
     });
-    const agentAppend = createToolMiddleware({
-      onResult({ result, originalResult }) {
+    const agentAppend = createMiddleware({
+      onToolOutput({ result, originalResult }) {
         events.push(`agent:${result}:${originalResult}`);
         return `${result}:agent`;
       },
     });
-    const requestAppend = createToolMiddleware({
-      onResult({ result, originalResult }) {
+    const requestAppend = createMiddleware({
+      onToolOutput({ result, originalResult }) {
         events.push(`request:${result}:${originalResult}`);
         return `${result}:request`;
       },
     });
     const agent = new AgentBuilder("test-agent", model)
       .tool(addTool)
-      .toolMiddlewares([keep, agentAppend])
+      .middlewares([keep, agentAppend])
       .build();
 
-    await expect(
-      agent.prompt("add").withToolMiddleware(requestAppend).send(),
-    ).resolves.toMatchObject({ output: "done" });
+    await expect(agent.prompt("add").withMiddleware(requestAppend).send()).resolves.toMatchObject({
+      output: "done",
+    });
 
     expect(events).toEqual(["keep:7:7", "agent:7:7", "request:7:agent:7"]);
     expect(model.requests[1]?.chatHistory.at(-1)).toEqual(
@@ -775,9 +774,9 @@ describe("PromptRequest", () => {
             },
           }),
         ])
-        .withToolMiddleware(
-          createToolMiddleware({
-            onResult({ result }) {
+        .withMiddleware(
+          createMiddleware({
+            onToolOutput({ result }) {
               return `${result}:legacy`;
             },
           }),
@@ -1401,7 +1400,7 @@ describe("PromptRequest", () => {
     });
   });
 
-  it("uses requestHook for one request instead of the agent hook", async () => {
+  it("uses withHook for one request instead of the agent hook", async () => {
     const model = new QueueModel([
       response([AssistantContent.toolCall("call_1", "add", { x: 2, y: 5 })]),
       response([AssistantContent.text("request hook used")]),
@@ -1418,7 +1417,7 @@ describe("PromptRequest", () => {
     });
     const agent = new AgentBuilder("test-agent", model).tool(addTool).hook(agentHook).build();
 
-    await expect(agent.prompt("add").requestHook(requestHook).send()).resolves.toMatchObject({
+    await expect(agent.prompt("add").withHook(requestHook).send()).resolves.toMatchObject({
       output: "request hook used",
     });
 

--- a/packages/core/test/public-exports.test.ts
+++ b/packages/core/test/public-exports.test.ts
@@ -67,11 +67,11 @@ describe("public exports", () => {
 
   it("exposes middleware helpers from public entrypoints", () => {
     expect("createMiddleware" in publicCore).toBe(true);
-    expect("createToolMiddleware" in publicCore).toBe(true);
+    expect("createToolMiddleware" in publicCore).toBe(false);
     expect("createMiddleware" in publicAgent).toBe(false);
     expect("createToolMiddleware" in publicAgent).toBe(false);
     expect("createMiddleware" in tool).toBe(true);
-    expect("createToolMiddleware" in tool).toBe(true);
+    expect("createToolMiddleware" in tool).toBe(false);
   });
 
   it("keeps runtime Agent and AgentSession out of public entrypoints", () => {

--- a/packages/core/test/skills.test.ts
+++ b/packages/core/test/skills.test.ts
@@ -10,7 +10,7 @@ import {
   type CompletionResponse,
   type CompletionStreamEvent,
   createHook,
-  createToolMiddleware,
+  createMiddleware,
   loadSkills,
   Message,
   SkillValidationError,
@@ -286,9 +286,9 @@ describe("skills", () => {
     const events: string[] = [];
     const agent = new AgentBuilder("test-agent", model)
       .skills(skillSet)
-      .toolMiddleware(
-        createToolMiddleware({
-          onResult({ result }) {
+      .middleware(
+        createMiddleware({
+          onToolOutput({ result }) {
             events.push(`middleware:${result}`);
             return "middleware changed result";
           },
@@ -335,9 +335,9 @@ describe("skills", () => {
     const events: string[] = [];
     const agent = new AgentBuilder("test-agent", model)
       .tools(skillSet.tools)
-      .toolMiddleware(
-        createToolMiddleware({
-          onResult({ result }) {
+      .middleware(
+        createMiddleware({
+          onToolOutput({ result }) {
             events.push(`middleware:${result}`);
             return "middleware changed result";
           },

--- a/packages/core/test/streaming.test.ts
+++ b/packages/core/test/streaming.test.ts
@@ -18,7 +18,6 @@ import {
   createMiddleware,
   createObserver,
   createTool,
-  createToolMiddleware,
   defineGuardrailPolicy,
   defineOutputGuardrail,
   getAssistantGenerationMetadata,
@@ -979,9 +978,9 @@ describe("PromptRequest streaming", () => {
     ]);
     const agent = new AgentBuilder("test-agent", model)
       .tool(addTool)
-      .toolMiddleware(
-        createToolMiddleware({
-          onResult({ result }) {
+      .middleware(
+        createMiddleware({
+          onToolOutput({ result }) {
             return `stored:${result}`;
           },
         }),

--- a/packages/tool-studio/src/runtime/agent-runs.ts
+++ b/packages/tool-studio/src/runtime/agent-runs.ts
@@ -354,7 +354,7 @@ function handleStreamingAgentRun(
     props.questionRuntime.createHook(questionContext),
   );
   if (effectiveHook !== undefined) {
-    run.request.requestHook(effectiveHook);
+    run.request.withHook(effectiveHook);
   }
 
   const runStream = mergeRunAndApprovalEvents(run.request.stream(), runtimeEvents);
@@ -442,7 +442,7 @@ async function startBufferedSessionRun(
   if (run.body.metadata !== undefined) approvalContext.metadata = run.body.metadata;
   run.request.approvals(props.approvalRuntime.createApprovals(approvalContext));
   if (effectiveHook !== undefined) {
-    run.request.requestHook(effectiveHook);
+    run.request.withHook(effectiveHook);
   }
 }
 


### PR DESCRIPTION
## Summary
- Remove deprecated `@anvia/core` middleware/hook aliases (`createToolMiddleware`, `ToolMiddleware`, `toolMiddleware(s)`, `withToolMiddleware(s)`, `requestHook`, `onResult`, `toolMiddlewares`) in favor of the current APIs.
- Migrate in-repo callers (Studio, tests, cookbook) and update docs/reference pages; add a breaking minor changeset.

## Test plan
- [x] `pnpm --filter @anvia/core typecheck`
- [x] `pnpm --filter @anvia/core test`
- [x] `pnpm --filter @anvia/studio typecheck`
- [x] `pnpm --filter www reference-check`
- [ ] Confirm no external examples/docs still reference the removed aliases


Made with [Cursor](https://cursor.com)