### PR TITLE
Improve sandbox file reads and fix streaming Markdown reveal

### DIFF
--- a/.changeset/calm-sandboxes-read.md
+++ b/.changeset/calm-sandboxes-read.md
@@ -1,0 +1,6 @@
+---
+"@anvia/sandbox": minor
+---
+
+Add bounded line pagination to the `read_file` agent tool and Docker sandbox sessions. File reads
+now return continuation metadata and use safe default line and byte limits.

--- a/.changeset/fix-stream-markdown-reveal.md
+++ b/.changeset/fix-stream-markdown-reveal.md
@@ -1,0 +1,7 @@
+---
+"@anvia/react-ui": patch
+---
+
+Prevent settled Markdown text from fading again when streaming resumes after a pause, preserve
+in-progress reveal timing across appended chunks, and render reveal text fully opaque when reduced
+motion is requested.

--- a/apps/www/src/content/docs/packages/sandbox/examples.md
+++ b/apps/www/src/content/docs/packages/sandbox/examples.md
@@ -37,7 +37,11 @@ const agent = new AgentBuilder("debugger", model)
     createSandboxTools(session, {
       include: ["exec_command", "read_file", "list_files"],
       exec: { allowedCommands: ["node", "pnpm", "ls", "cat"] },
-      readFile: { maxBytes: 64_000 },
+      readFile: {
+        defaultLineCount: 500,
+        maxLineCount: 2_000,
+        maxBytes: 64_000,
+      },
     }),
   )
   .approvals({

--- a/apps/www/src/content/docs/packages/sandbox/reference.md
+++ b/apps/www/src/content/docs/packages/sandbox/reference.md
@@ -78,11 +78,30 @@ interface SandboxSession {
   execStream(options: SandboxExecOptions): AsyncIterable<SandboxExecStreamEvent>;
   readFile(path: string): Promise<Uint8Array>;
   readTextFile(path: string): Promise<string>;
+  readTextFilePage?(
+    path: string,
+    options?: SandboxTextFileReadOptions,
+  ): Promise<SandboxTextFileReadResult>;
   writeFile(path: string, data: string | Uint8Array): Promise<void>;
   writeTextFile(path: string, content: string): Promise<void>;
   listFiles(path?: string): Promise<SandboxFileEntry[]>;
   destroy(): Promise<void>;
 }
+
+type SandboxTextFileReadOptions = {
+  startLine?: number;
+  lineCount?: number;
+  maxBytes?: number;
+};
+
+type SandboxTextFileReadResult = {
+  content: string;
+  startLine: number;
+  endLine: number | null;
+  nextStartLine: number | null;
+  truncated: boolean;
+  truncatedBy: "lines" | "bytes" | null;
+};
 ```
 
 Purpose: provider-neutral contracts for sandbox clients and live workspace sessions.
@@ -319,7 +338,7 @@ type SandboxToolsOptions = {
   include?: SandboxToolName[];
   execTimeoutMs?: number;
   exec?: SandboxExecToolPolicy;
-  readFile?: SandboxFileToolPolicy;
+  readFile?: SandboxReadFileToolPolicy;
   writeFile?: SandboxFileToolPolicy;
   process?: SandboxProcessToolPolicy;
 };
@@ -347,6 +366,11 @@ type SandboxFileToolPolicy = {
   maxBytes?: number;
 };
 
+type SandboxReadFileToolPolicy = SandboxFileToolPolicy & {
+  defaultLineCount?: number;
+  maxLineCount?: number;
+};
+
 type SandboxProcessToolPolicy = {
   maxLogBytes?: number;
   defaultWaitTimeoutMs?: number;
@@ -363,6 +387,15 @@ type SandboxToolsFactory = (
 Purpose: expose a live sandbox session as Anvia tools. The default bundle remains `exec_command`,
 `read_file`, `write_file`, and `list_files`. Published-port and managed-process tools are opt-in.
 They use the existing executable allow/block policy plus `SandboxProcessToolPolicy` limits.
+
+`read_file` returns structured page metadata and accepts one-based `startLine` and `lineCount`
+arguments. It defaults to 500 lines, allows at most 2,000 lines per call, and caps content at 64
+KiB. Configure those limits with `readFile.defaultLineCount`, `readFile.maxLineCount`, and
+`readFile.maxBytes`; tool-level hard limits are 10,000 lines and 1 MiB. When `nextStartLine` is
+present, pass it as the next call's `startLine`. Docker sessions read only the bounded page inside
+the container. Custom session providers can implement `readTextFilePage(...)` for the same bounded
+I/O behavior; otherwise the tool uses `readTextFile(...)` as a compatibility fallback before
+paginating the returned text.
 
 ## Hooks
 

--- a/packages/react-ui/src/stream/markdown-reveal.ts
+++ b/packages/react-ui/src/stream/markdown-reveal.ts
@@ -1,8 +1,15 @@
 export const streamRevealConfig = {
   bandGraphemes: 2,
+  durationMs: 180,
   minimumOpacity: 0.12,
   tailGraphemes: 24,
 } as const;
+
+export type StreamRevealLifecycle = {
+  activeScope: string | null;
+  settledRevealIds: Set<string>;
+  startedAtByRevealId: Map<string, number>;
+};
 
 type MarkdownNode = {
   type: string;
@@ -20,19 +27,27 @@ type TextTarget = {
   startOffset: number;
 };
 
-type RevealBand = {
+type RevealGrapheme = {
   endOffset: number;
   opacity: number;
   startOffset: number;
 };
 
-export function createStreamGradientRevealPlugin(frameId: number) {
+export function createStreamGradientRevealPlugin(
+  lifecycleScope: string,
+  lifecycle: StreamRevealLifecycle,
+) {
   return function streamGradientRevealPlugin() {
     return (tree: MarkdownNode) => {
+      if (lifecycle.activeScope !== lifecycleScope) {
+        lifecycle.activeScope = lifecycleScope;
+        lifecycle.settledRevealIds.clear();
+        lifecycle.startedAtByRevealId.clear();
+      }
       const targets = collectTextTargets(tree);
       const renderedText = targets.map((target) => target.node.value ?? "").join("");
-      const bands = createRevealBands(renderedText);
-      wrapStreamRevealBands(targets, bands, frameId);
+      const graphemes = createRevealGraphemes(renderedText);
+      wrapStreamRevealGraphemes(targets, graphemes, lifecycleScope, lifecycle);
     };
   };
 }
@@ -69,63 +84,88 @@ function collectTextTargets(tree: MarkdownNode): TextTarget[] {
   return targets;
 }
 
-function createRevealBands(content: string): RevealBand[] {
+function createRevealGraphemes(content: string): RevealGrapheme[] {
   const tail = segmentTailGraphemeRanges(content, streamRevealConfig.tailGraphemes);
-  const bands: RevealBand[] = [];
+  const graphemes: RevealGrapheme[] = [];
 
-  for (let index = 0; index < tail.length; index += streamRevealConfig.bandGraphemes) {
-    const first = tail[index];
-    const endIndex = Math.min(index + streamRevealConfig.bandGraphemes, tail.length) - 1;
-    const last = tail[endIndex];
-    if (first === undefined || last === undefined) {
+  for (let index = 0; index < tail.length; index += 1) {
+    const grapheme = tail[index];
+    const bandStartIndex =
+      Math.floor(index / streamRevealConfig.bandGraphemes) * streamRevealConfig.bandGraphemes;
+    const bandEndIndex =
+      Math.min(bandStartIndex + streamRevealConfig.bandGraphemes, tail.length) - 1;
+    if (grapheme === undefined) {
       continue;
     }
-    const progress = tail.length === 1 ? 1 : endIndex / (tail.length - 1);
-    bands.push({
-      startOffset: first.startOffset,
-      endOffset: last.endOffset,
+    const progress = tail.length === 1 ? 1 : bandEndIndex / (tail.length - 1);
+    graphemes.push({
+      startOffset: grapheme.startOffset,
+      endOffset: grapheme.endOffset,
       opacity: Math.max(
         streamRevealConfig.minimumOpacity,
         1 - progress * (1 - streamRevealConfig.minimumOpacity),
       ),
     });
   }
-  return bands;
+  return graphemes;
 }
 
-function wrapStreamRevealBands(
+function wrapStreamRevealGraphemes(
   targets: readonly TextTarget[],
-  bands: readonly RevealBand[],
-  frameId: number,
+  graphemes: readonly RevealGrapheme[],
+  lifecycleScope: string,
+  lifecycle: StreamRevealLifecycle,
 ): void {
+  const activeRevealIds = new Set<string>();
+  const nowMs = Date.now();
   for (const target of [...targets].reverse()) {
     const value = target.node.value ?? "";
-    const intersectingBands = bands.filter(
-      (band) => band.endOffset > target.startOffset && band.startOffset < target.endOffset,
+    const intersectingGraphemes = graphemes.filter(
+      (grapheme) =>
+        grapheme.endOffset > target.startOffset && grapheme.startOffset < target.endOffset,
     );
-    if (intersectingBands.length === 0) {
+    if (intersectingGraphemes.length === 0) {
       continue;
     }
 
     const replacement: MarkdownNode[] = [];
     let cursor = 0;
-    for (const band of intersectingBands) {
-      const start = Math.max(0, band.startOffset - target.startOffset);
-      const end = Math.min(value.length, band.endOffset - target.startOffset);
+    for (const grapheme of intersectingGraphemes) {
+      const start = Math.max(0, grapheme.startOffset - target.startOffset);
+      const end = Math.min(value.length, grapheme.endOffset - target.startOffset);
       if (start > cursor) {
         replacement.push({ type: "text", value: value.slice(cursor, start) });
       }
       if (end > start) {
-        replacement.push({
-          type: "element",
-          tagName: "span",
-          properties: {
-            "data-anvia-stream-frame-id": `${frameId}:${band.startOffset}`,
-            "data-anvia-stream-opacity": String(band.opacity),
-            "data-anvia-stream-reveal": "",
-          },
-          children: [{ type: "text", value: value.slice(start, end) }],
-        });
+        const text = value.slice(start, end);
+        const absoluteStart = target.startOffset + start;
+        const absoluteEnd = target.startOffset + end;
+        const revealId = `${lifecycleScope}:${absoluteStart}:${absoluteEnd}:${hashText(text)}`;
+        activeRevealIds.add(revealId);
+        const startedAt = lifecycle.startedAtByRevealId.get(revealId) ?? nowMs;
+        lifecycle.startedAtByRevealId.set(revealId, startedAt);
+        const elapsedMs = Math.max(0, nowMs - startedAt);
+        if (elapsedMs >= streamRevealConfig.durationMs) {
+          lifecycle.settledRevealIds.add(revealId);
+        }
+        if (lifecycle.settledRevealIds.has(revealId)) {
+          replacement.push({ type: "text", value: text });
+        } else {
+          const progress = Math.min(elapsedMs / streamRevealConfig.durationMs, 1);
+          const opacity = grapheme.opacity + (1 - grapheme.opacity) * progress;
+          const remainingMs = Math.max(1, streamRevealConfig.durationMs - elapsedMs);
+          replacement.push({
+            type: "element",
+            tagName: "span",
+            properties: {
+              "data-anvia-stream-duration-ms": String(remainingMs),
+              "data-anvia-stream-opacity": String(opacity),
+              "data-anvia-stream-reveal": "",
+              "data-anvia-stream-reveal-id": revealId,
+            },
+            children: [{ type: "text", value: text }],
+          });
+        }
       }
       cursor = Math.max(cursor, end);
     }
@@ -134,6 +174,29 @@ function wrapStreamRevealBands(
     }
     target.parent.children?.splice(target.index, 1, ...replacement);
   }
+
+  pruneRevealLifecycle(lifecycle, activeRevealIds);
+}
+
+function pruneRevealLifecycle(
+  lifecycle: StreamRevealLifecycle,
+  activeRevealIds: ReadonlySet<string>,
+): void {
+  for (const revealId of lifecycle.startedAtByRevealId.keys()) {
+    if (!activeRevealIds.has(revealId)) lifecycle.startedAtByRevealId.delete(revealId);
+  }
+  for (const revealId of lifecycle.settledRevealIds) {
+    if (!activeRevealIds.has(revealId)) lifecycle.settledRevealIds.delete(revealId);
+  }
+}
+
+function hashText(text: string): string {
+  let hash = 2_166_136_261;
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index);
+    hash = Math.imul(hash, 16_777_619);
+  }
+  return (hash >>> 0).toString(36);
 }
 
 function segmentTailGraphemeRanges(

--- a/packages/react-ui/src/stream/markdown.tsx
+++ b/packages/react-ui/src/stream/markdown.tsx
@@ -1,9 +1,11 @@
 import {
   type ComponentPropsWithoutRef,
+  type CSSProperties,
   createElement,
   forwardRef,
   memo,
   type ReactNode,
+  useCallback,
   useMemo,
   useRef,
 } from "react";
@@ -15,7 +17,7 @@ import remarkGfm from "remark-gfm";
 
 import { type PrimitiveProps, renderPrimitive } from "../primitives";
 import { splitStreamMarkdownBlocks } from "./markdown-blocks";
-import { createStreamGradientRevealPlugin } from "./markdown-reveal";
+import { createStreamGradientRevealPlugin, type StreamRevealLifecycle } from "./markdown-reveal";
 
 export type StreamMarkdownProps = Omit<PrimitiveProps<"div">, "children"> & {
   components?: Components;
@@ -32,12 +34,31 @@ export const StreamMarkdown = forwardRef<HTMLDivElement, StreamMarkdownProps>(
     { components, content, live = false, remarkPlugins, remarkRehypeOptions, ...props },
     ref,
   ) {
-    const previousContentRef = useRef(content);
-    const frameIdRef = useRef(0);
-    if (previousContentRef.current !== content) {
-      previousContentRef.current = content;
-      frameIdRef.current += 1;
+    const revealLifecycleRef = useRef({
+      activeScope: null,
+      content,
+      id: 0,
+      settledRevealIds: new Set<string>(),
+      startedAtByRevealId: new Map<string, number>(),
+    } satisfies StreamRevealLifecycle & { content: string; id: number });
+    const revealLifecycle = revealLifecycleRef.current;
+    if (revealLifecycle.content !== content) {
+      if (!content.startsWith(revealLifecycle.content)) {
+        revealLifecycle.id += 1;
+        revealLifecycle.activeScope = null;
+        revealLifecycle.settledRevealIds.clear();
+        revealLifecycle.startedAtByRevealId.clear();
+      }
+      revealLifecycle.content = content;
     }
+    if (!live && revealLifecycle.activeScope !== null) {
+      for (const revealId of revealLifecycle.startedAtByRevealId.keys()) {
+        revealLifecycle.settledRevealIds.add(revealId);
+      }
+    }
+    const settleReveal = useCallback((revealId: string) => {
+      revealLifecycleRef.current.settledRevealIds.add(revealId);
+    }, []);
 
     const blocks = useMemo(
       () =>
@@ -46,7 +67,10 @@ export const StreamMarkdown = forwardRef<HTMLDivElement, StreamMarkdownProps>(
         }),
       [content, remarkPlugins],
     );
-    const streamingComponents = useMemo(() => withStreamRevealComponent(components), [components]);
+    const streamingComponents = useMemo(
+      () => withStreamRevealComponent(components, settleReveal),
+      [components, settleReveal],
+    );
 
     return renderPrimitive(
       "div",
@@ -56,8 +80,9 @@ export const StreamMarkdown = forwardRef<HTMLDivElement, StreamMarkdownProps>(
           <StreamMarkdownBlock
             components={streamingComponents}
             content={block.content}
-            frameId={live && index === blocks.length - 1 ? frameIdRef.current : 0}
             live={live && index === blocks.length - 1}
+            revealLifecycle={revealLifecycle}
+            revealScope={`${revealLifecycle.id}:${block.startOffset}`}
             remarkPlugins={remarkPlugins ?? defaultRemarkPlugins}
             remarkRehypeOptions={remarkRehypeOptions}
             key={block.startOffset}
@@ -74,14 +99,15 @@ export const StreamMarkdown = forwardRef<HTMLDivElement, StreamMarkdownProps>(
 const StreamMarkdownBlock = memo(function StreamMarkdownBlock(props: {
   components: Components;
   content: string;
-  frameId: number;
   live: boolean;
+  revealLifecycle: StreamRevealLifecycle;
+  revealScope: string;
   remarkPlugins: ReactMarkdownOptions["remarkPlugins"];
   remarkRehypeOptions: ReactMarkdownOptions["remarkRehypeOptions"];
 }) {
   const revealPlugin = useMemo(
-    () => createStreamGradientRevealPlugin(props.frameId),
-    [props.frameId],
+    () => createStreamGradientRevealPlugin(props.revealScope, props.revealLifecycle),
+    [props.revealScope, props.revealLifecycle],
   );
   return (
     <ReactMarkdown
@@ -95,19 +121,23 @@ const StreamMarkdownBlock = memo(function StreamMarkdownBlock(props: {
   );
 });
 
-function withStreamRevealComponent(components: Components | undefined): Components {
+function withStreamRevealComponent(
+  components: Components | undefined,
+  onRevealSettled: (revealId: string) => void,
+): Components {
   const consumerSpan = components?.span;
   return {
     ...components,
     span(spanProps) {
       const safeProps = componentPropsWithoutKey(spanProps);
       const internalProps = safeProps as typeof safeProps & {
-        "data-anvia-stream-frame-id"?: string | undefined;
+        "data-anvia-stream-duration-ms"?: string | undefined;
         "data-anvia-stream-opacity"?: string | undefined;
         "data-anvia-stream-reveal"?: string | undefined;
+        "data-anvia-stream-reveal-id"?: string | undefined;
       };
       if (internalProps["data-anvia-stream-reveal"] !== undefined) {
-        return streamRevealSpan(internalProps);
+        return streamRevealSpan(internalProps, onRevealSettled);
       }
       if (consumerSpan !== undefined) {
         return createElement(consumerSpan, safeProps);
@@ -131,25 +161,39 @@ function componentPropsWithoutKey<T extends object>(props: T): T {
 function streamRevealSpan(
   props: ComponentPropsWithoutRef<"span"> & {
     node?: unknown;
-    "data-anvia-stream-frame-id"?: string | undefined;
+    "data-anvia-stream-duration-ms"?: string | undefined;
     "data-anvia-stream-opacity"?: string | undefined;
     "data-anvia-stream-reveal"?: string | undefined;
+    "data-anvia-stream-reveal-id"?: string | undefined;
   },
+  onRevealSettled: (revealId: string) => void,
 ): ReactNode {
   const {
     children,
     node: _node,
-    "data-anvia-stream-frame-id": frameId,
+    "data-anvia-stream-duration-ms": durationMs,
     "data-anvia-stream-opacity": opacity,
+    "data-anvia-stream-reveal-id": revealId,
+    onAnimationEnd,
     ...elementProps
   } = props;
   const parsedOpacity = Number(opacity);
+  const parsedDurationMs = Number(durationMs);
   return (
     <span
       {...elementProps}
-      data-anvia-stream-frame-id={frameId}
-      key={frameId ?? "stream-frame"}
-      style={{ opacity: Number.isFinite(parsedOpacity) ? parsedOpacity : 1 }}
+      data-anvia-stream-reveal-id={revealId}
+      key={revealId ?? "stream-reveal"}
+      onAnimationEnd={(event) => {
+        onAnimationEnd?.(event);
+        if (revealId !== undefined) onRevealSettled(revealId);
+      }}
+      style={
+        {
+          "--anvia-stream-reveal-opacity": Number.isFinite(parsedOpacity) ? parsedOpacity : 1,
+          "--anvia-stream-reveal-duration": `${Number.isFinite(parsedDurationMs) ? parsedDurationMs : 180}ms`,
+        } as CSSProperties
+      }
     >
       {children}
     </span>

--- a/packages/react-ui/src/stream/styles.css
+++ b/packages/react-ui/src/stream/styles.css
@@ -5,5 +5,13 @@
 }
 
 [data-anvia-stream-reveal] {
-  animation: anvia-stream-gradient-settle 180ms linear both;
+  opacity: var(--anvia-stream-reveal-opacity, 1);
+  animation: anvia-stream-gradient-settle var(--anvia-stream-reveal-duration, 180ms) linear both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-anvia-stream-reveal] {
+    opacity: 1;
+    animation: none;
+  }
 }

--- a/packages/react-ui/src/styles.css
+++ b/packages/react-ui/src/styles.css
@@ -96,11 +96,13 @@
 }
 
 [data-anvia-stream-reveal] {
-  animation: anvia-stream-gradient-settle 180ms linear both;
+  opacity: var(--anvia-stream-reveal-opacity, 1);
+  animation: anvia-stream-gradient-settle var(--anvia-stream-reveal-duration, 180ms) linear both;
 }
 
 @media (prefers-reduced-motion: reduce) {
   [data-anvia-stream-reveal] {
+    opacity: 1;
     animation: none;
   }
 }

--- a/packages/react-ui/test/stream-markdown.test.tsx
+++ b/packages/react-ui/test/stream-markdown.test.tsx
@@ -1,4 +1,5 @@
-import { render } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import { fireEvent, render } from "@testing-library/react";
 import type { ComponentPropsWithoutRef } from "react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -78,4 +79,171 @@ describe("StreamMarkdown", () => {
     rerender(<StreamMarkdown content="Settled text" live={false} />);
     expect(container.querySelector("[data-anvia-stream-reveal]")).toBeNull();
   });
+
+  it("applies reveal treatment to the initial live tail", () => {
+    const { container } = render(
+      <StreamMarkdown content="abcdefghijklmnopqrstuvwxyz0123456789" live />,
+    );
+    const reveals = revealElements(container);
+
+    expect(reveals).toHaveLength(24);
+    expect(
+      reveals.every(
+        (element) => Number(element.style.getPropertyValue("--anvia-stream-reveal-opacity")) <= 1,
+      ),
+    ).toBe(true);
+    expect(reveals.every((element) => revealId(element) !== null)).toBe(true);
+  });
+
+  it("does not reanimate settled text when content resumes", () => {
+    const clock = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const content = "abcdefghijklmnopqrstuvwxyz0123456789";
+    const { container, rerender } = render(<StreamMarkdown content={content} live />);
+    const settledIds = new Set(revealElements(container).map(requiredRevealId));
+
+    clock.mockReturnValue(1_200);
+    rerender(<StreamMarkdown content={`${content}XYZ`} live />);
+    clock.mockRestore();
+
+    const reveals = revealElements(container);
+    expect(reveals.map((element) => element.textContent).join("")).toBe("XYZ");
+    expect(reveals.every((element) => !settledIds.has(requiredRevealId(element)))).toBe(true);
+  });
+
+  it("preserves active reveal progress and creates lifecycles only for a multi-grapheme suffix", () => {
+    const clock = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const content = "abcdefghijklmnopqrstuvwxyz0123456789";
+    const { container, rerender } = render(<StreamMarkdown content={content} live />);
+    const previousIds = new Set(revealElements(container).map(requiredRevealId));
+
+    clock.mockReturnValue(1_060);
+    rerender(<StreamMarkdown content={`${content}XYZ`} live />);
+
+    const nextNodes = revealElements(container);
+    const retained = nextNodes.filter((element) => previousIds.has(requiredRevealId(element)));
+    const fresh = nextNodes.filter((element) => !previousIds.has(requiredRevealId(element)));
+    const retainedDurations = retained.map((element) =>
+      element.style.getPropertyValue("--anvia-stream-reveal-duration"),
+    );
+    const freshDurations = fresh.map((element) =>
+      element.style.getPropertyValue("--anvia-stream-reveal-duration"),
+    );
+    clock.mockRestore();
+
+    expect(retained.length).toBeGreaterThan(0);
+    expect(retained.every((element) => previousIds.has(requiredRevealId(element)))).toBe(true);
+    expect(retainedDurations.every((duration) => duration === "120ms")).toBe(true);
+    expect(fresh.map((element) => element.textContent).join("")).toBe("XYZ");
+    expect(freshDurations.every((duration) => duration === "180ms")).toBe(true);
+  });
+
+  it("does not reanimate the existing tail for a one-grapheme append", () => {
+    const content = "abcdefghijklmnopqrstuvwxyz0123456789";
+    const { container, rerender } = render(<StreamMarkdown content={content} live />);
+    settleReveals(container);
+
+    rerender(<StreamMarkdown content={`${content}Z`} live />);
+
+    const reveals = revealElements(container);
+    expect(reveals).toHaveLength(1);
+    expect(reveals[0]?.textContent).toBe("Z");
+  });
+
+  it("keeps emoji and combining sequences in whole reveal graphemes", () => {
+    const family = "👨‍👩‍👧‍👦";
+    const combining = "e\u0301";
+    const { container } = render(
+      <StreamMarkdown content={`abcdefghijklmnopqrstuvwxyz${family}${combining}`} live />,
+    );
+    const revealedText = revealElements(container).map((element) => element.textContent);
+
+    expect(revealedText).toContain(family);
+    expect(revealedText).toContain(combining);
+    expect(revealedText.slice(-2)).toEqual([family, combining]);
+    expect(revealedText).not.toContain("👨");
+    expect(revealedText).not.toContain("\u0301");
+  });
+
+  it("preserves links, formatting, and entities inside the revealed tail", () => {
+    const { container } = render(
+      <StreamMarkdown
+        content="A sufficiently long prefix for [the guide](https://example.com/docs) and **Tom &amp; Jerry**"
+        live
+      />,
+    );
+
+    expect(container.querySelector("a")?.getAttribute("href")).toBe("https://example.com/docs");
+    expect(container.querySelector("a")?.textContent).toBe("the guide");
+    expect(container.querySelector("strong")?.textContent).toBe("Tom & Jerry");
+    expect(container.querySelector("strong [data-anvia-stream-reveal]")).not.toBeNull();
+  });
+
+  it("resets reveal lifecycle state for non-append replacement", () => {
+    const initial = "abcdefghijklmnopqrstuvwxyz0123456789";
+    const replacement = "ZYXWVUTSRQPONMLKJIHGFEDCBA9876543210";
+    const { container, rerender } = render(<StreamMarkdown content={initial} live />);
+    const initialIds = new Set(revealElements(container).map(requiredRevealId));
+    settleReveals(container);
+
+    rerender(<StreamMarkdown content={replacement} live />);
+
+    const replacementReveals = revealElements(container);
+    expect(replacementReveals).toHaveLength(24);
+    expect(replacementReveals.every((element) => !initialIds.has(requiredRevealId(element)))).toBe(
+      true,
+    );
+  });
+
+  it("renders all content fully visible when live is false", () => {
+    const { container } = render(
+      <StreamMarkdown content="abcdefghijklmnopqrstuvwxyz0123456789" live={false} />,
+    );
+
+    expect(revealElements(container)).toHaveLength(0);
+    expect(container.textContent).toBe("abcdefghijklmnopqrstuvwxyz0123456789");
+  });
+
+  it("keeps completed content settled if the same stream becomes live again", () => {
+    const content = "abcdefghijklmnopqrstuvwxyz0123456789";
+    const { container, rerender } = render(<StreamMarkdown content={content} live />);
+
+    rerender(<StreamMarkdown content={content} live={false} />);
+    rerender(<StreamMarkdown content={`${content}Z`} live />);
+
+    const reveals = revealElements(container);
+    expect(reveals).toHaveLength(1);
+    expect(reveals[0]?.textContent).toBe("Z");
+  });
+
+  it("forces full opacity when reduced motion is requested", () => {
+    for (const stylesheet of ["src/stream/styles.css", "src/styles.css"]) {
+      const styles = readFileSync(stylesheet, "utf8");
+      const reducedMotionRule = styles.match(
+        /@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{([\s\S]*?)\n\}/u,
+      )?.[1];
+
+      expect(reducedMotionRule).toContain("animation: none");
+      expect(reducedMotionRule).toContain("opacity: 1");
+    }
+  });
 });
+
+function revealElements(container: HTMLElement): HTMLSpanElement[] {
+  return Array.from(container.querySelectorAll<HTMLSpanElement>("[data-anvia-stream-reveal]"));
+}
+
+function revealId(element: HTMLElement): string | null {
+  return element.getAttribute("data-anvia-stream-reveal-id");
+}
+
+function requiredRevealId(element: HTMLElement): string {
+  const id = revealId(element);
+  if (id === null) throw new Error("Expected reveal lifecycle ID.");
+  return id;
+}
+
+function settleReveals(container: HTMLElement): void {
+  for (const element of revealElements(container)) {
+    fireEvent.animationEnd(element);
+  }
+}

--- a/packages/tool-sandbox/src/docker-sandbox.ts
+++ b/packages/tool-sandbox/src/docker-sandbox.ts
@@ -12,6 +12,7 @@ import {
   SandboxTimeoutError,
 } from "./errors";
 import { containerPath, normalizeSandboxPath, parentSandboxPath } from "./path";
+import { createTextFilePage } from "./text-file";
 import type {
   DockerSandboxCreateSessionOptions,
   DockerSandboxOptions,
@@ -35,6 +36,8 @@ import type {
   SandboxProcessStopOptions,
   SandboxPublishedPort,
   SandboxSessionEvent,
+  SandboxTextFileReadOptions,
+  SandboxTextFileReadResult,
   SandboxWaitForPortOptions,
   SandboxWorkspaceOptions,
 } from "./types";
@@ -44,6 +47,8 @@ const defaultWorkdir = "/workspace";
 const defaultTimeoutMs = 30_000;
 const defaultMaxOutputBytes = 1024 * 1024;
 const defaultMaxProcesses = 4;
+const defaultTextFilePageLines = 500;
+const defaultTextFilePageBytes = 64 * 1024;
 // Docker Desktop may accept a host-side TCP connection before a container service is ready. Probe
 // Linux socket state in the container so readiness requires an all-interface listening socket.
 const portProbeScript = [
@@ -59,6 +64,15 @@ const portProbeScript = [
   '  done < "$table"',
   "done",
   "exit 1",
+].join("\n");
+const textFilePageScript = [
+  'start="$1"',
+  'count="$2"',
+  'max_bytes="$3"',
+  'file="$4"',
+  'end="$((start + count))"',
+  '[ -f "$file" ] || { echo "Not a readable file: $file" >&2; exit 66; }',
+  'sed -n "$start,$end p;$end q" "$file" | head -c "$max_bytes"',
 ].join("\n");
 
 export class DockerSandbox implements Sandbox {
@@ -622,6 +636,55 @@ class DockerSandboxSessionImpl implements DockerSandboxSession {
     return new TextDecoder().decode(bytes);
   }
 
+  async readTextFilePage(
+    filePath: string,
+    options: SandboxTextFileReadOptions = {},
+  ): Promise<SandboxTextFileReadResult> {
+    return this.runOperation(async () => {
+      const startLine = options.startLine ?? 1;
+      const lineCount = options.lineCount ?? defaultTextFilePageLines;
+      const maxBytes = options.maxBytes ?? defaultTextFilePageBytes;
+      assertTextFileReadOptions(startLine, lineCount, maxBytes);
+
+      const normalized = normalizeSandboxPath(filePath);
+      const captureBytes = maxBytes + 4;
+      const result = await runDockerCli(
+        [
+          "exec",
+          "-w",
+          this.workdir,
+          this.containerName,
+          "sh",
+          "-c",
+          textFilePageScript,
+          "anvia-read-file-page",
+          String(startLine),
+          String(lineCount),
+          String(captureBytes),
+          containerPath(this.workdir, normalized),
+        ],
+        {
+          ...this.cliOptions(),
+          maxOutputBytes: captureBytes,
+        },
+      );
+
+      if (result.exitCode !== 0) {
+        throw new SandboxDockerCommandError(
+          `Unable to read sandbox text file: ${filePath}`,
+          result,
+        );
+      }
+
+      return createTextFilePage(result.stdout, {
+        startLine,
+        lineCount,
+        maxBytes,
+        contentStartLine: startLine,
+      });
+    });
+  }
+
   async writeFile(filePath: string, data: string | Uint8Array): Promise<void> {
     await this.runOperation(async () => {
       const size = byteLength(data);
@@ -949,6 +1012,18 @@ function assertWaitOptions(timeoutMs: number, intervalMs: number): void {
   }
   if (!Number.isInteger(intervalMs) || intervalMs <= 0) {
     throw new SandboxPortError("Port wait intervalMs must be a positive integer.");
+  }
+}
+
+function assertTextFileReadOptions(startLine: number, lineCount: number, maxBytes: number): void {
+  if (!Number.isInteger(startLine) || startLine <= 0) {
+    throw new RangeError("Text file startLine must be a positive integer.");
+  }
+  if (!Number.isInteger(lineCount) || lineCount <= 0) {
+    throw new RangeError("Text file lineCount must be a positive integer.");
+  }
+  if (!Number.isInteger(maxBytes) || maxBytes <= 0) {
+    throw new RangeError("Text file maxBytes must be a positive integer.");
   }
 }
 

--- a/packages/tool-sandbox/src/text-file.ts
+++ b/packages/tool-sandbox/src/text-file.ts
@@ -1,0 +1,63 @@
+import type { SandboxTextFileReadResult } from "./types";
+
+interface CreateTextFilePageOptions {
+  startLine: number;
+  lineCount: number;
+  maxBytes: number;
+  contentStartLine?: number;
+}
+
+export function createTextFilePage(
+  text: string,
+  options: CreateTextFilePageOptions,
+): SandboxTextFileReadResult {
+  const contentStartLine = options.contentStartLine ?? 1;
+  const relativeStart = Math.max(0, options.startLine - contentStartLine);
+  const lines = splitLines(text).slice(relativeStart, relativeStart + options.lineCount + 1);
+  const hasMoreLines = lines.length > options.lineCount;
+  const selectedLines = lines.slice(0, options.lineCount);
+  const selectedContent = selectedLines.join("");
+  const selectedBytes = Buffer.from(selectedContent);
+
+  if (selectedBytes.byteLength > options.maxBytes) {
+    const content = decodeCompleteUtf8(selectedBytes.subarray(0, options.maxBytes));
+    const lineBreaks = countLineBreaks(content);
+    const endedAtLineBoundary = content.endsWith("\n");
+    return {
+      content,
+      startLine: options.startLine,
+      endLine:
+        content.length === 0
+          ? null
+          : options.startLine + lineBreaks - (endedAtLineBoundary ? 1 : 0),
+      nextStartLine: endedAtLineBoundary ? options.startLine + lineBreaks : null,
+      truncated: true,
+      truncatedBy: "bytes",
+    };
+  }
+
+  return {
+    content: selectedContent,
+    startLine: options.startLine,
+    endLine: selectedLines.length === 0 ? null : options.startLine + selectedLines.length - 1,
+    nextStartLine: hasMoreLines ? options.startLine + selectedLines.length : null,
+    truncated: hasMoreLines,
+    truncatedBy: hasMoreLines ? "lines" : null,
+  };
+}
+
+function splitLines(text: string): string[] {
+  return text.match(/[^\n]*\n|[^\n]+$/g) ?? [];
+}
+
+function countLineBreaks(text: string): number {
+  let count = 0;
+  for (const character of text) {
+    if (character === "\n") count += 1;
+  }
+  return count;
+}
+
+function decodeCompleteUtf8(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes, { stream: true });
+}

--- a/packages/tool-sandbox/src/tools.ts
+++ b/packages/tool-sandbox/src/tools.ts
@@ -2,6 +2,7 @@ import { type AnyTool, createTool } from "@anvia/core/tool";
 import { z } from "zod";
 import { isSandboxPortSession, isSandboxProcessSession } from "./capabilities";
 import { SandboxToolPolicyError } from "./errors";
+import { createTextFilePage } from "./text-file";
 import type {
   SandboxExecOptions,
   SandboxExecResult,
@@ -34,6 +35,19 @@ const execCommandInput = z.object({
 
 const readFileInput = z.object({
   path: z.string().min(1).describe("Relative file path inside the sandbox."),
+  startLine: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("One-based first line to read. Defaults to 1."),
+  lineCount: z
+    .number()
+    .int()
+    .positive()
+    .max(10_000)
+    .optional()
+    .describe("Maximum lines to return. Defaults to 500."),
 });
 
 const writeFileInput = z.object({
@@ -92,6 +106,19 @@ const waitForPortInput = z.object({
 
 const textOutput = z.string();
 const maxToolLogBytes = 1024 * 1024;
+const defaultReadFileLineCount = 500;
+const defaultReadFileMaxLineCount = 2_000;
+const defaultReadFileMaxBytes = 64 * 1024;
+const maxToolReadFileBytes = 1024 * 1024;
+const maxToolReadFileLines = 10_000;
+const readFileOutput = z.object({
+  content: z.string(),
+  startLine: z.number().int().positive(),
+  endLine: z.number().int().positive().nullable(),
+  nextStartLine: z.number().int().positive().nullable(),
+  truncated: z.boolean(),
+  truncatedBy: z.enum(["lines", "bytes"]).nullable(),
+});
 const sandboxToolMetadataKey = Symbol.for("anvia.sandbox.tool.metadata");
 
 export function createSandboxTools(
@@ -206,13 +233,34 @@ function createExecCommandTool(session: SandboxSession, options: SandboxToolsOpt
 function createReadFileTool(session: SandboxSession, options: SandboxToolsOptions): AnyTool {
   return createTool({
     name: "read_file",
-    description: "Read a text file from the sandbox workspace.",
+    description:
+      "Read a bounded page of a text file from the sandbox workspace. Continue with nextStartLine when provided.",
     input: readFileInput,
-    output: textOutput,
-    execute: async ({ path }) => {
-      const content = await session.readTextFile(path);
-      assertReadAllowed(content, options);
-      return content;
+    output: readFileOutput,
+    execute: async ({ path, startLine, lineCount }) => {
+      const limits = resolveReadFileLimits(options);
+      const effectiveStartLine = startLine ?? 1;
+      const effectiveLineCount = lineCount ?? limits.defaultLineCount;
+
+      if (effectiveLineCount > limits.maxLineCount) {
+        throw new SandboxToolPolicyError(
+          `File read line count exceeds sandbox tool policy (${effectiveLineCount} > ${limits.maxLineCount}).`,
+        );
+      }
+
+      if (session.readTextFilePage !== undefined) {
+        return session.readTextFilePage(path, {
+          startLine: effectiveStartLine,
+          lineCount: effectiveLineCount,
+          maxBytes: limits.maxBytes,
+        });
+      }
+
+      return createTextFilePage(await session.readTextFile(path), {
+        startLine: effectiveStartLine,
+        lineCount: effectiveLineCount,
+        maxBytes: limits.maxBytes,
+      });
     },
   });
 }
@@ -497,10 +545,33 @@ function assertContentAllowed(content: string, options: SandboxToolsOptions): vo
   }
 }
 
-function assertReadAllowed(content: string, options: SandboxToolsOptions): void {
-  const maxBytes = options.readFile?.maxBytes;
+function resolveReadFileLimits(options: SandboxToolsOptions): {
+  defaultLineCount: number;
+  maxLineCount: number;
+  maxBytes: number;
+} {
+  const defaultLineCount = options.readFile?.defaultLineCount ?? defaultReadFileLineCount;
+  const maxLineCount = options.readFile?.maxLineCount ?? defaultReadFileMaxLineCount;
+  const maxBytes = options.readFile?.maxBytes ?? defaultReadFileMaxBytes;
 
-  if (maxBytes !== undefined && Buffer.byteLength(content) > maxBytes) {
-    throw new SandboxToolPolicyError("File content exceeds sandbox tool policy.");
+  if (!Number.isInteger(defaultLineCount) || defaultLineCount <= 0) {
+    throw new SandboxToolPolicyError("File defaultLineCount must be a positive integer.");
   }
+  if (!Number.isInteger(maxLineCount) || maxLineCount <= 0 || maxLineCount > maxToolReadFileLines) {
+    throw new SandboxToolPolicyError(
+      `File maxLineCount must be a positive integer no greater than ${maxToolReadFileLines}.`,
+    );
+  }
+  if (defaultLineCount > maxLineCount) {
+    throw new SandboxToolPolicyError(
+      `File defaultLineCount exceeds maxLineCount (${defaultLineCount} > ${maxLineCount}).`,
+    );
+  }
+  if (!Number.isInteger(maxBytes) || maxBytes <= 0 || maxBytes > maxToolReadFileBytes) {
+    throw new SandboxToolPolicyError(
+      `File maxBytes must be a positive integer no greater than ${maxToolReadFileBytes}.`,
+    );
+  }
+
+  return { defaultLineCount, maxLineCount, maxBytes };
 }

--- a/packages/tool-sandbox/src/types.ts
+++ b/packages/tool-sandbox/src/types.ts
@@ -35,10 +35,29 @@ export interface SandboxSession {
   execStream(options: SandboxExecOptions): AsyncIterable<SandboxExecStreamEvent>;
   readFile(path: string): Promise<Uint8Array>;
   readTextFile(path: string): Promise<string>;
+  readTextFilePage?(
+    path: string,
+    options?: SandboxTextFileReadOptions,
+  ): Promise<SandboxTextFileReadResult>;
   writeFile(path: string, data: string | Uint8Array): Promise<void>;
   writeTextFile(path: string, content: string): Promise<void>;
   listFiles(path?: string): Promise<SandboxFileEntry[]>;
   destroy(): Promise<void>;
+}
+
+export interface SandboxTextFileReadOptions {
+  startLine?: number;
+  lineCount?: number;
+  maxBytes?: number;
+}
+
+export interface SandboxTextFileReadResult {
+  content: string;
+  startLine: number;
+  endLine: number | null;
+  nextStartLine: number | null;
+  truncated: boolean;
+  truncatedBy: "lines" | "bytes" | null;
 }
 
 export interface SandboxPortSession extends SandboxSession {
@@ -60,7 +79,12 @@ export interface SandboxProcessSession extends SandboxSession {
   stopProcess(processId: string, options?: SandboxProcessStopOptions): Promise<SandboxProcessInfo>;
 }
 
-export interface DockerSandboxSession extends SandboxPortSession, SandboxProcessSession {}
+export interface DockerSandboxSession extends SandboxPortSession, SandboxProcessSession {
+  readTextFilePage(
+    path: string,
+    options?: SandboxTextFileReadOptions,
+  ): Promise<SandboxTextFileReadResult>;
+}
 
 export interface SandboxCreateSessionOptions {
   id?: string;
@@ -241,7 +265,7 @@ export interface SandboxToolsOptions {
   include?: SandboxToolName[];
   execTimeoutMs?: number;
   exec?: SandboxExecToolPolicy;
-  readFile?: SandboxFileToolPolicy;
+  readFile?: SandboxReadFileToolPolicy;
   writeFile?: SandboxFileToolPolicy;
   process?: SandboxProcessToolPolicy;
 }
@@ -267,6 +291,11 @@ export interface SandboxExecToolPolicy {
 
 export interface SandboxFileToolPolicy {
   maxBytes?: number;
+}
+
+export interface SandboxReadFileToolPolicy extends SandboxFileToolPolicy {
+  defaultLineCount?: number;
+  maxLineCount?: number;
 }
 
 export interface SandboxProcessToolPolicy {

--- a/packages/tool-sandbox/test/docker-sandbox.integration.test.ts
+++ b/packages/tool-sandbox/test/docker-sandbox.integration.test.ts
@@ -33,8 +33,24 @@ describe.skipIf(!runDockerTests)("DockerSandbox integration", () => {
 
       await session.writeTextFile("out/result.txt", "done");
       await expect(session.readTextFile("out/result.txt")).resolves.toBe("done");
+      await session.writeTextFile("out/lines.txt", "one\ntwo\nthree\nfour\n");
+      await expect(
+        session.readTextFilePage("out/lines.txt", {
+          startLine: 2,
+          lineCount: 2,
+          maxBytes: 1_024,
+        }),
+      ).resolves.toEqual({
+        content: "two\nthree\n",
+        startLine: 2,
+        endLine: 3,
+        nextStartLine: 4,
+        truncated: true,
+        truncatedBy: "lines",
+      });
       await expect(session.listFiles("out")).resolves.toEqual([
         { path: "out/result.txt", type: "file", size: 4 },
+        { path: "out/lines.txt", type: "file", size: 19 },
       ]);
     } finally {
       await session.destroy();

--- a/packages/tool-sandbox/test/text-file.test.ts
+++ b/packages/tool-sandbox/test/text-file.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { createTextFilePage } from "../src/text-file";
+
+describe("createTextFilePage", () => {
+  it("returns a line page with continuation metadata", () => {
+    expect(
+      createTextFilePage("one\ntwo\nthree\nfour\n", {
+        startLine: 2,
+        lineCount: 2,
+        maxBytes: 1_024,
+      }),
+    ).toEqual({
+      content: "two\nthree\n",
+      startLine: 2,
+      endLine: 3,
+      nextStartLine: 4,
+      truncated: true,
+      truncatedBy: "lines",
+    });
+  });
+
+  it("returns an empty page when startLine is past the end", () => {
+    expect(
+      createTextFilePage("one\ntwo\n", {
+        startLine: 10,
+        lineCount: 2,
+        maxBytes: 1_024,
+      }),
+    ).toEqual({
+      content: "",
+      startLine: 10,
+      endLine: null,
+      nextStartLine: null,
+      truncated: false,
+      truncatedBy: null,
+    });
+  });
+
+  it("truncates oversized pages at a complete UTF-8 boundary", () => {
+    expect(
+      createTextFilePage("abc😀def\nnext\n", {
+        startLine: 1,
+        lineCount: 2,
+        maxBytes: 6,
+      }),
+    ).toEqual({
+      content: "abc",
+      startLine: 1,
+      endLine: 1,
+      nextStartLine: null,
+      truncated: true,
+      truncatedBy: "bytes",
+    });
+  });
+
+  it("provides continuation when byte truncation ends on a line boundary", () => {
+    expect(
+      createTextFilePage("one\ntwo\nthree\n", {
+        startLine: 1,
+        lineCount: 3,
+        maxBytes: 4,
+      }),
+    ).toEqual({
+      content: "one\n",
+      startLine: 1,
+      endLine: 1,
+      nextStartLine: 2,
+      truncated: true,
+      truncatedBy: "bytes",
+    });
+  });
+});

--- a/packages/tool-sandbox/test/tools.test.ts
+++ b/packages/tool-sandbox/test/tools.test.ts
@@ -86,7 +86,7 @@ describe("createSandboxTools", () => {
     );
   });
 
-  it("enforces file tool byte policies", async () => {
+  it("applies bounded read and write file policies", async () => {
     const session = createSession();
     const tools = Object.fromEntries(
       createSandboxTools(session, {
@@ -95,11 +95,27 @@ describe("createSandboxTools", () => {
       }).map((tool) => [tool.name, tool] as const),
     );
 
-    await expect(tools.read_file?.call({ path: "a.txt" })).rejects.toThrow(
-      "File content exceeds sandbox tool policy",
-    );
+    await tools.read_file?.call({ path: "a.txt" });
+    expect(session.readTextFilePage).toHaveBeenCalledWith("a.txt", {
+      startLine: 1,
+      lineCount: 500,
+      maxBytes: 4,
+    });
     await expect(tools.write_file?.call({ path: "a.txt", content: "content" })).rejects.toThrow(
       "File content exceeds sandbox tool policy",
+    );
+  });
+
+  it("enforces read_file line policies", async () => {
+    const [tool] = createSandboxTools(createSession(), {
+      include: ["read_file"],
+      readFile: { defaultLineCount: 20, maxLineCount: 50 },
+    });
+    if (tool === undefined) throw new Error("Expected read_file tool.");
+
+    await tool.call({ path: "a.txt" });
+    await expect(tool.call({ path: "a.txt", lineCount: 51 })).rejects.toThrow(
+      "File read line count exceeds sandbox tool policy",
     );
   });
 
@@ -110,14 +126,42 @@ describe("createSandboxTools", () => {
     );
 
     await tools.write_file?.call({ path: "a.txt", content: "content" });
-    const read = await tools.read_file?.call({ path: "a.txt" });
+    const read = await tools.read_file?.call({ path: "a.txt", startLine: 6, lineCount: 10 });
     const list = await tools.list_files?.call({ path: "." });
 
     expect(session.writeTextFile).toHaveBeenCalledWith("a.txt", "content");
-    expect(session.readTextFile).toHaveBeenCalledWith("a.txt");
+    expect(session.readTextFilePage).toHaveBeenCalledWith("a.txt", {
+      startLine: 6,
+      lineCount: 10,
+      maxBytes: 64 * 1024,
+    });
     expect(session.listFiles).toHaveBeenCalledWith(".");
-    expect(read).toBe("file content");
+    expect(read).toEqual({
+      content: "file content",
+      startLine: 6,
+      endLine: 6,
+      nextStartLine: null,
+      truncated: false,
+      truncatedBy: null,
+    });
     expect(list).toContain("file 12b\ta.txt");
+  });
+
+  it("falls back to bounded in-memory pagination for custom sessions", async () => {
+    const session = createSession();
+    delete session.readTextFilePage;
+    vi.mocked(session.readTextFile).mockResolvedValue("one\ntwo\nthree\nfour\n");
+    const [tool] = createSandboxTools(session, { include: ["read_file"] });
+    if (tool === undefined) throw new Error("Expected read_file tool.");
+
+    await expect(tool.call({ path: "a.txt", startLine: 2, lineCount: 2 })).resolves.toEqual({
+      content: "two\nthree\n",
+      startLine: 2,
+      endLine: 3,
+      nextStartLine: 4,
+      truncated: true,
+      truncatedBy: "lines",
+    });
   });
 
   it("creates opt-in published port and managed process tools", () => {
@@ -247,6 +291,14 @@ function createSession(): SandboxSession {
     }),
     readFile: vi.fn(async () => new TextEncoder().encode("file content")),
     readTextFile: vi.fn(async () => "file content"),
+    readTextFilePage: vi.fn(async (_path, options) => ({
+      content: "file content",
+      startLine: options?.startLine ?? 1,
+      endLine: options?.startLine ?? 1,
+      nextStartLine: null,
+      truncated: false,
+      truncatedBy: null,
+    })),
     writeFile: vi.fn(async () => undefined),
     writeTextFile: vi.fn(async () => undefined),
     listFiles: vi.fn(async () => [{ path: "a.txt", type: "file" as const, size: 12 }]),
@@ -255,8 +307,13 @@ function createSession(): SandboxSession {
 }
 
 function createManagedSession(): DockerSandboxSession {
+  const session = createSession();
+  if (session.readTextFilePage === undefined) {
+    throw new Error("Expected paginated text reader.");
+  }
   return {
-    ...createSession(),
+    ...session,
+    readTextFilePage: session.readTextFilePage,
     publishedPorts: [{ containerPort: 5173, host: "127.0.0.1", hostPort: 49_152, protocol: "tcp" }],
     waitForPort: vi.fn(async () => ({
       containerPort: 5173,


### PR DESCRIPTION
## Summary

### Sandbox file reads

- add line-based pagination to the `read_file` agent tool with `startLine` and `lineCount`
- default reads to 500 lines and 64 KiB, with configurable policy limits
- return structured continuation and truncation metadata
- perform bounded reads inside Docker containers instead of copying large files into host memory
- retain a compatibility fallback for custom sandbox providers

### Streaming Markdown reveal

- preserve stable per-grapheme reveal lifecycles across append-only Markdown updates
- resume in-progress opacity animations from elapsed progress and keep settled text fully visible
- retain the 24-grapheme tail and two-grapheme opacity-band appearance without splitting Unicode graphemes
- reset reveal state for non-append replacements and mark completed live content as settled
- force reveal spans to full opacity under reduced motion

## Root causes

`read_file` accepted only a path, read the entire file before applying `maxBytes`, and returned no
pagination metadata. Large files could therefore consume excessive memory and tool context.

`StreamMarkdown` incremented a global frame ID on every content update, and reveal span keys
included that frame ID. Each appended chunk remounted the entire tail. After a provider pause,
previously settled spans restarted from low opacity. Two-grapheme wrapper boundaries also shifted
on odd-sized appends, so removing only the frame ID was insufficient.

## Changesets

- minor changeset for `@anvia/sandbox`
- patch changeset for `@anvia/react-ui`

## Validation

- `pnpm --filter @anvia/sandbox typecheck`
- `pnpm --filter @anvia/sandbox test` — 42 tests passed, 8 skipped
- `ANVIA_SANDBOX_DOCKER_TESTS=1 pnpm --filter @anvia/sandbox exec vitest run test/docker-sandbox.integration.test.ts` — 7 tests passed
- `pnpm --filter @anvia/sandbox build`
- `pnpm --filter www reference-check`
- `pnpm --filter @anvia/react-ui test` — 102 tests passed
- `pnpm --filter @anvia/react-ui typecheck`
- `pnpm --filter @anvia/react-ui build`
- `pnpm --filter @anvia/react test` — 98 tests passed
- `pnpm --filter @anvia/react typecheck`
- `pnpm --filter @anvia/react build`

No generated `dist` files are included.
