### PR TITLE
Add Qdrant hybrid RRF search with sparse embeddings

### DIFF
--- a/.changeset/qdrant-hybrid-rrf.md
+++ b/.changeset/qdrant-hybrid-rrf.md
@@ -1,0 +1,11 @@
+---
+"@anvia/core": minor
+"@anvia/fastembed": minor
+"@anvia/qdrant": minor
+---
+
+Add sparse embedding contracts and Qdrant hybrid RRF search.
+
+Core gains `SparseVector` / `SparseEmbeddingModel`, plus `embedSparseTexts`, `embedSparseQuery`,
+and `embedHybridDocuments`. `@anvia/fastembed` wraps FastEmbed SPLADE++. `@anvia/qdrant` supports
+named dense+sparse collections and fused hybrid search via the same `index(...).search(...)` path.

--- a/apps/www/src/content/docs/advanced/embeddings.md
+++ b/apps/www/src/content/docs/advanced/embeddings.md
@@ -113,6 +113,35 @@ const embedded = await embedDocuments(embeddingModel, documents, {
 
 Start conservatively. Higher concurrency can improve backfill speed, but it can also trigger provider rate limits or overload local embedding models.
 
+## Hybrid Dense + Sparse Embeddings
+
+For hybrid retrieval (for example Qdrant RRF), embed documents with both a dense model and a
+sparse model such as FastEmbed SPLADE++:
+
+```ts
+import { embedHybridDocuments } from "@anvia/core/embeddings";
+import {
+  createFastEmbedEmbeddingModel,
+  createFastEmbedSparseEmbeddingModel,
+} from "@anvia/fastembed";
+
+const dense = await createFastEmbedEmbeddingModel();
+const sparse = await createFastEmbedSparseEmbeddingModel();
+
+const embedded = await embedHybridDocuments(
+  { dense, sparse },
+  articles,
+  {
+    id: (article) => article.slug,
+    content: (article) => `${article.title}\n${article.body}`,
+  },
+);
+```
+
+Each result includes `embeddings` and aligned `sparseEmbeddings`. Use a hybrid-capable store such
+as `@anvia/qdrant` with `connect({ hybrid: true })` and `index({ dense, sparse, fusion: "rrf" })`.
+The search request shape stays `{ query, topK }` — fusion happens inside the store.
+
 ## Metadata Values
 
 Vector metadata supports strings, numbers, booleans, and `null`. Avoid nested objects in metadata. If you need richer source information, keep it in your product database and store a stable id in vector metadata.

--- a/apps/www/src/content/docs/packages/core/reference/embeddings.md
+++ b/apps/www/src/content/docs/packages/core/reference/embeddings.md
@@ -30,6 +30,33 @@ Return behavior: `embedTexts(...)` must return one embedding per input text.
 
 Notable errors: provider implementations may throw; helpers throw when the returned count does not match the input count.
 
+## SparseEmbeddingModel and SparseEmbedding
+
+```ts
+type SparseVector = {
+  indices: number[];
+  values: number[];
+};
+
+type SparseEmbedding = {
+  document: string;
+  vector: SparseVector;
+};
+
+interface SparseEmbeddingModel {
+  readonly maxBatchSize?: number;
+  embedTexts(texts: string[]): Promise<SparseEmbedding[]>;
+  embedQuery(query: string): Promise<SparseEmbedding>;
+}
+```
+
+Purpose: sparse lexical/neural encoder contract for hybrid retrieval channels.
+
+Return behavior: `embedTexts(...)` encodes passages for indexing; `embedQuery(...)` encodes
+search queries and may use a different representation for models such as SPLADE.
+
+Notable errors: helpers throw when returned sparse embedding counts do not match input length.
+
 ## EmbeddedDocument and Metadata
 
 ```ts
@@ -41,12 +68,14 @@ type EmbeddedDocument<T, Metadata extends VectorMetadata = VectorMetadata> = {
   document: T;
   metadata?: Metadata;
   embeddings: Embedding[];
+  sparseEmbeddings?: SparseEmbedding[];
 };
 ```
 
 Purpose: document plus one or more embeddings for vector stores.
 
-Return behavior: produced by `embedDocuments(...)`.
+Return behavior: produced by `embedDocuments(...)` or `embedHybridDocuments(...)`. When sparse
+vectors are present they must be aligned 1:1 with `embeddings` by chunk index.
 
 Notable errors: none directly.
 
@@ -59,11 +88,16 @@ type EmbedDocumentsOptions<T, Metadata extends VectorMetadata = VectorMetadata> 
   metadata?: (document: T, index: number) => Metadata | undefined;
   concurrency?: number;
 };
+
+type EmbedHybridDocumentsOptions = {
+  dense: EmbeddingModel;
+  sparse: SparseEmbeddingModel;
+};
 ```
 
 Purpose: controls how typed documents become embedding inputs and metadata.
 
-Return behavior: used by `embedDocuments(...)`.
+Return behavior: used by `embedDocuments(...)` and `embedHybridDocuments(...)`.
 
 Notable errors: invalid content callbacks can throw and fail embedding.
 
@@ -72,16 +106,31 @@ Notable errors: invalid content callbacks can throw and fail embedding.
 ```ts
 function embedText(model: EmbeddingModel, text: string): Promise<Embedding>;
 function embedTexts(model: EmbeddingModel, texts: string[]): Promise<Embedding[]>;
+function embedSparseTexts(
+  model: SparseEmbeddingModel,
+  texts: string[],
+): Promise<SparseEmbedding[]>;
+function embedSparseQuery(
+  model: SparseEmbeddingModel,
+  query: string,
+): Promise<SparseEmbedding>;
 function embedDocuments<T, Metadata extends VectorMetadata = VectorMetadata>(
   model: EmbeddingModel,
   documents: T[],
   options: EmbedDocumentsOptions<T, Metadata>,
 ): Promise<Array<EmbeddedDocument<T, Metadata>>>;
+function embedHybridDocuments<T, Metadata extends VectorMetadata = VectorMetadata>(
+  models: { dense: EmbeddingModel; sparse: SparseEmbeddingModel },
+  documents: T[],
+  options: EmbedDocumentsOptions<T, Metadata>,
+): Promise<Array<EmbeddedDocument<T, Metadata>>>;
 ```
 
-Purpose: normalize batching, concurrency, and count validation.
+Purpose: batch dense and sparse embedding helpers for typed documents.
 
-Return behavior: `embedTexts([])` returns `[]`; `embedText(...)` returns the first embedding from a single-item call.
+Return behavior: `embedTexts([])` returns `[]`; `embedText(...)` returns the first embedding from a
+single-item call; `embedHybridDocuments(...)` attaches aligned dense and sparse vectors for hybrid
+stores such as Qdrant RRF search.
 
 Notable errors: throws when the embedding model returns no embedding or a mismatched embedding count.
 

--- a/apps/www/src/content/docs/packages/fastembed/reference.md
+++ b/apps/www/src/content/docs/packages/fastembed/reference.md
@@ -87,3 +87,81 @@ Purpose: convenience wrapper around `FastEmbedEmbeddingModel.create(...)`.
 Return behavior: resolves a ready embedding model.
 
 Notable errors: same as `FastEmbedEmbeddingModel.create(...)`.
+
+## DEFAULT_FASTEMBED_SPARSE_EMBEDDING_MODEL
+
+```ts
+const DEFAULT_FASTEMBED_SPARSE_EMBEDDING_MODEL = "prithivida/Splade_PP_en_v1";
+```
+
+Purpose: default FastEmbed sparse model id used by `FastEmbedSparseEmbeddingModel.create(...)`.
+
+Return behavior: constant string.
+
+Notable errors: none directly.
+
+## FastEmbed Sparse Types
+
+```ts
+type FastEmbedSparseEmbeddingModelName = "prithivida/Splade_PP_en_v1";
+
+type FastEmbedSparseRuntime = {
+  passageEmbed(texts: string[], batchSize?: number): AsyncIterable<SparseVector[]>;
+  queryEmbed(query: string): Promise<SparseVector>;
+};
+
+type FastEmbedSparseEmbeddingModelOptions = {
+  model?: FastEmbedSparseEmbeddingModelName;
+  maxBatchSize?: number;
+  initOptions?: {
+    executionProviders?: ExecutionProvider[];
+    maxLength?: number;
+    cacheDir?: string;
+    showDownloadProgress?: boolean;
+    modelName?: string;
+  };
+};
+```
+
+Purpose: local FastEmbed SPLADE++ sparse model configuration and runtime contract.
+
+Return behavior: consumed by the sparse embedding model.
+
+Notable errors: invalid runtime output causes embedding calls to throw.
+
+## FastEmbedSparseEmbeddingModel
+
+```ts
+class FastEmbedSparseEmbeddingModel implements SparseEmbeddingModel {
+  readonly model: string;
+  readonly maxBatchSize: number;
+  constructor(runtime: FastEmbedSparseRuntime, options?: FastEmbedSparseEmbeddingModelOptions);
+  static create(
+    options?: FastEmbedSparseEmbeddingModelOptions,
+  ): Promise<FastEmbedSparseEmbeddingModel>;
+  embedTexts(texts: string[]): Promise<SparseEmbedding[]>;
+  embedQuery(query: string): Promise<SparseEmbedding>;
+}
+```
+
+Purpose: local FastEmbed sparse adapter for hybrid retrieval with Anvia.
+
+Return behavior: `create(...)` initializes FastEmbed `SparseTextEmbedding`; `embedTexts(...)`
+uses passage encoding; `embedQuery(...)` uses query encoding.
+
+Notable errors: rejects if model loading fails, runtime output shape is invalid, or the embedding
+count does not match input length.
+
+## createFastEmbedSparseEmbeddingModel
+
+```ts
+function createFastEmbedSparseEmbeddingModel(
+  options?: FastEmbedSparseEmbeddingModelOptions,
+): Promise<FastEmbedSparseEmbeddingModel>;
+```
+
+Purpose: convenience wrapper around `FastEmbedSparseEmbeddingModel.create(...)`.
+
+Return behavior: resolves a ready sparse embedding model.
+
+Notable errors: same as `FastEmbedSparseEmbeddingModel.create(...)`.

--- a/apps/www/src/content/docs/packages/qdrant/getting-started.md
+++ b/apps/www/src/content/docs/packages/qdrant/getting-started.md
@@ -51,6 +51,45 @@ const results = await index.search({
 
 console.log(results);
 ```
+
+## Hybrid search (dense + sparse RRF)
+
+```ts
+import { embedHybridDocuments } from "@anvia/core/embeddings";
+import {
+  createFastEmbedEmbeddingModel,
+  createFastEmbedSparseEmbeddingModel,
+} from "@anvia/fastembed";
+import { QdrantVectorStore } from "@anvia/qdrant";
+
+const dense = await createFastEmbedEmbeddingModel();
+const sparse = await createFastEmbedSparseEmbeddingModel();
+
+const store = await QdrantVectorStore.connect({
+  collectionName: "support_hybrid",
+  vectorSize: 384,
+  hybrid: true,
+});
+
+const documents = await embedHybridDocuments(
+  { dense, sparse },
+  [{ id: "password-reset", text: "Password reset links expire after 30 minutes." }],
+  {
+    id: (document) => document.id,
+    content: (document) => document.text,
+  },
+);
+
+await store.upsertDocuments(documents);
+
+const results = await store.index({ dense, sparse, fusion: "rrf" }).search({
+  query: "How long does a reset link last?",
+  topK: 3,
+});
+```
+
+Hybrid collections use named dense and sparse vectors. Dense-only collections stay on the
+existing unnamed-vector path — create a new collection when enabling hybrid.
 ## Connection boundary
 
 Create the store once during application startup or ingestion setup. The returned index should be passed to agents, tools, or retrieval helpers; database clients, collection names, credentials, and schema decisions should stay outside prompt construction.

--- a/apps/www/src/content/docs/packages/qdrant/getting-started.md
+++ b/apps/www/src/content/docs/packages/qdrant/getting-started.md
@@ -54,6 +54,12 @@ console.log(results);
 
 ## Hybrid search (dense + sparse RRF)
 
+Also install `@anvia/fastembed` and `fastembed` when using local SPLADE++ sparse embeddings:
+
+```sh
+pnpm add @anvia/fastembed fastembed
+```
+
 ```ts
 import { embedHybridDocuments } from "@anvia/core/embeddings";
 import {

--- a/apps/www/src/content/docs/packages/qdrant/reference.md
+++ b/apps/www/src/content/docs/packages/qdrant/reference.md
@@ -48,13 +48,14 @@ type QdrantHybridIndexOptions = {
   prefetchLimit?: number;
 };
 
+type QdrantIndexOptions = EmbeddingModel | QdrantHybridIndexOptions;
+
 class QdrantVectorStore<T, Metadata extends VectorMetadata = VectorMetadata> {
   static connect<T, Metadata extends VectorMetadata = VectorMetadata>(
     options: QdrantVectorStoreConnectOptions,
   ): Promise<QdrantVectorStore<T, Metadata>>;
   upsertDocuments(documents: Array<EmbeddedDocument<T, Metadata>>): Promise<void>;
-  index(model: EmbeddingModel): QdrantVectorIndex<T, Metadata>;
-  index(options: QdrantHybridIndexOptions): QdrantVectorIndex<T, Metadata>;
+  index(options: QdrantIndexOptions): QdrantVectorIndex<T, Metadata>;
 }
 ```
 

--- a/apps/www/src/content/docs/packages/qdrant/reference.md
+++ b/apps/www/src/content/docs/packages/qdrant/reference.md
@@ -13,6 +13,7 @@ Import from `@anvia/qdrant`.
 
 ```ts
 type QdrantDistance = "Cosine" | "Dot" | "Euclid";
+type QdrantFusion = "rrf" | "dbsf";
 
 type QdrantVectorStoreConnectOptions = {
   client?: QdrantClientLike;
@@ -20,12 +21,16 @@ type QdrantVectorStoreConnectOptions = {
   vectorSize: number;
   createIfMissing?: boolean;
   distance?: QdrantDistance;
+  hybrid?: boolean;
+  denseVectorName?: string;
+  sparseVectorName?: string;
 };
 ```
 
 Purpose: connection options for a Qdrant collection.
 
-Return behavior: consumed by `QdrantVectorStore.connect(...)`.
+Return behavior: consumed by `QdrantVectorStore.connect(...)`. Dense-only collections use an
+unnamed vector config. `hybrid: true` creates named dense + sparse vectors for RRF search.
 
 Notable errors: missing collections reject when `createIfMissing` is `false`; collection creation requires `vectorSize`.
 
@@ -34,20 +39,32 @@ Design note: `connect(...)` performs async collection lookup or creation before 
 ## QdrantVectorStore
 
 ```ts
+type QdrantHybridIndexOptions = {
+  dense: EmbeddingModel;
+  sparse: SparseEmbeddingModel;
+  fusion?: QdrantFusion;
+  denseVectorName?: string;
+  sparseVectorName?: string;
+  prefetchLimit?: number;
+};
+
 class QdrantVectorStore<T, Metadata extends VectorMetadata = VectorMetadata> {
   static connect<T, Metadata extends VectorMetadata = VectorMetadata>(
     options: QdrantVectorStoreConnectOptions,
   ): Promise<QdrantVectorStore<T, Metadata>>;
   upsertDocuments(documents: Array<EmbeddedDocument<T, Metadata>>): Promise<void>;
   index(model: EmbeddingModel): QdrantVectorIndex<T, Metadata>;
+  index(options: QdrantHybridIndexOptions): QdrantVectorIndex<T, Metadata>;
 }
 ```
 
 Purpose: Qdrant-backed document storage.
 
-Return behavior: `connect(...)` resolves a store; `index(...)` binds it to an embedding model.
+Return behavior: `connect(...)` resolves a store; `index(denseModel)` binds dense-only search;
+`index({ dense, sparse })` binds hybrid RRF search when the collection was created with
+`hybrid: true`.
 
-Notable errors: connection and upsert calls reject on Qdrant errors; `upsertDocuments(...)` throws when a document has no embeddings or metadata uses reserved `__anvia_*` keys.
+Notable errors: connection and upsert calls reject on Qdrant errors; `upsertDocuments(...)` throws when a document has no embeddings, hybrid upserts lack aligned `sparseEmbeddings`, or metadata uses reserved `__anvia_*` keys. Mixing dense-only and hybrid index modes throws.
 
 ## QdrantVectorIndex
 
@@ -62,9 +79,12 @@ class QdrantVectorIndex<T, Metadata extends VectorMetadata = VectorMetadata>
 
 Purpose: query-time Qdrant search adapter.
 
-Return behavior: embeds the query, calls Qdrant, deduplicates multi-embedding document IDs, and returns normalized results.
+Return behavior: embeds the query, calls Qdrant (`search` for dense-only or `query` with
+prefetch + RRF for hybrid), deduplicates multi-embedding document IDs, and returns normalized
+results. The search request shape stays `{ query, topK, filter?, threshold? }`.
 
-Notable errors: embedding or Qdrant query failures reject.
+Notable errors: embedding or Qdrant query failures reject. Hybrid search requires a client that
+implements `query(...)`.
 
 ## filterToQdrantFilter
 

--- a/packages/core/src/embeddings/embed.ts
+++ b/packages/core/src/embeddings/embed.ts
@@ -4,6 +4,9 @@ import type {
   EmbeddedDocument,
   Embedding,
   EmbeddingModel,
+  EmbedHybridDocumentsOptions,
+  SparseEmbedding,
+  SparseEmbeddingModel,
   VectorMetadata,
 } from "./types";
 
@@ -37,21 +40,43 @@ export async function embedTexts(model: EmbeddingModel, texts: string[]): Promis
   return embeddings;
 }
 
+export async function embedSparseTexts(
+  model: SparseEmbeddingModel,
+  texts: string[],
+): Promise<SparseEmbedding[]> {
+  if (texts.length === 0) {
+    return [];
+  }
+
+  const maxBatchSize = Math.max(1, Math.trunc(model.maxBatchSize ?? texts.length));
+  const batches: string[][] = [];
+  for (let index = 0; index < texts.length; index += maxBatchSize) {
+    batches.push(texts.slice(index, index + maxBatchSize));
+  }
+
+  const results = await mapWithConcurrency(batches, 1, (batch) => model.embedTexts(batch));
+  const embeddings = results.flat();
+  if (embeddings.length !== texts.length) {
+    throw new Error(
+      `Sparse embedding model returned ${embeddings.length} embeddings for ${texts.length} texts`,
+    );
+  }
+  return embeddings;
+}
+
+export async function embedSparseQuery(
+  model: SparseEmbeddingModel,
+  query: string,
+): Promise<SparseEmbedding> {
+  return model.embedQuery(query);
+}
+
 export async function embedDocuments<T, Metadata extends VectorMetadata = VectorMetadata>(
   model: EmbeddingModel,
   documents: T[],
   options: EmbedDocumentsOptions<T, Metadata>,
 ): Promise<Array<EmbeddedDocument<T, Metadata>>> {
-  const prepared = documents.map((document, index) => {
-    const content = options.content(document, index);
-    const texts = Array.isArray(content) ? content : [content];
-    return {
-      id: options.id?.(document, index) ?? `doc${index}`,
-      document,
-      metadata: options.metadata?.(document, index),
-      texts,
-    };
-  });
+  const prepared = prepareDocuments(documents, options);
 
   const flatTexts = prepared.flatMap((item, documentIndex) =>
     item.texts.map((text) => ({ documentIndex, text })),
@@ -81,11 +106,114 @@ export async function embedDocuments<T, Metadata extends VectorMetadata = Vector
   }
 
   return prepared.map((item, index) => {
-    const embeddings = byDocument.get(index) ?? [];
+    const documentEmbeddings = byDocument.get(index) ?? [];
     if (item.metadata === undefined) {
-      return { id: item.id, document: item.document, embeddings };
+      return { id: item.id, document: item.document, embeddings: documentEmbeddings };
     }
-    return { id: item.id, document: item.document, metadata: item.metadata, embeddings };
+    return {
+      id: item.id,
+      document: item.document,
+      metadata: item.metadata,
+      embeddings: documentEmbeddings,
+    };
+  });
+}
+
+export async function embedHybridDocuments<T, Metadata extends VectorMetadata = VectorMetadata>(
+  models: EmbedHybridDocumentsOptions,
+  documents: T[],
+  options: EmbedDocumentsOptions<T, Metadata>,
+): Promise<Array<EmbeddedDocument<T, Metadata>>> {
+  const prepared = prepareDocuments(documents, options);
+  const flatTexts = prepared.flatMap((item, documentIndex) =>
+    item.texts.map((text) => ({ documentIndex, text })),
+  );
+  const concurrency = Math.max(1, Math.trunc(options.concurrency ?? 1));
+
+  const denseBatches = chunk(
+    flatTexts,
+    Math.max(1, Math.trunc(models.dense.maxBatchSize ?? (flatTexts.length || 1))),
+  );
+  const sparseBatches = chunk(
+    flatTexts,
+    Math.max(1, Math.trunc(models.sparse.maxBatchSize ?? (flatTexts.length || 1))),
+  );
+
+  const [denseResults, sparseResults] = await Promise.all([
+    mapWithConcurrency(denseBatches, concurrency, async (batch) => {
+      const batchEmbeddings = await models.dense.embedTexts(batch.map((item) => item.text));
+      if (batchEmbeddings.length !== batch.length) {
+        throw new Error(
+          `Embedding model returned ${batchEmbeddings.length} embeddings for ${batch.length} texts`,
+        );
+      }
+      return batch.map((item, index) => ({
+        documentIndex: item.documentIndex,
+        embedding: batchEmbeddings[index] as Embedding,
+      }));
+    }),
+    mapWithConcurrency(sparseBatches, concurrency, async (batch) => {
+      const batchEmbeddings = await models.sparse.embedTexts(batch.map((item) => item.text));
+      if (batchEmbeddings.length !== batch.length) {
+        throw new Error(
+          `Sparse embedding model returned ${batchEmbeddings.length} embeddings for ${batch.length} texts`,
+        );
+      }
+      return batch.map((item, index) => ({
+        documentIndex: item.documentIndex,
+        embedding: batchEmbeddings[index] as SparseEmbedding,
+      }));
+    }),
+  ]);
+
+  const denseByDocument = new Map<number, Embedding[]>();
+  for (const item of denseResults.flat()) {
+    const list = denseByDocument.get(item.documentIndex) ?? [];
+    list.push(item.embedding);
+    denseByDocument.set(item.documentIndex, list);
+  }
+
+  const sparseByDocument = new Map<number, SparseEmbedding[]>();
+  for (const item of sparseResults.flat()) {
+    const list = sparseByDocument.get(item.documentIndex) ?? [];
+    list.push(item.embedding);
+    sparseByDocument.set(item.documentIndex, list);
+  }
+
+  return prepared.map((item, index) => {
+    const embeddings = denseByDocument.get(index) ?? [];
+    const sparseEmbeddings = sparseByDocument.get(index) ?? [];
+    if (embeddings.length !== sparseEmbeddings.length) {
+      throw new Error(
+        `Hybrid embedding produced ${embeddings.length} dense and ${sparseEmbeddings.length} sparse vectors for document ${item.id}`,
+      );
+    }
+    if (item.metadata === undefined) {
+      return { id: item.id, document: item.document, embeddings, sparseEmbeddings };
+    }
+    return {
+      id: item.id,
+      document: item.document,
+      metadata: item.metadata,
+      embeddings,
+      sparseEmbeddings,
+    };
+  });
+}
+
+function prepareDocuments<T, Metadata extends VectorMetadata>(
+  documents: T[],
+  options: EmbedDocumentsOptions<T, Metadata>,
+) {
+  return documents.map((document, index) => {
+    const content = options.content(document, index);
+    const texts = Array.isArray(content) ? content : [content];
+    return {
+      id: options.id?.(document, index) ?? `doc${index}`,
+      document,
+      metadata: options.metadata?.(document, index),
+      texts,
+    };
   });
 }
 

--- a/packages/core/src/embeddings/types.ts
+++ b/packages/core/src/embeddings/types.ts
@@ -3,10 +3,29 @@ export type Embedding = {
   vector: number[];
 };
 
+export type SparseVector = {
+  indices: number[];
+  values: number[];
+};
+
+export type SparseEmbedding = {
+  document: string;
+  vector: SparseVector;
+};
+
 export interface EmbeddingModel {
   readonly dimensions?: number | undefined;
   readonly maxBatchSize?: number | undefined;
   embedTexts(texts: string[]): Promise<Embedding[]>;
+}
+
+/** Sparse lexical/neural encoder used for hybrid retrieval channels. */
+export interface SparseEmbeddingModel {
+  readonly maxBatchSize?: number | undefined;
+  /** Embed passage/document texts for indexing. */
+  embedTexts(texts: string[]): Promise<SparseEmbedding[]>;
+  /** Embed a search query (may differ from passage encoding for models like SPLADE). */
+  embedQuery(query: string): Promise<SparseEmbedding>;
 }
 
 export type EmbeddedDocument<T, Metadata extends VectorMetadata = VectorMetadata> = {
@@ -14,6 +33,8 @@ export type EmbeddedDocument<T, Metadata extends VectorMetadata = VectorMetadata
   document: T;
   metadata?: Metadata | undefined;
   embeddings: Embedding[];
+  /** Optional sparse vectors aligned 1:1 with `embeddings` by chunk index. */
+  sparseEmbeddings?: SparseEmbedding[] | undefined;
 };
 
 export type VectorMetadataValue = string | number | boolean | null;
@@ -24,4 +45,9 @@ export type EmbedDocumentsOptions<T, Metadata extends VectorMetadata = VectorMet
   content(document: T, index: number): string | string[];
   metadata?: ((document: T, index: number) => Metadata | undefined) | undefined;
   concurrency?: number | undefined;
+};
+
+export type EmbedHybridDocumentsOptions = {
+  dense: EmbeddingModel;
+  sparse: SparseEmbeddingModel;
 };

--- a/packages/core/test/embeddings-vector-store.test.ts
+++ b/packages/core/test/embeddings-vector-store.test.ts
@@ -17,12 +17,17 @@ import {
   type Embedding,
   type EmbeddingModel,
   embedDocuments,
+  embedHybridDocuments,
+  embedSparseQuery,
+  embedSparseTexts,
   embedText,
   embedTexts,
   embedTools,
   euclideanDistance,
   InMemoryVectorStore,
   manhattanDistance,
+  type SparseEmbedding,
+  type SparseEmbeddingModel,
   type StreamingCompletionModel,
   Usage,
   vectorFilter,
@@ -39,6 +44,21 @@ class KeywordEmbeddingModel implements EmbeddingModel {
   async embedTexts(texts: string[]): Promise<Embedding[]> {
     this.calls.push(texts);
     return texts.map((document) => ({ document, vector: vectorFor(document) }));
+  }
+}
+
+class KeywordSparseEmbeddingModel implements SparseEmbeddingModel {
+  readonly maxBatchSize = 8;
+
+  async embedTexts(texts: string[]): Promise<SparseEmbedding[]> {
+    return texts.map((document) => ({
+      document,
+      vector: sparseVectorFor(document),
+    }));
+  }
+
+  async embedQuery(query: string): Promise<SparseEmbedding> {
+    return { document: query, vector: sparseVectorFor(query) };
   }
 }
 
@@ -180,6 +200,32 @@ describe("embeddings", () => {
       },
       { id: "b", metadata: { title: "Dogs" }, embeddings: [{ document: "dog" }] },
     ]);
+  });
+
+  it("embeds hybrid dense and sparse documents with aligned vectors", async () => {
+    const dense = new KeywordEmbeddingModel();
+    const sparse = new KeywordSparseEmbeddingModel();
+    const docs = [
+      { id: "a", texts: ["cat guide"] },
+      { id: "b", texts: ["dog note", "dog care"] },
+    ];
+
+    const embedded = await embedHybridDocuments({ dense, sparse }, docs, {
+      id: (doc) => doc.id,
+      content: (doc) => doc.texts,
+    });
+
+    expect(embedded).toHaveLength(2);
+    expect(embedded[0]?.embeddings).toHaveLength(1);
+    expect(embedded[0]?.sparseEmbeddings).toHaveLength(1);
+    expect(embedded[1]?.embeddings).toHaveLength(2);
+    expect(embedded[1]?.sparseEmbeddings).toHaveLength(2);
+    expect(embedded[0]?.sparseEmbeddings?.[0]?.vector.indices.length).toBeGreaterThan(0);
+
+    await expect(embedSparseTexts(sparse, ["alpha", "beta"])).resolves.toHaveLength(2);
+    await expect(embedSparseQuery(sparse, "query")).resolves.toMatchObject({
+      document: "query",
+    });
   });
 
   it("computes vector distances", () => {
@@ -618,6 +664,24 @@ function vectorFor(text: string): number[] {
     return [0.25, 0, 0.75];
   }
   return [0, 0, 1];
+}
+
+function sparseVectorFor(text: string): { indices: number[]; values: number[] } {
+  const tokens = text
+    .toLowerCase()
+    .split(/\W+/)
+    .filter((token) => token.length > 0);
+  const indices: number[] = [];
+  const values: number[] = [];
+  for (const token of tokens) {
+    let hash = 0;
+    for (let index = 0; index < token.length; index += 1) {
+      hash = (hash * 31 + token.charCodeAt(index)) >>> 0;
+    }
+    indices.push(hash % 10_000);
+    values.push(1);
+  }
+  return { indices, values };
 }
 
 async function sampleEmbedded(model: EmbeddingModel) {

--- a/packages/embedding-fastembed/README.md
+++ b/packages/embedding-fastembed/README.md
@@ -73,6 +73,19 @@ const embeddingModel = await createFastEmbedEmbeddingModel({
 });
 ```
 
+## Sparse embeddings (SPLADE++)
+
+```ts
+import { createFastEmbedSparseEmbeddingModel } from "@anvia/fastembed";
+
+const sparse = await createFastEmbedSparseEmbeddingModel();
+const [passage] = await sparse.embedTexts(["Password reset links expire after 30 minutes."]);
+const query = await sparse.embedQuery("How long does a reset link last?");
+```
+
+The default sparse model is `prithivida/Splade_PP_en_v1`. Use it with dense embeddings and a
+hybrid-capable store such as `@anvia/qdrant` (`hybrid: true` + RRF).
+
 ## Exports
 
 - `FastEmbedEmbeddingModel`
@@ -81,6 +94,12 @@ const embeddingModel = await createFastEmbedEmbeddingModel({
 - `FastEmbedEmbeddingModelName`
 - `FastEmbedEmbeddingModelOptions`
 - `FastEmbedRuntime`
+- `FastEmbedSparseEmbeddingModel`
+- `createFastEmbedSparseEmbeddingModel`
+- `DEFAULT_FASTEMBED_SPARSE_EMBEDDING_MODEL`
+- `FastEmbedSparseEmbeddingModelName`
+- `FastEmbedSparseEmbeddingModelOptions`
+- `FastEmbedSparseRuntime`
 
 ## Development
 

--- a/packages/embedding-fastembed/src/helpers.ts
+++ b/packages/embedding-fastembed/src/helpers.ts
@@ -1,3 +1,5 @@
+import type { SparseVector } from "@anvia/core/embeddings";
+
 export function parseBatch(batch: unknown, offset: number): number[][] {
   if (!Array.isArray(batch)) {
     throw new Error(`FastEmbed embedding model returned an invalid batch at offset ${offset}`);
@@ -14,6 +16,36 @@ export function parseBatch(batch: unknown, offset: number): number[][] {
   });
 }
 
+export function parseSparseBatch(batch: unknown, offset: number): SparseVector[] {
+  if (!Array.isArray(batch)) {
+    throw new Error(
+      `FastEmbed sparse embedding model returned an invalid batch at offset ${offset}`,
+    );
+  }
+  return batch.map((vector, index) => parseSparseVector(vector, offset + index));
+}
+
+export function parseSparseVector(vector: unknown, index: number): SparseVector {
+  if (
+    typeof vector !== "object" ||
+    vector === null ||
+    !("indices" in vector) ||
+    !("values" in vector)
+  ) {
+    throw new Error(
+      `FastEmbed sparse embedding model returned an invalid vector at index ${index}`,
+    );
+  }
+  const indices = numberArray((vector as { indices: unknown }).indices);
+  const values = numberArray((vector as { values: unknown }).values);
+  if (indices === undefined || values === undefined || indices.length !== values.length) {
+    throw new Error(
+      `FastEmbed sparse embedding model returned an invalid vector at index ${index}`,
+    );
+  }
+  return { indices, values };
+}
+
 function vectorToArray(vector: unknown): number[] | undefined {
   if (Array.isArray(vector) && vector.every((item) => typeof item === "number")) {
     return vector;
@@ -23,5 +55,15 @@ function vectorToArray(vector: unknown): number[] | undefined {
     return Array.from(vector as unknown as ArrayLike<number>);
   }
 
+  return undefined;
+}
+
+function numberArray(value: unknown): number[] | undefined {
+  if (Array.isArray(value) && value.every((item) => typeof item === "number")) {
+    return value;
+  }
+  if (ArrayBuffer.isView(value) && !(value instanceof DataView)) {
+    return Array.from(value as unknown as ArrayLike<number>);
+  }
   return undefined;
 }

--- a/packages/embedding-fastembed/src/helpers.ts
+++ b/packages/embedding-fastembed/src/helpers.ts
@@ -52,7 +52,10 @@ function vectorToArray(vector: unknown): number[] | undefined {
   }
 
   if (ArrayBuffer.isView(vector) && !(vector instanceof DataView)) {
-    return Array.from(vector as unknown as ArrayLike<number>);
+    const values = Array.from(vector as unknown as ArrayLike<unknown>);
+    if (values.every((item) => typeof item === "number")) {
+      return values;
+    }
   }
 
   return undefined;
@@ -63,7 +66,10 @@ function numberArray(value: unknown): number[] | undefined {
     return value;
   }
   if (ArrayBuffer.isView(value) && !(value instanceof DataView)) {
-    return Array.from(value as unknown as ArrayLike<number>);
+    const values = Array.from(value as unknown as ArrayLike<unknown>);
+    if (values.every((item) => typeof item === "number")) {
+      return values;
+    }
   }
   return undefined;
 }

--- a/packages/embedding-fastembed/src/index.ts
+++ b/packages/embedding-fastembed/src/index.ts
@@ -3,8 +3,16 @@ export {
   DEFAULT_FASTEMBED_EMBEDDING_MODEL,
   FastEmbedEmbeddingModel,
 } from "./model.js";
+export {
+  createFastEmbedSparseEmbeddingModel,
+  DEFAULT_FASTEMBED_SPARSE_EMBEDDING_MODEL,
+  FastEmbedSparseEmbeddingModel,
+} from "./sparse-model.js";
 export type {
   FastEmbedEmbeddingModelName,
   FastEmbedEmbeddingModelOptions,
   FastEmbedRuntime,
+  FastEmbedSparseEmbeddingModelName,
+  FastEmbedSparseEmbeddingModelOptions,
+  FastEmbedSparseRuntime,
 } from "./types.js";

--- a/packages/embedding-fastembed/src/sparse-model.ts
+++ b/packages/embedding-fastembed/src/sparse-model.ts
@@ -1,0 +1,66 @@
+import type { SparseEmbedding, SparseEmbeddingModel, SparseVector } from "@anvia/core/embeddings";
+import { SparseEmbeddingModel as FastEmbedSparseModel, SparseTextEmbedding } from "fastembed";
+import { parseSparseBatch, parseSparseVector } from "./helpers.js";
+import type {
+  FastEmbedSparseEmbeddingModelName,
+  FastEmbedSparseEmbeddingModelOptions,
+  FastEmbedSparseRuntime,
+} from "./types.js";
+
+export const DEFAULT_FASTEMBED_SPARSE_EMBEDDING_MODEL: FastEmbedSparseEmbeddingModelName =
+  FastEmbedSparseModel.SpladePPEnV1;
+
+export class FastEmbedSparseEmbeddingModel implements SparseEmbeddingModel {
+  readonly model: string;
+  readonly maxBatchSize: number;
+
+  constructor(
+    private readonly runtime: FastEmbedSparseRuntime,
+    options: FastEmbedSparseEmbeddingModelOptions = {},
+  ) {
+    this.model = options.model ?? DEFAULT_FASTEMBED_SPARSE_EMBEDDING_MODEL;
+    this.maxBatchSize = Math.max(1, Math.trunc(options.maxBatchSize ?? 256));
+  }
+
+  static async create(
+    options: FastEmbedSparseEmbeddingModelOptions = {},
+  ): Promise<FastEmbedSparseEmbeddingModel> {
+    const model = options.model ?? DEFAULT_FASTEMBED_SPARSE_EMBEDDING_MODEL;
+    const initOptions = Object.assign({}, options.initOptions, { model });
+    const runtime = await SparseTextEmbedding.init(initOptions as never);
+    return new FastEmbedSparseEmbeddingModel(runtime, { ...options, model });
+  }
+
+  async embedTexts(texts: string[]): Promise<SparseEmbedding[]> {
+    if (texts.length === 0) {
+      return [];
+    }
+
+    const vectors: SparseVector[] = [];
+    for await (const batch of this.runtime.passageEmbed(texts, this.maxBatchSize)) {
+      vectors.push(...parseSparseBatch(batch, vectors.length));
+    }
+
+    if (vectors.length !== texts.length) {
+      throw new Error(
+        `FastEmbed sparse embedding model returned ${vectors.length} embeddings for ${texts.length} texts`,
+      );
+    }
+
+    return texts.map((document, index) => ({
+      document,
+      vector: vectors[index] as SparseVector,
+    }));
+  }
+
+  async embedQuery(query: string): Promise<SparseEmbedding> {
+    const vector = parseSparseVector(await this.runtime.queryEmbed(query), 0);
+    return { document: query, vector };
+  }
+}
+
+export function createFastEmbedSparseEmbeddingModel(
+  options: FastEmbedSparseEmbeddingModelOptions = {},
+): Promise<FastEmbedSparseEmbeddingModel> {
+  return FastEmbedSparseEmbeddingModel.create(options);
+}

--- a/packages/embedding-fastembed/src/types.ts
+++ b/packages/embedding-fastembed/src/types.ts
@@ -1,9 +1,22 @@
-import type { ExecutionProvider, EmbeddingModel as FastEmbedModel } from "fastembed";
+import type { SparseVector } from "@anvia/core/embeddings";
+import type {
+  ExecutionProvider,
+  EmbeddingModel as FastEmbedModel,
+  SparseEmbeddingModel as FastEmbedSparseModel,
+} from "fastembed";
 
 export type FastEmbedEmbeddingModelName = `${Exclude<FastEmbedModel, FastEmbedModel.CUSTOM>}`;
 
+export type FastEmbedSparseEmbeddingModelName =
+  `${Exclude<FastEmbedSparseModel, FastEmbedSparseModel.CUSTOM>}`;
+
 export type FastEmbedRuntime = {
   embed(texts: string[], batchSize?: number): AsyncIterable<unknown>;
+};
+
+export type FastEmbedSparseRuntime = {
+  passageEmbed(texts: string[], batchSize?: number): AsyncIterable<unknown>;
+  queryEmbed(query: string): Promise<unknown>;
 };
 
 export type FastEmbedEmbeddingModelOptions = {
@@ -19,3 +32,19 @@ export type FastEmbedEmbeddingModelOptions = {
       }
     | undefined;
 };
+
+export type FastEmbedSparseEmbeddingModelOptions = {
+  model?: FastEmbedSparseEmbeddingModelName | undefined;
+  maxBatchSize?: number | undefined;
+  initOptions?:
+    | {
+        executionProviders?: ExecutionProvider[] | undefined;
+        maxLength?: number | undefined;
+        cacheDir?: string | undefined;
+        showDownloadProgress?: boolean | undefined;
+        modelName?: string | undefined;
+      }
+    | undefined;
+};
+
+export type { SparseVector };

--- a/packages/embedding-fastembed/test/embedding.test.ts
+++ b/packages/embedding-fastembed/test/embedding.test.ts
@@ -17,6 +17,12 @@ vi.mock("fastembed", () => ({
   FlagEmbedding: {
     init: initMock,
   },
+  SparseEmbeddingModel: {
+    SpladePPEnV1: "prithivida/Splade_PP_en_v1",
+  },
+  SparseTextEmbedding: {
+    init: vi.fn(),
+  },
 }));
 
 describe("FastEmbedEmbeddingModel", () => {

--- a/packages/embedding-fastembed/test/sparse-embedding.test.ts
+++ b/packages/embedding-fastembed/test/sparse-embedding.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createFastEmbedSparseEmbeddingModel,
+  DEFAULT_FASTEMBED_SPARSE_EMBEDDING_MODEL,
+  FastEmbedSparseEmbeddingModel,
+  type FastEmbedSparseRuntime,
+} from "../src/index";
+
+const initMock = vi.hoisted(() => vi.fn());
+
+vi.mock("fastembed", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fastembed")>();
+  return {
+    ...actual,
+    SparseEmbeddingModel: {
+      ...actual.SparseEmbeddingModel,
+      SpladePPEnV1: "prithivida/Splade_PP_en_v1",
+    },
+    SparseTextEmbedding: {
+      init: initMock,
+    },
+  };
+});
+
+describe("FastEmbedSparseEmbeddingModel", () => {
+  it("embeds passages and queries with a provided sparse runtime", async () => {
+    const runtime: FastEmbedSparseRuntime = {
+      passageEmbed: vi.fn(async function* () {
+        yield [
+          { indices: [1, 2], values: [0.5, 0.25] },
+          { indices: [3], values: [1] },
+        ];
+      }),
+      queryEmbed: vi.fn(async () => ({ indices: [9], values: [0.9] })),
+    };
+    const model = new FastEmbedSparseEmbeddingModel(runtime, {
+      model: "prithivida/Splade_PP_en_v1",
+      maxBatchSize: 4,
+    });
+
+    await expect(model.embedTexts(["alpha", "beta"])).resolves.toEqual([
+      { document: "alpha", vector: { indices: [1, 2], values: [0.5, 0.25] } },
+      { document: "beta", vector: { indices: [3], values: [1] } },
+    ]);
+    await expect(model.embedQuery("search")).resolves.toEqual({
+      document: "search",
+      vector: { indices: [9], values: [0.9] },
+    });
+    expect(runtime.passageEmbed).toHaveBeenCalledWith(["alpha", "beta"], 4);
+    expect(runtime.queryEmbed).toHaveBeenCalledWith("search");
+    expect(model.model).toBe(DEFAULT_FASTEMBED_SPARSE_EMBEDDING_MODEL);
+  });
+
+  it("creates a default SPLADE++ sparse model", async () => {
+    const runtime: FastEmbedSparseRuntime = {
+      passageEmbed: vi.fn(async function* () {
+        yield [{ indices: [1], values: [1] }];
+      }),
+      queryEmbed: vi.fn(async () => ({ indices: [1], values: [1] })),
+    };
+    initMock.mockResolvedValueOnce(runtime);
+
+    const model = await createFastEmbedSparseEmbeddingModel();
+    expect(model.model).toBe("prithivida/Splade_PP_en_v1");
+    expect(initMock).toHaveBeenCalled();
+  });
+});

--- a/packages/embedding-fastembed/test/sparse-embedding.test.ts
+++ b/packages/embedding-fastembed/test/sparse-embedding.test.ts
@@ -64,4 +64,20 @@ describe("FastEmbedSparseEmbeddingModel", () => {
     expect(model.model).toBe("prithivida/Splade_PP_en_v1");
     expect(initMock).toHaveBeenCalled();
   });
+
+  it("rejects bigint typed-array sparse vectors", async () => {
+    const runtime: FastEmbedSparseRuntime = {
+      passageEmbed: vi.fn(async function* () {
+        yield [{ indices: new BigInt64Array([1n]), values: new Float32Array([1]) }];
+      }),
+      queryEmbed: vi.fn(async () => ({
+        indices: new BigUint64Array([1n]),
+        values: new Float32Array([1]),
+      })),
+    };
+    const model = new FastEmbedSparseEmbeddingModel(runtime);
+
+    await expect(model.embedTexts(["alpha"])).rejects.toThrow("invalid vector");
+    await expect(model.embedQuery("search")).rejects.toThrow("invalid vector");
+  });
 });

--- a/packages/vector-qdrant/README.md
+++ b/packages/vector-qdrant/README.md
@@ -1,19 +1,11 @@
-# @anvia/qdrant
+# `@anvia/qdrant`
 
-Qdrant vector store adapter for Anvia.
+Qdrant adapter for Anvia vector stores.
 
-Use this package when you want to store Anvia embedded documents in Qdrant and query them through Anvia's vector search interfaces.
+## Install
 
-## Installation
-
-```sh
+```bash
 pnpm add @anvia/qdrant @anvia/core @qdrant/js-client-rest
-```
-
-In this monorepo, the package is available through the workspace:
-
-```sh
-pnpm --filter @anvia/qdrant build
 ```
 
 ## Usage
@@ -23,82 +15,63 @@ import { embedDocuments } from "@anvia/core/embeddings";
 import { OpenAIClient } from "@anvia/openai";
 import { QdrantVectorStore } from "@anvia/qdrant";
 
-const openai = new OpenAIClient({
-  apiKey,
-});
-
+const openai = new OpenAIClient({ apiKey: process.env.OPENAI_API_KEY! });
 const embeddings = openai.embeddingModel("text-embedding-3-small");
 
 const documents = await embedDocuments(
   embeddings,
-  [
-    {
-      id: "password-reset",
-      title: "Password reset policy",
-      body: "Password reset links expire after 30 minutes.",
-      product: "support",
-    },
-    {
-      id: "priority-support",
-      title: "Priority support",
-      body: "Enterprise customers receive priority support.",
-      product: "support",
-    },
-  ],
+  [{ id: "1", text: "Anvia is a TypeScript AI toolkit." }],
   {
     id: (document) => document.id,
-    content: (document) => `${document.title}\n${document.body}`,
-    metadata: (document) => ({
-      product: document.product,
-      title: document.title,
-    }),
+    content: (document) => document.text,
   },
 );
 
 const store = await QdrantVectorStore.connect({
-  collectionName: "support_docs",
+  collectionName: "docs",
   vectorSize: 1536,
 });
 
 await store.upsertDocuments(documents);
 
-const index = store.index(embeddings);
-const results = await index.search({
-  query: "How long does a password reset link last?",
-  topK: 3,
+const results = await store.index(embeddings).search({
+  query: "What is Anvia?",
+  topK: 5,
 });
-
-console.log(results);
 ```
 
-## Qdrant
-
-By default, `QdrantVectorStore.connect` creates a `QdrantClient` from the `@qdrant/js-client-rest` package. You can also pass a custom client:
+## Hybrid search
 
 ```ts
+import { embedHybridDocuments } from "@anvia/core/embeddings";
+import {
+  createFastEmbedEmbeddingModel,
+  createFastEmbedSparseEmbeddingModel,
+} from "@anvia/fastembed";
+import { QdrantVectorStore } from "@anvia/qdrant";
+
+const dense = await createFastEmbedEmbeddingModel();
+const sparse = await createFastEmbedSparseEmbeddingModel();
+
 const store = await QdrantVectorStore.connect({
-  client,
-  collectionName: "support_docs",
-  vectorSize: 1536,
-  createIfMissing: true,
+  collectionName: "docs_hybrid",
+  vectorSize: 384,
+  hybrid: true,
 });
-```
 
-Qdrant requires collection dimensions before creating a collection, so `vectorSize` is required.
+await store.upsertDocuments(
+  await embedHybridDocuments(
+    { dense, sparse },
+    [{ id: "1", text: "Anvia is a TypeScript AI toolkit." }],
+    {
+      id: (document) => document.id,
+      content: (document) => document.text,
+    },
+  ),
+);
 
-`connect(...)` is async by design. It verifies or creates the Qdrant collection before returning a store, so configuration and connection errors fail early instead of surfacing later from `upsertDocuments(...)` or `search(...)`. Constructors stay synchronous and side-effect free.
-
-## Exports
-
-- `QdrantVectorStore`
-- `QdrantVectorIndex`
-- `filterToQdrantFilter`
-- `QdrantVectorStoreConnectOptions`
-
-## Development
-
-```sh
-pnpm --filter @anvia/qdrant typecheck
-pnpm --filter @anvia/qdrant test
-pnpm --filter @anvia/qdrant build
+const results = await store.index({ dense, sparse, fusion: "rrf" }).search({
+  query: "What is Anvia?",
+  topK: 5,
+});
 ```

--- a/packages/vector-qdrant/README.md
+++ b/packages/vector-qdrant/README.md
@@ -42,6 +42,12 @@ const results = await store.index(embeddings).search({
 
 ## Hybrid search
 
+Also install a sparse embedding model. For local SPLADE++:
+
+```bash
+pnpm add @anvia/fastembed fastembed
+```
+
 ```ts
 import { embedHybridDocuments } from "@anvia/core/embeddings";
 import {

--- a/packages/vector-qdrant/src/helpers.ts
+++ b/packages/vector-qdrant/src/helpers.ts
@@ -2,6 +2,8 @@ import { createHash } from "node:crypto";
 import type { EmbeddedDocument, VectorMetadata } from "@anvia/core/embeddings";
 import type { VectorSearchResult } from "@anvia/core/vector-store";
 import {
+  defaultDenseVectorName,
+  defaultSparseVectorName,
   documentIdPayloadKey,
   documentPayloadKey,
   type QdrantClientLike,
@@ -69,8 +71,8 @@ export function qdrantPoints<T, Metadata extends VectorMetadata>(
     }
   }
 
-  const denseName = options.denseVectorName ?? "dense";
-  const sparseName = options.sparseVectorName ?? "sparse";
+  const denseName = options.denseVectorName ?? defaultDenseVectorName;
+  const sparseName = options.sparseVectorName ?? defaultSparseVectorName;
 
   return document.embeddings.map((embedding, index) => {
     const logicalId =

--- a/packages/vector-qdrant/src/helpers.ts
+++ b/packages/vector-qdrant/src/helpers.ts
@@ -44,15 +44,33 @@ export function parseDocument<T>(document: unknown): T {
 
 export function qdrantPoints<T, Metadata extends VectorMetadata>(
   document: EmbeddedDocument<T, Metadata>,
+  options: {
+    hybrid?: boolean | undefined;
+    denseVectorName?: string | undefined;
+    sparseVectorName?: string | undefined;
+  } = {},
 ): Array<{
   id: string;
-  vector: number[];
+  vector: number[] | Record<string, unknown>;
   payload: Record<string, unknown>;
 }> {
   if (document.embeddings.length === 0) {
     throw new Error(`Document ${document.id} has no embeddings`);
   }
   assertNoReservedMetadata(document.metadata);
+
+  const hybrid = options.hybrid === true;
+  if (hybrid) {
+    const sparseEmbeddings = document.sparseEmbeddings;
+    if (sparseEmbeddings === undefined || sparseEmbeddings.length !== document.embeddings.length) {
+      throw new Error(
+        `Hybrid Qdrant upsert requires sparseEmbeddings aligned with embeddings for document ${document.id}`,
+      );
+    }
+  }
+
+  const denseName = options.denseVectorName ?? "dense";
+  const sparseName = options.sparseVectorName ?? "sparse";
 
   return document.embeddings.map((embedding, index) => {
     const logicalId =
@@ -62,9 +80,30 @@ export function qdrantPoints<T, Metadata extends VectorMetadata>(
       [documentPayloadKey]: serializeDocument(document.document),
     };
     Object.assign(payload, document.metadata);
+
+    if (!hybrid) {
+      return {
+        id: pointId(logicalId),
+        vector: embedding.vector,
+        payload,
+      };
+    }
+
+    const sparse = document.sparseEmbeddings?.[index];
+    if (sparse === undefined) {
+      throw new Error(
+        `Hybrid Qdrant upsert requires sparseEmbeddings aligned with embeddings for document ${document.id}`,
+      );
+    }
     return {
       id: pointId(logicalId),
-      vector: embedding.vector,
+      vector: {
+        [denseName]: embedding.vector,
+        [sparseName]: {
+          indices: sparse.vector.indices,
+          values: sparse.vector.values,
+        },
+      },
       payload,
     };
   });

--- a/packages/vector-qdrant/src/index.ts
+++ b/packages/vector-qdrant/src/index.ts
@@ -4,5 +4,7 @@ export { QdrantVectorStore } from "./store.js";
 export type {
   QdrantClientLike,
   QdrantDistance,
+  QdrantFusion,
+  QdrantHybridIndexOptions,
   QdrantVectorStoreConnectOptions,
 } from "./types.js";

--- a/packages/vector-qdrant/src/index.ts
+++ b/packages/vector-qdrant/src/index.ts
@@ -6,5 +6,6 @@ export type {
   QdrantDistance,
   QdrantFusion,
   QdrantHybridIndexOptions,
+  QdrantIndexOptions,
   QdrantVectorStoreConnectOptions,
 } from "./types.js";

--- a/packages/vector-qdrant/src/search-index.ts
+++ b/packages/vector-qdrant/src/search-index.ts
@@ -1,4 +1,10 @@
-import { type EmbeddingModel, embedText, type VectorMetadata } from "@anvia/core/embeddings";
+import {
+  type EmbeddingModel,
+  embedSparseQuery,
+  embedText,
+  type SparseEmbeddingModel,
+  type VectorMetadata,
+} from "@anvia/core/embeddings";
 import type { Tool } from "@anvia/core/tool";
 import {
   createVectorSearchTool,
@@ -9,7 +15,15 @@ import {
 } from "@anvia/core/vector-store";
 import { filterToQdrantFilter } from "./filters.js";
 import { parseQueryResults } from "./helpers.js";
-import type { QdrantClientLike } from "./types.js";
+import type { QdrantClientLike, QdrantFusion } from "./types.js";
+
+export type QdrantVectorIndexHybridOptions = {
+  sparse: SparseEmbeddingModel;
+  fusion: QdrantFusion;
+  denseVectorName: string;
+  sparseVectorName: string;
+  prefetchLimit?: number | undefined;
+};
 
 export class QdrantVectorIndex<T, Metadata extends VectorMetadata = VectorMetadata>
   implements VectorSearchIndex<T, Metadata>
@@ -18,14 +32,54 @@ export class QdrantVectorIndex<T, Metadata extends VectorMetadata = VectorMetada
     private readonly model: EmbeddingModel,
     private readonly client: QdrantClientLike,
     private readonly collectionName: string,
+    private readonly hybrid?: QdrantVectorIndexHybridOptions | undefined,
   ) {}
 
   async search(request: VectorSearchRequest): Promise<Array<VectorSearchResult<T, Metadata>>> {
-    const queryEmbedding = await embedText(this.model, request.query);
-    const response = await this.client.search(this.collectionName, {
-      vector: queryEmbedding.vector,
+    if (this.hybrid === undefined) {
+      const queryEmbedding = await embedText(this.model, request.query);
+      const response = await this.client.search(this.collectionName, {
+        vector: queryEmbedding.vector,
+        limit: request.topK,
+        filter: filterToQdrantFilter(request.filter),
+        with_payload: true,
+      });
+      return parseQueryResults<T, Metadata>(response, request.threshold);
+    }
+
+    if (typeof this.client.query !== "function") {
+      throw new TypeError("Hybrid Qdrant search requires a client that implements query(...).");
+    }
+
+    const prefetchLimit = Math.max(
+      request.topK,
+      Math.trunc(this.hybrid.prefetchLimit ?? request.topK * 5),
+    );
+    const [denseEmbedding, sparseEmbedding] = await Promise.all([
+      embedText(this.model, request.query),
+      embedSparseQuery(this.hybrid.sparse, request.query),
+    ]);
+
+    const response = await this.client.query(this.collectionName, {
+      prefetch: [
+        {
+          query: denseEmbedding.vector,
+          using: this.hybrid.denseVectorName,
+          limit: prefetchLimit,
+          filter: filterToQdrantFilter(request.filter),
+        },
+        {
+          query: {
+            indices: sparseEmbedding.vector.indices,
+            values: sparseEmbedding.vector.values,
+          },
+          using: this.hybrid.sparseVectorName,
+          limit: prefetchLimit,
+          filter: filterToQdrantFilter(request.filter),
+        },
+      ],
+      query: { fusion: this.hybrid.fusion },
       limit: request.topK,
-      filter: filterToQdrantFilter(request.filter),
       with_payload: true,
     });
     return parseQueryResults<T, Metadata>(response, request.threshold);

--- a/packages/vector-qdrant/src/store.ts
+++ b/packages/vector-qdrant/src/store.ts
@@ -1,42 +1,98 @@
 import type { EmbeddedDocument, EmbeddingModel, VectorMetadata } from "@anvia/core/embeddings";
 import { defaultQdrantClient, qdrantPoints } from "./helpers.js";
 import { QdrantVectorIndex } from "./search-index.js";
-import type { QdrantClientLike, QdrantVectorStoreConnectOptions } from "./types.js";
+import {
+  defaultDenseVectorName,
+  defaultSparseVectorName,
+  isQdrantHybridIndexOptions,
+  type QdrantClientLike,
+  type QdrantIndexOptions,
+  type QdrantVectorStoreConnectOptions,
+} from "./types.js";
 
 export class QdrantVectorStore<T, Metadata extends VectorMetadata = VectorMetadata> {
   private constructor(
     private readonly client: QdrantClientLike,
     private readonly collectionName: string,
+    private readonly options: {
+      hybrid: boolean;
+      denseVectorName: string;
+      sparseVectorName: string;
+    },
   ) {}
 
   static async connect<T, Metadata extends VectorMetadata = VectorMetadata>(
     options: QdrantVectorStoreConnectOptions,
   ): Promise<QdrantVectorStore<T, Metadata>> {
     const client = options.client ?? (await defaultQdrantClient());
+    const hybrid = options.hybrid === true;
+    const denseVectorName = options.denseVectorName ?? defaultDenseVectorName;
+    const sparseVectorName = options.sparseVectorName ?? defaultSparseVectorName;
+    const storeOptions = { hybrid, denseVectorName, sparseVectorName };
+
     if (options.createIfMissing === false) {
       await client.getCollection(options.collectionName);
-      return new QdrantVectorStore<T, Metadata>(client, options.collectionName);
+      return new QdrantVectorStore<T, Metadata>(client, options.collectionName, storeOptions);
     }
 
     try {
       await client.getCollection(options.collectionName);
     } catch {
-      await client.createCollection(options.collectionName, {
-        vectors: {
-          size: options.vectorSize,
-          distance: options.distance ?? "Cosine",
-        },
-      });
+      if (hybrid) {
+        await client.createCollection(options.collectionName, {
+          vectors: {
+            [denseVectorName]: {
+              size: options.vectorSize,
+              distance: options.distance ?? "Cosine",
+            },
+          },
+          sparse_vectors: {
+            [sparseVectorName]: {},
+          },
+        });
+      } else {
+        await client.createCollection(options.collectionName, {
+          vectors: {
+            size: options.vectorSize,
+            distance: options.distance ?? "Cosine",
+          },
+        });
+      }
     }
-    return new QdrantVectorStore<T, Metadata>(client, options.collectionName);
+    return new QdrantVectorStore<T, Metadata>(client, options.collectionName, storeOptions);
   }
 
   async upsertDocuments(documents: Array<EmbeddedDocument<T, Metadata>>): Promise<void> {
-    const points = documents.flatMap((document) => qdrantPoints(document));
+    const points = documents.flatMap((document) =>
+      qdrantPoints(document, {
+        hybrid: this.options.hybrid,
+        denseVectorName: this.options.denseVectorName,
+        sparseVectorName: this.options.sparseVectorName,
+      }),
+    );
     await this.client.upsert(this.collectionName, { points });
   }
 
-  index(model: EmbeddingModel): QdrantVectorIndex<T, Metadata> {
-    return new QdrantVectorIndex(model, this.client, this.collectionName);
+  index(options: QdrantIndexOptions): QdrantVectorIndex<T, Metadata> {
+    if (isQdrantHybridIndexOptions(options)) {
+      if (!this.options.hybrid) {
+        throw new TypeError(
+          "Hybrid Qdrant index requires QdrantVectorStore.connect({ hybrid: true }).",
+        );
+      }
+      return new QdrantVectorIndex(options.dense, this.client, this.collectionName, {
+        sparse: options.sparse,
+        fusion: options.fusion ?? "rrf",
+        denseVectorName: options.denseVectorName ?? this.options.denseVectorName,
+        sparseVectorName: options.sparseVectorName ?? this.options.sparseVectorName,
+        prefetchLimit: options.prefetchLimit,
+      });
+    }
+    if (this.options.hybrid) {
+      throw new TypeError(
+        "Dense-only Qdrant index requires store.index({ dense, sparse }) when the collection was created with hybrid: true.",
+      );
+    }
+    return new QdrantVectorIndex(options as EmbeddingModel, this.client, this.collectionName);
   }
 }

--- a/packages/vector-qdrant/src/types.ts
+++ b/packages/vector-qdrant/src/types.ts
@@ -1,14 +1,22 @@
+import type { EmbeddingModel, SparseEmbeddingModel } from "@anvia/core/embeddings";
+
 export const documentIdPayloadKey = "__anvia_document_id";
 export const documentPayloadKey = "__anvia_document";
 export const reservedPayloadPrefix = "__anvia_";
 
+export const defaultDenseVectorName = "dense";
+export const defaultSparseVectorName = "sparse";
+
 export type QdrantDistance = "Cosine" | "Dot" | "Euclid";
+
+export type QdrantFusion = "rrf" | "dbsf";
 
 export type QdrantClientLike = {
   getCollection(collectionName: string): Promise<unknown>;
   createCollection(collectionName: string, options: Record<string, unknown>): Promise<unknown>;
   upsert(collectionName: string, options: Record<string, unknown>): Promise<unknown>;
   search(collectionName: string, options: Record<string, unknown>): Promise<unknown>;
+  query?(collectionName: string, options: Record<string, unknown>): Promise<unknown>;
 };
 
 export type QdrantVectorStoreConnectOptions = {
@@ -17,4 +25,27 @@ export type QdrantVectorStoreConnectOptions = {
   vectorSize: number;
   createIfMissing?: boolean | undefined;
   distance?: QdrantDistance | undefined;
+  /** Create a named dense + sparse collection for hybrid/RRF search. */
+  hybrid?: boolean | undefined;
+  denseVectorName?: string | undefined;
+  sparseVectorName?: string | undefined;
 };
+
+export type QdrantHybridIndexOptions = {
+  dense: EmbeddingModel;
+  sparse: SparseEmbeddingModel;
+  fusion?: QdrantFusion | undefined;
+  denseVectorName?: string | undefined;
+  sparseVectorName?: string | undefined;
+  prefetchLimit?: number | undefined;
+};
+
+export type QdrantIndexOptions = EmbeddingModel | QdrantHybridIndexOptions;
+
+export function isQdrantHybridIndexOptions(
+  options: QdrantIndexOptions,
+): options is QdrantHybridIndexOptions {
+  return (
+    typeof options === "object" && options !== null && "dense" in options && "sparse" in options
+  );
+}

--- a/packages/vector-qdrant/test/qdrant-vector-store.test.ts
+++ b/packages/vector-qdrant/test/qdrant-vector-store.test.ts
@@ -1,3 +1,4 @@
+import type { SparseEmbedding, SparseEmbeddingModel } from "@anvia/core/embeddings";
 import { type Embedding, type EmbeddingModel, embedDocuments } from "@anvia/core/embeddings";
 import { vectorFilter } from "@anvia/core/vector-store";
 import { describe, expect, it } from "vitest";
@@ -12,11 +13,25 @@ class MockEmbeddingModel implements EmbeddingModel {
   }
 }
 
+class MockSparseEmbeddingModel implements SparseEmbeddingModel {
+  async embedTexts(texts: string[]): Promise<SparseEmbedding[]> {
+    return texts.map((document) => ({
+      document,
+      vector: { indices: [1, 2], values: [0.5, 0.25] },
+    }));
+  }
+
+  async embedQuery(query: string): Promise<SparseEmbedding> {
+    return { document: query, vector: { indices: [7], values: [1] } };
+  }
+}
+
 class MockQdrantClient {
   readonly collections = new Set<string>();
   readonly creates: unknown[] = [];
   readonly upserts: unknown[] = [];
   readonly searches: unknown[] = [];
+  readonly queries: unknown[] = [];
 
   async getCollection(collectionName: string): Promise<unknown> {
     if (!this.collections.has(collectionName)) {
@@ -67,6 +82,23 @@ class MockQdrantClient {
       },
     ];
   }
+
+  async query(collectionName: string, options: unknown): Promise<unknown> {
+    this.queries.push({ collectionName, options });
+    return {
+      points: [
+        {
+          id: "point1",
+          score: 1.2,
+          payload: {
+            __anvia_document_id: "doc1",
+            __anvia_document: JSON.stringify({ title: "Cat guide" }),
+            kind: "animal",
+          },
+        },
+      ],
+    };
+  }
 }
 
 describe("QdrantVectorStore", () => {
@@ -88,6 +120,143 @@ describe("QdrantVectorStore", () => {
         },
       },
     });
+  });
+
+  it("creates a hybrid collection with named dense and sparse vectors", async () => {
+    const client = new MockQdrantClient();
+
+    await QdrantVectorStore.connect({
+      client,
+      collectionName: "hybrid_docs",
+      vectorSize: 2,
+      hybrid: true,
+    });
+
+    expect(client.creates[0]).toEqual({
+      collectionName: "hybrid_docs",
+      options: {
+        vectors: {
+          dense: {
+            size: 2,
+            distance: "Cosine",
+          },
+        },
+        sparse_vectors: {
+          sparse: {},
+        },
+      },
+    });
+  });
+
+  it("upserts hybrid points and searches with prefetch RRF", async () => {
+    const client = new MockQdrantClient();
+    const dense = new MockEmbeddingModel();
+    const sparse = new MockSparseEmbeddingModel();
+    const store = await QdrantVectorStore.connect<{ title: string }>({
+      client,
+      collectionName: "hybrid_docs",
+      vectorSize: 2,
+      hybrid: true,
+    });
+
+    await store.upsertDocuments([
+      {
+        id: "doc1",
+        document: { title: "Cat guide" },
+        embeddings: [{ document: "Cat guide", vector: [1, 0] }],
+        sparseEmbeddings: [
+          { document: "Cat guide", vector: { indices: [1, 2], values: [0.5, 0.25] } },
+        ],
+        metadata: { kind: "animal" },
+      },
+    ]);
+
+    const results = await store.index({ dense, sparse }).search({
+      query: "cat",
+      topK: 2,
+    });
+
+    expect(client.upserts[0]).toMatchObject({
+      options: {
+        points: [
+          {
+            vector: {
+              dense: [1, 0],
+              sparse: { indices: [1, 2], values: [0.5, 0.25] },
+            },
+          },
+        ],
+      },
+    });
+    expect(client.searches).toEqual([]);
+    expect(client.queries[0]).toMatchObject({
+      collectionName: "hybrid_docs",
+      options: {
+        prefetch: [
+          { query: [1, 0], using: "dense", limit: 10 },
+          { query: { indices: [7], values: [1] }, using: "sparse", limit: 10 },
+        ],
+        query: { fusion: "rrf" },
+        limit: 2,
+        with_payload: true,
+      },
+    });
+    expect(results).toEqual([
+      {
+        id: "doc1",
+        score: 1.2,
+        document: { title: "Cat guide" },
+        metadata: { kind: "animal" },
+      },
+    ]);
+  });
+
+  it("rejects hybrid index on dense-only collections", async () => {
+    const client = new MockQdrantClient();
+    const store = await QdrantVectorStore.connect({
+      client,
+      collectionName: "docs",
+      vectorSize: 2,
+    });
+
+    expect(() =>
+      store.index({
+        dense: new MockEmbeddingModel(),
+        sparse: new MockSparseEmbeddingModel(),
+      }),
+    ).toThrow("hybrid: true");
+  });
+
+  it("rejects dense-only index on hybrid collections", async () => {
+    const client = new MockQdrantClient();
+    const store = await QdrantVectorStore.connect({
+      client,
+      collectionName: "hybrid_docs",
+      vectorSize: 2,
+      hybrid: true,
+    });
+
+    expect(() => store.index(new MockEmbeddingModel())).toThrow("dense, sparse");
+  });
+
+  it("rejects hybrid upsert without sparse embeddings", async () => {
+    const client = new MockQdrantClient();
+    const store = await QdrantVectorStore.connect({
+      client,
+      collectionName: "hybrid_docs",
+      vectorSize: 2,
+      hybrid: true,
+    });
+
+    await expect(
+      store.upsertDocuments([
+        {
+          id: "doc1",
+          document: "missing sparse",
+          embeddings: [{ document: "missing sparse", vector: [1, 0] }],
+        },
+      ]),
+    ).rejects.toThrow("sparseEmbeddings");
   });
 
   it("respects createIfMissing false", async () => {


### PR DESCRIPTION
## Summary
- Add sparse embedding contracts and helpers in `@anvia/core` (`SparseEmbeddingModel`, `embedHybridDocuments`, etc.)
- Wrap FastEmbed SPLADE++ in `@anvia/fastembed` for local sparse passage/query encoding
- Enable Qdrant hybrid collections (`hybrid: true`) with named dense+sparse vectors and RRF fusion through the existing `index(...).search(...)` path

## Test plan
- [x] `pnpm --filter @anvia/core test -- embeddings-vector-store`
- [x] `pnpm --filter @anvia/fastembed test`
- [x] `pnpm --filter @anvia/qdrant test`
- [x] `pnpm --filter @anvia/core typecheck` / `@anvia/fastembed` / `@anvia/qdrant`
- [x] `pnpm --filter www reference-check`
- [ ] Smoke against a real Qdrant instance with dense + SPLADE++ hybrid upsert/search (optional)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hybrid dense-and-sparse embeddings with separate document and query support.
  * Added FastEmbed SPLADE++ sparse embedding support.
  * Added Qdrant hybrid search with named vectors and reciprocal rank fusion.
  * Added configurable fusion, vector names, and prefetch settings.
* **Documentation**
  * Added setup guides, API references, and examples for hybrid embeddings and search.
* **Tests**
  * Added coverage for sparse embeddings, hybrid indexing, upserts, and search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->