### PR TITLE
Prevent stale release PR updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,15 +9,14 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: package-release
-  cancel-in-progress: false
-
 jobs:
   version:
     name: Create release pull request
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    concurrency:
+      group: package-release-version
+      cancel-in-progress: true
     permissions:
       contents: write
       pull-requests: write
@@ -42,7 +41,19 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Check release freshness
+        id: freshness
+        run: |
+          git fetch origin main
+          if [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" ]; then
+            echo "current=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "current=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping a stale release run because main has advanced."
+          fi
+
       - name: Create release pull request
+        if: steps.freshness.outputs.current == 'true'
         uses: changesets/action@v1
         with:
           version: pnpm version-packages
@@ -55,6 +66,9 @@ jobs:
     name: Publish packages to npm
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    concurrency:
+      group: package-release-publish
+      cancel-in-progress: false
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
## Summary

- isolate version-PR and manual-publish concurrency so publishing remains non-canceling
- cancel superseded version-PR jobs
- verify a version job still represents the latest `main` before Changesets can update the release branch

## Root cause

Two successful `main` release runs were queued close together. GitHub ran the newer checkout first, then an older checkout. The older Changesets action force-pushed its stale generated commit over PR #304's correct head.

## Validation

- parsed `.github/workflows/release.yml` with PyYAML
- `git diff --check`
- restored PR #304 by rerunning its current-`main` release workflow; the PR is mergeable and contains only the two outstanding changesets

No changeset is included because this changes repository release automation and does not alter a published package API or behavior.
