### PR TITLE
feat(lens): add managed dataset client

### DIFF
--- a/.changeset/bright-lenses-fetch.md
+++ b/.changeset/bright-lenses-fetch.md
@@ -1,0 +1,6 @@
+---
+"@anvia/lens": minor
+---
+
+Add an authenticated managed-dataset client that fetches immutable published versions with
+automatic pagination and returns cases ready for `@anvia/core/evals`.

--- a/apps/www/src/content/docs/packages/lens/reference.md
+++ b/apps/www/src/content/docs/packages/lens/reference.md
@@ -43,9 +43,24 @@ the isolated Lens log provider. Evaluation metadata and case payloads are omitte
 Enable them independently with `includeMetadata: true` and `includePayloads: true`. Captured
 evaluation payloads inherit the tracing instance's redaction transforms and capture-size limit.
 
+## createLensDatasetClient
+
+```ts
+function createLensDatasetClient(
+  tracing: LensTracing,
+  options?: LensDatasetClientOptions,
+): LensDatasetClient;
+```
+
+Creates an authenticated client for published managed datasets. `getDataset(name, { version? })`
+returns a `LensDataset` with paginated `LensDatasetItem` values. It selects the latest published
+version when no version is supplied and throws `LensDatasetError` for API, network, and invalid
+response failures.
+
 ## Configuration and redaction helpers
 
 `resolveLensConfig` resolves and validates configuration. `createLensRedactor` returns a deep,
 non-mutating redactor. `DEFAULT_PATTERNS` contains the built-in patterns. Public supporting types
-are `LensCaptureMode`, `LensEvalReporter`, `LensEvalReporterOptions`, `LensRedactionOptions`,
-`LensRedactorPattern`, `LensTracing`, and `LensTracingOptions`.
+are `LensCaptureMode`, `LensDataset`, `LensDatasetClient`, `LensDatasetClientOptions`,
+`LensDatasetGetOptions`, `LensDatasetItem`, `LensEvalReporter`, `LensEvalReporterOptions`,
+`LensRedactionOptions`, `LensRedactorPattern`, `LensTracing`, and `LensTracingOptions`.

--- a/apps/www/src/content/docs/packages/lens/usage-patterns.md
+++ b/apps/www/src/content/docs/packages/lens/usage-patterns.md
@@ -52,3 +52,25 @@ Lens receives run start and finish events plus suite, case, metric, outcome, and
 Use the returned `result.run.id` to link directly to a run. Case payloads and metadata are omitted
 by default; enable `includePayloads` and `includeMetadata` only when those values are approved for
 export. Payload capture uses the tracing instance's redaction transforms and capture-size limit.
+
+## Run a managed dataset
+
+```ts
+import { runEvalSuite } from "@anvia/core/evals";
+import { createLensDatasetClient } from "@anvia/lens";
+
+const datasets = createLensDatasetClient(tracing);
+const dataset = await datasets.getDataset("support-cases", { version: "v2" });
+
+await runEvalSuite({
+  name: "support-regression",
+  run: { datasetName: dataset.name, datasetVersion: dataset.version },
+  cases: dataset.items,
+  target,
+  metrics,
+  reporters: [createLensEvalReporter(tracing)],
+});
+```
+
+The same project public and secret keys used for telemetry authenticate dataset reads. Only
+published versions are available. Omit `version` to fetch the latest published version.

--- a/apps/www/src/content/docs/packages/lens/usage-patterns.md
+++ b/apps/www/src/content/docs/packages/lens/usage-patterns.md
@@ -57,7 +57,7 @@ export. Payload capture uses the tracing instance's redaction transforms and cap
 
 ```ts
 import { runEvalSuite } from "@anvia/core/evals";
-import { createLensDatasetClient } from "@anvia/lens";
+import { createLensDatasetClient, createLensEvalReporter } from "@anvia/lens";
 
 const datasets = createLensDatasetClient(tracing);
 const dataset = await datasets.getDataset("support-cases", { version: "v2" });

--- a/packages/observability-lens/README.md
+++ b/packages/observability-lens/README.md
@@ -58,6 +58,32 @@ const reporter = createLensEvalReporter(tracing, {
 Evaluation payloads include the case input, expected value, contexts, and target output. They use
 the tracing instance's redaction transforms and `captureMaxBytes` limit.
 
+## Managed datasets
+
+Fetch an immutable dataset version managed in Lens and pass its items directly to the core eval
+runner:
+
+```ts
+import { runEvalSuite } from "@anvia/core/evals";
+import { createLensDatasetClient } from "@anvia/lens";
+
+const datasets = createLensDatasetClient(tracing);
+const dataset = await datasets.getDataset<string, string>("support-cases", { version: "v2" });
+
+await runEvalSuite({
+  name: "support-regression",
+  run: { datasetName: dataset.name, datasetVersion: dataset.version },
+  cases: dataset.items,
+  target,
+  metrics,
+  reporters: [reporter],
+});
+```
+
+The client reuses the tracing instance's base URL and project credentials, automatically paginates,
+and selects the latest published version when `version` is omitted. Draft and archived versions are
+not readable through the public API.
+
 Configuration can also be provided through `ANVIA_LENS_BASE_URL`, `ANVIA_LENS_PUBLIC_KEY`,
 `ANVIA_LENS_SECRET_KEY`, `ANVIA_LENS_SERVICE_NAME`, `ANVIA_LENS_ENVIRONMENT`, and
 `ANVIA_LENS_RELEASE`.

--- a/packages/observability-lens/src/dataset-client.ts
+++ b/packages/observability-lens/src/dataset-client.ts
@@ -1,0 +1,242 @@
+import type { JsonValue } from "@anvia/core/completion";
+import { getResolvedLensConfig } from "./tracing.js";
+import type {
+  LensDataset,
+  LensDatasetClient,
+  LensDatasetClientOptions,
+  LensDatasetGetOptions,
+  LensDatasetItem,
+  LensTracing,
+} from "./types.js";
+
+const DEFAULT_PAGE_SIZE = 50;
+const MAX_PAGINATION_PAGES = 100;
+
+export class LensDatasetError extends Error {
+  constructor(
+    message: string,
+    readonly status: number | undefined,
+    readonly code: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "LensDatasetError";
+  }
+}
+
+export function createLensDatasetClient(
+  tracing: LensTracing,
+  options: LensDatasetClientOptions = {},
+): LensDatasetClient {
+  const tracingConfig = getResolvedLensConfig(tracing);
+  if (tracingConfig === undefined) {
+    throw new TypeError("createLensDatasetClient requires a tracing instance from lens.create()");
+  }
+  const baseUrl = (options.baseUrl ?? tracingConfig.baseUrl).replace(/\/+$/, "");
+  const publicKey = options.publicKey ?? tracingConfig.publicKey;
+  const secretKey = options.secretKey ?? tracingConfig.secretKey;
+  const timeoutMs = options.timeoutMs ?? tracingConfig.timeoutMs;
+  const pageSize = options.pageSize ?? DEFAULT_PAGE_SIZE;
+  if (!Number.isInteger(pageSize) || pageSize < 1 || pageSize > 100) {
+    throw new TypeError("Anvia Lens dataset pageSize must be an integer between 1 and 100");
+  }
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new TypeError("Anvia Lens dataset timeoutMs must be a positive number");
+  }
+  const authorization = `Basic ${Buffer.from(`${publicKey}:${secretKey}`).toString("base64")}`;
+
+  return {
+    async getDataset<Input = unknown, Expected = unknown>(
+      name: string,
+      getOptions: LensDatasetGetOptions = {},
+    ) {
+      const normalizedName = name.trim();
+      if (normalizedName.length === 0) throw new TypeError("Anvia Lens dataset name is required");
+      const items: LensDatasetItem<Input, Expected>[] = [];
+      let dataset: Omit<LensDataset<Input, Expected>, "items"> | undefined;
+      for (let page = 1; page <= MAX_PAGINATION_PAGES; page += 1) {
+        const url = new URL(`${baseUrl}/api/public/datasets/${encodeURIComponent(normalizedName)}`);
+        url.searchParams.set("page", String(page));
+        url.searchParams.set("limit", String(pageSize));
+        if (getOptions.version !== undefined) url.searchParams.set("version", getOptions.version);
+        const response = await request(url, authorization, timeoutMs);
+        const parsed = await parseDatasetResponse<Input, Expected>(response);
+        dataset ??= {
+          name: parsed.name,
+          version: parsed.version,
+          ...(parsed.description === undefined ? {} : { description: parsed.description }),
+          ...(parsed.metadata === undefined ? {} : { metadata: parsed.metadata }),
+        };
+        if (dataset.name !== parsed.name || dataset.version !== parsed.version) {
+          throw new LensDatasetError(
+            "Lens returned inconsistent dataset pages",
+            response.status,
+            "invalid_response",
+          );
+        }
+        items.push(...parsed.items);
+        if (page >= parsed.totalPages) break;
+      }
+      if (dataset === undefined) {
+        throw new LensDatasetError("Lens returned no dataset pages", undefined, "invalid_response");
+      }
+      return { ...dataset, items };
+    },
+  };
+}
+
+async function request(url: URL, authorization: string, timeoutMs: number): Promise<Response> {
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "GET",
+      headers: { Accept: "application/json", Authorization: authorization },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (cause) {
+    throw new LensDatasetError("Unable to reach Anvia Lens", undefined, "network_error", { cause });
+  }
+  if (!response.ok) {
+    const error = await readApiError(response);
+    throw new LensDatasetError(error.message, response.status, error.code);
+  }
+  return response;
+}
+
+function parseDatasetResponse<Input, Expected>(
+  response: Response,
+): Promise<{
+  name: string;
+  version: string;
+  description?: string | undefined;
+  metadata?: Record<string, JsonValue | undefined> | undefined;
+  items: LensDatasetItem<Input, Expected>[];
+  totalPages: number;
+}> {
+  return response
+    .json()
+    .catch((cause) => {
+      throw new LensDatasetError(
+        "Lens returned invalid JSON",
+        response.status,
+        "invalid_response",
+        {
+          cause,
+        },
+      );
+    })
+    .then((value: unknown) => {
+      if (!isRecord(value) || typeof value.name !== "string" || typeof value.version !== "string") {
+        throw invalidResponse(response, "Lens returned an invalid dataset");
+      }
+      if (!Array.isArray(value.items) || !isRecord(value.meta)) {
+        throw invalidResponse(response, "Lens returned invalid dataset pagination");
+      }
+      const totalPages = value.meta.totalPages;
+      if (!Number.isInteger(totalPages) || (totalPages as number) < 0) {
+        throw invalidResponse(response, "Lens returned invalid dataset pagination");
+      }
+      const items = value.items.map((item) => parseItem<Input, Expected>(item, response));
+      const result: {
+        name: string;
+        version: string;
+        description?: string;
+        metadata?: Record<string, JsonValue | undefined>;
+        items: LensDatasetItem<Input, Expected>[];
+        totalPages: number;
+      } = { name: value.name, version: value.version, items, totalPages: totalPages as number };
+      if (value.description !== undefined) {
+        if (typeof value.description !== "string") {
+          throw invalidResponse(response, "Lens returned an invalid dataset description");
+        }
+        result.description = value.description;
+      }
+      if (value.metadata !== undefined) {
+        if (!isJsonRecord(value.metadata)) {
+          throw invalidResponse(response, "Lens returned invalid dataset metadata");
+        }
+        result.metadata = value.metadata;
+      }
+      return result;
+    });
+}
+
+function parseItem<Input, Expected>(
+  value: unknown,
+  response: Response,
+): LensDatasetItem<Input, Expected> {
+  if (!isRecord(value) || typeof value.id !== "string" || !("input" in value)) {
+    throw invalidResponse(response, "Lens returned an invalid dataset item");
+  }
+  if (!isJsonValue(value.input)) {
+    throw invalidResponse(response, "Lens returned a non-JSON dataset input");
+  }
+  const item: LensDatasetItem<Input, Expected> = { id: value.id, input: value.input as Input };
+  if (value.expected !== undefined) {
+    if (!isJsonValue(value.expected)) {
+      throw invalidResponse(response, "Lens returned a non-JSON expected value");
+    }
+    item.expected = value.expected as Expected;
+  }
+  if (value.context !== undefined) item.context = stringArray(value.context, response, "context");
+  if (value.retrievalContext !== undefined) {
+    item.retrievalContext = stringArray(value.retrievalContext, response, "retrieval context");
+  }
+  if (value.metadata !== undefined) {
+    if (!isJsonRecord(value.metadata)) {
+      throw invalidResponse(response, "Lens returned invalid case metadata");
+    }
+    item.metadata = value.metadata;
+  }
+  return item;
+}
+
+async function readApiError(response: Response): Promise<{ code: string; message: string }> {
+  try {
+    const value: unknown = await response.json();
+    if (isRecord(value) && isRecord(value.error)) {
+      return {
+        code: typeof value.error.code === "string" ? value.error.code : "request_failed",
+        message:
+          typeof value.error.message === "string"
+            ? value.error.message
+            : `Lens request failed (${response.status})`,
+      };
+    }
+  } catch {
+    // Fall through to a stable error when the server did not return JSON.
+  }
+  return { code: "request_failed", message: `Lens request failed (${response.status})` };
+}
+
+function invalidResponse(response: Response, message: string): LensDatasetError {
+  return new LensDatasetError(message, response.status, "invalid_response");
+}
+
+function stringArray(value: unknown, response: Response, label: string): string[] {
+  if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
+    throw invalidResponse(response, `Lens returned invalid ${label}`);
+  }
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isJsonRecord(value: unknown): value is Record<string, JsonValue> {
+  return isRecord(value) && Object.values(value).every(isJsonValue);
+}
+
+function isJsonValue(value: unknown): value is JsonValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean" ||
+    (typeof value === "number" && Number.isFinite(value))
+  ) {
+    return true;
+  }
+  if (Array.isArray(value)) return value.every(isJsonValue);
+  return isJsonRecord(value);
+}

--- a/packages/observability-lens/src/dataset-client.ts
+++ b/packages/observability-lens/src/dataset-client.ts
@@ -54,6 +54,7 @@ export function createLensDatasetClient(
       if (normalizedName.length === 0) throw new TypeError("Anvia Lens dataset name is required");
       const items: LensDatasetItem<Input, Expected>[] = [];
       let dataset: Omit<LensDataset<Input, Expected>, "items"> | undefined;
+      let totalPages: number | undefined;
       for (let page = 1; page <= MAX_PAGINATION_PAGES; page += 1) {
         const url = new URL(`${baseUrl}/api/public/datasets/${encodeURIComponent(normalizedName)}`);
         url.searchParams.set("page", String(page));
@@ -74,8 +75,24 @@ export function createLensDatasetClient(
             "invalid_response",
           );
         }
+        if (totalPages === undefined) {
+          totalPages = parsed.totalPages;
+        } else if (totalPages !== parsed.totalPages) {
+          throw new LensDatasetError(
+            "Lens returned inconsistent dataset pagination",
+            response.status,
+            "invalid_response",
+          );
+        }
         items.push(...parsed.items);
-        if (page >= parsed.totalPages) break;
+        if (page >= totalPages) break;
+        if (page === MAX_PAGINATION_PAGES) {
+          throw new LensDatasetError(
+            "Lens dataset exceeds the pagination limit",
+            response.status,
+            "pagination_limit",
+          );
+        }
       }
       if (dataset === undefined) {
         throw new LensDatasetError("Lens returned no dataset pages", undefined, "invalid_response");

--- a/packages/observability-lens/src/index.ts
+++ b/packages/observability-lens/src/index.ts
@@ -1,8 +1,14 @@
 export { resolveLensConfig } from "./config.js";
+export { createLensDatasetClient, LensDatasetError } from "./dataset-client.js";
 export { createLensRedactor, DEFAULT_PATTERNS } from "./redaction.js";
 export { createLensEvalReporter, lens } from "./tracing.js";
 export type {
   LensCaptureMode,
+  LensDataset,
+  LensDatasetClient,
+  LensDatasetClientOptions,
+  LensDatasetGetOptions,
+  LensDatasetItem,
   LensEvalReporter,
   LensEvalReporterOptions,
   LensRedactionOptions,

--- a/packages/observability-lens/src/tracing.ts
+++ b/packages/observability-lens/src/tracing.ts
@@ -18,6 +18,7 @@ import type {
 const internals = Symbol("@anvia/lens.internals");
 
 type LensInternals = {
+  config: ReturnType<typeof resolveLensConfig>;
   loggerProvider: LoggerProvider;
   logger: ReturnType<LoggerProvider["getLogger"]>;
   captureMaxBytes: number;
@@ -26,6 +27,10 @@ type LensInternals = {
 };
 
 type InternalLensTracing = LensTracing & { [internals]: LensInternals };
+
+export function getResolvedLensConfig(tracing: LensTracing) {
+  return (tracing as Partial<InternalLensTracing>)[internals]?.config;
+}
 
 export const lens = {
   create(options: LensTracingOptions = {}): LensTracing {
@@ -91,6 +96,7 @@ class LensAgentObserver implements InternalLensTracing {
     const transformInput = options.redactInputs ? redactor.redact : undefined;
     const transformOutput = options.redactOutputs ? redactor.redact : undefined;
     this[internals] = {
+      config,
       loggerProvider,
       logger,
       captureMaxBytes: config.captureMaxBytes,

--- a/packages/observability-lens/src/types.ts
+++ b/packages/observability-lens/src/types.ts
@@ -1,3 +1,4 @@
+import type { JsonValue } from "@anvia/core/completion";
 import type { EvalReporter } from "@anvia/core/evals";
 import type { AgentObserver } from "@anvia/core/observability";
 
@@ -45,3 +46,39 @@ export type LensEvalReporter<Input = unknown, Output = unknown, Expected = unkno
   Output,
   Expected
 >;
+
+export type LensDatasetClientOptions = {
+  baseUrl?: string | undefined;
+  publicKey?: string | undefined;
+  secretKey?: string | undefined;
+  pageSize?: number | undefined;
+  timeoutMs?: number | undefined;
+};
+
+export type LensDatasetGetOptions = {
+  version?: string | undefined;
+};
+
+export type LensDatasetItem<Input = unknown, Expected = unknown> = {
+  id: string;
+  input: Input;
+  expected?: Expected | undefined;
+  context?: string[] | undefined;
+  retrievalContext?: string[] | undefined;
+  metadata?: Record<string, JsonValue | undefined> | undefined;
+};
+
+export type LensDataset<Input = unknown, Expected = unknown> = {
+  name: string;
+  version: string;
+  description?: string | undefined;
+  metadata?: Record<string, JsonValue | undefined> | undefined;
+  items: LensDatasetItem<Input, Expected>[];
+};
+
+export type LensDatasetClient = {
+  getDataset<Input = unknown, Expected = unknown>(
+    name: string,
+    options?: LensDatasetGetOptions,
+  ): Promise<LensDataset<Input, Expected>>;
+};

--- a/packages/observability-lens/test/dataset-client.test.ts
+++ b/packages/observability-lens/test/dataset-client.test.ts
@@ -82,6 +82,61 @@ describe("Lens dataset client", () => {
     await expect(invalid).rejects.toMatchObject({ code: "invalid_response" });
   });
 
+  it("rejects inconsistent pagination instead of combining unstable pages", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          response({
+            name: "changing",
+            version: "v1",
+            items: [{ id: "a", input: "first" }],
+            meta: { page: 1, limit: 1, totalItems: 2, totalPages: 2 },
+          }),
+        )
+        .mockResolvedValueOnce(
+          response({
+            name: "changing",
+            version: "v1",
+            items: [{ id: "b", input: "second" }],
+            meta: { page: 2, limit: 1, totalItems: 3, totalPages: 3 },
+          }),
+        ),
+    );
+    tracing = createTracing();
+
+    await expect(
+      createLensDatasetClient(tracing, { pageSize: 1 }).getDataset("changing"),
+    ).rejects.toMatchObject({
+      code: "invalid_response",
+      message: "Lens returned inconsistent dataset pagination",
+    });
+  });
+
+  it("rejects datasets that exceed the pagination safety limit", async () => {
+    const fetchMock = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        response({
+          name: "too-large",
+          version: "v1",
+          items: [{ id: "case", input: "value" }],
+          meta: { page: 1, limit: 1, totalItems: 101, totalPages: 101 },
+        }),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    tracing = createTracing();
+
+    await expect(
+      createLensDatasetClient(tracing, { pageSize: 1 }).getDataset("too-large"),
+    ).rejects.toMatchObject({
+      code: "pagination_limit",
+      message: "Lens dataset exceeds the pagination limit",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(100);
+  });
+
   it("validates client options and tracing ownership", async () => {
     tracing = createTracing();
     expect(() => createLensDatasetClient(tracing as never, { pageSize: 0 })).toThrow(

--- a/packages/observability-lens/test/dataset-client.test.ts
+++ b/packages/observability-lens/test/dataset-client.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createLensDatasetClient, LensDatasetError, lens } from "../src/index";
+import type { LensTracing } from "../src/types";
+
+let tracing: LensTracing | undefined;
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  await tracing?.shutdown();
+  tracing = undefined;
+});
+
+describe("Lens dataset client", () => {
+  it("fetches every page with tracing credentials and a selected version", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        response({
+          name: "support/cases",
+          version: "v2",
+          description: "Regression cases",
+          items: [{ id: "a", input: { question: "Hi" }, expected: "Hello" }],
+          meta: { page: 1, limit: 1, totalItems: 2, totalPages: 2 },
+        }),
+      )
+      .mockResolvedValueOnce(
+        response({
+          name: "support/cases",
+          version: "v2",
+          description: "Regression cases",
+          items: [{ id: "b", input: "Bye", context: ["policy"] }],
+          meta: { page: 2, limit: 1, totalItems: 2, totalPages: 2 },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    tracing = createTracing();
+    const dataset = await createLensDatasetClient(tracing, { pageSize: 1 }).getDataset(
+      "support/cases",
+      { version: "v2" },
+    );
+
+    expect(dataset).toEqual({
+      name: "support/cases",
+      version: "v2",
+      description: "Regression cases",
+      items: [
+        { id: "a", input: { question: "Hi" }, expected: "Hello" },
+        { id: "b", input: "Bye", context: ["policy"] },
+      ],
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [firstUrl, firstInit] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(firstUrl.toString()).toBe(
+      "https://lens.example/api/public/datasets/support%2Fcases?page=1&limit=1&version=v2",
+    );
+    expect(firstInit.headers).toEqual(
+      expect.objectContaining({
+        Authorization: `Basic ${Buffer.from("pk:sk").toString("base64")}`,
+      }),
+    );
+  });
+
+  it("surfaces typed API and invalid-response errors", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(response({ error: { code: "not_found", message: "Missing" } }, 404))
+        .mockResolvedValueOnce(response({ name: "bad", items: [], meta: { totalPages: 1 } })),
+    );
+    tracing = createTracing();
+    const client = createLensDatasetClient(tracing);
+
+    await expect(client.getDataset("missing")).rejects.toMatchObject({
+      name: "LensDatasetError",
+      status: 404,
+      code: "not_found",
+      message: "Missing",
+    });
+    const invalid = client.getDataset("bad");
+    await expect(invalid).rejects.toBeInstanceOf(LensDatasetError);
+    await expect(invalid).rejects.toMatchObject({ code: "invalid_response" });
+  });
+
+  it("validates client options and tracing ownership", async () => {
+    tracing = createTracing();
+    expect(() => createLensDatasetClient(tracing as never, { pageSize: 0 })).toThrow(
+      "pageSize must be an integer between 1 and 100",
+    );
+    expect(() => createLensDatasetClient({} as LensTracing)).toThrow(
+      "requires a tracing instance from lens.create()",
+    );
+  });
+});
+
+function createTracing(): LensTracing {
+  return lens.create({
+    baseUrl: "https://lens.example",
+    publicKey: "pk",
+    secretKey: "sk",
+    serviceName: "dataset-test",
+  });
+}
+
+function response(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}


### PR DESCRIPTION
## Summary

- add a typed, read-only managed dataset client to `@anvia/lens`
- reuse tracing credentials and configuration for authenticated dataset reads
- support explicit versions, latest-published selection, automatic pagination, timeouts, and typed API/network/response errors
- document using Lens-managed datasets with `runEvalSuite`
- add a minor changeset for the new public API

## Why

Lens can now author and publish immutable evaluation datasets. This gives Anvia applications a native way to fetch those published cases and run them through the existing local evaluation runtime without coupling evaluation execution to Lens.

## Impact

Consumers can call `createLensDatasetClient(tracing).getDataset(name, { version })` and pass the returned items directly to `runEvalSuite`. Existing tracing and evaluation-reporting behavior is unchanged.

## Validation

- `pnpm check`
- `pnpm --filter @anvia/lens typecheck`
- `pnpm --filter @anvia/lens test` (8 tests)
- `pnpm --filter @anvia/lens build`
- `pnpm --filter www reference-check`
- `pnpm --filter www build` (538 pages)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated access to managed Lens datasets.
  * Retrieve published dataset versions, select specific versions, and automatically combine paginated results.
  * Added structured errors for configuration, network, response, and dataset validation issues.
  * Exposed dataset client functionality and supporting types for evaluation workflows.

* **Documentation**
  * Added reference and usage guidance for retrieving datasets and running evaluations with Lens data.
  * Documented authentication, version availability, pagination, and dataset access restrictions.

* **Tests**
  * Added coverage for pagination, version selection, validation, errors, and client cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->