### PR TITLE
Add first-class resume support to stream APIs

### DIFF
--- a/.changeset/resume-api-dx.md
+++ b/.changeset/resume-api-dx.md
@@ -1,0 +1,11 @@
+---
+"@anvia/core": minor
+"@anvia/server": minor
+"@anvia/react": patch
+---
+
+Add first-class stream resume to the shared request and response APIs.
+
+`UIStreamRequest` now includes optional `resume: { streamId, after }`. `@anvia/server` adds a
+`createEventStream({ resume })` / `createUIStreamResponse({ resume })` overload so routes can
+continue in-flight streams without manually composing `resumeStreamEvents`.

--- a/apps/www/src/content/docs/advanced/resumable-streams.md
+++ b/apps/www/src/content/docs/advanced/resumable-streams.md
@@ -71,12 +71,41 @@ function latestUserMessage(messages: Message[]): Message {
   return message;
 }
 
+function parseChatBody(value: unknown): UIStreamRequest {
+  if (typeof value !== "object" || value === null) {
+    throw new Error("Expected a JSON object chat body.");
+  }
+  const body = value as Partial<UIStreamRequest>;
+  if (!Array.isArray(body.messages) || body.stream !== true) {
+    throw new Error("Expected messages and stream: true.");
+  }
+  if (body.resume !== undefined) {
+    const resume = body.resume;
+    if (
+      typeof resume !== "object" ||
+      resume === null ||
+      typeof resume.streamId !== "string" ||
+      typeof resume.after !== "number" ||
+      !Number.isFinite(resume.after) ||
+      resume.after < 0
+    ) {
+      throw new Error("Expected a valid resume cursor.");
+    }
+  }
+  return body as UIStreamRequest;
+}
+
 export async function POST(request: Request, params: { threadId: string }) {
   const user = await requireUser(request);
-  const body = (await request.json()) as UIStreamRequest;
+  const body = parseChatBody(await request.json());
   const agent = createSupportAgent(user);
 
   if (body.resume !== undefined) {
+    await assertStreamAccess({
+      user,
+      threadId: params.threadId,
+      streamId: body.resume.streamId,
+    });
     return createEventStream({
       format: "jsonl",
       resume: {
@@ -107,6 +136,9 @@ export async function POST(request: Request, params: { threadId: string }) {
   );
 }
 ```
+
+`parseChatBody` and `assertStreamAccess` are application helpers. Validate the request at the route
+boundary, then authorize `streamId` against the authenticated user and thread before replaying.
 
 The response reader can disconnect while the run continues. The resumable server wrapper keeps
 draining the source stream into the store, so a later request can replay missed events.

--- a/apps/www/src/content/docs/advanced/resumable-streams.md
+++ b/apps/www/src/content/docs/advanced/resumable-streams.md
@@ -19,10 +19,14 @@ retention.
 
 ## End-To-End Shape
 
-Use one POST route for both starting and resuming:
+Use one POST route for both starting and resuming. The shared request body is `UIStreamRequest`,
+which already includes an optional `resume` cursor:
 
 ```ts
-type ChatBody = UIStreamRequest & {
+type UIStreamRequest = {
+  messages: Message[];
+  stream: true;
+  metadata?: JsonValue;
   resume?: {
     streamId: string;
     after: number;
@@ -55,17 +59,9 @@ import type { UIStreamRequest } from "@anvia/core/ui";
 import {
   createEventStream,
   createMemoryResumableStreamStore,
-  resumeStreamEvents,
 } from "@anvia/server";
 
 const resumableStore = createMemoryResumableStreamStore();
-
-type ChatBody = UIStreamRequest & {
-  resume?: {
-    streamId: string;
-    after: number;
-  };
-};
 
 function latestUserMessage(messages: Message[]): Message {
   const message = messages.at(-1);
@@ -77,18 +73,18 @@ function latestUserMessage(messages: Message[]): Message {
 
 export async function POST(request: Request, params: { threadId: string }) {
   const user = await requireUser(request);
-  const body = (await request.json()) as ChatBody;
+  const body = (await request.json()) as UIStreamRequest;
   const agent = createSupportAgent(user);
 
   if (body.resume !== undefined) {
-    return createEventStream(
-      resumeStreamEvents({
-        id: body.resume.streamId,
+    return createEventStream({
+      format: "jsonl",
+      resume: {
+        streamId: body.resume.streamId,
         after: body.resume.after,
         store: resumableStore,
-      }),
-      { format: "jsonl" },
-    );
+      },
+    });
   }
 
   const runId = crypto.randomUUID();
@@ -220,7 +216,7 @@ export const resumableStore: ResumableStreamStore = {
 
 `subscribe(...)` is the key operation. It must first yield stored records after the requested cursor,
 then keep yielding live records while the stream is still running. Once the run closes, the iterable
-finishes and `resumeStreamEvents(...)` emits `stream_end`.
+finishes and `createEventStream({ resume })` emits `stream_end`.
 
 ## Operational Rules
 

--- a/apps/www/src/content/docs/basics/react-client.md
+++ b/apps/www/src/content/docs/basics/react-client.md
@@ -67,6 +67,10 @@ type UIStreamRequest = {
   messages: Message[];
   stream: true;
   metadata?: JsonValue;
+  resume?: {
+    streamId: string;
+    after: number;
+  };
 };
 ```
 

--- a/apps/www/src/content/docs/packages/core/reference/ui.md
+++ b/apps/www/src/content/docs/packages/core/reference/ui.md
@@ -60,10 +60,16 @@ type UIMessagePart =
   | { id: string; type: "attachment"; attachment: UIAttachment }
   | { id: string; type: "error"; error: UIError };
 
+type UIStreamResume = {
+  streamId: string;
+  after: number;
+};
+
 type UIStreamRequest = {
   messages: Message[];
   stream: true;
   metadata?: JsonValue;
+  resume?: UIStreamResume;
 };
 
 type UIStreamEvent =

--- a/apps/www/src/content/docs/packages/react/reference.md
+++ b/apps/www/src/content/docs/packages/react/reference.md
@@ -67,10 +67,16 @@ type UIMessagePart =
   | { id: string; type: "attachment"; attachment: UIAttachment }
   | { id: string; type: "error"; error: UIError };
 
+type UIStreamResume = {
+  streamId: string;
+  after: number;
+};
+
 type UIStreamRequest = {
   messages: Message[];
   stream: true;
   metadata?: unknown;
+  resume?: UIStreamResume;
 };
 
 type UIStreamEvent =
@@ -112,10 +118,7 @@ type CreateChatRequestArgs = {
 
 type UseChatStatus = "idle" | "streaming" | "error";
 
-type ChatResumeCursor = {
-  streamId: string;
-  after: number;
-};
+type ChatResumeCursor = UIStreamResume;
 
 type ChatResumeStorage = "sessionStorage" | "localStorage" | Storage;
 
@@ -427,9 +430,10 @@ Passing `humanInput` tracks streamed tool approval and question events in `human
 
 Passing `resume: { key }` stores the active `streamId`, last event cursor, and current messages in
 `sessionStorage` by default. On mount, `useChat` sends the same endpoint a POST body with
-`resume: { streamId, after }`, unwraps `ResumableStreamEnvelope` records, replays missed events, and
-continues tailing live events until `stream_end`. Custom `createRequest` callbacks receive
-`args.resume` and should forward it when using resumable server routes.
+`resume: { streamId, after }` on `UIStreamRequest`, unwraps `ResumableStreamEnvelope` records,
+replays missed events, and continues tailing live events until `stream_end`. Custom `createRequest`
+callbacks receive `args.resume` and should forward it when using resumable server routes such as
+`createEventStream({ resume })`.
 
 ## useSmoothStreamText
 

--- a/apps/www/src/content/docs/packages/server/reference.md
+++ b/apps/www/src/content/docs/packages/server/reference.md
@@ -29,6 +29,20 @@ type CreateEventStreamOptions<TEvent> = {
   sse?: SseStreamOptions<TEvent>;
 };
 
+type CreateEventStreamResumeOptions<TEvent> = {
+  format?: EventStreamFormat;
+  headers?: HeadersInit;
+  status?: number;
+  statusText?: string;
+  resume: {
+    streamId: string;
+    after: number;
+    store: ResumableStreamStore<TEvent>;
+  };
+  jsonl?: JsonlStreamOptions<ResumableStreamEnvelope<TEvent>>;
+  sse?: SseStreamOptions<ResumableStreamEnvelope<TEvent>>;
+};
+
 type JsonlStreamOptions<TEvent> = {
   serialize?: (event: TEvent | EventStreamErrorEvent) => string;
 };
@@ -93,19 +107,16 @@ interface ResumableStreamStore<TEvent = unknown> {
 ```ts
 function createEventStream<TEvent>(
   events: AsyncIterable<TEvent>,
-  options?: {
-    format?: "jsonl" | "sse";
-    headers?: HeadersInit;
-    status?: number;
-    statusText?: string;
-    resumable?: CreateResumableStreamOptions<TEvent>;
-    jsonl?: JsonlStreamOptions<TEvent>;
-    sse?: SseStreamOptions<TEvent>;
-  },
+  options?: CreateEventStreamOptions<TEvent>,
+): Response;
+
+function createEventStream<TEvent>(
+  options: CreateEventStreamResumeOptions<TEvent>,
 ): Response;
 ```
 
-Purpose: convert an async iterable of events into an HTTP `Response`.
+Purpose: convert an async iterable of events into an HTTP `Response`, or continue a previously
+started resumable stream.
 
 Default behavior: writes JSONL with `content-type: application/x-ndjson; charset=utf-8`, `cache-control: no-cache, no-transform`, `connection: keep-alive`, and `x-accel-buffering: no`.
 
@@ -113,6 +124,20 @@ Use `format: "sse"` to emit `text/event-stream`.
 
 Pass `resumable: { id, store }` to wrap events in `stream_start`, `stream_event`, and
 `stream_end` envelopes and persist ordered events for later replay.
+
+Continue an in-flight stream with the resume overload:
+
+```ts
+if (body.resume !== undefined) {
+  return createEventStream({
+    resume: {
+      streamId: body.resume.streamId,
+      after: body.resume.after,
+      store,
+    },
+  });
+}
+```
 
 ## createResumableStream
 
@@ -134,21 +159,8 @@ function resumeStreamEvents<TEvent>(
 ): AsyncIterable<ResumableStreamEnvelope<TEvent>>;
 ```
 
-Purpose: replay stored events after `after`, then tail live events until the stream closes.
-
-Use it from the same route that starts a stream:
-
-```ts
-if (body.resume !== undefined) {
-  return createEventStream(
-    resumeStreamEvents({
-      id: body.resume.streamId,
-      after: body.resume.after,
-      store,
-    }),
-  );
-}
-```
+Purpose: advanced helper that replays stored events after `after`, then tails live events until the
+stream closes. Prefer `createEventStream({ resume })` from route handlers.
 
 ## createMemoryResumableStreamStore
 
@@ -166,9 +178,14 @@ function createUIStreamResponse(
   events: AsyncIterable<UIStreamEvent>,
   options?: CreateEventStreamOptions<UIStreamEvent>,
 ): Response;
+
+function createUIStreamResponse(
+  options: CreateEventStreamResumeOptions<UIStreamEvent>,
+): Response;
 ```
 
-Purpose: convert a standard `UIStreamEvent` iterable into an HTTP response for `@anvia/react` hooks.
+Purpose: convert a standard `UIStreamEvent` iterable into an HTTP response for `@anvia/react` hooks,
+or continue a resumable UI stream with the same resume overload as `createEventStream`.
 
 Default behavior: uses the same JSONL response format and headers as `createEventStream(...)` unless `format: "sse"` is passed.
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -152,6 +152,7 @@ export type {
   UIMessageRole,
   UIStreamEvent,
   UIStreamRequest,
+  UIStreamResume,
 } from "./ui";
 export {
   coreMessagesToUIMessages,

--- a/packages/core/src/ui/index.ts
+++ b/packages/core/src/ui/index.ts
@@ -11,4 +11,5 @@ export type {
   UIMessageRole,
   UIStreamEvent,
   UIStreamRequest,
+  UIStreamResume,
 } from "./types";

--- a/packages/core/src/ui/types.ts
+++ b/packages/core/src/ui/types.ts
@@ -73,10 +73,16 @@ export type UIMessagePart =
 
 export type UIToolMessagePart = Extract<UIMessagePart, { type: "tool" }>;
 
+export type UIStreamResume = {
+  streamId: string;
+  after: number;
+};
+
 export type UIStreamRequest = {
   messages: Message[];
   stream: true;
   metadata?: JsonValue;
+  resume?: UIStreamResume;
 };
 
 export type UIStreamEvent =

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -66,8 +66,10 @@ type UIStreamRequest = {
 ```
 
 Hooks convert their local `UIMessage[]` state into core messages before sending. Custom
-`createRequest` callbacks receive `{ messages, uiMessages, coreMessages }`, where `messages` and
-`uiMessages` are UI-shaped for compatibility and `coreMessages` is the default wire payload.
+`createRequest` callbacks receive `{ messages, uiMessages, coreMessages, resume? }`, where
+`messages` and `uiMessages` are UI-shaped for compatibility, `coreMessages` is the default wire
+payload, and `resume` is the optional continue-stream cursor (`ChatResumeCursor` /
+`UIStreamResume`) that must be forwarded on resumable routes.
 
 The shared boundary is:
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -58,6 +58,10 @@ type UIStreamRequest = {
   messages: Message[];
   stream: true;
   metadata?: JsonValue;
+  resume?: {
+    streamId: string;
+    after: number;
+  };
 };
 ```
 
@@ -81,5 +85,5 @@ createEventStream(createCompletionStream(model, { messages: body.messages }));
 ```
 
 For chat streams that should survive navigation or reload, pair `useChat({ resume: { key } })` with
-an endpoint that returns `createEventStream(events, { resumable: { id, store } })` and handles
-resume bodies containing `{ resume: { streamId, after } }`.
+an endpoint that returns `createEventStream(events, { resumable: { id, store } })` and continues with
+`createEventStream({ resume: { streamId, after, store } })` when the request body includes `resume`.

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -47,6 +47,7 @@ export type {
   UIMessageRole,
   UIStreamEvent,
   UIStreamRequest,
+  UIStreamResume,
   UseChatOptions,
   UseChatResult,
   UseChatStatus,

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,5 +1,11 @@
 import type { Message } from "@anvia/core/completion";
-import type { CreateUIAttachment, UIMessage, UIStreamEvent, UIStreamRequest } from "@anvia/core/ui";
+import type {
+  CreateUIAttachment,
+  UIMessage,
+  UIStreamEvent,
+  UIStreamRequest,
+  UIStreamResume,
+} from "@anvia/core/ui";
 
 export type {
   CreateUIAttachment,
@@ -10,6 +16,7 @@ export type {
   UIMessageRole,
   UIStreamEvent,
   UIStreamRequest,
+  UIStreamResume,
 } from "@anvia/core/ui";
 
 export type EventStreamFormat = "jsonl" | "sse";
@@ -23,10 +30,7 @@ export type EventTransport<TRequest, TEvent> = {
   send(request: TRequest, options?: TransportOptions): AsyncIterable<TEvent>;
 };
 
-export type ChatResumeCursor = {
-  streamId: string;
-  after: number;
-};
+export type ChatResumeCursor = UIStreamResume;
 
 export type ChatResumeStorage = "sessionStorage" | "localStorage" | Storage;
 

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -242,7 +242,7 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
       const createRequest =
         options.createRequest ??
         ((args: CreateChatRequestArgs) => {
-          const request: UIStreamRequest & { resume?: ChatResumeCursor } = {
+          const request: UIStreamRequest = {
             messages: args.coreMessages,
             stream: true,
           };

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -13,7 +13,9 @@ return createUIStreamResponse(uiEvents, {
 ## Exports
 
 - `createEventStream(events, options)` returns a streaming `Response`.
+- `createEventStream({ resume })` continues a previously started resumable stream.
 - `createUIStreamResponse(events, options)` returns a streaming `Response` for `UIStreamEvent` values.
+- `createUIStreamResponse({ resume })` continues a resumable UI stream.
 - `createJsonlStream(events, options)` returns a JSONL `ReadableStream<Uint8Array>`.
 - `createSseStream(events, options)` returns a Server-Sent Event `ReadableStream<Uint8Array>`.
 - `createResumableStream(events, options)` wraps events in resumable stream envelopes.
@@ -22,4 +24,4 @@ return createUIStreamResponse(uiEvents, {
 
 JSONL is the default transport format. Use `format: "sse"` when you need `text/event-stream` compatibility.
 Pass `resumable: { id, store }` to `createEventStream` when clients need to recover streams after
-navigation or reload.
+navigation or reload. Continue those streams with `createEventStream({ resume: { streamId, after, store } })`.

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -8,6 +8,7 @@ export {
 export { createSseStream } from "./sse";
 export type {
   CreateEventStreamOptions,
+  CreateEventStreamResumeOptions,
   CreateResumableStreamOptions,
   EventStreamErrorEvent,
   EventStreamFormat,

--- a/packages/server/src/response.ts
+++ b/packages/server/src/response.ts
@@ -163,6 +163,8 @@ function isResumableStreamStore(value: unknown): value is ResumableStreamStore {
     typeof value === "object" &&
     value !== null &&
     "subscribe" in value &&
-    typeof value.subscribe === "function"
+    typeof value.subscribe === "function" &&
+    "status" in value &&
+    typeof value.status === "function"
   );
 }

--- a/packages/server/src/response.ts
+++ b/packages/server/src/response.ts
@@ -1,19 +1,80 @@
 import type { UIStreamEvent } from "@anvia/core/ui";
 import { createJsonlStream } from "./jsonl";
-import { createResumableStream } from "./resumable";
+import { createResumableStream, resumeStreamEvents } from "./resumable";
 import { createSseStream } from "./sse";
 import type {
   CreateEventStreamOptions,
+  CreateEventStreamResumeOptions,
+  EventStreamFormat,
   JsonlStreamOptions,
   ResumableStreamEnvelope,
+  ResumableStreamStore,
   SseStreamOptions,
 } from "./types";
 
 type ResponseStreamEvent<TEvent> = TEvent | ResumableStreamEnvelope<TEvent>;
 
+type EventStreamResponseOptions<TEvent> = {
+  format?: EventStreamFormat;
+  headers?: HeadersInit;
+  status?: number;
+  statusText?: string;
+  jsonl?: JsonlStreamOptions<ResponseStreamEvent<TEvent>>;
+  sse?: SseStreamOptions<ResponseStreamEvent<TEvent>>;
+};
+
 export function createEventStream<TEvent>(
   events: AsyncIterable<TEvent>,
+  options?: CreateEventStreamOptions<TEvent>,
+): Response;
+export function createEventStream<TEvent>(
+  options: CreateEventStreamResumeOptions<TEvent>,
+): Response;
+export function createEventStream<TEvent>(
+  eventsOrOptions: AsyncIterable<TEvent> | CreateEventStreamResumeOptions<TEvent>,
   options: CreateEventStreamOptions<TEvent> = {},
+): Response {
+  if (isResumeOptions(eventsOrOptions)) {
+    const resume = eventsOrOptions.resume;
+    return createEventStreamResponse(
+      resumeStreamEvents({
+        id: resume.streamId,
+        after: resume.after,
+        store: resume.store,
+      }),
+      copyResponseOptions(eventsOrOptions),
+    );
+  }
+
+  const eventsForResponse: AsyncIterable<ResponseStreamEvent<TEvent>> =
+    options.resumable === undefined
+      ? (eventsOrOptions as AsyncIterable<ResponseStreamEvent<TEvent>>)
+      : createResumableStream(eventsOrOptions, options.resumable);
+
+  return createEventStreamResponse(eventsForResponse, copyResponseOptions(options));
+}
+
+export function createUIStreamResponse(
+  events: AsyncIterable<UIStreamEvent>,
+  options?: CreateEventStreamOptions<UIStreamEvent>,
+): Response;
+export function createUIStreamResponse(
+  options: CreateEventStreamResumeOptions<UIStreamEvent>,
+): Response;
+export function createUIStreamResponse(
+  eventsOrOptions: AsyncIterable<UIStreamEvent> | CreateEventStreamResumeOptions<UIStreamEvent>,
+  options: CreateEventStreamOptions<UIStreamEvent> = {},
+): Response {
+  if (isResumeOptions(eventsOrOptions)) {
+    return createEventStream(eventsOrOptions);
+  }
+
+  return createEventStream(eventsOrOptions, options);
+}
+
+function createEventStreamResponse<TEvent>(
+  events: AsyncIterable<ResponseStreamEvent<TEvent>>,
+  options: EventStreamResponseOptions<TEvent>,
 ): Response {
   const format = options.format ?? "jsonl";
   const headers = new Headers(options.headers);
@@ -28,20 +89,10 @@ export function createEventStream<TEvent>(
     headers.set("x-accel-buffering", "no");
   }
 
-  const eventsForResponse: AsyncIterable<ResponseStreamEvent<TEvent>> =
-    options.resumable === undefined
-      ? (events as AsyncIterable<ResponseStreamEvent<TEvent>>)
-      : createResumableStream(events, options.resumable);
   const body =
     format === "sse"
-      ? createSseStream(
-          eventsForResponse,
-          options.sse as SseStreamOptions<ResponseStreamEvent<TEvent>> | undefined,
-        )
-      : createJsonlStream(
-          eventsForResponse,
-          options.jsonl as JsonlStreamOptions<ResponseStreamEvent<TEvent>> | undefined,
-        );
+      ? createSseStream(events, options.sse)
+      : createJsonlStream(events, options.jsonl);
 
   if (!headers.has("content-type")) {
     headers.set(
@@ -61,9 +112,57 @@ export function createEventStream<TEvent>(
   return new Response(body, responseInit);
 }
 
-export function createUIStreamResponse(
-  events: AsyncIterable<UIStreamEvent>,
-  options: CreateEventStreamOptions<UIStreamEvent> = {},
-): Response {
-  return createEventStream(events, options);
+function copyResponseOptions<TEvent>(options: {
+  format?: EventStreamFormat;
+  headers?: HeadersInit;
+  status?: number;
+  statusText?: string;
+  jsonl?: unknown;
+  sse?: unknown;
+}): EventStreamResponseOptions<TEvent> {
+  const next: EventStreamResponseOptions<TEvent> = {};
+  if (options.format !== undefined) next.format = options.format;
+  if (options.headers !== undefined) next.headers = options.headers;
+  if (options.status !== undefined) next.status = options.status;
+  if (options.statusText !== undefined) next.statusText = options.statusText;
+  if (options.jsonl !== undefined) {
+    next.jsonl = options.jsonl as JsonlStreamOptions<ResponseStreamEvent<TEvent>>;
+  }
+  if (options.sse !== undefined) {
+    next.sse = options.sse as SseStreamOptions<ResponseStreamEvent<TEvent>>;
+  }
+  return next;
+}
+
+function isResumeOptions<TEvent>(
+  value: AsyncIterable<TEvent> | CreateEventStreamResumeOptions<TEvent>,
+): value is CreateEventStreamResumeOptions<TEvent> {
+  if (typeof value !== "object" || value === null || Symbol.asyncIterator in value) {
+    return false;
+  }
+  if (!("resume" in value) || typeof value.resume !== "object" || value.resume === null) {
+    return false;
+  }
+
+  const resume = value.resume as {
+    streamId?: unknown;
+    after?: unknown;
+    store?: unknown;
+  };
+  return (
+    typeof resume.streamId === "string" &&
+    typeof resume.after === "number" &&
+    Number.isFinite(resume.after) &&
+    resume.after >= 0 &&
+    isResumableStreamStore(resume.store)
+  );
+}
+
+function isResumableStreamStore(value: unknown): value is ResumableStreamStore {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "subscribe" in value &&
+    typeof value.subscribe === "function"
+  );
 }

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -15,6 +15,20 @@ export type CreateEventStreamOptions<TEvent> = {
   sse?: SseStreamOptions<TEvent>;
 };
 
+export type CreateEventStreamResumeOptions<TEvent> = {
+  format?: EventStreamFormat;
+  headers?: HeadersInit;
+  status?: number;
+  statusText?: string;
+  resume: {
+    streamId: string;
+    after: number;
+    store: ResumableStreamStore<TEvent>;
+  };
+  jsonl?: JsonlStreamOptions<ResumableStreamEnvelope<TEvent>>;
+  sse?: SseStreamOptions<ResumableStreamEnvelope<TEvent>>;
+};
+
 export type JsonlStreamOptions<TEvent> = {
   serialize?: (event: TEvent | EventStreamErrorEvent) => string;
 };

--- a/packages/server/test/streams.test.ts
+++ b/packages/server/test/streams.test.ts
@@ -1,3 +1,4 @@
+import type { UIStreamEvent } from "@anvia/core/ui";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -159,6 +160,94 @@ describe("@anvia/server streams", () => {
       eventId: 2,
       status: "completed",
     });
+  });
+
+  it("resumes through createEventStream without double-wrapping envelopes", async () => {
+    const store = createMemoryResumableStreamStore<{ type: string }>();
+    await store.open({ streamId: "run_1" });
+    await store.append({ streamId: "run_1", event: { type: "one" } });
+    await store.append({ streamId: "run_1", event: { type: "two" } });
+
+    const response = createEventStream({
+      resume: {
+        streamId: "run_1",
+        after: 1,
+        store,
+      },
+    });
+    const reader = response.body?.getReader();
+    if (reader === undefined) {
+      throw new Error("Expected response body");
+    }
+    const decoder = new TextDecoder();
+
+    const first = await reader.read();
+    expect(first.done).toBe(false);
+    expect(JSON.parse(decoder.decode(first.value))).toEqual({
+      type: "stream_start",
+      streamId: "run_1",
+      eventId: 0,
+    });
+
+    const second = await reader.read();
+    expect(second.done).toBe(false);
+    expect(JSON.parse(decoder.decode(second.value))).toEqual({
+      type: "stream_event",
+      streamId: "run_1",
+      eventId: 2,
+      event: { type: "two" },
+    });
+
+    const endRead = reader.read();
+    await store.close({ streamId: "run_1", status: "completed" });
+    const end = await endRead;
+    expect(end.done).toBe(false);
+    expect(JSON.parse(decoder.decode(end.value))).toEqual({
+      type: "stream_end",
+      streamId: "run_1",
+      eventId: 2,
+      status: "completed",
+    });
+    expect(await reader.read()).toEqual({ done: true, value: undefined });
+  });
+
+  it("resumes UI stream responses through createUIStreamResponse", async () => {
+    const store = createMemoryResumableStreamStore<UIStreamEvent>();
+    await store.open({ streamId: "run_1" });
+    await store.append({
+      streamId: "run_1",
+      event: {
+        type: "text_delta",
+        messageId: "assistant_1",
+        partId: "assistant_1_text",
+        delta: "hi",
+      },
+    });
+    await store.close({ streamId: "run_1", status: "completed" });
+
+    const response = createUIStreamResponse({
+      resume: {
+        streamId: "run_1",
+        after: 0,
+        store,
+      },
+    });
+
+    expect(parseJsonl(await response.text())).toEqual([
+      { type: "stream_start", streamId: "run_1", eventId: 0 },
+      {
+        type: "stream_event",
+        streamId: "run_1",
+        eventId: 1,
+        event: {
+          type: "text_delta",
+          messageId: "assistant_1",
+          partId: "assistant_1_text",
+          delta: "hi",
+        },
+      },
+      { type: "stream_end", streamId: "run_1", eventId: 1, status: "completed" },
+    ]);
   });
 
   it("omits the resume cursor when none is supplied", async () => {


### PR DESCRIPTION
## Summary
- Add `UIStreamResume` and optional `resume` on `UIStreamRequest` so React and server share one continue-stream request shape.
- Extend `createEventStream` / `createUIStreamResponse` with a `{ resume }` overload that replays via the store without double-wrapping envelopes.
- Update docs and tests for the start/continue route pattern; keep `resumeStreamEvents` as a low-level escape hatch.

## Test plan
- [x] `pnpm --filter @anvia/core typecheck`
- [x] `pnpm --filter @anvia/server typecheck test`
- [x] `pnpm --filter @anvia/react typecheck`
- [x] `pnpm --filter www reference-check`
- [ ] Manually verify a chat route can start with `resumable: { id, store }` and continue with `createEventStream({ resume })` after refresh when `useChat({ resume: { key } })` is enabled


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added first-class stream resumption for event and UI streams.
  * Requests can resume streams using a stream ID and event position.
  * Server responses can continue stored streams after navigation or reload.
  * Preserved support for JSONL and SSE formats.

* **Documentation**
  * Updated client, React, and server guidance with resumable-stream examples and configuration details.
  * Clarified how to use resumable stores and request forwarding.

* **Tests**
  * Added coverage for resuming stored events, live completion events, and UI streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->