### PR TITLE
Add model-aware context usage

### DIFF
--- a/.changeset/wise-context-windows.md
+++ b/.changeset/wise-context-windows.md
@@ -1,0 +1,15 @@
+---
+"@anvia/core": minor
+"@anvia/openai": minor
+"@anvia/anthropic": minor
+"@anvia/gemini": minor
+"@anvia/mistral": minor
+"@anvia/grok": minor
+"@anvia/react": minor
+"@anvia/react-ui": minor
+"@anvia/server": minor
+---
+
+Add model-aware context limits and provider-reported active context usage to completion responses,
+agent results, streams, persisted generation metadata, memory-backed agent sessions, React hooks,
+server UI streams, and a React context meter primitive.

--- a/apps/www/src/content/docs/packages/anthropic/reference.md
+++ b/apps/www/src/content/docs/packages/anthropic/reference.md
@@ -76,7 +76,9 @@ class AnthropicCompletionModel implements StreamingCompletionModel {
   constructor(
     client: Anthropic | AnthropicVertex,
     defaultModel?: AnthropicCompletionModelName,
+    options?: CompletionModelMetadataOptions,
   );
+  getModelInfo(model?: AnthropicCompletionModelName): CompletionModelInfo | undefined;
   completion(request: CompletionRequest): Promise<CompletionResponse>;
   streamCompletion(request: CompletionRequest): AsyncIterable<CompletionStreamEvent>;
 }

--- a/apps/www/src/content/docs/packages/core/reference/agent.md
+++ b/apps/www/src/content/docs/packages/core/reference/agent.md
@@ -82,13 +82,14 @@ Notable errors: `session(...)` throws when no memory store is configured or the 
 type AgentSession<M extends CompletionModel = CompletionModel> = {
   prompt(prompt: string | Message): PromptRequest<M>;
   messages(): Promise<Message[]>;
+  contextUsage(): Promise<ContextUsage | undefined>;
   clear(): Promise<void>;
 };
 ```
 
 Purpose: durable conversation scope created by `agent.session(sessionId, options?)`.
 
-Return behavior: `prompt(...)` loads messages from the configured memory store before the run and appends new messages according to the agent memory policy. Session prompts do not accept `Message[]`; use `agent.prompt(Message[])` for explicit stateless transcripts.
+Return behavior: `prompt(...)` loads messages from the configured memory store before the run and appends new messages according to the agent memory policy. `contextUsage()` returns the newest persisted assistant generation's context snapshot. Session prompts do not accept `Message[]`; use `agent.prompt(Message[])` for explicit stateless transcripts.
 
 Notable errors: methods throw when the built agent has no memory store configured.
 

--- a/apps/www/src/content/docs/packages/core/reference/completion.md
+++ b/apps/www/src/content/docs/packages/core/reference/completion.md
@@ -408,7 +408,8 @@ interface StreamingCompletionModel<RawResponse = unknown> extends CompletionMode
 Purpose: provider adapter interfaces. The metadata fields identify the adapter, its default model name, and the normalized request features the adapter supports.
 
 Context usage is the latest completed provider call's raw active occupancy. It uses
-`Usage.totalTokens`, includes the generated output, and is not cumulative across an agent run.
+`Usage.inputTokens`, does not project generated output into the next turn, and is not cumulative
+across an agent run.
 Percentages use the full model context window and are clamped to `0–100`; display-specific reserved
 headroom is intentionally left to applications. Unknown models return `undefined` unless their
 provider model receives a `modelOverrides` entry.

--- a/apps/www/src/content/docs/packages/core/reference/completion.md
+++ b/apps/www/src/content/docs/packages/core/reference/completion.md
@@ -96,6 +96,7 @@ type AssistantGenerationMetadata = {
   provider: string;
   model: string;
   usage: Usage;
+  contextUsage?: ContextUsage;
   sources?: CompletionSource[];
   providerToolCalls?: ProviderToolCall[];
 };
@@ -297,6 +298,7 @@ type CompletionRequest = {
 type CompletionResponse<RawResponse = unknown> = {
   choice: AssistantContent[];
   usage: Usage;
+  contextUsage?: ContextUsage;
   rawResponse: RawResponse;
   messageId?: string;
   sources?: CompletionSource[];
@@ -329,6 +331,45 @@ Notable errors: provider adapters can throw transport, authentication, or provid
 ## Completion Models
 
 ```ts
+type ModelContextLimits = {
+  contextWindow: number;
+  maxInputTokens?: number;
+  maxOutputTokens?: number;
+};
+
+type CompletionModelInfo<ModelName extends string = string> = {
+  id: ModelName;
+  context: ModelContextLimits;
+};
+
+type CompletionModelMetadataOptions = {
+  modelOverrides?: Readonly<Record<string, ModelContextLimits>>;
+};
+
+type ContextUsage = {
+  model: CompletionModelInfo;
+  usedTokens: number;
+  remainingTokens: number;
+  usedPercent: number;
+  remainingPercent: number;
+};
+
+function calculateContextUsage(
+  usage: Usage,
+  model: CompletionModelInfo | undefined,
+): ContextUsage | undefined;
+
+function resolveCompletionModelInfo(
+  model: string,
+  catalog: Readonly<Record<string, ModelContextLimits>>,
+  overrides?: Readonly<Record<string, ModelContextLimits>>,
+): CompletionModelInfo | undefined;
+
+function withContextUsage(
+  response: CompletionResponse,
+  model: CompletionModelInfo | undefined,
+): CompletionResponse;
+
 type CompletionModelCapabilities = {
   streaming: boolean;
   tools: boolean;
@@ -344,6 +385,7 @@ interface CompletionModel<RawResponse = unknown> {
   readonly provider: string;
   readonly defaultModel: string;
   readonly capabilities: CompletionModelCapabilities;
+  getModelInfo?(model?: string): CompletionModelInfo | undefined;
   completion(request: CompletionRequest): Promise<CompletionResponse<RawResponse>>;
 }
 
@@ -364,6 +406,12 @@ interface StreamingCompletionModel<RawResponse = unknown> extends CompletionMode
 ```
 
 Purpose: provider adapter interfaces. The metadata fields identify the adapter, its default model name, and the normalized request features the adapter supports.
+
+Context usage is the latest completed provider call's raw active occupancy. It uses
+`Usage.totalTokens`, includes the generated output, and is not cumulative across an agent run.
+Percentages use the full model context window and are clamped to `0–100`; display-specific reserved
+headroom is intentionally left to applications. Unknown models return `undefined` unless their
+provider model receives a `modelOverrides` entry.
 
 `ToolCallArgumentsMode` is `"append" | "replace"`. An omitted mode means append. Providers use
 `"replace"` when a completion event contains a full argument snapshot rather than the next fragment.

--- a/apps/www/src/content/docs/packages/core/reference/ui.md
+++ b/apps/www/src/content/docs/packages/core/reference/ui.md
@@ -82,12 +82,20 @@ type UIStreamEvent =
       partId: string;
       part: Extract<UIMessagePart, { type: "tool" }>;
     }
-  | { type: "message_end"; messageId: string; usage?: Usage; metadata?: JsonValue }
+  | {
+      type: "message_end";
+      messageId: string;
+      usage?: Usage;
+      contextUsage?: ContextUsage;
+      metadata?: JsonValue;
+    }
   | { type: "error"; error: UIError };
 
 ```
 
-Purpose: shared UI message shape for React-facing completion and chat state. React hooks can consume raw completion streams, raw agent streams, or `UIStreamEvent` records.
+Purpose: shared UI message shape for React-facing completion and chat state. React hooks can consume
+raw completion streams, raw agent streams, or `UIStreamEvent` records. A terminal `message_end`
+event can carry the model-aware `contextUsage` snapshot for the completed call.
 
 ## uiMessagesToCoreMessages
 

--- a/apps/www/src/content/docs/packages/gemini/reference.md
+++ b/apps/www/src/content/docs/packages/gemini/reference.md
@@ -82,7 +82,8 @@ Gemini audio generation is not implemented in v1.
 
 ```ts
 class GeminiCompletionModel implements StreamingCompletionModel {
-  constructor(client: GoogleGenAI, defaultModel?: GeminiCompletionModelName);
+  constructor(client: GoogleGenAI, defaultModel?: GeminiCompletionModelName, options?: CompletionModelMetadataOptions);
+  getModelInfo(model?: GeminiCompletionModelName): CompletionModelInfo | undefined;
   completion(request: CompletionRequest): Promise<CompletionResponse>;
   streamCompletion(request: CompletionRequest): AsyncIterable<CompletionStreamEvent>;
 }

--- a/apps/www/src/content/docs/packages/grok/reference.md
+++ b/apps/www/src/content/docs/packages/grok/reference.md
@@ -57,14 +57,16 @@ Purpose: typed model identifiers for autocomplete while preserving support for c
 ```ts
 class GrokResponsesCompletionModel implements StreamingCompletionModel {
   readonly provider: "grok";
-  constructor(client: OpenAI, defaultModel?: GrokCompletionModelName);
+  constructor(client: OpenAI, defaultModel?: GrokCompletionModelName, options?: CompletionModelMetadataOptions);
+  getModelInfo(model?: GrokCompletionModelName): CompletionModelInfo | undefined;
   completion(request: CompletionRequest): Promise<CompletionResponse>;
   streamCompletion(request: CompletionRequest): AsyncIterable<CompletionStreamEvent>;
 }
 
 class GrokChatCompletionModel implements StreamingCompletionModel {
   readonly provider: "grok-chat";
-  constructor(client: OpenAI, defaultModel?: GrokCompletionModelName);
+  constructor(client: OpenAI, defaultModel?: GrokCompletionModelName, options?: CompletionModelMetadataOptions);
+  getModelInfo(model?: GrokCompletionModelName): CompletionModelInfo | undefined;
   completion(request: CompletionRequest): Promise<CompletionResponse>;
   streamCompletion(request: CompletionRequest): AsyncIterable<CompletionStreamEvent>;
 }

--- a/apps/www/src/content/docs/packages/mistral/reference.md
+++ b/apps/www/src/content/docs/packages/mistral/reference.md
@@ -53,7 +53,8 @@ Purpose: typed model identifiers for autocomplete while preserving support for c
 
 ```ts
 class MistralCompletionModel implements StreamingCompletionModel {
-  constructor(client: Mistral, defaultModel?: MistralCompletionModelName);
+  constructor(client: Mistral, defaultModel?: MistralCompletionModelName, options?: CompletionModelMetadataOptions);
+  getModelInfo(model?: MistralCompletionModelName): CompletionModelInfo | undefined;
   completion(request: CompletionRequest): Promise<CompletionResponse>;
   streamCompletion(request: CompletionRequest): AsyncIterable<CompletionStreamEvent>;
 }

--- a/apps/www/src/content/docs/packages/openai/reference.md
+++ b/apps/www/src/content/docs/packages/openai/reference.md
@@ -102,7 +102,8 @@ Notable errors: rejects on OpenAI SDK errors or mismatched embedding counts.
 
 ```ts
 class OpenAIResponsesCompletionModel implements StreamingCompletionModel {
-  constructor(client: OpenAI, defaultModel?: OpenAICompletionModelName);
+  constructor(client: OpenAI, defaultModel?: OpenAICompletionModelName, options?: CompletionModelMetadataOptions);
+  getModelInfo(model?: OpenAICompletionModelName): CompletionModelInfo | undefined;
   completion(request: CompletionRequest): Promise<CompletionResponse>;
   streamCompletion(request: CompletionRequest): AsyncIterable<CompletionStreamEvent>;
 }
@@ -118,7 +119,8 @@ Notable errors: rejects or yields errors from OpenAI Responses API calls.
 
 ```ts
 class OpenAIChatCompletionModel implements StreamingCompletionModel {
-  constructor(client: OpenAI, defaultModel?: OpenAICompletionModelName);
+  constructor(client: OpenAI, defaultModel?: OpenAICompletionModelName, options?: CompletionModelMetadataOptions);
+  getModelInfo(model?: OpenAICompletionModelName): CompletionModelInfo | undefined;
   completion(request: CompletionRequest): Promise<CompletionResponse>;
   streamCompletion(request: CompletionRequest): AsyncIterable<CompletionStreamEvent>;
 }

--- a/apps/www/src/content/docs/packages/react-ui/reference.md
+++ b/apps/www/src/content/docs/packages/react-ui/reference.md
@@ -160,6 +160,29 @@ const ThreadListItem: {
 };
 ```
 
+## ContextMeter
+
+```ts
+type ContextMeterProps = Omit<PrimitiveProps<"div">, "children"> & {
+  usage?: ContextUsage;
+  display?: "remaining" | "used";
+  children?: React.ReactNode | ((usage: ContextUsage) => React.ReactNode);
+};
+
+const ContextMeter: React.ForwardRefExoticComponent<ContextMeterProps>;
+```
+
+Purpose: render the context percentage from `useChat().contextUsage` or
+`useCompletion().contextUsage`. It displays remaining context by default, returns `null` when no
+snapshot is available, and emits an accessible progress bar plus `data-anvia-context-meter*`
+styling hooks.
+
+```tsx
+const chat = useChat();
+
+return <ContextMeter usage={chat.contextUsage} />;
+```
+
 ## Streamed text smoothing
 
 `Message.Parts`, `Message.Text`, and `Message.Markdown` accept an optional `stream` lifecycle:

--- a/apps/www/src/content/docs/packages/react/reference.md
+++ b/apps/www/src/content/docs/packages/react/reference.md
@@ -89,7 +89,13 @@ type UIStreamEvent =
       partId: string;
       part: Extract<UIMessagePart, { type: "tool" }>;
     }
-  | { type: "message_end"; messageId: string; usage?: unknown; metadata?: unknown }
+  | {
+      type: "message_end";
+      messageId: string;
+      usage?: unknown;
+      contextUsage?: ContextUsage;
+      metadata?: unknown;
+    }
   | { type: "error"; error: UIError };
 
 type SendMessageInput =
@@ -384,6 +390,7 @@ type UseChatOptions<TRequest = UIStreamRequest, TEvent = UIStreamEvent> = {
 type UseChatResult<TEvent = UIStreamEvent> = {
   messages: UIMessage[];
   events: TEvent[];
+  contextUsage: ContextUsage | undefined;
   suggestions?: ChatSuggestion[];
   setMessages: SetMessages;
   sendMessage(input: SendMessageInput): Promise<void>;
@@ -425,6 +432,10 @@ function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(options?: {
 Purpose: React chat state machine that sends `UIStreamRequest` by default and accumulates response events into `UIMessage[]`.
 
 Passing `endpoint` creates a default JSONL fetch transport. Passing `transport` makes the hook independent of HTTP. `sendMessage(...)` appends a user message, keeps the full UI message history in state, and sends the converted core message history. Custom request factories receive the UI array as `messages` for compatibility and the converted array as `coreMessages`. The hook applies raw `CompletionStreamEvent`, raw `AgentStreamEvent`, or `UIStreamEvent` records as the assistant response arrives. Tool-call deltas produce an `input-streaming` tool part automatically; append fragments are concatenated and replacement snapshots overwrite the provisional input.
+
+`contextUsage` is the latest completed call's model-aware context snapshot. The hook reads it from
+raw completion or agent `final` events, or from a UI `message_end` event. It remains `undefined`
+when the model does not declare a context window or the provider does not report input usage.
 
 Passing `humanInput` tracks streamed tool approval and question events in `humanInput.approvals` and `humanInput.questions`. The action helpers submit approval decisions and question answers through custom handlers or the default `/approvals/:id/decision` and `/questions/:id/answer` endpoint paths.
 
@@ -536,6 +547,7 @@ type UseCompletionResult<TEvent = UIStreamEvent> = {
   status: UseCompletionStatus;
   error: unknown;
   events: TEvent[];
+  contextUsage: ContextUsage | undefined;
 };
 
 function useCompletion<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
@@ -546,6 +558,9 @@ function useCompletion<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
 Purpose: React hook for text completion streaming that also exposes the underlying assistant `messages`.
 
 By default, `complete(prompt)` appends one user `UIMessage` to the current messages, converts the full UI history to core messages, sends `{ messages, stream: true }`, and consumes raw `CompletionStreamEvent`, raw `AgentStreamEvent`, or `UIStreamEvent` records. Custom request factories receive the UI array as `messages` for compatibility and the converted array as `coreMessages`. `completion` is a convenience string derived from the latest assistant text parts.
+
+`contextUsage` follows the same terminal-event behavior as `useChat` and represents the latest
+completed model call, not a client-side token estimate of an in-progress prompt.
 
 ## createDirectTransport
 

--- a/apps/www/src/content/docs/packages/server/reference.md
+++ b/apps/www/src/content/docs/packages/server/reference.md
@@ -187,6 +187,9 @@ function createUIStreamResponse(
 Purpose: convert a standard `UIStreamEvent` iterable into an HTTP response for `@anvia/react` hooks,
 or continue a resumable UI stream with the same resume overload as `createEventStream`.
 
+`message_end.contextUsage` is serialized unchanged, allowing the React hooks to expose the latest
+completed model call's context snapshot.
+
 Default behavior: uses the same JSONL response format and headers as `createEventStream(...)` unless `format: "sse"` is passed.
 
 ## createJsonlStream

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { isStreamingCompletionModel } from "../completion/create-completion";
 import type {
   CompletionModel,
+  ContextUsage,
   Document,
   JsonObject,
   JsonValue,
@@ -9,6 +10,7 @@ import type {
   ProviderTool,
   ToolChoice,
 } from "../completion/index";
+import { getAssistantGenerationMetadata } from "../completion/types";
 import type { GuardrailPolicy } from "../guardrails";
 import type { PromptHook } from "../hooks";
 import type { MemoryContext, MemoryRegistration, SessionOptions } from "../memory/types";
@@ -224,6 +226,21 @@ export class AgentSession<M extends CompletionModel = CompletionModel> {
       throw new Error(`Agent "${this.agent.id}" has no memory store configured.`);
     }
     return memory.store.load(this.context);
+  }
+
+  async contextUsage(): Promise<ContextUsage | undefined> {
+    const messages = await this.messages();
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const message = messages[index];
+      if (message === undefined) {
+        continue;
+      }
+      const generation = getAssistantGenerationMetadata(message);
+      if (generation !== undefined) {
+        return generation.contextUsage;
+      }
+    }
+    return undefined;
   }
 
   async clear(): Promise<void> {

--- a/packages/core/src/completion/types.ts
+++ b/packages/core/src/completion/types.ts
@@ -494,10 +494,77 @@ export type Usage = {
   details?: UsageDetails;
 };
 
+export type ModelContextLimits = {
+  contextWindow: number;
+  maxInputTokens?: number;
+  maxOutputTokens?: number;
+};
+
+export type CompletionModelInfo<ModelName extends string = string> = {
+  id: ModelName;
+  context: ModelContextLimits;
+};
+
+export type CompletionModelMetadataOptions = {
+  modelOverrides?: Readonly<Record<string, ModelContextLimits>>;
+};
+
+export type ContextUsage<ModelName extends string = string> = {
+  model: CompletionModelInfo<ModelName>;
+  usedTokens: number;
+  remainingTokens: number;
+  usedPercent: number;
+  remainingPercent: number;
+};
+
+export function calculateContextUsage<ModelName extends string>(
+  usage: Usage,
+  model: CompletionModelInfo<ModelName> | undefined,
+): ContextUsage<ModelName> | undefined {
+  if (
+    model === undefined ||
+    !Number.isFinite(usage.totalTokens) ||
+    usage.totalTokens <= 0 ||
+    !Number.isFinite(model.context.contextWindow) ||
+    model.context.contextWindow <= 0
+  ) {
+    return undefined;
+  }
+
+  const usedTokens = Math.max(0, usage.totalTokens);
+  const remainingTokens = Math.max(0, model.context.contextWindow - usedTokens);
+  const usedPercent = Math.min(100, (usedTokens / model.context.contextWindow) * 100);
+  return {
+    model,
+    usedTokens,
+    remainingTokens,
+    usedPercent,
+    remainingPercent: 100 - usedPercent,
+  };
+}
+
+export function withContextUsage<RawResponse, ModelName extends string>(
+  response: CompletionResponse<RawResponse>,
+  model: CompletionModelInfo<ModelName> | undefined,
+): CompletionResponse<RawResponse> {
+  const contextUsage = calculateContextUsage(response.usage, model);
+  return contextUsage === undefined ? response : { ...response, contextUsage };
+}
+
+export function resolveCompletionModelInfo<ModelName extends string>(
+  model: ModelName,
+  catalog: Readonly<Record<string, ModelContextLimits>>,
+  overrides?: Readonly<Record<string, ModelContextLimits>>,
+): CompletionModelInfo<ModelName> | undefined {
+  const context = overrides?.[model] ?? catalog[model];
+  return context === undefined ? undefined : { id: model, context };
+}
+
 export type AssistantGenerationMetadata = {
   provider: string;
   model: string;
   usage: Usage;
+  contextUsage?: ContextUsage;
   sources?: CompletionSource[];
   providerToolCalls?: ProviderToolCall[];
 };
@@ -584,6 +651,15 @@ export function getAssistantGenerationMetadata(
         : { details: { ...generation.usage.details } }),
     },
   };
+  if (isContextUsageValue(generation.contextUsage)) {
+    metadata.contextUsage = {
+      ...generation.contextUsage,
+      model: {
+        ...generation.contextUsage.model,
+        context: { ...generation.contextUsage.model.context },
+      },
+    };
+  }
   if (isCompletionSourceArray(generation.sources)) {
     metadata.sources = generation.sources.map((source) => ({ ...source }));
   }
@@ -598,6 +674,36 @@ export function getAssistantGenerationMetadata(
 
 function isJsonObjectValue(value: JsonValue | undefined): value is JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isContextUsageValue(value: JsonValue | undefined): value is JsonObject & ContextUsage {
+  if (!isJsonObjectValue(value) || !isJsonObjectValue(value.model)) {
+    return false;
+  }
+  const context = value.model.context;
+  return (
+    typeof value.model.id === "string" &&
+    isJsonObjectValue(context) &&
+    isPositiveFiniteNumber(context.contextWindow) &&
+    isOptionalPositiveFiniteNumber(context.maxInputTokens) &&
+    isOptionalPositiveFiniteNumber(context.maxOutputTokens) &&
+    isNonnegativeFiniteNumber(value.usedTokens) &&
+    isNonnegativeFiniteNumber(value.remainingTokens) &&
+    isPercentage(value.usedPercent) &&
+    isPercentage(value.remainingPercent)
+  );
+}
+
+function isPositiveFiniteNumber(value: JsonValue | undefined): value is number {
+  return isNonnegativeFiniteNumber(value) && value > 0;
+}
+
+function isOptionalPositiveFiniteNumber(value: JsonValue | undefined): boolean {
+  return value === undefined || isPositiveFiniteNumber(value);
+}
+
+function isPercentage(value: JsonValue | undefined): value is number {
+  return isNonnegativeFiniteNumber(value) && value <= 100;
 }
 
 function isUsageValue(value: JsonValue | undefined): value is JsonObject & Usage {
@@ -687,6 +793,7 @@ export type CompletionRequest<ModelName extends string = string> = {
 export type CompletionResponse<RawResponse = unknown> = {
   choice: AssistantContent[];
   usage: Usage;
+  contextUsage?: ContextUsage;
   rawResponse: RawResponse;
   messageId?: string;
   sources?: CompletionSource[];
@@ -708,6 +815,7 @@ export interface CompletionModel<RawResponse = unknown, ModelName extends string
   readonly provider: string;
   readonly defaultModel: ModelName;
   readonly capabilities: CompletionModelCapabilities;
+  getModelInfo?(model?: ModelName): CompletionModelInfo<ModelName> | undefined;
   traceRequest?(
     request: CompletionRequest<ModelName>,
     options?: { stream?: boolean | undefined },

--- a/packages/core/src/completion/types.ts
+++ b/packages/core/src/completion/types.ts
@@ -523,15 +523,15 @@ export function calculateContextUsage<ModelName extends string>(
 ): ContextUsage<ModelName> | undefined {
   if (
     model === undefined ||
-    !Number.isFinite(usage.totalTokens) ||
-    usage.totalTokens <= 0 ||
+    !Number.isFinite(usage.inputTokens) ||
+    usage.inputTokens <= 0 ||
     !Number.isFinite(model.context.contextWindow) ||
     model.context.contextWindow <= 0
   ) {
     return undefined;
   }
 
-  const usedTokens = Math.max(0, usage.totalTokens);
+  const usedTokens = Math.max(0, usage.inputTokens);
   const remainingTokens = Math.max(0, model.context.contextWindow - usedTokens);
   const usedPercent = Math.min(100, (usedTokens / model.context.contextWindow) * 100);
   return {
@@ -681,7 +681,7 @@ function isContextUsageValue(value: JsonValue | undefined): value is JsonObject 
     return false;
   }
   const context = value.model.context;
-  return (
+  if (
     typeof value.model.id === "string" &&
     isJsonObjectValue(context) &&
     isPositiveFiniteNumber(context.contextWindow) &&
@@ -691,7 +691,23 @@ function isContextUsageValue(value: JsonValue | undefined): value is JsonObject 
     isNonnegativeFiniteNumber(value.remainingTokens) &&
     isPercentage(value.usedPercent) &&
     isPercentage(value.remainingPercent)
-  );
+  ) {
+    const contextWindow = context.contextWindow;
+    const remainingTokens = Math.max(0, contextWindow - value.usedTokens);
+    const usedPercent = Math.min(100, (value.usedTokens / contextWindow) * 100);
+    const remainingPercent = (remainingTokens / contextWindow) * 100;
+    return (
+      value.remainingTokens === remainingTokens &&
+      approximatelyEqual(value.usedPercent, usedPercent) &&
+      approximatelyEqual(value.remainingPercent, remainingPercent)
+    );
+  }
+  return false;
+}
+
+function approximatelyEqual(left: number, right: number): boolean {
+  const scale = Math.max(1, Math.abs(left), Math.abs(right));
+  return Math.abs(left - right) <= Number.EPSILON * scale * 8;
 }
 
 function isPositiveFiniteNumber(value: JsonValue | undefined): value is number {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,10 +4,13 @@ export type {
   AssistantMessage,
   AssistantMessageOptions,
   CompletionModel,
+  CompletionModelInfo,
+  CompletionModelMetadataOptions,
   CompletionRequest,
   CompletionResponse,
   CompletionSource,
   CompletionTool,
+  ContextUsage,
   CreateCompletionBaseOptions,
   CreateCompletionInput,
   CreateCompletionOptions,
@@ -21,6 +24,7 @@ export type {
   JsonPrimitive,
   JsonValue,
   MessageOptions,
+  ModelContextLimits,
   ProviderTool,
   ProviderToolCall,
   SystemMessage,
@@ -36,6 +40,7 @@ export type {
 } from "./completion/index";
 export {
   AssistantContent,
+  calculateContextUsage,
   createCompletion,
   createCompletionStream,
   createParsedCompletion,
@@ -43,9 +48,11 @@ export {
   isJsonValue,
   isProviderTool,
   Message,
+  resolveCompletionModelInfo,
   ToolContent,
   Usage,
   UserContent,
+  withContextUsage,
 } from "./completion/index";
 export type {
   GuardrailBoundary,

--- a/packages/core/src/request/prompt-request.ts
+++ b/packages/core/src/request/prompt-request.ts
@@ -642,6 +642,7 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
             runId,
             output: result.output,
             usage: result.usage,
+            contextUsage: result.contextUsage,
             messages: result.messages,
             trace: result.trace,
             guardrails: result.guardrails,
@@ -785,6 +786,7 @@ export class PromptRequest<M extends CompletionModel = CompletionModel> {
           provider: this.agent.model.provider,
           model: request.model ?? this.agent.model.defaultModel,
           usage: { ...response.usage },
+          ...(response.contextUsage === undefined ? {} : { contextUsage: response.contextUsage }),
           ...(response.sources === undefined ? {} : { sources: response.sources }),
           ...(response.providerToolCalls === undefined
             ? {}
@@ -1330,11 +1332,16 @@ function responseStreamEvents(
 function generationArtifacts(messages: MessageType[]): {
   sources?: CompletionSource[];
   providerToolCalls?: ProviderToolCall[];
+  contextUsage?: import("../completion/index").ContextUsage;
 } {
   const sources = new Map<string, CompletionSource>();
   const providerToolCalls = new Map<string, ProviderToolCall>();
+  let contextUsage: import("../completion/index").ContextUsage | undefined;
   for (const message of messages) {
     const metadata = getAssistantGenerationMetadata(message);
+    if (metadata !== undefined) {
+      contextUsage = metadata.contextUsage;
+    }
     for (const source of metadata?.sources ?? []) {
       const key = `${source.url}\u0000${source.startIndex ?? ""}\u0000${source.endIndex ?? ""}`;
       sources.set(key, source);
@@ -1346,6 +1353,7 @@ function generationArtifacts(messages: MessageType[]): {
   return {
     ...(sources.size === 0 ? {} : { sources: [...sources.values()] }),
     ...(providerToolCalls.size === 0 ? {} : { providerToolCalls: [...providerToolCalls.values()] }),
+    ...(contextUsage === undefined ? {} : { contextUsage }),
   };
 }
 

--- a/packages/core/src/request/types.ts
+++ b/packages/core/src/request/types.ts
@@ -2,6 +2,7 @@ import type {
   CompletionRequest,
   CompletionResponse,
   CompletionSource,
+  ContextUsage,
   Message as MessageType,
   ProviderToolCall,
   ReasoningContentType,
@@ -16,6 +17,7 @@ import type { AgentGenerationModelInfo, AgentTraceInfo } from "../observability/
 export type PromptResponse = {
   output: string;
   usage: Usage;
+  contextUsage?: ContextUsage | undefined;
   messages: MessageType[];
   trace?: AgentTraceInfo | undefined;
   guardrails?: GuardrailDecisionRecord[] | undefined;
@@ -125,6 +127,7 @@ type AgentChildStreamEventBase<RawResponse = unknown> =
       runId: string;
       output: string;
       usage: Usage;
+      contextUsage?: ContextUsage | undefined;
       messages: MessageType[];
       trace?: AgentTraceInfo | undefined;
       guardrails?: GuardrailDecisionRecord[] | undefined;

--- a/packages/core/src/ui/types.ts
+++ b/packages/core/src/ui/types.ts
@@ -1,4 +1,4 @@
-import type { ImageDetail, JsonValue, Message, Usage } from "../completion/types";
+import type { ContextUsage, ImageDetail, JsonValue, Message, Usage } from "../completion/types";
 
 export type UIMessageRole = "system" | "user" | "assistant" | "tool";
 
@@ -112,6 +112,7 @@ export type UIStreamEvent =
       type: "message_end";
       messageId: string;
       usage?: Usage;
+      contextUsage?: ContextUsage;
       metadata?: JsonValue;
     }
   | {

--- a/packages/core/test/memory.test.ts
+++ b/packages/core/test/memory.test.ts
@@ -7,6 +7,7 @@ import {
   type CompletionRequest,
   type CompletionResponse,
   type CompletionStreamEvent,
+  type ContextUsage,
   cancelPrompt,
   createHook,
   createMiddleware,
@@ -113,10 +114,12 @@ class RecordingMemoryStore implements MemoryStore {
 function response(
   choice: CompletionResponse["choice"],
   usage: CompletionResponse["usage"] = Usage.empty(),
+  contextUsage?: ContextUsage,
 ): CompletionResponse {
   return {
     choice,
     usage,
+    ...(contextUsage === undefined ? {} : { contextUsage }),
     rawResponse: {},
   };
 }
@@ -271,6 +274,48 @@ describe("agent memory", () => {
 
     expect(resultMetadata).toEqual(expected);
     expect(persistedMetadata).toEqual(expected);
+  });
+
+  it("persists and returns the latest context usage for a session", async () => {
+    const store = new RecordingMemoryStore();
+    const contextUsage: ContextUsage = {
+      model: { id: "test", context: { contextWindow: 100, maxOutputTokens: 20 } },
+      usedTokens: 25,
+      remainingTokens: 75,
+      usedPercent: 25,
+      remainingPercent: 75,
+    };
+    const model = new QueueModel([
+      response(
+        [AssistantContent.text("done")],
+        {
+          inputTokens: 20,
+          outputTokens: 5,
+          totalTokens: 25,
+          cachedInputTokens: 0,
+          cacheCreationInputTokens: 0,
+        },
+        contextUsage,
+      ),
+      response([AssistantContent.text("unknown model")], {
+        inputTokens: 30,
+        outputTokens: 5,
+        totalTokens: 35,
+        cachedInputTokens: 0,
+        cacheCreationInputTokens: 0,
+      }),
+    ]);
+    const agent = new AgentBuilder("test-agent", model).memory(store).build();
+    const session = agent.session("context-usage");
+
+    const result = await session.prompt("hello").send();
+
+    expect(result.contextUsage).toEqual(contextUsage);
+    await expect(session.contextUsage()).resolves.toEqual(contextUsage);
+
+    const unknownResult = await session.prompt("switch model").send();
+    expect(unknownResult.contextUsage).toBeUndefined();
+    await expect(session.contextUsage()).resolves.toBeUndefined();
   });
 
   it("records failed runs after preserving completed messages", async () => {

--- a/packages/core/test/message-content.test.ts
+++ b/packages/core/test/message-content.test.ts
@@ -309,6 +309,48 @@ describe("message attachment content", () => {
     ).toMatchObject({ usage: { details: { total: 9 } } });
   });
 
+  it("rejects internally inconsistent context usage metadata", () => {
+    const messageWithContextUsage = (contextUsage: JsonValue) =>
+      Message.assistant("assistant", {
+        metadata: {
+          anvia: {
+            generation: {
+              provider: "test",
+              model: "test-model",
+              usage: {
+                inputTokens: 60,
+                outputTokens: 15,
+                totalTokens: 75,
+                cachedInputTokens: 0,
+                cacheCreationInputTokens: 0,
+              },
+              contextUsage,
+            },
+          },
+        },
+      });
+    const validContextUsage = {
+      model: { id: "test-model", context: { contextWindow: 100 } },
+      usedTokens: 60,
+      remainingTokens: 40,
+      usedPercent: 60,
+      remainingPercent: 40,
+    };
+
+    expect(
+      getAssistantGenerationMetadata(messageWithContextUsage(validContextUsage)),
+    ).toMatchObject({ contextUsage: validContextUsage });
+    for (const inconsistent of [
+      { ...validContextUsage, remainingTokens: 90 },
+      { ...validContextUsage, usedPercent: 10 },
+      { ...validContextUsage, remainingPercent: 10 },
+    ]) {
+      expect(
+        getAssistantGenerationMetadata(messageWithContextUsage(inconsistent)),
+      ).not.toHaveProperty("contextUsage");
+    }
+  });
+
   it("validates strict JSON values without accepting lossy structures", () => {
     const shared = { value: 1 };
     expect(isJsonValue({ shared, duplicate: shared, list: [null, true, 1, "ok"] })).toBe(true);

--- a/packages/core/test/usage.test.ts
+++ b/packages/core/test/usage.test.ts
@@ -79,7 +79,7 @@ describe("context usage", () => {
     cacheCreationInputTokens: 0,
   };
 
-  it("uses provider total tokens as raw context occupancy", () => {
+  it("uses provider input tokens as raw context occupancy", () => {
     expect(
       calculateContextUsage(usage, {
         id: "model-a",
@@ -90,16 +90,16 @@ describe("context usage", () => {
         id: "model-a",
         context: { contextWindow: 100, maxInputTokens: 80, maxOutputTokens: 20 },
       },
-      usedTokens: 75,
-      remainingTokens: 25,
-      usedPercent: 75,
-      remainingPercent: 25,
+      usedTokens: 60,
+      remainingTokens: 40,
+      usedPercent: 60,
+      remainingPercent: 40,
     });
   });
 
   it("clamps percentages while preserving over-limit token usage", () => {
     const contextUsage = calculateContextUsage(
-      { ...usage, totalTokens: 125 },
+      { ...usage, inputTokens: 125, totalTokens: 140 },
       { id: "model-a", context: { contextWindow: 100 } },
     );
 

--- a/packages/core/test/usage.test.ts
+++ b/packages/core/test/usage.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { Usage } from "../src/completion";
+import {
+  calculateContextUsage,
+  resolveCompletionModelInfo,
+  Usage,
+  withContextUsage,
+} from "../src/completion";
 
 describe("Usage", () => {
   it("adds complete mutually exclusive details", () => {
@@ -62,5 +67,69 @@ describe("Usage", () => {
       details: { input: 2, output: 1, total: 3 },
     };
     expect(Usage.add(Usage.empty(), usage)).toEqual(usage);
+  });
+});
+
+describe("context usage", () => {
+  const usage = {
+    inputTokens: 60,
+    outputTokens: 15,
+    totalTokens: 75,
+    cachedInputTokens: 20,
+    cacheCreationInputTokens: 0,
+  };
+
+  it("uses provider total tokens as raw context occupancy", () => {
+    expect(
+      calculateContextUsage(usage, {
+        id: "model-a",
+        context: { contextWindow: 100, maxInputTokens: 80, maxOutputTokens: 20 },
+      }),
+    ).toEqual({
+      model: {
+        id: "model-a",
+        context: { contextWindow: 100, maxInputTokens: 80, maxOutputTokens: 20 },
+      },
+      usedTokens: 75,
+      remainingTokens: 25,
+      usedPercent: 75,
+      remainingPercent: 25,
+    });
+  });
+
+  it("clamps percentages while preserving over-limit token usage", () => {
+    const contextUsage = calculateContextUsage(
+      { ...usage, totalTokens: 125 },
+      { id: "model-a", context: { contextWindow: 100 } },
+    );
+
+    expect(contextUsage).toMatchObject({
+      usedTokens: 125,
+      remainingTokens: 0,
+      usedPercent: 100,
+      remainingPercent: 0,
+    });
+  });
+
+  it("returns undefined without authoritative usage or model limits", () => {
+    expect(calculateContextUsage(Usage.empty(), undefined)).toBeUndefined();
+    expect(
+      calculateContextUsage(Usage.empty(), {
+        id: "model-a",
+        context: { contextWindow: 100 },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("resolves overrides before catalogs and decorates responses", () => {
+    const info = resolveCompletionModelInfo(
+      "custom",
+      { custom: { contextWindow: 100 } },
+      { custom: { contextWindow: 200 } },
+    );
+    const response = withContextUsage({ choice: [], usage, rawResponse: {} }, info);
+
+    expect(response.contextUsage?.model.context.contextWindow).toBe(200);
+    expect(resolveCompletionModelInfo("unknown", {})).toBeUndefined();
   });
 });

--- a/packages/provider-anthropic/src/anthropic/completion.ts
+++ b/packages/provider-anthropic/src/anthropic/completion.ts
@@ -5,6 +5,8 @@ import {
   type AssistantContent as AssistantContentType,
   assertCompletionRequestSupported,
   type CompletionModelCapabilities,
+  type CompletionModelInfo,
+  type CompletionModelMetadataOptions,
   type CompletionRequest,
   type CompletionResponse,
   type CompletionStreamEvent,
@@ -14,6 +16,7 @@ import {
   type JsonValue,
   type Message as MessageType,
   type ReasoningContent,
+  resolveCompletionModelInfo,
   type StreamingCompletionModel,
   type ToolChoice,
   type ToolContent,
@@ -21,10 +24,14 @@ import {
   type ToolResultContent,
   Usage,
   type UserContent,
+  withContextUsage,
 } from "@anvia/core/completion";
 import { orderedRequestMessages } from "../request-messages";
 import { isPlainObject, numberFrom, stringFrom } from "../utils";
-import type { AnthropicCompletionModelName } from "./models";
+import {
+  ANTHROPIC_COMPLETION_MODEL_CONTEXT_LIMITS,
+  type AnthropicCompletionModelName,
+} from "./models";
 
 type AnthropicCreateParams = Record<string, unknown>;
 type AnthropicMessage = Record<string, unknown>;
@@ -49,7 +56,18 @@ export class AnthropicCompletionModel
   constructor(
     private readonly client: Anthropic | AnthropicVertex,
     readonly defaultModel: AnthropicCompletionModelName = "claude-sonnet-4-20250514",
+    private readonly metadataOptions: CompletionModelMetadataOptions = {},
   ) {}
+
+  getModelInfo(
+    model: AnthropicCompletionModelName = this.defaultModel,
+  ): CompletionModelInfo<AnthropicCompletionModelName> | undefined {
+    return resolveCompletionModelInfo(
+      model,
+      ANTHROPIC_COMPLETION_MODEL_CONTEXT_LIMITS,
+      this.metadataOptions.modelOverrides,
+    );
+  }
 
   traceRequest(
     request: CompletionRequest<AnthropicCompletionModelName>,
@@ -68,7 +86,10 @@ export class AnthropicCompletionModel
     assertCompletionRequestSupported(this, request);
     const params = toAnthropicMessagesParams(this.defaultModel, request);
     const response = await this.client.messages.create(params as never);
-    return fromAnthropicMessage(response);
+    return withContextUsage(
+      fromAnthropicMessage(response),
+      this.getModelInfo(request.model ?? this.defaultModel),
+    );
   }
 
   async *streamCompletion(
@@ -103,7 +124,7 @@ export class AnthropicCompletionModel
           applyAnthropicStreamUsage(event, streamUsage, streamUsageFields) || hasStreamUsage;
       }
       for (const mapped of fromAnthropicStreamEvent(event)) {
-        const streamMapped =
+        const usageMapped =
           mapped.type === "final" && hasStreamUsage
             ? {
                 ...mapped,
@@ -113,6 +134,16 @@ export class AnthropicCompletionModel
                 },
               }
             : mapped;
+        const streamMapped =
+          usageMapped.type === "final"
+            ? {
+                ...usageMapped,
+                response: withContextUsage(
+                  usageMapped.response,
+                  this.getModelInfo(request.model ?? this.defaultModel),
+                ),
+              }
+            : usageMapped;
         if (
           streamMapped.type === "tool_call_delta" &&
           streamMapped.argumentsDelta !== undefined &&
@@ -138,7 +169,13 @@ export class AnthropicCompletionModel
         if (streamMessageId !== undefined) {
           response.messageId = streamMessageId;
         }
-        yield { type: "final", response };
+        yield {
+          type: "final",
+          response: withContextUsage(
+            response,
+            this.getModelInfo(request.model ?? this.defaultModel),
+          ),
+        };
       }
     }
   }

--- a/packages/provider-anthropic/src/anthropic/models.ts
+++ b/packages/provider-anthropic/src/anthropic/models.ts
@@ -1,3 +1,4 @@
+import type { ModelContextLimits } from "@anvia/core/completion";
 import type { ModelId } from "@anvia/core/model-listing";
 
 export type KnownAnthropicCompletionModelName =
@@ -27,3 +28,34 @@ export type KnownAnthropicCompletionModelName =
   | "claude-sonnet-5";
 
 export type AnthropicCompletionModelName = ModelId<KnownAnthropicCompletionModelName>;
+
+const CONTEXT_200K_32K = { contextWindow: 200_000, maxOutputTokens: 32_000 };
+const CONTEXT_200K_64K = { contextWindow: 200_000, maxOutputTokens: 64_000 };
+const CONTEXT_1M_128K = { contextWindow: 1_000_000, maxOutputTokens: 128_000 };
+
+export const ANTHROPIC_COMPLETION_MODEL_CONTEXT_LIMITS = {
+  "claude-3-5-sonnet-20240620": { contextWindow: 200_000, maxOutputTokens: 8_192 },
+  "claude-3-5-sonnet-20241022": { contextWindow: 200_000, maxOutputTokens: 8_192 },
+  "claude-3-7-sonnet-20250219": CONTEXT_200K_64K,
+  "claude-3-haiku-20240307": { contextWindow: 200_000, maxOutputTokens: 4_096 },
+  "claude-3-opus-20240229": { contextWindow: 200_000, maxOutputTokens: 4_096 },
+  "claude-3-sonnet-20240229": { contextWindow: 200_000, maxOutputTokens: 4_096 },
+  "claude-fable-5": CONTEXT_1M_128K,
+  "claude-haiku-4-5": CONTEXT_200K_64K,
+  "claude-haiku-4-5-20251001": CONTEXT_200K_64K,
+  "claude-opus-4-0": CONTEXT_200K_32K,
+  "claude-opus-4-1": CONTEXT_200K_32K,
+  "claude-opus-4-1-20250805": CONTEXT_200K_32K,
+  "claude-opus-4-20250514": CONTEXT_200K_32K,
+  "claude-opus-4-5": CONTEXT_200K_64K,
+  "claude-opus-4-5-20251101": CONTEXT_200K_64K,
+  "claude-opus-4-6": CONTEXT_1M_128K,
+  "claude-opus-4-7": CONTEXT_1M_128K,
+  "claude-opus-4-8": CONTEXT_1M_128K,
+  "claude-sonnet-4-0": CONTEXT_200K_64K,
+  "claude-sonnet-4-20250514": CONTEXT_200K_64K,
+  "claude-sonnet-4-5": CONTEXT_200K_64K,
+  "claude-sonnet-4-5-20250929": CONTEXT_200K_64K,
+  "claude-sonnet-4-6": { contextWindow: 1_000_000, maxOutputTokens: 64_000 },
+  "claude-sonnet-5": CONTEXT_1M_128K,
+} satisfies Readonly<Record<KnownAnthropicCompletionModelName, ModelContextLimits>>;

--- a/packages/provider-anthropic/test/anthropic-completion.test.ts
+++ b/packages/provider-anthropic/test/anthropic-completion.test.ts
@@ -36,6 +36,15 @@ describe("Anthropic Messages mapping", () => {
     });
   });
 
+  it("exposes model-specific context limits", () => {
+    const model = new AnthropicCompletionModel({} as never, "claude-sonnet-4-20250514");
+
+    expect(model.getModelInfo()).toEqual({
+      id: "claude-sonnet-4-20250514",
+      context: { contextWindow: 200_000, maxOutputTokens: 64_000 },
+    });
+  });
+
   it("rejects unsupported output schemas before provider calls", async () => {
     const calls: unknown[] = [];
     const model = new AnthropicCompletionModel(

--- a/packages/provider-gemini/src/gemini/completion.ts
+++ b/packages/provider-gemini/src/gemini/completion.ts
@@ -3,12 +3,15 @@ import {
   type AssistantContent as AssistantContentType,
   assertCompletionRequestSupported,
   type CompletionModelCapabilities,
+  type CompletionModelInfo,
+  type CompletionModelMetadataOptions,
   type CompletionRequest,
   type CompletionResponse,
   type CompletionStreamEvent,
   type JsonObject,
   type JsonValue,
   type Message as MessageType,
+  resolveCompletionModelInfo,
   type StreamingCompletionModel,
   type ToolCallArgumentsMode,
   type ToolChoice,
@@ -16,10 +19,11 @@ import {
   type ToolDefinition,
   Usage,
   type UserContent,
+  withContextUsage,
 } from "@anvia/core/completion";
 import type { GoogleGenAI } from "@google/genai";
 import { orderedRequestMessages } from "../request-messages";
-import type { GeminiCompletionModelName } from "./models";
+import { GEMINI_COMPLETION_MODEL_CONTEXT_LIMITS, type GeminiCompletionModelName } from "./models";
 
 type GeminiGenerateParams = Record<string, unknown>;
 type GeminiConfig = Record<string, unknown>;
@@ -46,7 +50,18 @@ export class GeminiCompletionModel
   constructor(
     private readonly client: GoogleGenAI,
     readonly defaultModel: GeminiCompletionModelName = "gemini-2.5-flash",
+    private readonly metadataOptions: CompletionModelMetadataOptions = {},
   ) {}
+
+  getModelInfo(
+    model: GeminiCompletionModelName = this.defaultModel,
+  ): CompletionModelInfo<GeminiCompletionModelName> | undefined {
+    return resolveCompletionModelInfo(
+      model,
+      GEMINI_COMPLETION_MODEL_CONTEXT_LIMITS,
+      this.metadataOptions.modelOverrides,
+    );
+  }
 
   traceRequest(
     request: CompletionRequest<GeminiCompletionModelName>,
@@ -62,7 +77,10 @@ export class GeminiCompletionModel
     assertCompletionRequestSupported(this, request);
     const params = toGeminiGenerateContentParams(this.defaultModel, request);
     const response = await this.client.models.generateContent(params as never);
-    return fromGeminiGenerateContentResponse(response);
+    return withContextUsage(
+      fromGeminiGenerateContentResponse(response),
+      this.getModelInfo(request.model ?? this.defaultModel),
+    );
   }
 
   async *streamCompletion(
@@ -73,7 +91,15 @@ export class GeminiCompletionModel
     const stream = await this.client.models.generateContentStream(params as never);
     for await (const chunk of stream as unknown as AsyncIterable<unknown>) {
       for (const event of fromGeminiGenerateContentStreamChunk(chunk)) {
-        yield event;
+        yield event.type === "final"
+          ? {
+              ...event,
+              response: withContextUsage(
+                event.response,
+                this.getModelInfo(request.model ?? this.defaultModel),
+              ),
+            }
+          : event;
       }
     }
   }

--- a/packages/provider-gemini/src/gemini/models.ts
+++ b/packages/provider-gemini/src/gemini/models.ts
@@ -1,3 +1,4 @@
+import type { ModelContextLimits } from "@anvia/core/completion";
 import type { ModelId } from "@anvia/core/model-listing";
 
 export type KnownGeminiCompletionModelName =
@@ -24,6 +25,72 @@ export type KnownGeminiCompletionModelName =
   | "gemma-4-31b-it";
 
 export type GeminiCompletionModelName = ModelId<KnownGeminiCompletionModelName>;
+
+const CONTEXT_1M_64K = {
+  contextWindow: 1_048_576,
+  maxInputTokens: 1_048_576,
+  maxOutputTokens: 65_536,
+};
+
+export const GEMINI_COMPLETION_MODEL_CONTEXT_LIMITS = {
+  "gemini-2.0-flash": {
+    contextWindow: 1_048_576,
+    maxInputTokens: 1_048_576,
+    maxOutputTokens: 8_192,
+  },
+  "gemini-2.0-flash-lite": {
+    contextWindow: 1_048_576,
+    maxInputTokens: 1_048_576,
+    maxOutputTokens: 8_192,
+  },
+  "gemini-2.5-flash": CONTEXT_1M_64K,
+  "gemini-2.5-flash-image": {
+    contextWindow: 32_768,
+    maxInputTokens: 32_768,
+    maxOutputTokens: 32_768,
+  },
+  "gemini-2.5-flash-lite": CONTEXT_1M_64K,
+  "gemini-2.5-flash-preview-tts": {
+    contextWindow: 8_192,
+    maxInputTokens: 8_192,
+    maxOutputTokens: 16_384,
+  },
+  "gemini-2.5-pro": CONTEXT_1M_64K,
+  "gemini-2.5-pro-preview-tts": {
+    contextWindow: 8_192,
+    maxInputTokens: 8_192,
+    maxOutputTokens: 16_384,
+  },
+  "gemini-3-flash-preview": CONTEXT_1M_64K,
+  "gemini-3-pro-image-preview": {
+    contextWindow: 131_072,
+    maxInputTokens: 131_072,
+    maxOutputTokens: 32_768,
+  },
+  "gemini-3-pro-preview": CONTEXT_1M_64K,
+  "gemini-3.1-flash-image-preview": {
+    contextWindow: 65_536,
+    maxInputTokens: 65_536,
+    maxOutputTokens: 65_536,
+  },
+  "gemini-3.1-flash-lite": CONTEXT_1M_64K,
+  "gemini-3.1-flash-lite-preview": CONTEXT_1M_64K,
+  "gemini-3.1-pro-preview": CONTEXT_1M_64K,
+  "gemini-3.1-pro-preview-customtools": CONTEXT_1M_64K,
+  "gemini-3.5-flash": CONTEXT_1M_64K,
+  "gemini-flash-latest": CONTEXT_1M_64K,
+  "gemini-flash-lite-latest": CONTEXT_1M_64K,
+  "gemma-4-26b-a4b-it": {
+    contextWindow: 262_144,
+    maxInputTokens: 262_144,
+    maxOutputTokens: 32_768,
+  },
+  "gemma-4-31b-it": {
+    contextWindow: 262_144,
+    maxInputTokens: 262_144,
+    maxOutputTokens: 32_768,
+  },
+} satisfies Readonly<Record<KnownGeminiCompletionModelName, ModelContextLimits>>;
 
 export type KnownGeminiEmbeddingModelName = "gemini-embedding-001";
 

--- a/packages/provider-gemini/test/completion.test.ts
+++ b/packages/provider-gemini/test/completion.test.ts
@@ -31,6 +31,19 @@ describe("Gemini completion mapping", () => {
     });
   });
 
+  it("exposes model-specific context limits", () => {
+    const model = new GeminiCompletionModel({} as never, "gemini-2.5-flash");
+
+    expect(model.getModelInfo()).toEqual({
+      id: "gemini-2.5-flash",
+      context: {
+        contextWindow: 1_048_576,
+        maxInputTokens: 1_048_576,
+        maxOutputTokens: 65_536,
+      },
+    });
+  });
+
   it("sends image input to the provider", async () => {
     const calls: unknown[] = [];
     const model = new GeminiCompletionModel(

--- a/packages/provider-grok/src/grok/completion.ts
+++ b/packages/provider-grok/src/grok/completion.ts
@@ -1,15 +1,18 @@
 import type {
   CompletionModelCapabilities,
+  CompletionModelInfo,
+  CompletionModelMetadataOptions,
   CompletionRequest,
   CompletionResponse,
   CompletionStreamEvent,
   JsonObject,
   StreamingCompletionModel,
 } from "@anvia/core/completion";
+import { resolveCompletionModelInfo, withContextUsage } from "@anvia/core/completion";
 import { OpenAIChatCompletionModel, OpenAIResponsesCompletionModel } from "@anvia/openai";
 import type { OpenAI } from "openai";
 import { GROK_4_5 } from "./constants";
-import type { GrokCompletionModelName } from "./models";
+import { GROK_COMPLETION_MODEL_CONTEXT_LIMITS, type GrokCompletionModelName } from "./models";
 
 export class GrokResponsesCompletionModel
   implements StreamingCompletionModel<unknown, GrokCompletionModelName>
@@ -21,9 +24,20 @@ export class GrokResponsesCompletionModel
   constructor(
     client: OpenAI,
     readonly defaultModel: GrokCompletionModelName = GROK_4_5,
+    private readonly metadataOptions: CompletionModelMetadataOptions = {},
   ) {
     this.delegate = new OpenAIResponsesCompletionModel(client, defaultModel);
     this.capabilities = { ...this.delegate.capabilities, providerTools: true };
+  }
+
+  getModelInfo(
+    model: GrokCompletionModelName = this.defaultModel,
+  ): CompletionModelInfo<GrokCompletionModelName> | undefined {
+    return resolveCompletionModelInfo(
+      model,
+      GROK_COMPLETION_MODEL_CONTEXT_LIMITS,
+      this.metadataOptions.modelOverrides,
+    );
   }
 
   traceRequest(
@@ -40,14 +54,27 @@ export class GrokResponsesCompletionModel
     request: CompletionRequest<GrokCompletionModelName>,
   ): Promise<CompletionResponse> {
     assertGrokProviderTools(request);
-    return await this.delegate.completion(request);
+    return withContextUsage(
+      await this.delegate.completion(request),
+      this.getModelInfo(request.model ?? this.defaultModel),
+    );
   }
 
-  streamCompletion(
+  async *streamCompletion(
     request: CompletionRequest<GrokCompletionModelName>,
   ): AsyncIterable<CompletionStreamEvent> {
     assertGrokProviderTools(request);
-    return this.delegate.streamCompletion(request);
+    for await (const event of this.delegate.streamCompletion(request)) {
+      yield event.type === "final"
+        ? {
+            ...event,
+            response: withContextUsage(
+              event.response,
+              this.getModelInfo(request.model ?? this.defaultModel),
+            ),
+          }
+        : event;
+    }
   }
 }
 
@@ -61,9 +88,20 @@ export class GrokChatCompletionModel
   constructor(
     client: OpenAI,
     readonly defaultModel: GrokCompletionModelName = GROK_4_5,
+    private readonly metadataOptions: CompletionModelMetadataOptions = {},
   ) {
     this.delegate = new OpenAIChatCompletionModel(client, defaultModel);
     this.capabilities = this.delegate.capabilities;
+  }
+
+  getModelInfo(
+    model: GrokCompletionModelName = this.defaultModel,
+  ): CompletionModelInfo<GrokCompletionModelName> | undefined {
+    return resolveCompletionModelInfo(
+      model,
+      GROK_COMPLETION_MODEL_CONTEXT_LIMITS,
+      this.metadataOptions.modelOverrides,
+    );
   }
 
   traceRequest(
@@ -80,14 +118,27 @@ export class GrokChatCompletionModel
     request: CompletionRequest<GrokCompletionModelName>,
   ): Promise<CompletionResponse> {
     assertGrokProviderTools(request);
-    return await this.delegate.completion(request);
+    return withContextUsage(
+      await this.delegate.completion(request),
+      this.getModelInfo(request.model ?? this.defaultModel),
+    );
   }
 
-  streamCompletion(
+  async *streamCompletion(
     request: CompletionRequest<GrokCompletionModelName>,
   ): AsyncIterable<CompletionStreamEvent> {
     assertGrokProviderTools(request);
-    return this.delegate.streamCompletion(request);
+    for await (const event of this.delegate.streamCompletion(request)) {
+      yield event.type === "final"
+        ? {
+            ...event,
+            response: withContextUsage(
+              event.response,
+              this.getModelInfo(request.model ?? this.defaultModel),
+            ),
+          }
+        : event;
+    }
   }
 }
 

--- a/packages/provider-grok/src/grok/models.ts
+++ b/packages/provider-grok/src/grok/models.ts
@@ -1,3 +1,4 @@
+import type { ModelContextLimits } from "@anvia/core/completion";
 import type { ModelId } from "@anvia/core/model-listing";
 
 export type KnownGrokCompletionModelName =
@@ -11,6 +12,19 @@ export type KnownGrokCompletionModelName =
   | "grok-build-0.1";
 
 export type GrokCompletionModelName = ModelId<KnownGrokCompletionModelName>;
+
+const CONTEXT_1M_30K = { contextWindow: 1_000_000, maxOutputTokens: 30_000 };
+
+export const GROK_COMPLETION_MODEL_CONTEXT_LIMITS = {
+  "grok-4.5": { contextWindow: 500_000 },
+  "grok-4.20": CONTEXT_1M_30K,
+  "grok-4.20-0309-non-reasoning": CONTEXT_1M_30K,
+  "grok-4.20-0309-reasoning": CONTEXT_1M_30K,
+  "grok-4.20-multi-agent-0309": CONTEXT_1M_30K,
+  "grok-4.20-non-reasoning": CONTEXT_1M_30K,
+  "grok-4.3": CONTEXT_1M_30K,
+  "grok-build-0.1": { contextWindow: 256_000, maxOutputTokens: 256_000 },
+} satisfies Readonly<Record<KnownGrokCompletionModelName, ModelContextLimits>>;
 
 export type KnownGrokImageGenerationModelName = "grok-imagine-image" | "grok-imagine-image-quality";
 

--- a/packages/provider-grok/test/completion.test.ts
+++ b/packages/provider-grok/test/completion.test.ts
@@ -24,6 +24,15 @@ describe("Grok completion models", () => {
     });
   });
 
+  it("exposes model-specific context limits", () => {
+    const model = new GrokResponsesCompletionModel({} as never, "grok-4.5");
+
+    expect(model.getModelInfo()).toEqual({
+      id: "grok-4.5",
+      context: { contextWindow: 500_000 },
+    });
+  });
+
   it("combines local, Grok, and legacy raw Responses tools", async () => {
     const calls: unknown[] = [];
     const model = new GrokResponsesCompletionModel(

--- a/packages/provider-mistral/src/mistral/completion.ts
+++ b/packages/provider-mistral/src/mistral/completion.ts
@@ -3,6 +3,8 @@ import {
   type AssistantContent as AssistantContentType,
   assertCompletionRequestSupported,
   type CompletionModelCapabilities,
+  type CompletionModelInfo,
+  type CompletionModelMetadataOptions,
   type CompletionRequest,
   type CompletionResponse,
   type CompletionStreamEvent,
@@ -10,17 +12,19 @@ import {
   type JsonObject,
   type JsonValue,
   type Message as MessageType,
+  resolveCompletionModelInfo,
   type StreamingCompletionModel,
   type ToolChoice,
   type ToolContent,
   type ToolDefinition,
   Usage,
   type UserContent,
+  withContextUsage,
 } from "@anvia/core/completion";
 import type { Mistral } from "@mistralai/mistralai";
 import { orderedRequestMessages } from "../request-messages";
 import { isPlainObject, numberFrom, parseToolArguments, schemaName, stringFrom } from "../utils";
-import type { MistralCompletionModelName } from "./models";
+import { MISTRAL_COMPLETION_MODEL_CONTEXT_LIMITS, type MistralCompletionModelName } from "./models";
 
 type MistralChatParams = Record<string, unknown>;
 type MistralChatMessage = Record<string, unknown>;
@@ -42,7 +46,18 @@ export class MistralCompletionModel
   constructor(
     private readonly client: Mistral,
     readonly defaultModel: MistralCompletionModelName = "mistral-large-latest",
+    private readonly metadataOptions: CompletionModelMetadataOptions = {},
   ) {}
+
+  getModelInfo(
+    model: MistralCompletionModelName = this.defaultModel,
+  ): CompletionModelInfo<MistralCompletionModelName> | undefined {
+    return resolveCompletionModelInfo(
+      model,
+      MISTRAL_COMPLETION_MODEL_CONTEXT_LIMITS,
+      this.metadataOptions.modelOverrides,
+    );
+  }
 
   traceRequest(
     request: CompletionRequest<MistralCompletionModelName>,
@@ -58,7 +73,10 @@ export class MistralCompletionModel
     assertCompletionRequestSupported(this, request);
     const params = toMistralChatParams(this.defaultModel, request);
     const response = await this.client.chat.complete(params as never);
-    return fromMistralChatResponse(response);
+    return withContextUsage(
+      fromMistralChatResponse(response),
+      this.getModelInfo(request.model ?? this.defaultModel),
+    );
   }
 
   async *streamCompletion(
@@ -69,7 +87,15 @@ export class MistralCompletionModel
     const stream = await this.client.chat.stream(params as never);
     for await (const chunk of stream as unknown as AsyncIterable<unknown>) {
       for (const event of fromMistralChatStreamChunk(chunk)) {
-        yield event;
+        yield event.type === "final"
+          ? {
+              ...event,
+              response: withContextUsage(
+                event.response,
+                this.getModelInfo(request.model ?? this.defaultModel),
+              ),
+            }
+          : event;
       }
     }
   }

--- a/packages/provider-mistral/src/mistral/models.ts
+++ b/packages/provider-mistral/src/mistral/models.ts
@@ -1,3 +1,4 @@
+import type { ModelContextLimits } from "@anvia/core/completion";
 import type { ModelId } from "@anvia/core/model-listing";
 
 export type KnownMistralCompletionModelName =
@@ -32,6 +33,42 @@ export type KnownMistralCompletionModelName =
   | "pixtral-large-latest";
 
 export type MistralCompletionModelName = ModelId<KnownMistralCompletionModelName>;
+
+const CONTEXT_128K = { contextWindow: 128_000, maxOutputTokens: 128_000 };
+const CONTEXT_256K = { contextWindow: 256_000, maxOutputTokens: 256_000 };
+const CONTEXT_262K = { contextWindow: 262_144, maxOutputTokens: 262_144 };
+
+export const MISTRAL_COMPLETION_MODEL_CONTEXT_LIMITS = {
+  "codestral-latest": { contextWindow: 256_000, maxOutputTokens: 4_096 },
+  "devstral-2512": CONTEXT_262K,
+  "devstral-latest": CONTEXT_262K,
+  "devstral-medium-2507": CONTEXT_128K,
+  "devstral-medium-latest": CONTEXT_262K,
+  "devstral-small-2505": CONTEXT_128K,
+  "devstral-small-2507": CONTEXT_128K,
+  "labs-devstral-small-2512": CONTEXT_256K,
+  "magistral-medium-latest": { contextWindow: 128_000, maxOutputTokens: 16_384 },
+  "magistral-small": CONTEXT_128K,
+  "ministral-3b-latest": CONTEXT_128K,
+  "ministral-8b-latest": CONTEXT_128K,
+  "mistral-large-2411": { contextWindow: 131_072, maxOutputTokens: 16_384 },
+  "mistral-large-2512": CONTEXT_262K,
+  "mistral-large-latest": CONTEXT_262K,
+  "mistral-medium-2505": { contextWindow: 131_072, maxOutputTokens: 131_072 },
+  "mistral-medium-2508": CONTEXT_262K,
+  "mistral-medium-2604": CONTEXT_262K,
+  "mistral-medium-latest": CONTEXT_262K,
+  "mistral-nemo": CONTEXT_128K,
+  "mistral-small-2506": { contextWindow: 128_000, maxOutputTokens: 16_384 },
+  "mistral-small-2603": CONTEXT_256K,
+  "mistral-small-latest": CONTEXT_256K,
+  "open-mistral-7b": { contextWindow: 8_000, maxOutputTokens: 8_000 },
+  "open-mistral-nemo": CONTEXT_128K,
+  "open-mixtral-8x22b": { contextWindow: 64_000, maxOutputTokens: 64_000 },
+  "open-mixtral-8x7b": { contextWindow: 32_000, maxOutputTokens: 32_000 },
+  "pixtral-12b": CONTEXT_128K,
+  "pixtral-large-latest": CONTEXT_128K,
+} satisfies Readonly<Record<KnownMistralCompletionModelName, ModelContextLimits>>;
 
 export type KnownMistralEmbeddingModelName = "mistral-embed";
 

--- a/packages/provider-mistral/test/completion.test.ts
+++ b/packages/provider-mistral/test/completion.test.ts
@@ -33,6 +33,15 @@ describe("Mistral completion mapping", () => {
     });
   });
 
+  it("exposes model-specific context limits", () => {
+    const model = new MistralCompletionModel({} as never, "mistral-large-latest");
+
+    expect(model.getModelInfo()).toEqual({
+      id: "mistral-large-latest",
+      context: { contextWindow: 262_144, maxOutputTokens: 262_144 },
+    });
+  });
+
   it("rejects unsupported image input before provider calls", async () => {
     const calls: unknown[] = [];
     const model = new MistralCompletionModel(

--- a/packages/provider-openai/src/openai/chat-completion.ts
+++ b/packages/provider-openai/src/openai/chat-completion.ts
@@ -3,6 +3,8 @@ import {
   type AssistantContent as AssistantContentType,
   assertCompletionRequestSupported,
   type CompletionModelCapabilities,
+  type CompletionModelInfo,
+  type CompletionModelMetadataOptions,
   type CompletionRequest,
   type CompletionResponse,
   type CompletionStreamEvent,
@@ -11,11 +13,13 @@ import {
   type JsonObject,
   type JsonValue,
   type Message as MessageType,
+  resolveCompletionModelInfo,
   type StreamingCompletionModel,
   type ToolChoice,
   type ToolContent,
   type ToolDefinition,
   type UserContent,
+  withContextUsage,
 } from "@anvia/core/completion";
 import type { OpenAI } from "openai";
 import { orderedRequestMessages } from "../request-messages";
@@ -27,7 +31,7 @@ import {
   schemaName,
   stringFrom,
 } from "../utils";
-import type { OpenAICompletionModelName } from "./models";
+import { OPENAI_COMPLETION_MODEL_CONTEXT_LIMITS, type OpenAICompletionModelName } from "./models";
 
 type ChatCompletionParams = Record<string, unknown>;
 type ChatMessage = Record<string, unknown>;
@@ -71,7 +75,18 @@ export class OpenAIChatCompletionModel
   constructor(
     private readonly client: OpenAI,
     readonly defaultModel: OpenAICompletionModelName = "openai/gpt-5.2",
+    private readonly metadataOptions: CompletionModelMetadataOptions = {},
   ) {}
+
+  getModelInfo(
+    model: OpenAICompletionModelName = this.defaultModel,
+  ): CompletionModelInfo<OpenAICompletionModelName> | undefined {
+    return resolveCompletionModelInfo(
+      model,
+      OPENAI_COMPLETION_MODEL_CONTEXT_LIMITS,
+      this.metadataOptions.modelOverrides,
+    );
+  }
 
   traceRequest(
     request: CompletionRequest<OpenAICompletionModelName>,
@@ -92,7 +107,10 @@ export class OpenAIChatCompletionModel
     assertCompletionRequestSupported(this, request);
     const params = toOpenAIChatCompletionParams(this.defaultModel, request);
     const response = await this.client.chat.completions.create(params as never);
-    return fromOpenAIChatCompletionResponse(response);
+    return withContextUsage(
+      fromOpenAIChatCompletionResponse(response),
+      this.getModelInfo(request.model ?? this.defaultModel),
+    );
   }
 
   async *streamCompletion(
@@ -110,7 +128,15 @@ export class OpenAIChatCompletionModel
     for await (const chunk of stream as unknown as AsyncIterable<unknown>) {
       const mapping = streamState.mapChunk(chunk);
       for (const event of mapping.events) {
-        yield event;
+        yield event.type === "final"
+          ? {
+              ...event,
+              response: withContextUsage(
+                event.response,
+                this.getModelInfo(request.model ?? this.defaultModel),
+              ),
+            }
+          : event;
       }
     }
     streamState.assertComplete();

--- a/packages/provider-openai/src/openai/models.ts
+++ b/packages/provider-openai/src/openai/models.ts
@@ -1,3 +1,4 @@
+import type { ModelContextLimits } from "@anvia/core/completion";
 import type { ModelId } from "@anvia/core/model-listing";
 
 export type KnownOpenAICompletionModelName =
@@ -46,6 +47,71 @@ export type KnownOpenAICompletionModelName =
   | "o4-mini-deep-research";
 
 export type OpenAICompletionModelName = ModelId<KnownOpenAICompletionModelName>;
+
+const CONTEXT_128K_16K = { contextWindow: 128_000, maxOutputTokens: 16_384 };
+const CONTEXT_200K_100K = { contextWindow: 200_000, maxOutputTokens: 100_000 };
+const CONTEXT_400K_128K = {
+  contextWindow: 400_000,
+  maxInputTokens: 272_000,
+  maxOutputTokens: 128_000,
+};
+const CONTEXT_1M_128K = {
+  contextWindow: 1_050_000,
+  maxInputTokens: 922_000,
+  maxOutputTokens: 128_000,
+};
+
+export const OPENAI_COMPLETION_MODEL_CONTEXT_LIMITS: Readonly<Record<string, ModelContextLimits>> =
+  {
+    "gpt-3.5-turbo": { contextWindow: 16_385, maxOutputTokens: 4_096 },
+    "gpt-4": { contextWindow: 8_192, maxOutputTokens: 8_192 },
+    "gpt-4-turbo": { contextWindow: 128_000, maxOutputTokens: 4_096 },
+    "gpt-4.1": { contextWindow: 1_047_576, maxOutputTokens: 32_768 },
+    "gpt-4.1-mini": { contextWindow: 1_047_576, maxOutputTokens: 32_768 },
+    "gpt-4.1-nano": { contextWindow: 1_047_576, maxOutputTokens: 32_768 },
+    "gpt-4o": CONTEXT_128K_16K,
+    "gpt-4o-2024-05-13": { contextWindow: 128_000, maxOutputTokens: 4_096 },
+    "gpt-4o-2024-08-06": CONTEXT_128K_16K,
+    "gpt-4o-2024-11-20": CONTEXT_128K_16K,
+    "gpt-4o-mini": CONTEXT_128K_16K,
+    "gpt-5": CONTEXT_400K_128K,
+    "gpt-5-chat-latest": CONTEXT_400K_128K,
+    "gpt-5-codex": CONTEXT_400K_128K,
+    "gpt-5-mini": CONTEXT_400K_128K,
+    "gpt-5-nano": CONTEXT_400K_128K,
+    "gpt-5-pro": { contextWindow: 400_000, maxInputTokens: 272_000, maxOutputTokens: 272_000 },
+    "gpt-5.1": CONTEXT_400K_128K,
+    "gpt-5.1-chat-latest": CONTEXT_128K_16K,
+    "gpt-5.1-codex": CONTEXT_400K_128K,
+    "gpt-5.1-codex-max": CONTEXT_400K_128K,
+    "gpt-5.1-codex-mini": CONTEXT_400K_128K,
+    "gpt-5.2": CONTEXT_400K_128K,
+    "openai/gpt-5.2": CONTEXT_400K_128K,
+    "gpt-5.2-chat-latest": CONTEXT_128K_16K,
+    "gpt-5.2-codex": CONTEXT_400K_128K,
+    "gpt-5.2-pro": CONTEXT_400K_128K,
+    "gpt-5.3-chat-latest": CONTEXT_128K_16K,
+    "gpt-5.3-codex": CONTEXT_400K_128K,
+    "gpt-5.3-codex-spark": {
+      contextWindow: 128_000,
+      maxInputTokens: 100_000,
+      maxOutputTokens: 32_000,
+    },
+    "gpt-5.4": CONTEXT_1M_128K,
+    "gpt-5.4-mini": CONTEXT_400K_128K,
+    "gpt-5.4-nano": CONTEXT_400K_128K,
+    "gpt-5.4-pro": CONTEXT_1M_128K,
+    "gpt-5.5": CONTEXT_1M_128K,
+    "gpt-5.5-pro": CONTEXT_1M_128K,
+    o1: CONTEXT_200K_100K,
+    "o1-pro": CONTEXT_200K_100K,
+    o3: CONTEXT_200K_100K,
+    "o3-deep-research": CONTEXT_200K_100K,
+    "o3-mini": CONTEXT_200K_100K,
+    "o3-pro": CONTEXT_200K_100K,
+    "o4-mini": CONTEXT_200K_100K,
+    "o4-mini-deep-research": CONTEXT_200K_100K,
+  };
 
 export type KnownOpenAIEmbeddingModelName =
   | "text-embedding-3-large"

--- a/packages/provider-openai/src/openai/responses.ts
+++ b/packages/provider-openai/src/openai/responses.ts
@@ -3,6 +3,8 @@ import {
   type AssistantContent as AssistantContentType,
   assertCompletionRequestSupported,
   type CompletionModelCapabilities,
+  type CompletionModelInfo,
+  type CompletionModelMetadataOptions,
   type CompletionRequest,
   type CompletionResponse,
   type CompletionSource,
@@ -16,12 +18,14 @@ import {
   type ProviderToolCall,
   type Reasoning,
   type ReasoningContent,
+  resolveCompletionModelInfo,
   type StreamingCompletionModel,
   type ToolChoice,
   type ToolContent,
   type ToolDefinition,
   type ToolResultContent,
   type UserContent,
+  withContextUsage,
 } from "@anvia/core/completion";
 import type { OpenAI } from "openai";
 import { orderedRequestMessages } from "../request-messages";
@@ -33,7 +37,7 @@ import {
   schemaName,
   stringFrom,
 } from "../utils";
-import type { OpenAICompletionModelName } from "./models";
+import { OPENAI_COMPLETION_MODEL_CONTEXT_LIMITS, type OpenAICompletionModelName } from "./models";
 
 type ResponsesCreateParams = Record<string, unknown>;
 type ResponsesInputItem = Record<string, unknown>;
@@ -56,7 +60,18 @@ export class OpenAIResponsesCompletionModel
   constructor(
     private readonly client: OpenAI,
     readonly defaultModel: OpenAICompletionModelName = "gpt-5",
+    private readonly metadataOptions: CompletionModelMetadataOptions = {},
   ) {}
+
+  getModelInfo(
+    model: OpenAICompletionModelName = this.defaultModel,
+  ): CompletionModelInfo<OpenAICompletionModelName> | undefined {
+    return resolveCompletionModelInfo(
+      model,
+      OPENAI_COMPLETION_MODEL_CONTEXT_LIMITS,
+      this.metadataOptions.modelOverrides,
+    );
+  }
 
   traceRequest(
     request: CompletionRequest<OpenAICompletionModelName>,
@@ -75,7 +90,10 @@ export class OpenAIResponsesCompletionModel
     assertCompletionRequestSupported(this, request);
     const params = toOpenAIResponsesParams(this.defaultModel, request);
     const response = await this.client.responses.create(params as never);
-    return fromOpenAIResponse(response);
+    return withContextUsage(
+      fromOpenAIResponse(response),
+      this.getModelInfo(request.model ?? this.defaultModel),
+    );
   }
 
   async *streamCompletion(
@@ -87,7 +105,15 @@ export class OpenAIResponsesCompletionModel
     for await (const event of stream as unknown as AsyncIterable<unknown>) {
       const mapped = fromOpenAIStreamEvent(event);
       if (mapped !== undefined) {
-        yield mapped;
+        yield mapped.type === "final"
+          ? {
+              ...mapped,
+              response: withContextUsage(
+                mapped.response,
+                this.getModelInfo(request.model ?? this.defaultModel),
+              ),
+            }
+          : mapped;
       }
     }
   }

--- a/packages/provider-openai/test/openai-responses.test.ts
+++ b/packages/provider-openai/test/openai-responses.test.ts
@@ -68,8 +68,8 @@ describe("OpenAI Responses mapping", () => {
     const response = await completionModel.completion(request);
 
     expect(response.contextUsage).toMatchObject({
-      usedTokens: 75,
-      remainingTokens: 399_925,
+      usedTokens: 60,
+      remainingTokens: 399_940,
       model: { id: "gpt-5", context: { contextWindow: 400_000 } },
     });
 
@@ -92,7 +92,7 @@ describe("OpenAI Responses mapping", () => {
 
     expect(events.at(-1)).toMatchObject({
       type: "final",
-      response: { contextUsage: { usedTokens: 75, remainingTokens: 399_925 } },
+      response: { contextUsage: { usedTokens: 60, remainingTokens: 399_940 } },
     });
   });
 

--- a/packages/provider-openai/test/openai-responses.test.ts
+++ b/packages/provider-openai/test/openai-responses.test.ts
@@ -1,6 +1,7 @@
 import {
   AssistantContent,
   type CompletionRequest,
+  type CompletionStreamEvent,
   Message,
   ToolContent,
   Usage,
@@ -30,6 +31,68 @@ describe("OpenAI Responses mapping", () => {
       outputSchema: true,
       reasoning: true,
       providerTools: true,
+    });
+  });
+
+  it("resolves built-in, custom, and unknown model context limits", () => {
+    const model = new OpenAIResponsesCompletionModel({} as never, "gpt-5", {
+      modelOverrides: { custom: { contextWindow: 42_000, maxOutputTokens: 2_000 } },
+    });
+
+    expect(model.getModelInfo()).toMatchObject({
+      id: "gpt-5",
+      context: { contextWindow: 400_000, maxOutputTokens: 128_000 },
+    });
+    expect(model.getModelInfo("custom")).toEqual({
+      id: "custom",
+      context: { contextWindow: 42_000, maxOutputTokens: 2_000 },
+    });
+    expect(model.getModelInfo("unknown")).toBeUndefined();
+  });
+
+  it("attaches context usage to completed and streamed responses", async () => {
+    const rawResponse = {
+      output: [{ type: "message", content: [{ type: "output_text", text: "ok" }] }],
+      usage: { input_tokens: 60, output_tokens: 15, total_tokens: 75 },
+    };
+    const request: CompletionRequest = {
+      chatHistory: [Message.user("hello")],
+      documents: [],
+      tools: [],
+    };
+    const completionModel = new OpenAIResponsesCompletionModel(
+      { responses: { create: async () => rawResponse } } as never,
+      "gpt-5",
+    );
+
+    const response = await completionModel.completion(request);
+
+    expect(response.contextUsage).toMatchObject({
+      usedTokens: 75,
+      remainingTokens: 399_925,
+      model: { id: "gpt-5", context: { contextWindow: 400_000 } },
+    });
+
+    const streamModel = new OpenAIResponsesCompletionModel(
+      {
+        responses: {
+          create: async () => ({
+            async *[Symbol.asyncIterator]() {
+              yield { type: "response.completed", response: rawResponse };
+            },
+          }),
+        },
+      } as never,
+      "gpt-5",
+    );
+    const events: CompletionStreamEvent[] = [];
+    for await (const event of streamModel.streamCompletion(request)) {
+      events.push(event);
+    }
+
+    expect(events.at(-1)).toMatchObject({
+      type: "final",
+      response: { contextUsage: { usedTokens: 75, remainingTokens: 399_925 } },
     });
   });
 

--- a/packages/react-ui/src/context-meter.tsx
+++ b/packages/react-ui/src/context-meter.tsx
@@ -1,0 +1,55 @@
+import type { UseChatResult } from "@anvia/react";
+import { forwardRef, type ReactNode } from "react";
+
+import { type PrimitiveProps, renderPrimitive } from "./primitives";
+
+type ContextUsage = NonNullable<UseChatResult["contextUsage"]>;
+
+export type ContextMeterProps = Omit<PrimitiveProps<"div">, "children"> & {
+  usage?: ContextUsage;
+  display?: "remaining" | "used";
+  children?: ReactNode | ((usage: ContextUsage) => ReactNode);
+};
+
+export const ContextMeter = forwardRef<HTMLDivElement, ContextMeterProps>(function ContextMeter(
+  { usage, display = "remaining", children, ...props },
+  ref,
+) {
+  if (usage === undefined) {
+    return null;
+  }
+
+  const percent = display === "remaining" ? usage.remainingPercent : usage.usedPercent;
+  const roundedPercent = Math.round(percent);
+  const label = `${roundedPercent}% context ${display === "remaining" ? "left" : "used"}`;
+  const content =
+    typeof children === "function"
+      ? children(usage)
+      : (children ?? (
+          <>
+            <span data-anvia-context-meter-label="">{label}</span>
+            <span aria-hidden="true" data-anvia-context-meter-track="">
+              <span
+                data-anvia-context-meter-value=""
+                style={{ width: `${Math.min(100, Math.max(0, percent))}%` }}
+              />
+            </span>
+          </>
+        ));
+
+  return renderPrimitive(
+    "div",
+    {
+      ...props,
+      children: content,
+      "aria-label": props["aria-label"] ?? label,
+      "aria-valuemax": 100,
+      "aria-valuemin": 0,
+      "aria-valuenow": roundedPercent,
+      "data-anvia-context-meter": "",
+      "data-display": display,
+      role: props.role ?? "progressbar",
+    } as PrimitiveProps<"div">,
+    ref,
+  );
+});

--- a/packages/react-ui/src/index.ts
+++ b/packages/react-ui/src/index.ts
@@ -14,6 +14,7 @@ export {
   useCompletionContext,
   useCompletionInput,
 } from "./completion/index";
+export { ContextMeter, type ContextMeterProps } from "./context-meter";
 export {
   HumanInput,
   useApproval,

--- a/packages/react-ui/src/styles.css
+++ b/packages/react-ui/src/styles.css
@@ -97,14 +97,14 @@
   height: 0.25rem;
   overflow: hidden;
   border-radius: 9999px;
-  background: color-mix(in srgb, currentColor 20%, transparent);
+  background: color-mix(in srgb, currentcolor 20%, transparent);
 }
 
 [data-anvia-context-meter-value] {
   display: block;
   height: 100%;
   border-radius: inherit;
-  background: currentColor;
+  background: currentcolor;
 }
 
 [data-state="disabled"] {

--- a/packages/react-ui/src/styles.css
+++ b/packages/react-ui/src/styles.css
@@ -85,6 +85,28 @@
   z-index: 60;
 }
 
+[data-anvia-context-meter] {
+  display: inline-grid;
+  min-width: 8rem;
+  gap: 0.375rem;
+  font-size: 0.75rem;
+}
+
+[data-anvia-context-meter-track] {
+  display: block;
+  height: 0.25rem;
+  overflow: hidden;
+  border-radius: 9999px;
+  background: color-mix(in srgb, currentColor 20%, transparent);
+}
+
+[data-anvia-context-meter-value] {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: currentColor;
+}
+
 [data-state="disabled"] {
   opacity: 0.55;
 }

--- a/packages/react-ui/test/context-meter.test.tsx
+++ b/packages/react-ui/test/context-meter.test.tsx
@@ -1,0 +1,42 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ContextMeter } from "../src";
+
+const usage = {
+  model: { id: "gpt-5", context: { contextWindow: 400_000 } },
+  usedTokens: 100_000,
+  remainingTokens: 300_000,
+  usedPercent: 25,
+  remainingPercent: 75,
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ContextMeter", () => {
+  it("renders remaining context by default", () => {
+    render(<ContextMeter usage={usage} />);
+
+    const meter = screen.getByRole("progressbar", { name: "75% context left" });
+    expect(meter.getAttribute("aria-valuenow")).toBe("75");
+    expect(screen.getByText("75% context left")).toBeTruthy();
+    expect(meter.querySelector<HTMLElement>("[data-anvia-context-meter-value]")?.style.width).toBe(
+      "75%",
+    );
+  });
+
+  it("supports used context and custom content", () => {
+    const { rerender } = render(<ContextMeter display="used" usage={usage} />);
+    expect(screen.getByRole("progressbar", { name: "25% context used" })).toBeTruthy();
+
+    rerender(<ContextMeter usage={usage}>{(value) => `${value.usedTokens} tokens`}</ContextMeter>);
+    expect(screen.getByText("100000 tokens")).toBeTruthy();
+  });
+
+  it("renders nothing when usage is unavailable", () => {
+    const { container } = render(<ContextMeter />);
+    expect(container.childElementCount).toBe(0);
+  });
+});

--- a/packages/react-ui/test/helpers.tsx
+++ b/packages/react-ui/test/helpers.tsx
@@ -21,6 +21,7 @@ export function createChatController(
   return {
     messages: [],
     events: [],
+    contextUsage: undefined,
     suggestions: [],
     setMessages: vi.fn(),
     sendMessage: vi.fn(async () => {}),
@@ -60,6 +61,7 @@ export function createCompletionController(
     status: "idle",
     error: undefined,
     events: [],
+    contextUsage: undefined,
     ...overrides,
   };
 }

--- a/packages/react/src/context-usage.ts
+++ b/packages/react/src/context-usage.ts
@@ -1,0 +1,80 @@
+import type { ContextUsage } from "@anvia/core/completion";
+import type { UIMessage } from "@anvia/core/ui";
+
+export type ContextUsageUpdate = {
+  contextUsage: ContextUsage | undefined;
+};
+
+export function contextUsageUpdateFromEvent(event: unknown): ContextUsageUpdate | undefined {
+  if (!isRecord(event)) {
+    return undefined;
+  }
+
+  if (event.type === "message_end") {
+    return { contextUsage: contextUsageValue(event.contextUsage) };
+  }
+
+  if (event.type === "final") {
+    const direct = contextUsageValue(event.contextUsage);
+    const response = isRecord(event.response)
+      ? contextUsageValue(event.response.contextUsage)
+      : undefined;
+    return { contextUsage: direct ?? response };
+  }
+
+  return undefined;
+}
+
+export function contextUsageFromMessages(messages: UIMessage[]): ContextUsage | undefined {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role !== "assistant" || !isRecord(message.metadata)) {
+      continue;
+    }
+    const anvia = message.metadata.anvia;
+    const generation = isRecord(anvia) ? anvia.generation : undefined;
+    if (isRecord(generation)) {
+      return contextUsageValue(generation.contextUsage);
+    }
+  }
+  return undefined;
+}
+
+function contextUsageValue(value: unknown): ContextUsage | undefined {
+  if (!isRecord(value) || !isRecord(value.model) || !isRecord(value.model.context)) {
+    return undefined;
+  }
+  if (
+    typeof value.model.id !== "string" ||
+    !isPositiveNumber(value.model.context.contextWindow) ||
+    !isOptionalPositiveNumber(value.model.context.maxInputTokens) ||
+    !isOptionalPositiveNumber(value.model.context.maxOutputTokens) ||
+    !isNonnegativeNumber(value.usedTokens) ||
+    !isNonnegativeNumber(value.remainingTokens) ||
+    !isPercentage(value.usedPercent) ||
+    !isPercentage(value.remainingPercent)
+  ) {
+    return undefined;
+  }
+  return value as unknown as ContextUsage;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonnegativeNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function isPositiveNumber(value: unknown): value is number {
+  return isNonnegativeNumber(value) && value > 0;
+}
+
+function isOptionalPositiveNumber(value: unknown): boolean {
+  return value === undefined || isPositiveNumber(value);
+}
+
+function isPercentage(value: unknown): value is number {
+  return isNonnegativeNumber(value) && value <= 100;
+}

--- a/packages/react/src/context-usage.ts
+++ b/packages/react/src/context-usage.ts
@@ -56,7 +56,23 @@ function contextUsageValue(value: unknown): ContextUsage | undefined {
   ) {
     return undefined;
   }
+  const contextWindow = value.model.context.contextWindow;
+  const remainingTokens = Math.max(0, contextWindow - value.usedTokens);
+  const usedPercent = Math.min(100, (value.usedTokens / contextWindow) * 100);
+  const remainingPercent = (remainingTokens / contextWindow) * 100;
+  if (
+    value.remainingTokens !== remainingTokens ||
+    !approximatelyEqual(value.usedPercent, usedPercent) ||
+    !approximatelyEqual(value.remainingPercent, remainingPercent)
+  ) {
+    return undefined;
+  }
   return value as unknown as ContextUsage;
+}
+
+function approximatelyEqual(left: number, right: number): boolean {
+  const scale = Math.max(1, Math.abs(left), Math.abs(right));
+  return Math.abs(left - right) <= Number.EPSILON * scale * 8;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,4 +1,4 @@
-import type { Message } from "@anvia/core/completion";
+import type { ContextUsage, Message } from "@anvia/core/completion";
 import type {
   CreateUIAttachment,
   UIMessage,
@@ -202,6 +202,7 @@ export type SetMessages = (
 export type UseChatResult<TEvent = UIStreamEvent> = {
   messages: UIMessage[];
   events: TEvent[];
+  contextUsage: ContextUsage | undefined;
   suggestions?: ChatSuggestion[];
   setMessages: SetMessages;
   sendMessage(input: SendMessageInput): Promise<void>;

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -5,7 +5,7 @@ import {
   uiMessagesToCoreMessages,
 } from "@anvia/core/ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-
+import { contextUsageFromMessages, contextUsageUpdateFromEvent } from "./context-usage";
 import {
   defaultAnswerQuestion,
   defaultDecideApproval,
@@ -47,6 +47,9 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
 ): UseChatResult<TEvent> {
   const [messages, setMessagesState] = useState(() => [...(options.initialMessages ?? [])]);
   const [events, setEvents] = useState<TEvent[]>([]);
+  const [contextUsage, setContextUsage] = useState(() =>
+    contextUsageFromMessages(options.initialMessages ?? []),
+  );
   const [status, setStatus] = useState<UseChatResult<TEvent>["status"]>("idle");
   const [error, setError] = useState<unknown>();
   const [approvals, setApprovals] = useState<ToolApproval[]>([]);
@@ -169,6 +172,10 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
   const applyEvent = useCallback(
     (event: TEvent) => {
       const mappedUIEvent = options.eventToUIEvent?.(event);
+      const contextUpdate = contextUsageUpdateFromEvent(mappedUIEvent ?? event);
+      if (contextUpdate !== undefined) {
+        setContextUsage(contextUpdate.contextUsage);
+      }
       if (mappedUIEvent !== undefined) {
         setMessages((current) => applyUIStreamEvent(current, mappedUIEvent));
         return;
@@ -258,6 +265,7 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
       }
 
       setMessages(nextMessages);
+      setContextUsage(contextUsageFromMessages(nextMessages));
       setEvents([]);
       setError(undefined);
       clearHumanInput();
@@ -514,6 +522,7 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
       abortRef.current = undefined;
       clearResumeState();
       setMessages(nextMessages);
+      setContextUsage(contextUsageFromMessages(nextMessages));
       setEvents([]);
       clearHumanInput();
       setError(undefined);
@@ -526,6 +535,7 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
   return {
     messages,
     events,
+    contextUsage,
     suggestions: options.suggestions ?? [],
     setMessages,
     sendMessage,

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -109,12 +109,23 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
     }) as EventTransport<TRequest, TEvent>;
   }, [options.transport, options.endpoint, options.format]);
 
-  const setMessages = useCallback<UseChatResult<TEvent>["setMessages"]>((nextMessages) => {
+  const updateMessages = useCallback<UseChatResult<TEvent>["setMessages"]>((nextMessages) => {
     const next =
       typeof nextMessages === "function" ? nextMessages(messagesRef.current) : nextMessages;
     messagesRef.current = next;
     setMessagesState(next);
   }, []);
+
+  const setMessages = useCallback<UseChatResult<TEvent>["setMessages"]>(
+    (nextMessages) => {
+      updateMessages((current) => {
+        const next = typeof nextMessages === "function" ? nextMessages(current) : nextMessages;
+        setContextUsage(contextUsageFromMessages(next));
+        return next;
+      });
+    },
+    [updateMessages],
+  );
 
   const setStreamId = useCallback((nextStreamId: string | undefined) => {
     streamIdRef.current = nextStreamId;
@@ -177,7 +188,7 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
         setContextUsage(contextUpdate.contextUsage);
       }
       if (mappedUIEvent !== undefined) {
-        setMessages((current) => applyUIStreamEvent(current, mappedUIEvent));
+        updateMessages((current) => applyUIStreamEvent(current, mappedUIEvent));
         return;
       }
 
@@ -188,7 +199,7 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
 
       if (!hasCustomEventMapper) {
         let handled = false;
-        setMessages((current) => {
+        updateMessages((current) => {
           const next = applyAnviaStreamEvent(current, event);
           if (next === undefined) {
             return current;
@@ -203,15 +214,15 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
 
       const delta = options.eventToDelta?.(event);
       if (delta !== undefined && delta.length > 0) {
-        setMessages((current) => appendAssistantDelta(current, delta));
+        updateMessages((current) => appendAssistantDelta(current, delta));
       }
 
       const final = options.eventToFinal?.(event);
       if (final !== undefined) {
-        setMessages((current) => replaceAssistantText(current, final));
+        updateMessages((current) => replaceAssistantText(current, final));
       }
     },
-    [options, setMessages],
+    [options, updateMessages],
   );
 
   const applyHumanInputEvent = useCallback(
@@ -264,7 +275,7 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
         setStreamId(runOptions.resume.streamId);
       }
 
-      setMessages(nextMessages);
+      updateMessages(nextMessages);
       setContextUsage(contextUsageFromMessages(nextMessages));
       setEvents([]);
       setError(undefined);
@@ -352,7 +363,7 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
       clearResumeState,
       options,
       persistResumeState,
-      setMessages,
+      updateMessages,
       setStreamId,
       transport,
     ],
@@ -521,7 +532,7 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
       abortRef.current?.abort();
       abortRef.current = undefined;
       clearResumeState();
-      setMessages(nextMessages);
+      updateMessages(nextMessages);
       setContextUsage(contextUsageFromMessages(nextMessages));
       setEvents([]);
       clearHumanInput();
@@ -529,7 +540,7 @@ export function useChat<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
       setStatus("idle");
       setIsResuming(false);
     },
-    [clearHumanInput, clearResumeState, setMessages],
+    [clearHumanInput, clearResumeState, updateMessages],
   );
 
   return {

--- a/packages/react/src/use-completion.ts
+++ b/packages/react/src/use-completion.ts
@@ -1,4 +1,4 @@
-import type { Message } from "@anvia/core/completion";
+import type { ContextUsage, Message } from "@anvia/core/completion";
 import {
   type UIMessage,
   type UIStreamEvent,
@@ -6,7 +6,7 @@ import {
   uiMessagesToCoreMessages,
 } from "@anvia/core/ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-
+import { contextUsageFromMessages, contextUsageUpdateFromEvent } from "./context-usage";
 import { createFetchTransport } from "./transport";
 import type { EventStreamFormat, EventTransport } from "./types";
 import {
@@ -51,6 +51,7 @@ export type UseCompletionResult<TEvent = UIStreamEvent> = {
   status: UseCompletionStatus;
   error: unknown;
   events: TEvent[];
+  contextUsage: ContextUsage | undefined;
 };
 
 export function useCompletion<TRequest = UIStreamRequest, TEvent = UIStreamEvent>(
@@ -79,6 +80,9 @@ export function useCompletion<TRequest = UIStreamRequest, TEvent = UIStreamEvent
   const [messages, setMessagesState] = useState<UIMessage[]>(() => [...initialMessages]);
   const [input, setInput] = useState("");
   const [events, setEvents] = useState<TEvent[]>([]);
+  const [contextUsage, setContextUsage] = useState<ContextUsage | undefined>(() =>
+    contextUsageFromMessages(initialMessages),
+  );
   const [status, setStatus] = useState<UseCompletionStatus>("idle");
   const [error, setError] = useState<unknown>();
   const abortRef = useRef<AbortController | undefined>(undefined);
@@ -116,6 +120,10 @@ export function useCompletion<TRequest = UIStreamRequest, TEvent = UIStreamEvent
   const applyEvent = useCallback(
     (event: TEvent) => {
       const mappedUIEvent = options.eventToUIEvent?.(event);
+      const contextUpdate = contextUsageUpdateFromEvent(mappedUIEvent ?? event);
+      if (contextUpdate !== undefined) {
+        setContextUsage(contextUpdate.contextUsage);
+      }
       if (mappedUIEvent !== undefined) {
         setMessagesState((current) => {
           const next = applyUIStreamEvent(current, mappedUIEvent);
@@ -250,6 +258,7 @@ export function useCompletion<TRequest = UIStreamRequest, TEvent = UIStreamEvent
       abortRef.current = undefined;
       if (Array.isArray(messagesOrCompletion)) {
         setMessages(messagesOrCompletion);
+        setContextUsage(contextUsageFromMessages(messagesOrCompletion));
       } else if (typeof messagesOrCompletion === "string") {
         setMessages([
           {
@@ -258,8 +267,10 @@ export function useCompletion<TRequest = UIStreamRequest, TEvent = UIStreamEvent
             parts: [{ id: "reset_assistant_text", type: "text", text: messagesOrCompletion }],
           },
         ]);
+        setContextUsage(undefined);
       } else {
         setMessages([]);
+        setContextUsage(undefined);
       }
       setEvents([]);
       setError(undefined);
@@ -280,6 +291,7 @@ export function useCompletion<TRequest = UIStreamRequest, TEvent = UIStreamEvent
     status,
     error,
     events,
+    contextUsage,
   };
 }
 

--- a/packages/react/test/transport.test.ts
+++ b/packages/react/test/transport.test.ts
@@ -282,6 +282,13 @@ describe("@anvia/react useChat", () => {
         yield {
           type: "message_end",
           messageId: "assistant_1",
+          contextUsage: {
+            model: { id: "gpt-5", context: { contextWindow: 400_000 } },
+            usedTokens: 100_000,
+            remainingTokens: 300_000,
+            usedPercent: 25,
+            remainingPercent: 75,
+          },
           metadata: { providerMessageId: "provider_1" },
         };
       },
@@ -296,6 +303,10 @@ describe("@anvia/react useChat", () => {
     expect(result.current.status).toBe("idle");
     expect(result.current.error).toBeUndefined();
     expect(result.current.text).toBe("Hello");
+    expect(result.current.contextUsage).toMatchObject({
+      usedTokens: 100_000,
+      remainingPercent: 75,
+    });
     expect(result.current.messages).toMatchObject([
       {
         id: "user_1",
@@ -777,6 +788,13 @@ describe("@anvia/react useChat", () => {
           response: {
             choice: [AssistantContent.text("Hello")],
             usage: Usage.empty(),
+            contextUsage: {
+              model: { id: "gpt-5", context: { contextWindow: 400_000 } },
+              usedTokens: 100_000,
+              remainingTokens: 300_000,
+              usedPercent: 25,
+              remainingPercent: 75,
+            },
             rawResponse: {},
             messageId: "provider_1",
           },
@@ -790,6 +808,10 @@ describe("@anvia/react useChat", () => {
     });
 
     expect(result.current.text).toBe("Hello");
+    expect(result.current.contextUsage).toMatchObject({
+      usedTokens: 100_000,
+      remainingPercent: 75,
+    });
     expect(result.current.messages).toMatchObject([
       { role: "user", parts: [{ type: "text", text: "hi" }] },
       {

--- a/packages/react/test/transport.test.ts
+++ b/packages/react/test/transport.test.ts
@@ -251,6 +251,49 @@ describe("@anvia/react useChat", () => {
     expect(result.current.messages).toEqual(initialMessages);
   });
 
+  it("synchronizes context usage when callers replace messages", () => {
+    const contextUsage = {
+      model: { id: "gpt-5", context: { contextWindow: 400_000 } },
+      usedTokens: 100_000,
+      remainingTokens: 300_000,
+      usedPercent: 25,
+      remainingPercent: 75,
+    };
+    const loadedMessage: UIMessage = {
+      id: "assistant_loaded",
+      role: "assistant",
+      parts: [{ id: "text_loaded", type: "text", text: "loaded" }],
+      metadata: { anvia: { generation: { contextUsage } } },
+    };
+    const loadedMessages = [loadedMessage];
+    const transport: EventTransport<UIStreamRequest, UIStreamEvent> = {
+      send: vi.fn(async function* (): AsyncIterable<UIStreamEvent> {
+        yield* [];
+      }),
+    };
+    const { result } = renderHook(() => useChat({ transport }));
+
+    act(() => result.current.setMessages(loadedMessages));
+    expect(result.current.contextUsage).toEqual(contextUsage);
+
+    act(() => result.current.setMessages(() => []));
+    expect(result.current.contextUsage).toBeUndefined();
+
+    act(() =>
+      result.current.setMessages([
+        {
+          ...loadedMessage,
+          metadata: {
+            anvia: {
+              generation: { contextUsage: { ...contextUsage, remainingTokens: 1 } },
+            },
+          },
+        },
+      ]),
+    );
+    expect(result.current.contextUsage).toBeUndefined();
+  });
+
   it("sends converted core messages and applies UI stream events", async () => {
     const onEvent = vi.fn();
     const metadata = { composer: { entities: [{ id: "document-1" }] } };

--- a/packages/react/test/use-completion.test.ts
+++ b/packages/react/test/use-completion.test.ts
@@ -34,6 +34,13 @@ describe("@anvia/react useCompletion", () => {
           response: {
             choice: [AssistantContent.text("Hello")],
             usage: Usage.empty(),
+            contextUsage: {
+              model: { id: "gpt-5", context: { contextWindow: 400_000 } },
+              usedTokens: 200_000,
+              remainingTokens: 200_000,
+              usedPercent: 50,
+              remainingPercent: 50,
+            },
             rawResponse: {},
           },
         };
@@ -49,6 +56,10 @@ describe("@anvia/react useCompletion", () => {
     expect(result.current.status).toBe("idle");
     expect(result.current.error).toBeUndefined();
     expect(result.current.completion).toBe("Hello");
+    expect(result.current.contextUsage).toMatchObject({
+      usedTokens: 200_000,
+      remainingPercent: 50,
+    });
     expect(result.current.messages).toMatchObject([
       { role: "user", parts: [{ type: "text", text: "hello" }] },
       {

--- a/packages/server/test/streams.test.ts
+++ b/packages/server/test/streams.test.ts
@@ -455,6 +455,23 @@ describe("@anvia/server streams", () => {
     );
   });
 
+  it("preserves context usage in UI message-end events", async () => {
+    const event: UIStreamEvent = {
+      type: "message_end",
+      messageId: "msg_1",
+      contextUsage: {
+        model: { id: "gpt-5", context: { contextWindow: 400_000 } },
+        usedTokens: 100_000,
+        remainingTokens: 300_000,
+        usedPercent: 25,
+        remainingPercent: 75,
+      },
+    };
+    const response = createUIStreamResponse(events([event]));
+
+    expect(parseJsonl(await response.text())).toEqual([event]);
+  });
+
   it("supports custom jsonl serializers", async () => {
     const text = await readText(
       createJsonlStream(events([{ type: "one" }]), {


### PR DESCRIPTION
## Summary

- add model-owned context-window metadata and context-usage calculation to the core completion contract
- populate model limits and provider-reported active context usage for OpenAI, Anthropic, Gemini, Mistral, and Grok
- propagate context usage through completion responses, agent results and events, request streams, persisted generation metadata, and memory-backed sessions
- expose the latest completed context snapshot from React hooks and UI terminal events
- add an accessible React UI `ContextMeter` and preserve context usage through server UI streams
- document all new public APIs and add a changeset

## Why

AI applications need the same session context-window percentage shown by coding agents such as Codex and Claude Code. The denominator must belong to the selected model, while the numerator should use provider-reported input tokens from the latest completed model call.

This keeps the value model-aware and avoids presenting client-side token estimates as authoritative usage.

## API behavior

`contextUsage` is available only when the model declares a context window and the provider reports input usage. It describes the latest completed call. Output tokens are not projected into the next request.

React applications can read `useChat().contextUsage` or `useCompletion().contextUsage`, and render it with `<ContextMeter usage={contextUsage} />`.

## Validation

- `pnpm check`
- Core typecheck and 386 tests
- React typecheck, build, and 98 tests
- React UI typecheck, build, and 105 tests
- Server typecheck, build, and 26 tests
- affected provider package typechecks and tests
- full workspace tests
- `pnpm --filter www reference-check`
- `pnpm --filter www build`

The full workspace typecheck was also run earlier; its only failure is the pre-existing invalid `rows` prop in `examples/fullstack-agent/src/App.tsx:146`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model-aware context usage reporting, including token counts, limits, and percentages for supported providers.
  * Context usage now flows through completions, streaming responses, agent sessions, persistence, server events, and React hooks.
  * Added the accessible `ContextMeter` component for displaying used or remaining context.
  * Added model metadata lookup and optional metadata overrides across supported completion providers.

* **Documentation**
  * Updated API references with context usage fields, model metadata, provider support, and usage examples.

* **Tests**
  * Added coverage for calculations, streaming, persistence, provider limits, and the context meter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->