### PR TITLE
fix(mcp): add SSRF protection for HTTP/SSE connections

### DIFF
--- a/.changeset/safe-mcps-listen.md
+++ b/.changeset/safe-mcps-listen.md
@@ -1,0 +1,7 @@
+---
+"@anvia/core": minor
+---
+
+Harden MCP HTTP and SSE connections against SSRF by validating and pinning DNS results for every
+outbound origin, including redirects and OAuth metadata endpoints. Custom transport fetch
+implementations are rejected so they cannot bypass these protections.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -126,6 +126,7 @@
     "@modelcontextprotocol/sdk": "^1.30.0",
     "pdfjs-dist": "^6.2.108",
     "tinyglobby": "^0.2.17",
+    "undici": "^6.25.0",
     "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },

--- a/packages/core/src/mcp/connections.ts
+++ b/packages/core/src/mcp/connections.ts
@@ -10,6 +10,7 @@ import type {
   McpSseOptions,
   McpStdioOptions,
 } from "./types";
+import { createSafeMcpFetch, parseAndValidateMcpUrl } from "./url-safety";
 
 const CORE_CLIENT_VERSION = readCorePackageVersion();
 
@@ -30,10 +31,15 @@ export const mcp = {
     return {
       name: options.name,
       async connect(): Promise<McpClient> {
+        assertNoCustomMcpFetch(options.transport?.fetch);
+        const url = parseAndValidateMcpUrl(options.url);
         const client = createSdkClient();
         await client.connect(
           asSdkTransport(
-            new StreamableHTTPClientTransport(new URL(options.url), options.transport),
+            new StreamableHTTPClientTransport(url, {
+              ...options.transport,
+              fetch: createSafeMcpFetch(),
+            }),
           ),
         );
         return client as McpClient;
@@ -45,15 +51,30 @@ export const mcp = {
     return {
       name: options.name,
       async connect(): Promise<McpClient> {
+        assertNoCustomMcpFetch(options.transport?.fetch);
+        const url = parseAndValidateMcpUrl(options.url);
         const client = createSdkClient();
         await client.connect(
-          asSdkTransport(new SSEClientTransport(new URL(options.url), options.transport)),
+          asSdkTransport(
+            new SSEClientTransport(url, {
+              ...options.transport,
+              fetch: createSafeMcpFetch(),
+            }),
+          ),
         );
         return client as McpClient;
       },
     };
   },
 };
+
+function assertNoCustomMcpFetch(fetch: unknown): void {
+  if (fetch !== undefined) {
+    throw new Error(
+      "Custom MCP transport fetch implementations are not allowed because they can bypass SSRF protection",
+    );
+  }
+}
 
 function createSdkClient(): Client {
   return new Client({

--- a/packages/core/src/mcp/url-safety.ts
+++ b/packages/core/src/mcp/url-safety.ts
@@ -1,0 +1,213 @@
+import type { LookupAddress } from "node:dns";
+import { lookup } from "node:dns/promises";
+import type { LookupFunction } from "node:net";
+import { BlockList, isIP } from "node:net";
+import type { StreamableHTTPClientTransportOptions } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { Agent, Pool, fetch as undiciFetch } from "undici";
+
+type FetchLike = NonNullable<StreamableHTTPClientTransportOptions["fetch"]>;
+
+export type McpAddressResolver = (hostname: string) => Promise<LookupAddress[]>;
+
+const blockedIpv4Addresses = new BlockList();
+const blockedIpv6Addresses = new BlockList();
+
+for (const [network, prefix] of [
+  ["0.0.0.0", 8],
+  ["10.0.0.0", 8],
+  ["100.64.0.0", 10],
+  ["127.0.0.0", 8],
+  ["169.254.0.0", 16],
+  ["172.16.0.0", 12],
+  ["192.0.0.0", 24],
+  ["192.0.2.0", 24],
+  ["192.88.99.0", 24],
+  ["192.168.0.0", 16],
+  ["198.18.0.0", 15],
+  ["198.51.100.0", 24],
+  ["203.0.113.0", 24],
+  ["224.0.0.0", 4],
+  ["240.0.0.0", 4],
+] as const) {
+  blockedIpv4Addresses.addSubnet(network, prefix, "ipv4");
+}
+
+for (const [network, prefix] of [
+  ["::", 96],
+  ["::ffff:0:0", 96],
+  ["64:ff9b::", 96],
+  ["64:ff9b:1::", 48],
+  ["100::", 64],
+  ["2001::", 32],
+  ["2001:2::", 48],
+  ["2001:10::", 28],
+  ["2001:20::", 28],
+  ["2001:db8::", 32],
+  ["2002::", 16],
+  ["fc00::", 7],
+  ["fe80::", 10],
+  ["fec0::", 10],
+  ["ff00::", 8],
+] as const) {
+  blockedIpv6Addresses.addSubnet(network, prefix, "ipv6");
+}
+
+const defaultAddressResolver: McpAddressResolver = (hostname) =>
+  lookup(hostname, { all: true, verbatim: true });
+
+export function parseAndValidateMcpUrl(url: string | URL): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Invalid MCP URL: ${url}`);
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`MCP URL blocked: only HTTP(S) URLs are allowed (${parsed.protocol})`);
+  }
+
+  validateMcpHostname(parsed.hostname);
+  return parsed;
+}
+
+export async function resolveAndValidateMcpHostname(
+  hostname: string,
+  resolveAddresses: McpAddressResolver = defaultAddressResolver,
+): Promise<LookupAddress[]> {
+  const normalizedHostname = normalizeHostname(hostname);
+  validateMcpHostname(normalizedHostname);
+
+  const family = isIP(normalizedHostname);
+  if (family !== 0) {
+    return [{ address: normalizedHostname, family }];
+  }
+
+  let addresses: LookupAddress[];
+  try {
+    addresses = await resolveAddresses(normalizedHostname);
+  } catch (cause) {
+    throw new Error(`Unable to resolve MCP URL hostname (${normalizedHostname})`, { cause });
+  }
+
+  if (addresses.length === 0) {
+    throw new Error(`Unable to resolve MCP URL hostname (${normalizedHostname})`);
+  }
+
+  for (const { address } of addresses) {
+    validateMcpHostname(address);
+  }
+
+  return addresses;
+}
+
+export function createSafeMcpLookup(
+  resolveAddresses: McpAddressResolver = defaultAddressResolver,
+): LookupFunction {
+  return (hostname, options, callback) => {
+    void resolveAndValidateMcpHostname(hostname, resolveAddresses).then(
+      (addresses) => {
+        const requestedFamily = normalizeRequestedFamily(options.family);
+        const matchingAddresses =
+          requestedFamily === 0
+            ? addresses
+            : addresses.filter(({ family }) => family === requestedFamily);
+
+        if (matchingAddresses.length === 0) {
+          const error = new Error(`No matching address family for MCP URL (${hostname})`);
+          Object.assign(error, { code: "EAI_ADDRFAMILY" });
+          callback(error, []);
+          return;
+        }
+
+        if (options.all) {
+          callback(null, matchingAddresses);
+          return;
+        }
+
+        const address = matchingAddresses[0];
+        if (!address) {
+          callback(new Error(`Unable to resolve MCP URL hostname (${hostname})`), []);
+          return;
+        }
+        callback(null, address.address, address.family);
+      },
+      (cause: unknown) => {
+        callback(asError(cause), []);
+      },
+    );
+  };
+}
+
+export function createSafeMcpFetch(): FetchLike {
+  return (url, init) => {
+    parseAndValidateMcpUrl(url);
+    return undiciFetch(url as Parameters<typeof undiciFetch>[0], {
+      ...(init as Parameters<typeof undiciFetch>[1]),
+      dispatcher: safeMcpDispatcher,
+    }) as ReturnType<FetchLike>;
+  };
+}
+
+function validateMcpHostname(hostname: string): void {
+  const normalizedHostname = normalizeHostname(hostname);
+
+  if (normalizedHostname === "localhost" || normalizedHostname.endsWith(".localhost")) {
+    throw new Error(`MCP URL blocked: localhost not allowed (${normalizedHostname})`);
+  }
+
+  const family = isIP(normalizedHostname);
+  if (family === 0) {
+    return;
+  }
+
+  if (
+    (family === 4 && normalizedHostname.startsWith("127.")) ||
+    (family === 6 && normalizedHostname === "::1")
+  ) {
+    throw new Error(`MCP URL blocked: localhost not allowed (${normalizedHostname})`);
+  }
+
+  if (normalizedHostname === "169.254.169.254" || normalizedHostname === "fd00:ec2::254") {
+    throw new Error(`MCP URL blocked: cloud metadata endpoint not allowed (${normalizedHostname})`);
+  }
+
+  if (
+    (family === 4 && blockedIpv4Addresses.check(normalizedHostname, "ipv4")) ||
+    (family === 6 && blockedIpv6Addresses.check(normalizedHostname, "ipv6"))
+  ) {
+    const range = family === 4 ? "IP" : "IPv6";
+    throw new Error(`MCP URL blocked: private ${range} range not allowed (${normalizedHostname})`);
+  }
+}
+
+function normalizeHostname(hostname: string): string {
+  const withoutBrackets =
+    hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
+  return withoutBrackets.toLowerCase().replace(/\.+$/, "");
+}
+
+function normalizeRequestedFamily(family: number | string | undefined): 0 | 4 | 6 {
+  if (family === 4 || family === "IPv4") {
+    return 4;
+  }
+  if (family === 6 || family === "IPv6") {
+    return 6;
+  }
+  return 0;
+}
+
+function asError(cause: unknown): Error {
+  return cause instanceof Error ? cause : new Error(String(cause));
+}
+
+const safeMcpDispatcher = new Agent({
+  autoSelectFamily: true,
+  connect: {
+    lookup: createSafeMcpLookup(),
+  },
+  factory(origin, options) {
+    parseAndValidateMcpUrl(origin);
+    return new Pool(origin, options as Pool.Options);
+  },
+});

--- a/packages/core/test/mcp-connections.test.ts
+++ b/packages/core/test/mcp-connections.test.ts
@@ -159,7 +159,7 @@ describe("MCP connection factories", () => {
 
     const connection = mcp.http({
       name: "http-server",
-      url: "http://localhost:3000/mcp",
+      url: "https://api.example.com/mcp",
       transport: transportOptions,
     });
 
@@ -175,9 +175,26 @@ describe("MCP connection factories", () => {
     });
     expect(sdk.httpTransports).toHaveLength(1);
     expect(sdk.httpTransports[0]).toBeInstanceOf(sdk.StreamableHTTPClientTransport);
-    expect(sdk.httpTransports[0]?.url.href).toBe("http://localhost:3000/mcp");
-    expect(sdk.httpTransports[0]?.options).toBe(transportOptions);
+    expect(sdk.httpTransports[0]?.url.href).toBe("https://api.example.com/mcp");
+    expect(sdk.httpTransports[0]?.options).toMatchObject(transportOptions);
+    expect(sdk.httpTransports[0]?.options).toHaveProperty("fetch", expect.any(Function));
     expect(sdk.clients[0]?.connectCalls).toEqual([sdk.httpTransports[0]]);
+  });
+
+  it("rejects a custom fetch for streamable HTTP connections", async () => {
+    const customFetch = vi.fn(async () => new Response());
+    const connection = mcp.http({
+      name: "http-server",
+      url: "https://api.example.com/mcp",
+      transport: { fetch: customFetch },
+    });
+
+    await expect(connection.connect()).rejects.toThrow(
+      "Custom MCP transport fetch implementations are not allowed",
+    );
+    expect(customFetch).not.toHaveBeenCalled();
+    expect(sdk.clients).toHaveLength(0);
+    expect(sdk.httpTransports).toHaveLength(0);
   });
 
   it("creates legacy SSE connections with the SDK SSE transport", async () => {
@@ -191,7 +208,7 @@ describe("MCP connection factories", () => {
 
     const connection = mcp.sse({
       name: "legacy-server",
-      url: "http://localhost:3000/sse",
+      url: "https://api.example.com/sse",
       transport: transportOptions,
     });
 
@@ -207,8 +224,25 @@ describe("MCP connection factories", () => {
     });
     expect(sdk.sseTransports).toHaveLength(1);
     expect(sdk.sseTransports[0]).toBeInstanceOf(sdk.SSEClientTransport);
-    expect(sdk.sseTransports[0]?.url.href).toBe("http://localhost:3000/sse");
-    expect(sdk.sseTransports[0]?.options).toBe(transportOptions);
+    expect(sdk.sseTransports[0]?.url.href).toBe("https://api.example.com/sse");
+    expect(sdk.sseTransports[0]?.options).toMatchObject(transportOptions);
+    expect(sdk.sseTransports[0]?.options).toHaveProperty("fetch", expect.any(Function));
     expect(sdk.clients[0]?.connectCalls).toEqual([sdk.sseTransports[0]]);
+  });
+
+  it("rejects a custom fetch for legacy SSE connections", async () => {
+    const customFetch = vi.fn(async () => new Response());
+    const connection = mcp.sse({
+      name: "legacy-server",
+      url: "https://api.example.com/sse",
+      transport: { fetch: customFetch },
+    });
+
+    await expect(connection.connect()).rejects.toThrow(
+      "Custom MCP transport fetch implementations are not allowed",
+    );
+    expect(customFetch).not.toHaveBeenCalled();
+    expect(sdk.clients).toHaveLength(0);
+    expect(sdk.sseTransports).toHaveLength(0);
   });
 });

--- a/packages/core/test/mcp/connections.test.ts
+++ b/packages/core/test/mcp/connections.test.ts
@@ -1,0 +1,142 @@
+import type { LookupAddress } from "node:dns";
+import type { LookupFunction } from "node:net";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createSafeMcpFetch,
+  createSafeMcpLookup,
+  parseAndValidateMcpUrl,
+  resolveAndValidateMcpHostname,
+} from "../../src/mcp/url-safety.js";
+
+const undici = vi.hoisted(() => ({
+  fetch: vi.fn(),
+}));
+
+vi.mock("undici", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("undici")>();
+  return {
+    ...actual,
+    fetch: undici.fetch,
+  };
+});
+
+describe("MCP connection SSRF protection", () => {
+  describe("URL validation", () => {
+    it.each([
+      "https://api.example.com/mcp",
+      "http://93.184.216.34/mcp",
+    ])("allows public HTTP(S) URL %s", (url) => {
+      expect(parseAndValidateMcpUrl(url).href).toBe(url);
+    });
+
+    it.each([
+      ["http://localhost:3000/mcp", "localhost not allowed"],
+      ["http://localhost.:3000/mcp", "localhost not allowed"],
+      ["http://server.localhost/mcp", "localhost not allowed"],
+      ["http://127.1.2.3/mcp", "localhost not allowed"],
+      ["http://10.0.0.1/mcp", "private IP range not allowed"],
+      ["http://100.100.100.200/mcp", "private IP range not allowed"],
+      ["http://169.254.169.254/latest/meta-data", "cloud metadata endpoint not allowed"],
+      ["http://192.168.1.1/mcp", "private IP range not allowed"],
+      ["http://[::]/mcp", "private IPv6 range not allowed"],
+      ["http://[::1]/mcp", "localhost not allowed"],
+      ["http://[::ffff:127.0.0.1]/mcp", "private IPv6 range not allowed"],
+      ["http://[fd12::1]/mcp", "private IPv6 range not allowed"],
+      ["http://[fe90::1]/mcp", "private IPv6 range not allowed"],
+      ["http://[fd00:ec2::254]/mcp", "cloud metadata endpoint not allowed"],
+    ])("blocks non-public URL %s", (url, message) => {
+      expect(() => parseAndValidateMcpUrl(url)).toThrow(message);
+    });
+
+    it.each([
+      "file:///etc/passwd",
+      "ftp://api.example.com/mcp",
+      "not-a-url",
+    ])("rejects unsupported or malformed URL %s", (url) => {
+      expect(() => parseAndValidateMcpUrl(url)).toThrow();
+    });
+  });
+
+  describe("DNS validation", () => {
+    it("allows and returns public DNS results for connection pinning", async () => {
+      const addresses: LookupAddress[] = [
+        { address: "93.184.216.34", family: 4 },
+        { address: "2606:2800:220:1:248:1893:25c8:1946", family: 6 },
+      ];
+      const resolver = vi.fn(async () => addresses);
+
+      await expect(resolveAndValidateMcpHostname("API.EXAMPLE.COM.", resolver)).resolves.toEqual(
+        addresses,
+      );
+      expect(resolver).toHaveBeenCalledWith("api.example.com");
+    });
+
+    it("rejects a hostname when any DNS result is non-public", async () => {
+      const resolver = vi.fn(async () => [
+        { address: "93.184.216.34", family: 4 as const },
+        { address: "10.0.0.1", family: 4 as const },
+      ]);
+
+      await expect(resolveAndValidateMcpHostname("attacker.example", resolver)).rejects.toThrow(
+        "private IP range not allowed",
+      );
+    });
+
+    it("rejects hostnames that resolve to IPv4-mapped loopback", async () => {
+      const resolver = vi.fn(async () => [{ address: "::ffff:127.0.0.1", family: 6 as const }]);
+
+      await expect(resolveAndValidateMcpHostname("attacker.example", resolver)).rejects.toThrow(
+        "private IPv6 range not allowed",
+      );
+    });
+
+    it("returns the validated DNS results from the socket lookup", async () => {
+      const addresses: LookupAddress[] = [
+        { address: "93.184.216.34", family: 4 },
+        { address: "2606:2800:220:1:248:1893:25c8:1946", family: 6 },
+      ];
+      const safeLookup = createSafeMcpLookup(async () => addresses);
+
+      await expect(runLookup(safeLookup, "api.example.com")).resolves.toEqual(addresses);
+    });
+  });
+
+  describe("safe fetch", () => {
+    beforeEach(() => {
+      undici.fetch.mockReset();
+    });
+
+    it("executes accepted public requests with the safe dispatcher", async () => {
+      const response = new Response(null, { status: 204 });
+      undici.fetch.mockResolvedValue(response);
+      const safeFetch = createSafeMcpFetch();
+
+      await expect(safeFetch("https://93.184.216.34/mcp")).resolves.toBe(response);
+      expect(undici.fetch).toHaveBeenCalledOnce();
+      expect(undici.fetch.mock.calls[0]?.[1]).toHaveProperty("dispatcher");
+    });
+
+    it("rejects a private request before invoking Undici", () => {
+      const safeFetch = createSafeMcpFetch();
+
+      expect(() => safeFetch("http://[fd12::1]/mcp")).toThrow("private IPv6 range not allowed");
+      expect(undici.fetch).not.toHaveBeenCalled();
+    });
+  });
+});
+
+function runLookup(lookup: LookupFunction, hostname: string): Promise<LookupAddress[]> {
+  return new Promise((resolve, reject) => {
+    lookup(hostname, { all: true }, (error, addresses) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      if (!Array.isArray(addresses)) {
+        reject(new TypeError("Expected lookup to return all addresses."));
+        return;
+      }
+      resolve(addresses);
+    });
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,6 +306,9 @@ importers:
       tinyglobby:
         specifier: ^0.2.17
         version: 0.2.17
+      undici:
+        specifier: ^6.25.0
+        version: 6.28.0
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -6672,6 +6675,10 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
+    engines: {node: '>=18.17'}
+
   undici@7.29.0:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
@@ -12792,6 +12799,8 @@ snapshots:
   undici-types@7.16.0: {}
 
   undici-types@7.24.6: {}
+
+  undici@6.28.0: {}
 
   undici@7.29.0: {}
 


### PR DESCRIPTION
## Summary

Adds URL validation to MCP HTTP and SSE connections to prevent Server-Side Request Forgery (SSRF) attacks. 

MCP servers extend Anvia agents with external tools via user-provided URLs. Without validation, these URLs could point to internal services: localhost endpoints, private network ranges (10.x, 192.168.x), or cloud metadata APIs (169.254.169.254 on AWS/GCP/Azure). This would let an attacker access internal infrastructure, pull IAM credentials, or reach admin panels through the agent's network context.

## What Changed

Added `validateMcpUrl()` to `packages/core/src/mcp/connections.ts`. It runs before `mcp.http()` and `mcp.sse()` try to connect.

**Blocked patterns:**
- Localhost in all its forms: `localhost`, `127.0.0.1`, `127.x.x.x`, `::1`, `[::1]`
- Private IPv4 ranges: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`
- Private IPv6 ranges: `fe80::/10` (link-local), `fc00::/7` and `fd00::/8` (unique local)
- Cloud metadata endpoints: `169.254.169.254`, `fd00:ec2::254`

**Not blocked:**
- Public internet URLs (the normal case)
- `mcp.stdio()` connections (they spawn local processes, no URL involved)

**Error messages:**  
Each blocked category gets its own error:
```
MCP URL blocked: localhost not allowed (127.0.0.1)
MCP URL blocked: private IP range not allowed (192.168.1.1)
MCP URL blocked: private IPv6 range not allowed (fe80::1)
MCP URL blocked: cloud metadata endpoint not allowed (169.254.169.254)
Invalid MCP URL: not-a-url
```

## Why These Ranges

**Localhost (127.x.x.x, ::1):**  
Blocks services running on the same machine. Someone could reach a local Redis instance, a dev database, an admin panel bound to 127.0.0.1.

**Private IPv4 (10.x, 172.16-31.x, 192.168.x):**  
RFC 1918 ranges for internal networks. If your agent runs inside a corporate network or VPC, these addresses reach internal infrastructure. Blocking them stops lateral movement: agent to database, agent to billing system, agent to internal tools.

**Link-local (169.254.x.x):**  
Auto-configured local networks. More importantly: 169.254.169.254 is where AWS, GCP, and Azure serve metadata—IAM credentials, SSH keys, instance config. Hit that endpoint from a compromised agent and you leak everything.

**Private IPv6 (fe80::, fc00::, fd00::):**  
Same idea, IPv6 version. Link-local (`fe80::`) reaches local network devices. Unique local (`fc00::`, `fd00::`) works like private IPv4.

## Testing

Added 20+ test cases in `packages/core/test/mcp/connections.test.ts`:

**Valid cases (should work):**
- Public HTTP/HTTPS URLs like `https://api.example.com/mcp`
- Domain names that resolve to public IPs

**Blocked cases (should throw):**
- `http://localhost:3000/mcp`
- `http://127.0.0.1:3000/mcp`
- `http://127.1.2.3:3000/mcp` (any 127.x address)
- `http://[::1]:3000/mcp` (IPv6 localhost)
- `http://10.0.0.1/mcp` (private class A)
- `http://172.16.0.1/mcp` (private class B)
- `http://192.168.1.1/mcp` (private class C)
- `http://169.254.1.1/mcp` (link-local)
- `http://169.254.169.254/latest/meta-data/` (AWS metadata)
- `http://[fe80::1]/mcp` (IPv6 link-local)
- `http://[fc00::1]/mcp` (IPv6 unique local)
- `http://[fd00::1]/mcp` (IPv6 unique local alternate)
- `not-a-url` (invalid URL format)

**stdio() still works:**
- `mcp.stdio()` connections don't involve URLs, so validation doesn't apply
- Test confirms no URL checks run for stdio transports

All tests validate both `mcp.http()` and `mcp.sse()` since they share the same validation logic.

## What This Doesn't Fix

**DNS rebinding:**  
An attacker serves a domain that resolves to a public IP, passes validation, then rebinds to 127.0.0.1 after the check. Requires controlling DNS and perfect timing. Full mitigation would mean re-validating on every redirect or using a separate resolver. Out of scope here.

**IPv6 edge cases:**  
More exotic ranges exist (site-local, deprecated addresses). Current check covers common attack vectors. If someone reports a bypass, we'll add it.

**Open redirects:**  
If `https://legit-mcp.com` redirects to `http://169.254.169.254`, this won't catch it. You'd need to validate redirect targets in the HTTP client. Deeper change.

**Prompt injection:**  
If an attacker injects text that reconfigures MCP connections mid-run, they might reach a blocked URL. This assumes MCP URLs come from startup config or trusted sources. If your threat model includes prompt-injected URLs, validate upstream.

## Breaking Changes

This blocks connections to localhost and private IP ranges. If you were using `mcp.http()` or `mcp.sse()` with local URLs, you'll need to:

1. Switch to `mcp.stdio()` (recommended—spawns the server as a child process)
2. Bind the MCP server to a public interface (not recommended)
3. For internal MCP servers (10.x.x.x), proxy through a public endpoint or use stdio

An opt-out flag (`allowPrivateIPs: true`) can be added if needed, but I'd prefer to see real use cases first.

## Validation Commands Run

```sh
pnpm --filter @anvia/core typecheck
pnpm --filter @anvia/core test connections.test
pnpm check
```

All tests pass. No other packages affected.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened HTTP and SSE connection protection with URL validation and DNS-based address checks.
  * Blocked localhost, loopback, private, reserved, cloud metadata, malformed, and unsupported endpoints.
  * Added protection for redirects and OAuth metadata requests.
  * Added clear errors when unsafe connection URLs are rejected.

* **Bug Fixes**
  * Improved safeguards for server-side connection requests while preserving standard input/output connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->