### PR TITLE
Add changesets for dependency updates

### DIFF
--- a/.changeset/bright-dependencies-release.md
+++ b/.changeset/bright-dependencies-release.md
@@ -1,0 +1,21 @@
+---
+"@anvia/core": patch
+"@anvia/memory-drizzle": patch
+"@anvia/memory-prisma": patch
+"@anvia/langfuse": patch
+"@anvia/lens": patch
+"@anvia/otel": patch
+"@anvia/anthropic": patch
+"@anvia/gemini": patch
+"@anvia/grok": patch
+"@anvia/mistral": patch
+"@anvia/openai": patch
+"@anvia/react-ui": patch
+"@anvia/studio": patch
+"@anvia/lancedb": patch
+"@anvia/milvus": patch
+"@anvia/pinecone": patch
+"@anvia/redis": patch
+---
+
+Publish the updated upstream runtime dependencies.


### PR DESCRIPTION
## Summary

- add patch changesets for the 17 publishable packages whose runtime dependencies were updated in #322
- leave `@anvia/qdrant` out because its changeset was already consumed and released as 0.3.1

## Why

The dependency updates in #322 changed 18 publishable package manifests, but only `@anvia/qdrant` received a changeset. Without this follow-up, the other dependency manifest updates would not be published to npm.

## Release impact

Changesets reports patch releases for the 17 explicitly listed packages. It also propagates patch bumps to five workspace dependents according to the repository's `updateInternalDependencies: patch` policy:

- `fullstack-agent`
- `langfuse-ops`
- `peer-core-compat`
- `@anvia/react`
- `@anvia/server`

## Validation

- `pnpm exec changeset status`
- `pnpm check`
- `git diff --check`
