### PR TITLE
Capture system prompts in generation traces

### DIFF
--- a/.changeset/calm-traces-instruct.md
+++ b/.changeset/calm-traces-instruct.md
@@ -1,0 +1,7 @@
+---
+"@anvia/otel": minor
+---
+
+Include request instructions in top-level and streamed child-agent generation inputs. Full-capture
+`anvia.generation.input` payloads now use `{ instructions, messages }`; input transforms receive the
+same structured object. Safe capture continues to omit the payload.

--- a/packages/observability-otel/src/helpers.ts
+++ b/packages/observability-otel/src/helpers.ts
@@ -89,7 +89,10 @@ export function generationStartAttributes(
   return compactAttributes({
     "anvia.generation.turn": args.turn,
     "anvia.generation.input": capturedJson(
-      modelInputMessages(args.request.chatHistory),
+      {
+        instructions: args.request.instructions,
+        messages: modelInputMessages(args.request.chatHistory),
+      },
       "input",
       options,
     ),

--- a/packages/observability-otel/src/tracing.ts
+++ b/packages/observability-otel/src/tracing.ts
@@ -208,30 +208,32 @@ class OtelToolObserver implements AgentToolObserver {
     const agent = this.childAgent(agentId, agentName, args);
 
     if (child.type === "turn_start") {
-      const generation = this.tracer.startSpan(
-        `${agentLabel(agentId, agentName)}.model.turn.${childTurn}`,
-        {
-          kind: SpanKind.CLIENT,
-          attributes: compactAttributes({
-            "anvia.child_agent.id": agentId,
-            "anvia.child_agent.name": agentName,
-            "anvia.child_agent.turn": childTurn,
-            "anvia.parent_tool.name": args.toolName,
-            "anvia.parent_tool.internal_call_id": args.internalCallId,
-            "anvia.parent_tool.call_id": args.toolCallId,
-            "anvia.generation.input": capturedJson(
-              {
-                prompt: modelInputMessage(child.prompt as Message),
-                history: modelInputMessages(child.history as Message[]),
-              },
-              "input",
-              this.options,
-            ),
-          }),
-        },
-        trace.setSpan(ROOT_CONTEXT, agent),
+      this.childGeneration(agentId, agentName, childTurn, args, agent).setAttributes(
+        compactAttributes({
+          "anvia.generation.input": capturedJson(
+            {
+              prompt: modelInputMessage(child.prompt as Message),
+              history: modelInputMessages(child.history as Message[]),
+            },
+            "input",
+            this.options,
+          ),
+        }),
       );
-      this.childGenerations.set(generationKey(agentId, childTurn), generation);
+      return;
+    }
+
+    if (child.type === "generation_start" && isRecord(child.request)) {
+      const generationArgs: AgentGenerationStartArgs = {
+        turn: childTurn,
+        request: child.request as AgentGenerationStartArgs["request"],
+      };
+      if (isRecord(child.modelInfo)) {
+        generationArgs.modelInfo = child.modelInfo as AgentGenerationStartArgs["modelInfo"];
+      }
+      this.childGeneration(agentId, agentName, childTurn, args, agent).setAttributes(
+        generationStartAttributes(generationArgs, this.options),
+      );
       return;
     }
 
@@ -399,6 +401,35 @@ class OtelToolObserver implements AgentToolObserver {
     );
     this.childAgents.set(agentId, span);
     return span;
+  }
+
+  private childGeneration(
+    agentId: string,
+    agentName: string | undefined,
+    turn: number,
+    args: AgentToolStartArgs,
+    agent: Span,
+  ): Span {
+    const key = generationKey(agentId, turn);
+    const existing = this.childGenerations.get(key);
+    if (existing !== undefined) return existing;
+    const generation = this.tracer.startSpan(
+      `${agentLabel(agentId, agentName)}.model.turn.${turn}`,
+      {
+        kind: SpanKind.CLIENT,
+        attributes: compactAttributes({
+          "anvia.child_agent.id": agentId,
+          "anvia.child_agent.name": agentName,
+          "anvia.child_agent.turn": turn,
+          "anvia.parent_tool.name": args.toolName,
+          "anvia.parent_tool.internal_call_id": args.internalCallId,
+          "anvia.parent_tool.call_id": args.toolCallId,
+        }),
+      },
+      trace.setSpan(ROOT_CONTEXT, agent),
+    );
+    this.childGenerations.set(key, generation);
+    return generation;
   }
 
   private findChildTool(

--- a/packages/observability-otel/test/otel.test.ts
+++ b/packages/observability-otel/test/otel.test.ts
@@ -420,6 +420,10 @@ describe("otel", () => {
       "anvia.usage.output_tokens": 3,
       "anvia.usage.total_tokens": 5,
     });
+    expect(JSON.parse(String(generationSpan?.attributes["anvia.generation.input"]))).toEqual({
+      instructions: "Answer clearly.",
+      messages: [userMessage("hello")],
+    });
     expect(generationSpan?.status).toEqual({ code: SpanStatusCode.OK });
     expect(generationSpan?.ended).toBe(true);
 
@@ -571,13 +575,18 @@ describe("otel", () => {
     await run?.startGeneration?.({
       ...generationStartArgs(),
       request: {
-        ...generationStartArgs().request,
+        model: "test-model",
         chatHistory: [Message.user("hello", { metadata })],
+        documents: [],
+        tools: [],
+        additionalParams: {},
       },
     });
-    expect(
-      JSON.parse(String(tracer.spans[1]?.attributes["anvia.generation.input"]))[0],
-    ).not.toHaveProperty("metadata");
+    const generationInput = JSON.parse(
+      String(tracer.spans[1]?.attributes["anvia.generation.input"]),
+    );
+    expect(generationInput).not.toHaveProperty("instructions");
+    expect(generationInput.messages[0]).not.toHaveProperty("metadata");
 
     await run?.end({
       output: "done",
@@ -588,6 +597,34 @@ describe("otel", () => {
       "metadata",
       metadata,
     );
+  });
+
+  it("transforms structured generation instructions and messages before capture", async () => {
+    const tracer = new FakeTracer();
+    const tracing = otel.create({
+      tracer: tracer.tracer,
+      transformInput: (value) =>
+        JSON.parse(JSON.stringify(value).replaceAll("private", "<redacted>")),
+    });
+    const run = await tracing.startRun({
+      prompt: userMessage("private prompt"),
+      history: [],
+      maxTurns: 1,
+    });
+
+    await run?.startGeneration?.({
+      ...generationStartArgs(),
+      request: {
+        ...generationStartArgs().request,
+        instructions: "private instructions",
+        chatHistory: [userMessage("private message")],
+      },
+    });
+
+    expect(JSON.parse(String(tracer.spans[1]?.attributes["anvia.generation.input"]))).toEqual({
+      instructions: "<redacted> instructions",
+      messages: [userMessage("<redacted> message")],
+    });
   });
 
   it("records generation request options and output schema metadata", async () => {
@@ -757,6 +794,28 @@ describe("otel", () => {
         agentId: "child",
         agentName: "Child Agent",
         event: {
+          type: "generation_start",
+          turn: 1,
+          request: {
+            ...generationStartArgs().request,
+            instructions: "Use the child policy.",
+            chatHistory: [userMessage("inspect")],
+          },
+          modelInfo: { provider: "test", defaultModel: "test-model" },
+        },
+      },
+    });
+    await tool?.streamEvent?.({
+      turn: 1,
+      toolName: "ask_child",
+      args: '{"prompt":"inspect"}',
+      toolCall: parentToolCall,
+      internalCallId: "internal-child",
+      toolCallId: "call-child",
+      event: {
+        agentId: "child",
+        agentName: "Child Agent",
+        event: {
           type: "tool_call",
           turn: 1,
           toolCall: AssistantContent.toolCall("call-add", "add", { x: 2, y: 5 }),
@@ -843,6 +902,10 @@ describe("otel", () => {
 
     expect(childAgent?.parentSpanId).toBe(parentTool?.spanContextValue.spanId);
     expect(childGeneration?.parentSpanId).toBe(childAgent?.spanContextValue.spanId);
+    expect(JSON.parse(String(childGeneration?.attributes["anvia.generation.input"]))).toEqual({
+      instructions: "Use the child policy.",
+      messages: [userMessage("inspect")],
+    });
     expect(childTool?.parentSpanId).toBe(childAgent?.spanContextValue.spanId);
     expect(childTool?.attributes).toMatchObject({
       "anvia.parent_tool.name": "ask_child",
@@ -883,10 +946,14 @@ describe("otel", () => {
         agentId: "child",
         agentName: "Child Agent",
         event: {
-          type: "turn_start",
+          type: "generation_start",
           turn: 1,
-          prompt: userMessage("private child prompt"),
-          history: [userMessage("private child history")],
+          request: {
+            ...generationStartArgs().request,
+            instructions: "private child instructions",
+            chatHistory: [userMessage("private child prompt")],
+          },
+          modelInfo: { provider: "test", defaultModel: "test-model" },
         },
       },
     });
@@ -1205,6 +1272,7 @@ function generationStartArgs(): AgentGenerationStartArgs {
     turn: 1,
     request: {
       model: "test-model",
+      instructions: "Answer clearly.",
       chatHistory: [userMessage("hello")],
       documents: [],
       tools: [],


### PR DESCRIPTION
## Summary

- capture generation input as a structured `{ instructions, messages }` payload
- update streamed child-agent spans from the finalized `generation_start` request
- preserve safe-mode payload omission and provisional child-turn fallback behavior
- add a minor changeset for `@anvia/otel`

## Root cause

The tracing integration captured only `request.chatHistory` for generation spans even though the system prompt lives separately in `request.instructions`. Streamed child-agent generations also relied on the earlier `turn_start` event instead of refreshing attributes from the finalized generation request.

## Impact

Full-capture traces now expose system instructions alongside model messages for both top-level and child-agent generations. Existing Lens structured-input rendering can display the instructions as the System row. Safe capture continues to omit input content.

## Validation

- `pnpm --filter @anvia/otel test` (24 tests)
- `pnpm --filter @anvia/otel typecheck`
- `pnpm --filter @anvia/otel --filter @anvia/lens build`
- `pnpm --filter @anvia/lens test` (14 tests)
- `pnpm --filter @anvia/lens typecheck`
- Biome and `git diff --check`

A live ingestion smoke test could not complete because the saved ingestion credentials returned `401 Invalid or revoked ingestion key`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generation input capture now includes request instructions alongside sanitized chat history.
  * Full-capture mode records inputs as structured `{ instructions, messages }` data.
  * Input transformations receive the same structured format.
  * Streamed child-agent generations now capture input and metadata consistently.

* **Bug Fixes**
  * Improved child-agent span reuse and generation tracking across streamed events.

* **Tests**
  * Added coverage for structured inputs, transformations, instructions, and streamed generation events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->