### PR TITLE
feat(lens): capture evaluation case payloads

### DIFF
--- a/.changeset/clean-jobs-observe.md
+++ b/.changeset/clean-jobs-observe.md
@@ -1,0 +1,6 @@
+---
+"@anvia/lens": minor
+"@anvia/otel": minor
+---
+
+Add opt-in evaluation case payload capture with inherited redaction and size limits.

--- a/apps/www/src/content/docs/packages/lens/reference.md
+++ b/apps/www/src/content/docs/packages/lens/reference.md
@@ -39,8 +39,9 @@ function createLensEvalReporter<Input, Output, Expected>(
 ```
 
 Emits evaluation-run lifecycle events and standard `gen_ai.evaluation.result` log events through
-the isolated Lens log provider. Evaluation metadata is omitted by default and can be enabled with
-`includeMetadata: true`.
+the isolated Lens log provider. Evaluation metadata and case payloads are omitted by default.
+Enable them independently with `includeMetadata: true` and `includePayloads: true`. Captured
+evaluation payloads inherit the tracing instance's redaction transforms and capture-size limit.
 
 ## Configuration and redaction helpers
 

--- a/apps/www/src/content/docs/packages/lens/usage-patterns.md
+++ b/apps/www/src/content/docs/packages/lens/usage-patterns.md
@@ -39,10 +39,16 @@ await runEvalSuite({
   cases,
   target,
   metrics,
-  reporters: [createLensEvalReporter(tracing)],
+  reporters: [
+    createLensEvalReporter(tracing, {
+      includePayloads: true,
+      includeMetadata: true,
+    }),
+  ],
 });
 ```
 
 Lens receives run start and finish events plus suite, case, metric, outcome, and trace correlation.
-Use the returned `result.run.id` to link directly to a run. Case, metric, outcome, and run metadata
-are omitted by default; set `includeMetadata: true` only when that metadata is approved for export.
+Use the returned `result.run.id` to link directly to a run. Case payloads and metadata are omitted
+by default; enable `includePayloads` and `includeMetadata` only when those values are approved for
+export. Payload capture uses the tracing instance's redaction transforms and capture-size limit.

--- a/examples/cookbook/10_integrations/08-lens-native.ts
+++ b/examples/cookbook/10_integrations/08-lens-native.ts
@@ -32,7 +32,7 @@ class StaticSupportModel implements CompletionModel {
 }
 
 const tracing = lens.create();
-const reporter = createLensEvalReporter(tracing);
+const reporter = createLensEvalReporter(tracing, { includePayloads: true });
 const agent = new AgentBuilder("lens-native-smoke", new StaticSupportModel())
   .name("Lens Native Smoke")
   .instructions("Answer support questions from the supplied policy.")

--- a/examples/cookbook/10_integrations/08-lens-native.ts
+++ b/examples/cookbook/10_integrations/08-lens-native.ts
@@ -42,10 +42,10 @@ const agent = new AgentBuilder("lens-native-smoke", new StaticSupportModel())
 try {
   const suite = await runEvalSuite({
     name: "lens-native-smoke",
-    run: { datasetName: "lens-smoke", datasetVersion: "v2" },
+    run: { datasetName: "lens-smoke", datasetVersion: "v3" },
     cases: [
       {
-        id: `refund-window-${Date.now()}`,
+        id: "refund-window",
         input: "How long are refunds available?",
         expected: "30 days",
       },

--- a/packages/observability-lens/README.md
+++ b/packages/observability-lens/README.md
@@ -45,9 +45,18 @@ console.log(suite.run.id);
 providers or capture unrelated application telemetry. Call `flush()` in short-lived processes and
 `shutdown()` before exit.
 
-Safe capture omits prompt and response bodies, and the Lens eval reporter omits case, metric,
-outcome, and run metadata by default. Opt into payload capture with `captureMode: "full"` and eval metadata
-with `createLensEvalReporter(tracing, { includeMetadata: true })`.
+Safe capture omits traced prompt and response bodies. The Lens eval reporter also omits evaluation
+case payloads and metadata by default. Enable them independently when approved for export:
+
+```ts
+const reporter = createLensEvalReporter(tracing, {
+  includePayloads: true,
+  includeMetadata: true,
+});
+```
+
+Evaluation payloads include the case input, expected value, contexts, and target output. They use
+the tracing instance's redaction transforms and `captureMaxBytes` limit.
 
 Configuration can also be provided through `ANVIA_LENS_BASE_URL`, `ANVIA_LENS_PUBLIC_KEY`,
 `ANVIA_LENS_SECRET_KEY`, `ANVIA_LENS_SERVICE_NAME`, `ANVIA_LENS_ENVIRONMENT`, and

--- a/packages/observability-lens/src/tracing.ts
+++ b/packages/observability-lens/src/tracing.ts
@@ -20,6 +20,9 @@ const internals = Symbol("@anvia/lens.internals");
 type LensInternals = {
   loggerProvider: LoggerProvider;
   logger: ReturnType<LoggerProvider["getLogger"]>;
+  captureMaxBytes: number;
+  transformInput: ((value: unknown) => unknown) | undefined;
+  transformOutput: ((value: unknown) => unknown) | undefined;
 };
 
 type InternalLensTracing = LensTracing & { [internals]: LensInternals };
@@ -41,6 +44,9 @@ export function createLensEvalReporter<Input = unknown, Output = unknown, Expect
   return createOtelEvalReporter<Input, Output, Expected>({
     ...options,
     includeMetadata: options.includeMetadata ?? false,
+    captureMaxBytes: internal.captureMaxBytes,
+    transformInput: internal.transformInput,
+    transformOutput: internal.transformOutput,
     logger: internal.logger,
   });
 }
@@ -81,15 +87,23 @@ class LensAgentObserver implements InternalLensTracing {
       forceFlushTimeoutMillis: config.timeoutMs,
     });
     const logger = loggerProvider.getLogger("@anvia/lens", "0.1.0");
-    this[internals] = { loggerProvider, logger };
-
     const redactor = createLensRedactor(options.redaction);
+    const transformInput = options.redactInputs ? redactor.redact : undefined;
+    const transformOutput = options.redactOutputs ? redactor.redact : undefined;
+    this[internals] = {
+      loggerProvider,
+      logger,
+      captureMaxBytes: config.captureMaxBytes,
+      transformInput,
+      transformOutput,
+    };
+
     this.delegate = otel.create({
       tracer: this.tracerProvider.getTracer("@anvia/lens", "0.1.0"),
       captureMode: config.captureMode,
       captureMaxBytes: config.captureMaxBytes,
-      transformInput: options.redactInputs ? redactor.redact : undefined,
-      transformOutput: options.redactOutputs ? redactor.redact : undefined,
+      transformInput,
+      transformOutput,
     }) as LensTracing;
   }
 

--- a/packages/observability-lens/src/types.ts
+++ b/packages/observability-lens/src/types.ts
@@ -31,6 +31,7 @@ export type LensTracingOptions = {
 export type LensEvalReporterOptions = {
   publishInvalid?: boolean | undefined;
   includeMetadata?: boolean | undefined;
+  includePayloads?: boolean | undefined;
   onMissingTrace?: "emit" | "ignore" | "warn" | "throw" | undefined;
 };
 

--- a/packages/observability-otel/src/eval-reporter.ts
+++ b/packages/observability-otel/src/eval-reporter.ts
@@ -27,6 +27,7 @@ export function createOtelEvalReporter<Input = unknown, Output = unknown, Expect
   const onMissingTrace = options.onMissingTrace ?? "emit";
   const publishInvalid = options.publishInvalid ?? true;
   const includeMetadata = options.includeMetadata ?? true;
+  const includePayloads = options.includePayloads ?? false;
 
   return {
     onRunStart(args) {
@@ -54,7 +55,12 @@ export function createOtelEvalReporter<Input = unknown, Output = unknown, Expect
         }
         return;
       }
-      emitEvaluation(logger, args, traceRef, eventContext, includeMetadata);
+      emitEvaluation(logger, args, traceRef, eventContext, includeMetadata, {
+        includePayloads,
+        captureMaxBytes: options.captureMaxBytes,
+        transformInput: options.transformInput,
+        transformOutput: options.transformOutput,
+      });
     },
     onRunEnd(args) {
       emitRunFinished(logger, args, includeMetadata);
@@ -68,6 +74,10 @@ function emitEvaluation<Input, Output, Score, Expected>(
   traceRef: EvalReportArgs<Input, Output, Score, Expected>["trace"],
   eventContext: Context | undefined,
   includeMetadata: boolean,
+  payloadOptions: Pick<
+    OtelEvalReporterOptions,
+    "includePayloads" | "captureMaxBytes" | "transformInput" | "transformOutput"
+  >,
 ): void {
   const projection = projectEvalOutcome(args.outcome, args.metric.dataType);
   const attributes: LogAttributes = {
@@ -107,6 +117,9 @@ function emitEvaluation<Input, Output, Score, Expected>(
     addMetadata(attributes, "anvia.eval.metric.metadata", args.metric.metadata);
     addMetadata(attributes, "anvia.eval.outcome.metadata", args.outcome.metadata);
   }
+  if (payloadOptions.includePayloads) {
+    addEvaluationPayload(attributes, args, payloadOptions);
+  }
 
   const record: Parameters<Logger["emit"]>[0] = {
     eventName: EVALUATION_EVENT_NAME,
@@ -116,6 +129,48 @@ function emitEvaluation<Input, Output, Score, Expected>(
   };
   if (eventContext !== undefined) record.context = eventContext;
   logger.emit(record);
+}
+
+function addEvaluationPayload<Input, Output, Score, Expected>(
+  attributes: LogAttributes,
+  args: EvalReportArgs<Input, Output, Score, Expected>,
+  options: Pick<OtelEvalReporterOptions, "captureMaxBytes" | "transformInput" | "transformOutput">,
+): void {
+  const transformInput = options.transformInput ?? identity;
+  const transformOutput = options.transformOutput ?? identity;
+  const payload: Record<string, unknown> = {
+    input: transformInput(args.case.input),
+  };
+  if (args.case.expected !== undefined) payload.expected = transformInput(args.case.expected);
+  if (args.case.context !== undefined) payload.context = transformInput(args.case.context);
+  if (args.case.retrievalContext !== undefined) {
+    payload.retrievalContext = transformInput(args.case.retrievalContext);
+  }
+  if (args.output !== undefined) payload.output = transformOutput(args.output);
+
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(payload);
+  } catch {
+    attributes["anvia.eval.payload.status"] = "serialization_error";
+    return;
+  }
+  const maxBytes = options.captureMaxBytes;
+  if (
+    maxBytes !== undefined &&
+    Number.isFinite(maxBytes) &&
+    maxBytes > 0 &&
+    new TextEncoder().encode(serialized).byteLength > Math.floor(maxBytes)
+  ) {
+    attributes["anvia.eval.payload.status"] = "size_limit";
+    return;
+  }
+  attributes["anvia.eval.payload"] = serialized;
+  attributes["anvia.eval.payload.status"] = "captured";
+}
+
+function identity(value: unknown): unknown {
+  return value;
 }
 
 function emitRunStarted(logger: Logger, args: EvalRunStartArgs, includeMetadata: boolean): void {

--- a/packages/observability-otel/src/types.ts
+++ b/packages/observability-otel/src/types.ts
@@ -21,5 +21,9 @@ export type OtelEvalReporterOptions = {
   loggerVersion?: string | undefined;
   publishInvalid?: boolean | undefined;
   includeMetadata?: boolean | undefined;
+  includePayloads?: boolean | undefined;
+  captureMaxBytes?: number | undefined;
+  transformInput?: ((value: unknown) => unknown) | undefined;
+  transformOutput?: ((value: unknown) => unknown) | undefined;
   onMissingTrace?: "emit" | "ignore" | "warn" | "throw" | undefined;
 };

--- a/packages/observability-otel/test/otel.test.ts
+++ b/packages/observability-otel/test/otel.test.ts
@@ -20,6 +20,78 @@ afterEach(() => {
 });
 
 describe("OpenTelemetry eval reporter", () => {
+  it("omits case payloads unless explicitly enabled", async () => {
+    const emit = vi.fn<Logger["emit"]>();
+    const reporter = createOtelEvalReporter({ logger: fakeLogger(emit) });
+
+    await reporter.report({
+      suiteName: "quality",
+      case: { id: "case-1", input: { prompt: "private" }, expected: "answer" },
+      output: { value: "answer" },
+      metric: { name: "quality", evaluate: () => EvalOutcome.pass(true) },
+      outcome: EvalOutcome.pass(true),
+    });
+
+    expect(emit.mock.calls[0]?.[0].attributes).not.toHaveProperty("anvia.eval.payload");
+    expect(emit.mock.calls[0]?.[0].attributes).not.toHaveProperty("anvia.eval.payload.status");
+  });
+
+  it("captures redacted evaluation payloads when enabled", async () => {
+    const emit = vi.fn<Logger["emit"]>();
+    const reporter = createOtelEvalReporter({
+      logger: fakeLogger(emit),
+      includePayloads: true,
+      transformInput: (value) =>
+        typeof value === "string" ? value.replaceAll("secret", "<redacted>") : value,
+      transformOutput: (value) => ({ redacted: value !== undefined }),
+    });
+
+    await reporter.report({
+      suiteName: "quality",
+      case: {
+        id: "case-1",
+        input: "secret question",
+        expected: "secret answer",
+        context: ["secret context"],
+        retrievalContext: ["secret retrieval"],
+      },
+      output: { value: "secret output" },
+      metric: { name: "quality", evaluate: () => EvalOutcome.pass(true) },
+      outcome: EvalOutcome.pass(true),
+    });
+
+    const attributes = emit.mock.calls[0]?.[0].attributes;
+    expect(attributes?.["anvia.eval.payload.status"]).toBe("captured");
+    expect(JSON.parse(String(attributes?.["anvia.eval.payload"]))).toEqual({
+      input: "<redacted> question",
+      expected: "<redacted> answer",
+      context: ["secret context"],
+      retrievalContext: ["secret retrieval"],
+      output: { redacted: true },
+    });
+  });
+
+  it("omits oversized evaluation payloads without emitting partial JSON", async () => {
+    const emit = vi.fn<Logger["emit"]>();
+    const reporter = createOtelEvalReporter({
+      logger: fakeLogger(emit),
+      includePayloads: true,
+      captureMaxBytes: 32,
+    });
+
+    await reporter.report({
+      suiteName: "quality",
+      case: { id: "case-1", input: "x".repeat(128) },
+      output: "answer",
+      metric: { name: "quality", evaluate: () => EvalOutcome.pass(true) },
+      outcome: EvalOutcome.pass(true),
+    });
+
+    const attributes = emit.mock.calls[0]?.[0].attributes;
+    expect(attributes?.["anvia.eval.payload.status"]).toBe("size_limit");
+    expect(attributes).not.toHaveProperty("anvia.eval.payload");
+  });
+
   it("emits a correlated GenAI evaluation result event", async () => {
     const emit = vi.fn<Logger["emit"]>();
     const logger = fakeLogger(emit);

--- a/scripts/test-lens-integration.mjs
+++ b/scripts/test-lens-integration.mjs
@@ -88,7 +88,7 @@ await waitFor(async () => {
 const evaluation = JSON.parse(
   clickhouse(
     `SELECT run_id, trace_id, observation_id, suite_name, case_id, metric_name, outcome,
-      service_name, environment, release
+      service_name, environment, release, payload, payload_status
       FROM evaluation_results FINAL
       WHERE project_id='${projectId}' AND trace_id='${traceId}'
       ORDER BY timestamp DESC LIMIT 1
@@ -101,6 +101,17 @@ if (evaluation.observation_id !== observationId) {
 if (evaluation.run_id !== runId) throw new Error("The evaluation was not grouped into its run");
 if (evaluation.metric_name !== "refund-policy-correctness" || evaluation.outcome !== "pass") {
   throw new Error("The stored evaluation metric or outcome is incorrect");
+}
+if (evaluation.payload_status !== "captured" || typeof evaluation.payload !== "string") {
+  throw new Error("The opt-in evaluation payload was not captured");
+}
+const evaluationPayload = JSON.parse(evaluation.payload);
+if (
+  evaluationPayload.input !== "How long are refunds available?" ||
+  evaluationPayload.expected !== "30 days" ||
+  evaluationPayload.output === undefined
+) {
+  throw new Error("The stored evaluation payload is incomplete or incorrect");
 }
 
 const capturedPayloads = Number(
@@ -139,6 +150,7 @@ console.log(
         caseId: evaluation.case_id,
         metric: evaluation.metric_name,
         outcome: evaluation.outcome,
+        payloadStatus: evaluation.payload_status,
       },
       safeCapture: true,
       durability: options.has("--durability") ? "verified" : "not requested",


### PR DESCRIPTION
## What changed

- add opt-in evaluation payload capture to `@anvia/lens` and `@anvia/otel`
- preserve safe defaults while inheriting Lens redaction transforms and capture-size limits
- emit explicit omission statuses for oversized or unserializable payloads
- document the new reporter option and add a release changeset

## Why

Lens run details and dataset inspection need the original evaluation input, expected value, context, and target output. The reporter previously sent only IDs, scores, explanations, and metadata.

## Validation

- `pnpm --filter @anvia/otel test`
- `pnpm --filter @anvia/otel typecheck`
- `pnpm --filter @anvia/otel build`
- `pnpm --filter @anvia/lens test`
- `pnpm --filter @anvia/lens typecheck`
- `pnpm --filter @anvia/lens build`
- `pnpm --filter www reference-check`
- Biome check on changed TypeScript files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in evaluation payload capture for Lens and OTEL reporters.
  * Payloads can include inputs, expected values, context, and outputs, with configurable redaction and size limits.
  * Payload and metadata capture can be enabled independently.
  * Payload status indicates successful capture, serialization issues, or size-limit exclusions.

* **Documentation**
  * Updated reporter guides, usage patterns, README content, and integration examples.

* **Tests**
  * Added coverage for default omission, transformations, successful capture, and size-limit handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->