### PR TITLE
Add Grok package docs to the docs site

### DIFF
--- a/apps/www/PLAN.md
+++ b/apps/www/PLAN.md
@@ -77,6 +77,7 @@ Adapters that connect external model providers to the runtime.
 - `@anvia/anthropic`
 - `@anvia/gemini`
 - `@anvia/mistral`
+- `@anvia/grok`
 
 ### Embeddings
 

--- a/apps/www/src/components/AgentGateway.astro
+++ b/apps/www/src/components/AgentGateway.astro
@@ -5,7 +5,7 @@ const capabilities = [
   {
     label: "Models",
     title: "Switch providers without rewiring",
-    body: "Use the same agent contract across OpenAI, Anthropic, Gemini, Mistral, and local model adapters.",
+    body: "Use the same agent contract across OpenAI, Anthropic, Gemini, Mistral, Grok, and local model adapters.",
   },
   {
     label: "Retrieval",

--- a/apps/www/src/content/docs/advanced/audio-generation.md
+++ b/apps/www/src/content/docs/advanced/audio-generation.md
@@ -11,7 +11,7 @@ Audio generation turns text into audio bytes through a provider-neutral model co
 
 Use this for narration, accessibility, agent voice responses, media workflows, and generated previews. Keep generation server-side or worker-side.
 
-The current provider adapter with audio generation is [OpenAI](/docs/providers/openai).
+The current provider adapters with audio generation are [OpenAI](/docs/providers/openai) and [Grok](/docs/providers/grok).
 
 ## Send A Request
 

--- a/apps/www/src/content/docs/advanced/image-generation.md
+++ b/apps/www/src/content/docs/advanced/image-generation.md
@@ -11,7 +11,7 @@ Image generation in core is a provider-neutral contract. A provider package impl
 
 Use image generation in server-side routes, workers, or internal tools. Do not expose provider credentials or raw generation clients to browser code.
 
-The current provider adapters with image generation are [OpenAI](/docs/providers/openai) and [Gemini](/docs/providers/gemini).
+The current provider adapters with image generation are [OpenAI](/docs/providers/openai), [Gemini](/docs/providers/gemini), and [Grok](/docs/providers/grok).
 
 ## Send A Request
 

--- a/apps/www/src/content/docs/advanced/model-listing.md
+++ b/apps/www/src/content/docs/advanced/model-listing.md
@@ -11,7 +11,7 @@ Model listing is a provider-neutral contract for discovering available provider 
 
 Do not treat a listed model as proof that every Anvia capability is supported. Providers differ in tool behavior, streaming, structured output, media support, context length, rate limits, and account access.
 
-Provider-specific model listing behavior is covered in the [OpenAI](/docs/providers/openai), [Anthropic](/docs/providers/anthropic), [Gemini](/docs/providers/gemini), and [Mistral](/docs/providers/mistral) provider guides.
+Provider-specific model listing behavior is covered in the [OpenAI](/docs/providers/openai), [Anthropic](/docs/providers/anthropic), [Gemini](/docs/providers/gemini), [Mistral](/docs/providers/mistral), and [Grok](/docs/providers/grok) provider guides.
 
 ## Contract
 

--- a/apps/www/src/content/docs/advanced/transcription.md
+++ b/apps/www/src/content/docs/advanced/transcription.md
@@ -11,7 +11,7 @@ Transcription converts audio bytes into text through a provider-neutral model co
 
 Use transcription in server routes, workers, upload processors, call review tools, meeting note workflows, and media pipelines.
 
-The current provider adapters with transcription are [OpenAI](/docs/providers/openai) and [Gemini](/docs/providers/gemini).
+The current provider adapters with transcription are [OpenAI](/docs/providers/openai), [Gemini](/docs/providers/gemini), and [Grok](/docs/providers/grok).
 
 ## Send A Request
 

--- a/apps/www/src/content/docs/basics/install-packages.md
+++ b/apps/www/src/content/docs/basics/install-packages.md
@@ -9,7 +9,7 @@ sidebar:
 
 Install `@anvia/core` plus one provider package. The core package is provider-neutral; a provider package turns a vendor API into a model that the core runtime can call.
 
-Read [Providers overview](/docs/providers/overview) if you need to choose between OpenAI, Anthropic, Gemini, and Mistral before continuing.
+Read [Providers overview](/docs/providers/overview) if you need to choose between OpenAI, Anthropic, Gemini, Mistral, and Grok before continuing.
 
 ## Prerequisites
 

--- a/apps/www/src/content/docs/packages/grok/changelog.md
+++ b/apps/www/src/content/docs/packages/grok/changelog.md
@@ -1,0 +1,122 @@
+---
+title: "@anvia/grok: Changelog"
+description: "Release history for @anvia/grok."
+section: packages
+sidebar:
+  group: "@anvia/grok"
+  order: 5
+  label: "Changelog"
+---
+
+Release history mirrored from `packages/provider-grok/CHANGELOG.md`.
+
+## 0.3.1
+
+### Patch Changes
+
+- 693ce2a: Trace complete model inputs and nested agent generations in Langfuse with safe and full capture
+  modes, consistent redaction, native prompt and time-to-first-token attributes, and reliable score
+  queue flushing. Normalize provider token totals and expose mutually exclusive usage detail buckets
+  for accurate cache- and reasoning-aware cost inference.
+- Updated dependencies [693ce2a]
+  - @anvia/openai@0.4.1
+
+## 0.3.0
+
+### Minor Changes
+
+- 32634d6: Add provider-executed tool contracts to the unified tools API, normalize citations and provider
+  tool events, and expose Grok live search, code interpreter, collections search, remote MCP, batch
+  TTS/STT, Grok 4.5 defaults, and documented image ratio handling.
+
+### Patch Changes
+
+- Updated dependencies [32634d6]
+  - @anvia/openai@0.4.0
+
+## 0.2.11
+
+### Patch Changes
+
+- Updated dependencies [ca24a5e]
+  - @anvia/openai@0.3.25
+
+## 0.2.10
+
+### Patch Changes
+
+- 2ae2087: Update upstream runtime dependencies for provider, vector store, observability, React UI,
+  and Studio packages.
+- Updated dependencies [2ae2087]
+  - @anvia/openai@0.3.24
+
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [1d8c883]
+  - @anvia/openai@0.3.23
+
+## 0.2.8
+
+### Patch Changes
+
+- Updated dependencies [d9ac48c]
+  - @anvia/openai@0.3.22
+
+## 0.2.7
+
+### Patch Changes
+
+- Updated dependencies [5b0719c]
+  - @anvia/openai@0.3.21
+
+## 0.2.6
+
+### Patch Changes
+
+- Updated dependencies [8b7fe0d]
+  - @anvia/openai@0.3.20
+
+## 0.2.5
+
+### Patch Changes
+
+- Updated dependencies [b5f285a]
+  - @anvia/openai@0.3.19
+
+## 0.2.4
+
+### Patch Changes
+
+- 433f642: Simplify provider request and response object construction while preserving adapter behavior.
+- Updated dependencies [433f642]
+  - @anvia/openai@0.3.18
+
+## 0.2.3
+
+### Patch Changes
+
+- Updated dependencies [204d342]
+  - @anvia/openai@0.3.17
+
+## 0.2.2
+
+### Patch Changes
+
+- Updated dependencies [498e95b]
+  - @anvia/openai@0.3.16
+
+## 0.2.1
+
+### Patch Changes
+
+- 32171dc: Add provider model-name types for autocomplete while preserving custom string model IDs.
+- Updated dependencies [32171dc]
+  - @anvia/openai@0.3.15
+
+## 0.2.0
+
+### Minor Changes
+
+- bfa3c9b: Add a first-class Grok provider package for xAI completions, image generation, and model listing.

--- a/apps/www/src/content/docs/packages/grok/examples.md
+++ b/apps/www/src/content/docs/packages/grok/examples.md
@@ -29,12 +29,12 @@ import { GrokClient } from "@anvia/grok";
 
 export function createSupportModel(): CompletionModel {
   const client = new GrokClient({ apiKey: process.env.XAI_API_KEY });
-  return client.completionModel();
+  return client.completionModel("grok-4.5");
 }
 
 export function createFallbackModel(): CompletionModel {
   const client = new GrokClient({ apiKey: process.env.XAI_API_KEY });
-  return client.completionModel();
+  return client.completionModel("grok-4.3");
 }
 ```
 The application can now choose a model before building the agent while keeping the agent factory provider-neutral.

--- a/apps/www/src/content/docs/packages/grok/examples.md
+++ b/apps/www/src/content/docs/packages/grok/examples.md
@@ -1,0 +1,77 @@
+---
+title: "@anvia/grok: Examples"
+description: "Small examples that show @anvia/grok at the package boundary."
+section: packages
+sidebar:
+  group: "@anvia/grok"
+  order: 4
+  label: "Examples"
+---
+## Minimal agent
+
+```ts
+import { AgentBuilder } from "@anvia/core";
+import { GrokClient } from "@anvia/grok";
+
+const client = new GrokClient({ apiKey: process.env.XAI_API_KEY });
+const agent = new AgentBuilder("support", client.completionModel())
+  .instructions("Answer clearly and concisely.")
+  .build();
+
+const response = await agent.prompt("Draft a short support reply.").send();
+console.log(response.output);
+```
+## Product-shaped model boundary
+
+```ts
+import type { CompletionModel } from "@anvia/core";
+import { GrokClient } from "@anvia/grok";
+
+export function createSupportModel(): CompletionModel {
+  const client = new GrokClient({ apiKey: process.env.XAI_API_KEY });
+  return client.completionModel();
+}
+
+export function createFallbackModel(): CompletionModel {
+  const client = new GrokClient({ apiKey: process.env.XAI_API_KEY });
+  return client.completionModel();
+}
+```
+The application can now choose a model before building the agent while keeping the agent factory provider-neutral.
+
+## Live search with server tools
+
+```ts
+import { AgentBuilder } from "@anvia/core/agent";
+import { GrokClient, tools as grokTools } from "@anvia/grok";
+
+const grok = new GrokClient({ apiKey: process.env.XAI_API_KEY });
+
+const agent = new AgentBuilder("researcher", grok.completionModel())
+  .tools([
+    grokTools.webSearch({ allowedDomains: ["x.ai"] }),
+    grokTools.codeInterpreter(),
+  ])
+  .additionalParams({ max_turns: 5 })
+  .build();
+
+const result = await agent.prompt("What are the latest xAI updates?").send();
+console.log(result.sources);
+console.log(result.providerToolCalls);
+```
+
+## Harness shape
+
+```ts
+import { describe, expect, it } from "vitest";
+
+describe("support model boundary", () => {
+  it("creates a completion model", () => {
+    const model = createSupportModel();
+
+    expect(model).toHaveProperty("completion");
+    expect(model).toHaveProperty("streamCompletion");
+  });
+});
+```
+Use live provider tests sparingly and gate them behind environment variables. Unit tests should usually check the model boundary and mock the model contract.

--- a/apps/www/src/content/docs/packages/grok/getting-started.md
+++ b/apps/www/src/content/docs/packages/grok/getting-started.md
@@ -1,0 +1,70 @@
+---
+title: "@anvia/grok: Getting Started"
+description: "Install @anvia/grok and wire it into an Anvia project."
+section: packages
+sidebar:
+  group: "@anvia/grok"
+  order: 2
+  label: "Getting Started"
+---
+## Install
+
+```sh
+pnpm add @anvia/grok @anvia/core
+```
+## Configure credentials
+
+Set `XAI_API_KEY` in the server environment. Keep provider keys on the server side; browser clients should call an application route that owns the model request.
+
+## Minimum setup
+
+```ts
+import { AgentBuilder } from "@anvia/core";
+import { GrokClient } from "@anvia/grok";
+
+const client = new GrokClient({
+  apiKey: process.env.XAI_API_KEY,
+});
+
+const model = client.completionModel(); // defaults to grok-4.5
+
+const agent = new AgentBuilder("assistant", model)
+  .instructions("Answer clearly and concisely.")
+  .build();
+
+const response = await agent.prompt("Summarize this ticket.").send();
+console.log(response.output);
+```
+
+`completionModel()` uses the Responses adapter by default. Use the Chat Completions adapter when a workflow needs that API shape:
+
+```ts
+const chatClient = new GrokClient({
+  apiKey: process.env.XAI_API_KEY,
+  completionApi: "chat",
+});
+
+const model = chatClient.completionModel("grok-4.5");
+```
+
+## Other model factories
+
+@anvia/grok also exposes image generation, batch speech, and transcription factories:
+
+```ts
+const imageModel = client.imageGenerationModel("grok-imagine-image");
+const speech = await client.audioGenerationModel().audioGeneration({
+  text: "Hello from Grok.",
+  voice: "eve",
+  speed: 1,
+});
+const transcript = await client.transcriptionModel().transcription({
+  data: speech.audio,
+  filename: "speech.mp3",
+  language: "en",
+});
+```
+
+## Next step
+
+Continue with [Usage Patterns](/docs/packages/grok/usage-patterns).

--- a/apps/www/src/content/docs/packages/grok/overview.md
+++ b/apps/www/src/content/docs/packages/grok/overview.md
@@ -1,0 +1,32 @@
+---
+title: "@anvia/grok: Overview"
+description: "Grok provider adapter for completions, live search, server tools, batch speech, image generation, and model listing."
+section: packages
+sidebar:
+  group: "@anvia/grok"
+  order: 1
+  label: "Overview"
+---
+## What it is
+
+Grok provider adapter for xAI completions, live search, server-executed tools, batch speech, image generation, and model listing.
+
+Use @anvia/grok when the application needs xAI Grok models behind Anvia agents, completions, pipelines, or extraction flows. It is one of the provider adapters that turn provider SDKs into Anvia model contracts.
+
+## Where it fits
+
+@anvia/grok plugs into `@anvia/core` by returning completion and related model objects from `GrokClient`. Build agents, extractors, and pipelines against the Anvia model interfaces so provider-specific details stay at the model selection boundary.
+
+The package owns mapping Anvia completion, image generation, audio generation, transcription, and listing contracts to xAI APIs. It also exposes typed server-executed tools for the Responses adapter. Keep prompt policy, document ingestion, credential management, and provider fallback decisions in application code.
+
+## Public surface
+
+The main documented exports are `GrokClient`, `GrokResponsesCompletionModel`, `GrokChatCompletionModel`, `GrokImageGenerationModel`, `GrokAudioGenerationModel`, `GrokTranscriptionModel`, `tools`, model constants, and the `grok` namespace. The reference page lists the package entrypoint and public symbols that are checked by the docs reference coverage script.
+
+## Next pages
+
+- [Getting Started](/docs/packages/grok/getting-started)
+- [Usage Patterns](/docs/packages/grok/usage-patterns)
+- [Examples](/docs/packages/grok/examples)
+- [Changelog](/docs/packages/grok/changelog)
+- [Reference](/docs/packages/grok/reference)

--- a/apps/www/src/content/docs/packages/grok/usage-patterns.md
+++ b/apps/www/src/content/docs/packages/grok/usage-patterns.md
@@ -41,7 +41,7 @@ Anvia keeps local tools in its executable `ToolSet` and sends Grok tools only to
 - Pair with `@anvia/core` for agents, direct completions, extractors, and pipelines.
 - Pair with `@anvia/server` and `@anvia/react` when exposing streamed runs to a browser UI.
 - Pair with `@anvia/logger`, `@anvia/langfuse`, or `@anvia/otel` when provider calls need operational visibility.
-- Pair provider embeddings with a vector-store package for RAG ingestion and search.
+- Pair an embedding-capable provider with a vector-store package for RAG ingestion and search.
 
 ## Do and do not
 

--- a/apps/www/src/content/docs/packages/grok/usage-patterns.md
+++ b/apps/www/src/content/docs/packages/grok/usage-patterns.md
@@ -1,0 +1,50 @@
+---
+title: "@anvia/grok: Usage Patterns"
+description: "Common ways to compose @anvia/grok with adjacent Anvia packages."
+section: packages
+sidebar:
+  group: "@anvia/grok"
+  order: 3
+  label: "Usage Patterns"
+---
+## Package boundary
+
+@anvia/grok owns the provider adapter. It should be created at the model boundary, then passed into `@anvia/core` as a completion, image generation, audio generation, transcription, or listing model where that package supports it.
+
+Keep prompts, tools, memory, retrieval, tenant routing, and fallback policy outside the provider adapter. That makes it possible to swap providers without rewriting agent or pipeline code.
+
+## Server-executed tools
+
+The Responses adapter can execute web search, X search, code interpreter, collections search, and remote MCP tools on xAI's servers. Pass them through the same `.tools(...)` API as local executable tools:
+
+```ts
+import { AgentBuilder } from "@anvia/core/agent";
+import { GrokClient, tools as grokTools } from "@anvia/grok";
+
+const grok = new GrokClient({ apiKey: process.env.XAI_API_KEY });
+
+const agent = new AgentBuilder("researcher", grok.completionModel())
+  .tools([
+    localDatabaseTool,
+    grokTools.webSearch({ allowedDomains: ["x.ai"] }),
+    grokTools.xSearch({ allowedHandles: ["xai"] }),
+    grokTools.codeInterpreter(),
+  ])
+  .additionalParams({ max_turns: 5 })
+  .build();
+```
+
+Anvia keeps local tools in its executable `ToolSet` and sends Grok tools only to xAI. Typed server tools require the Responses adapter; the Chat Completions adapter rejects them.
+
+## Common composition
+
+- Pair with `@anvia/core` for agents, direct completions, extractors, and pipelines.
+- Pair with `@anvia/server` and `@anvia/react` when exposing streamed runs to a browser UI.
+- Pair with `@anvia/logger`, `@anvia/langfuse`, or `@anvia/otel` when provider calls need operational visibility.
+- Pair provider embeddings with a vector-store package for RAG ingestion and search.
+
+## Do and do not
+
+Do construct `GrokClient` once per runtime boundary or request scope. Do record selected provider and model in logs or traces. Do pass provider-specific options through the model request only when the behavior is intentionally provider-specific.
+
+Do not import provider SDK types throughout product code. Do not put API keys in browser bundles. Do not hide fallback behavior inside the agent prompt; make model selection explicit and testable.

--- a/apps/www/src/lib/packages.ts
+++ b/apps/www/src/lib/packages.ts
@@ -462,6 +462,13 @@ const packageDefinitions: PackageFamilyDefinition[] = [
         "Mistral provider adapter for Anvia.",
         true,
       ),
+      definePackage(
+        "@anvia/grok",
+        "grok",
+        "packages/provider-grok",
+        "Grok provider adapter for Anvia.",
+        true,
+      ),
     ],
   },
   {


### PR DESCRIPTION
The @anvia/grok docs content existed in the working tree but was never committed, so the deployed site (anvia.dev/docs/packages) lists 27 packages without Grok.

## Changes
- Register @anvia/grok in apps/www/src/lib/packages.ts (Model Providers family)
- Add package docs pages: overview, getting-started, usage-patterns, examples, changelog (reference.md and providers/grok.md were already committed)
- Update cross-references in advanced docs (audio/image generation, transcription, model listing), install-packages, AgentGateway component, and PLAN.md

## Validation
- pnpm --filter www reference-check: passes (0 undocumented entrypoints/exports)
- pnpm --filter www build: passes (524 pages indexed)

No changeset needed: www is an ignored changeset workspace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Grok as a supported model provider across the product.
  * Added documentation for Grok-powered text, image, audio, speech, and transcription capabilities.
  * Added getting-started guidance, usage patterns, examples, and model-listing resources for the Grok integration.
  * Added the Grok package to the available provider package catalog.

* **Documentation**
  * Added Grok package overview and changelog documentation.
  * Documented configuration, supported capabilities, tools, testing guidance, and recommended integration practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->