### PR TITLE
Add Qdrant document operations

### DIFF
--- a/.changeset/calm-vectors-flow.md
+++ b/.changeset/calm-vectors-flow.md
@@ -1,0 +1,7 @@
+---
+"@anvia/qdrant": minor
+---
+
+Add logical document deletion, retrieval, and inspection; mutation consistency controls; hosted
+client options; existing collection validation; stale-point cleanup on document replacement;
+Manhattan distance; and server-side score thresholds.

--- a/packages/vector-qdrant/README.md
+++ b/packages/vector-qdrant/README.md
@@ -30,6 +30,10 @@ const documents = await embedDocuments(
 const store = await QdrantVectorStore.connect({
   collectionName: "docs",
   vectorSize: 1536,
+  clientOptions: {
+    url: process.env.QDRANT_URL!,
+    apiKey: process.env.QDRANT_API_KEY!,
+  },
 });
 
 await store.upsertDocuments(documents);
@@ -37,6 +41,59 @@ await store.upsertDocuments(documents);
 const results = await store.index(embeddings).search({
   query: "What is Anvia?",
   topK: 5,
+});
+```
+
+`upsertDocuments(...)` replaces every point previously stored for the same logical document IDs,
+including stale points left when a document changes from multiple embeddings to fewer embeddings.
+Mutations wait for Qdrant to apply them by default. You can override Qdrant's mutation controls when
+needed:
+
+```ts
+await store.upsertDocuments(documents, {
+  wait: false,
+  ordering: "strong",
+  timeout: 30,
+});
+```
+
+## Document management
+
+Document operations use Anvia's logical document IDs. A deletion therefore removes every Qdrant
+point created for a multi-embedding document.
+
+```ts
+await store.deleteDocuments(["1", "2"]);
+
+const documents = await store.getDocuments(["1", "2"]);
+
+const index = store.index(embeddings);
+const firstPage = await index.inspect({ limit: 50 });
+const nextPage = firstPage.nextCursor
+  ? await index.inspect({ limit: 50, cursor: firstPage.nextCursor })
+  : undefined;
+```
+
+For advanced Qdrant operations, construct and retain the native client instead of routing collection
+administration through the Anvia adapter:
+
+```ts
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({
+  url: process.env.QDRANT_URL!,
+  apiKey: process.env.QDRANT_API_KEY!,
+});
+const store = await QdrantVectorStore.connect({
+  client,
+  collectionName: "docs",
+  vectorSize: 1536,
+});
+
+await client.createPayloadIndex("docs", {
+  field_name: "category",
+  field_schema: "keyword",
+  wait: true,
 });
 ```
 

--- a/packages/vector-qdrant/README.md
+++ b/packages/vector-qdrant/README.md
@@ -47,7 +47,10 @@ const results = await store.index(embeddings).search({
 `upsertDocuments(...)` replaces every point previously stored for the same logical document IDs,
 including stale points left when a document changes from multiple embeddings to fewer embeddings.
 Mutations wait for Qdrant to apply them by default. You can override Qdrant's mutation controls when
-needed:
+needed. The official Qdrant client performs replacement as one ordered batch. Custom clients without
+`batchUpdate(...)` fall back to sequential deletion and insertion; that fallback is not atomic, so a
+failed insertion can leave the previous document removed. Require a `batchUpdate(...)`-capable
+client to avoid this two-request failure window.
 
 ```ts
 await store.upsertDocuments(documents, {
@@ -65,7 +68,7 @@ point created for a multi-embedding document.
 ```ts
 await store.deleteDocuments(["1", "2"]);
 
-const documents = await store.getDocuments(["1", "2"]);
+const storedDocuments = await store.getDocuments(["1", "2"]);
 
 const index = store.index(embeddings);
 const firstPage = await index.inspect({ limit: 50 });

--- a/packages/vector-qdrant/src/helpers.ts
+++ b/packages/vector-qdrant/src/helpers.ts
@@ -1,12 +1,19 @@
 import { createHash } from "node:crypto";
 import type { EmbeddedDocument, VectorMetadata } from "@anvia/core/embeddings";
-import type { VectorSearchResult } from "@anvia/core/vector-store";
+import type {
+  VectorInspectItem,
+  VectorInspectPage,
+  VectorSearchResult,
+} from "@anvia/core/vector-store";
+import type { QdrantClientParams } from "@qdrant/js-client-rest";
 import {
   defaultDenseVectorName,
   defaultSparseVectorName,
   documentIdPayloadKey,
   documentPayloadKey,
   type QdrantClientLike,
+  type QdrantDistance,
+  type QdrantMutationOptions,
   reservedPayloadPrefix,
 } from "./types.js";
 
@@ -142,9 +149,275 @@ export function parseQueryResults<T, Metadata extends VectorMetadata>(
   return [...byId.values()];
 }
 
-export async function defaultQdrantClient(): Promise<QdrantClientLike> {
+export async function qdrantDocumentPage<T, Metadata extends VectorMetadata>(
+  client: QdrantClientLike,
+  collectionName: string,
+  options: {
+    limit: number;
+    cursor?: string | undefined;
+    filter?: unknown;
+  },
+): Promise<VectorInspectPage<T, Metadata>> {
+  if (typeof client.scroll !== "function") {
+    throw new TypeError(
+      "Qdrant document inspection requires a client that implements scroll(...).",
+    );
+  }
+
+  const limit = Math.max(0, Math.trunc(options.limit));
+  const start = parseInspectCursor(options.cursor);
+  if (limit === 0) {
+    return { items: [] };
+  }
+
+  const seenDocumentIds = new Set<string>();
+  const seenOffsets = new Set<string | number>();
+  const items: Array<VectorInspectItem<T, Metadata>> = [];
+  let offset: unknown;
+  let hasMore = false;
+
+  while (true) {
+    const response = await client.scroll(collectionName, {
+      filter: options.filter,
+      limit: Math.max(100, limit * 2),
+      offset,
+      with_payload: true,
+      with_vector: false,
+    });
+    const page = rawScrollPage(response);
+
+    for (const point of page.points) {
+      const item = inspectItemFromPoint<T, Metadata>(point);
+      if (seenDocumentIds.has(item.id)) {
+        continue;
+      }
+      seenDocumentIds.add(item.id);
+      if (seenDocumentIds.size <= start) {
+        continue;
+      }
+      if (items.length === limit) {
+        hasMore = true;
+        break;
+      }
+      items.push(item);
+    }
+
+    if (
+      hasMore ||
+      page.nextOffset === undefined ||
+      page.points.length === 0 ||
+      seenOffsets.has(page.nextOffset)
+    ) {
+      break;
+    }
+    seenOffsets.add(page.nextOffset);
+    offset = page.nextOffset;
+  }
+
+  const result: VectorInspectPage<T, Metadata> = { items };
+  if (hasMore) {
+    result.nextCursor = String(start + items.length);
+  }
+  return result;
+}
+
+export function qdrantMutationRequest(
+  options: QdrantMutationOptions = {},
+): Record<string, unknown> {
+  const request: Record<string, unknown> = { wait: options.wait ?? true };
+  if (options.ordering !== undefined) {
+    request.ordering = options.ordering;
+  }
+  if (options.timeout !== undefined) {
+    request.timeout = options.timeout;
+  }
+  return request;
+}
+
+export function qdrantDocumentFilter(documentIds: string[]): Record<string, unknown> {
+  return {
+    must: [
+      {
+        key: documentIdPayloadKey,
+        match: { any: documentIds },
+      },
+    ],
+  };
+}
+
+export function validateQdrantCollection(
+  response: unknown,
+  options: {
+    vectorSize: number;
+    distance: QdrantDistance;
+    hybrid: boolean;
+    denseVectorName: string;
+    sparseVectorName: string;
+  },
+): void {
+  const info = unwrapResult(response);
+  const config = recordValue(info, "config");
+  const params = recordValue(config, "params");
+  const vectors = recordValue(params, "vectors");
+  if (vectors === undefined) {
+    // Keep lightweight custom clients compatible when they do not return collection configuration.
+    return;
+  }
+
+  const denseVector = options.hybrid
+    ? recordValue(vectors, options.denseVectorName)
+    : typeof vectors.size === "number"
+      ? vectors
+      : undefined;
+  if (denseVector === undefined) {
+    throw new Error(
+      options.hybrid
+        ? `Qdrant collection is missing dense vector ${options.denseVectorName}`
+        : "Qdrant collection uses named vectors but a dense-only collection was requested",
+    );
+  }
+
+  const actualSize = denseVector.size;
+  if (typeof actualSize === "number" && actualSize !== options.vectorSize) {
+    throw new Error(
+      `Qdrant collection vector size ${actualSize} does not match requested size ${options.vectorSize}`,
+    );
+  }
+  const actualDistance = denseVector.distance;
+  if (typeof actualDistance === "string" && actualDistance !== options.distance) {
+    throw new Error(
+      `Qdrant collection distance ${actualDistance} does not match requested distance ${options.distance}`,
+    );
+  }
+
+  const sparseVectors = recordValue(params, "sparse_vectors");
+  if (options.hybrid && recordValue(sparseVectors, options.sparseVectorName) === undefined) {
+    throw new Error(`Qdrant collection is missing sparse vector ${options.sparseVectorName}`);
+  }
+  if (!options.hybrid && sparseVectors !== undefined && Object.keys(sparseVectors).length > 0) {
+    throw new Error("Qdrant collection is hybrid but a dense-only collection was requested");
+  }
+}
+
+export function qdrantCollectionExists(response: unknown): boolean | undefined {
+  if (typeof response === "boolean") {
+    return response;
+  }
+  const result = unwrapResult(response);
+  return typeof result?.exists === "boolean" ? result.exists : undefined;
+}
+
+export function isQdrantNotFoundError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  const candidate = error as {
+    status?: unknown;
+    statusCode?: unknown;
+    response?: { status?: unknown } | undefined;
+    message?: unknown;
+  };
+  return (
+    candidate.status === 404 ||
+    candidate.statusCode === 404 ||
+    candidate.response?.status === 404 ||
+    (typeof candidate.message === "string" &&
+      /(?:\b404\b|not found|missing collection)/i.test(candidate.message))
+  );
+}
+
+export async function defaultQdrantClient(
+  options: QdrantClientParams = {},
+): Promise<QdrantClientLike> {
   const qdrant = await import("@qdrant/js-client-rest");
-  return new qdrant.QdrantClient({}) as QdrantClientLike;
+  return new qdrant.QdrantClient(options) as QdrantClientLike;
+}
+
+function parseInspectCursor(cursor: string | undefined): number {
+  if (cursor === undefined) {
+    return 0;
+  }
+  const value = Number(cursor);
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new TypeError(`Invalid Qdrant inspect cursor: ${cursor}`);
+  }
+  return value;
+}
+
+function rawScrollPage(response: unknown): {
+  points: Array<{
+    id: string | number;
+    payload?: Record<string, unknown> | null;
+  }>;
+  nextOffset?: string | number;
+} {
+  const result = unwrapResult(response);
+  const rawPoints = Array.isArray(result?.points) ? result.points : [];
+  const page: {
+    points: Array<{
+      id: string | number;
+      payload?: Record<string, unknown> | null;
+    }>;
+    nextOffset?: string | number;
+  } = {
+    points: rawPoints.flatMap((point) => {
+      if (typeof point !== "object" || point === null || !("id" in point)) {
+        return [];
+      }
+      const id = point.id;
+      if (typeof id !== "string" && typeof id !== "number") {
+        return [];
+      }
+      const parsed: { id: string | number; payload?: Record<string, unknown> | null } = { id };
+      if ("payload" in point && (point.payload === null || typeof point.payload === "object")) {
+        parsed.payload = point.payload as Record<string, unknown> | null;
+      }
+      return [parsed];
+    }),
+  };
+  if (
+    typeof result?.next_page_offset === "string" ||
+    typeof result?.next_page_offset === "number"
+  ) {
+    page.nextOffset = result.next_page_offset;
+  }
+  return page;
+}
+
+function inspectItemFromPoint<T, Metadata extends VectorMetadata>(point: {
+  id: string | number;
+  payload?: Record<string, unknown> | null;
+}): VectorInspectItem<T, Metadata> {
+  const item: VectorInspectItem<T, Metadata> = {
+    id: String(point.payload?.[documentIdPayloadKey] ?? point.id),
+    document: parseDocument<T>(point.payload?.[documentPayloadKey]),
+  };
+  const metadata = metadataFromPayload<Metadata>(point.payload);
+  if (metadata !== undefined) {
+    item.metadata = metadata;
+  }
+  return item;
+}
+
+function unwrapResult(value: unknown): Record<string, unknown> | undefined {
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const result = record.result;
+  return typeof result === "object" && result !== null
+    ? (result as Record<string, unknown>)
+    : record;
+}
+
+function recordValue(
+  value: Record<string, unknown> | undefined,
+  key: string,
+): Record<string, unknown> | undefined {
+  const nested = value?.[key];
+  return typeof nested === "object" && nested !== null
+    ? (nested as Record<string, unknown>)
+    : undefined;
 }
 
 function rawPoints(response: unknown): Array<{

--- a/packages/vector-qdrant/src/helpers.ts
+++ b/packages/vector-qdrant/src/helpers.ts
@@ -165,16 +165,19 @@ export async function qdrantDocumentPage<T, Metadata extends VectorMetadata>(
   }
 
   const limit = Math.max(0, Math.trunc(options.limit));
-  const start = parseInspectCursor(options.cursor);
+  const cursor = parseInspectCursor(options.cursor);
   if (limit === 0) {
     return { items: [] };
   }
 
-  const seenDocumentIds = new Set<string>();
+  const seenDocumentIds = new Set(cursor.documentIds);
   const seenOffsets = new Set<string | number>();
+  if (cursor.offset !== undefined) {
+    seenOffsets.add(cursor.offset);
+  }
   const items: Array<VectorInspectItem<T, Metadata>> = [];
-  let offset: unknown;
-  let hasMore = false;
+  let offset = cursor.offset;
+  let skip = cursor.skip;
 
   while (true) {
     const response = await client.scroll(collectionName, {
@@ -186,24 +189,30 @@ export async function qdrantDocumentPage<T, Metadata extends VectorMetadata>(
     });
     const page = rawScrollPage(response);
 
-    for (const point of page.points) {
+    for (let index = skip; index < page.points.length; index += 1) {
+      const point = page.points[index];
+      if (point === undefined) {
+        continue;
+      }
       const item = inspectItemFromPoint<T, Metadata>(point);
       if (seenDocumentIds.has(item.id)) {
         continue;
       }
-      seenDocumentIds.add(item.id);
-      if (seenDocumentIds.size <= start) {
-        continue;
-      }
       if (items.length === limit) {
-        hasMore = true;
-        break;
+        return {
+          items,
+          nextCursor: serializeInspectCursor({
+            offset,
+            skip: index,
+            documentIds: [...seenDocumentIds],
+          }),
+        };
       }
+      seenDocumentIds.add(item.id);
       items.push(item);
     }
 
     if (
-      hasMore ||
       page.nextOffset === undefined ||
       page.points.length === 0 ||
       seenOffsets.has(page.nextOffset)
@@ -212,13 +221,10 @@ export async function qdrantDocumentPage<T, Metadata extends VectorMetadata>(
     }
     seenOffsets.add(page.nextOffset);
     offset = page.nextOffset;
+    skip = 0;
   }
 
-  const result: VectorInspectPage<T, Metadata> = { items };
-  if (hasMore) {
-    result.nextCursor = String(start + items.length);
-  }
-  return result;
+  return { items };
 }
 
 export function qdrantMutationRequest(
@@ -333,15 +339,42 @@ export async function defaultQdrantClient(
   return new qdrant.QdrantClient(options) as QdrantClientLike;
 }
 
-function parseInspectCursor(cursor: string | undefined): number {
+type QdrantInspectCursor = {
+  offset?: string | number | undefined;
+  skip: number;
+  documentIds: string[];
+};
+
+function parseInspectCursor(cursor: string | undefined): QdrantInspectCursor {
   if (cursor === undefined) {
-    return 0;
+    return { skip: 0, documentIds: [] };
   }
-  const value = Number(cursor);
-  if (!Number.isSafeInteger(value) || value < 0) {
+  try {
+    const value = JSON.parse(decodeURIComponent(cursor)) as Record<string, unknown>;
+    const offset = value.offset;
+    const skip = value.skip;
+    const documentIds = value.documentIds;
+    if (
+      (offset !== undefined && typeof offset !== "string" && typeof offset !== "number") ||
+      !Number.isSafeInteger(skip) ||
+      (skip as number) < 0 ||
+      !Array.isArray(documentIds) ||
+      !documentIds.every((id) => typeof id === "string")
+    ) {
+      throw new TypeError("invalid cursor state");
+    }
+    return {
+      offset: offset as string | number | undefined,
+      skip: skip as number,
+      documentIds: documentIds as string[],
+    };
+  } catch {
     throw new TypeError(`Invalid Qdrant inspect cursor: ${cursor}`);
   }
-  return value;
+}
+
+function serializeInspectCursor(cursor: QdrantInspectCursor): string {
+  return encodeURIComponent(JSON.stringify(cursor));
 }
 
 function rawScrollPage(response: unknown): {

--- a/packages/vector-qdrant/src/index.ts
+++ b/packages/vector-qdrant/src/index.ts
@@ -7,5 +7,6 @@ export type {
   QdrantFusion,
   QdrantHybridIndexOptions,
   QdrantIndexOptions,
+  QdrantMutationOptions,
   QdrantVectorStoreConnectOptions,
 } from "./types.js";

--- a/packages/vector-qdrant/src/search-index.ts
+++ b/packages/vector-qdrant/src/search-index.ts
@@ -99,9 +99,9 @@ export class QdrantVectorIndex<T, Metadata extends VectorMetadata = VectorMetada
       ],
       query: { fusion: this.hybrid.fusion },
       limit: request.topK,
-      score_threshold: request.threshold,
       with_payload: true,
     });
+    // Hybrid thresholds apply to the final fused score, not either retriever's similarity scale.
     return parseQueryResults<T, Metadata>(response, request.threshold);
   }
 

--- a/packages/vector-qdrant/src/search-index.ts
+++ b/packages/vector-qdrant/src/search-index.ts
@@ -8,13 +8,15 @@ import {
 import type { Tool } from "@anvia/core/tool";
 import {
   createVectorSearchTool,
+  type VectorInspectPage,
+  type VectorInspectRequest,
   type VectorSearchIndex,
   type VectorSearchRequest,
   type VectorSearchResult,
   type VectorSearchToolOptions,
 } from "@anvia/core/vector-store";
 import { filterToQdrantFilter } from "./filters.js";
-import { parseQueryResults } from "./helpers.js";
+import { parseQueryResults, qdrantDocumentPage } from "./helpers.js";
 import type { QdrantClientLike, QdrantFusion } from "./types.js";
 
 export type QdrantVectorIndexHybridOptions = {
@@ -45,6 +47,7 @@ export class QdrantVectorIndex<T, Metadata extends VectorMetadata = VectorMetada
               query: queryEmbedding.vector,
               limit: request.topK,
               filter,
+              score_threshold: request.threshold,
               with_payload: true,
             })
           : typeof this.client.search === "function"
@@ -52,6 +55,7 @@ export class QdrantVectorIndex<T, Metadata extends VectorMetadata = VectorMetada
                 vector: queryEmbedding.vector,
                 limit: request.topK,
                 filter,
+                score_threshold: request.threshold,
                 with_payload: true,
               })
             : (() => {
@@ -95,6 +99,7 @@ export class QdrantVectorIndex<T, Metadata extends VectorMetadata = VectorMetada
       ],
       query: { fusion: this.hybrid.fusion },
       limit: request.topK,
+      score_threshold: request.threshold,
       with_payload: true,
     });
     return parseQueryResults<T, Metadata>(response, request.threshold);
@@ -102,6 +107,13 @@ export class QdrantVectorIndex<T, Metadata extends VectorMetadata = VectorMetada
 
   async searchIds(request: VectorSearchRequest): Promise<Array<{ score: number; id: string }>> {
     return (await this.search(request)).map(({ score, id }) => ({ score, id }));
+  }
+
+  async inspect(request: VectorInspectRequest): Promise<VectorInspectPage<T, Metadata>> {
+    return qdrantDocumentPage<T, Metadata>(this.client, this.collectionName, {
+      ...request,
+      filter: filterToQdrantFilter(request.filter),
+    });
   }
 
   asTool(options: VectorSearchToolOptions): Tool<{ query: string; topK?: number }, unknown> {

--- a/packages/vector-qdrant/src/store.ts
+++ b/packages/vector-qdrant/src/store.ts
@@ -1,5 +1,15 @@
 import type { EmbeddedDocument, EmbeddingModel, VectorMetadata } from "@anvia/core/embeddings";
-import { defaultQdrantClient, qdrantPoints } from "./helpers.js";
+import type { VectorInspectItem } from "@anvia/core/vector-store";
+import {
+  defaultQdrantClient,
+  isQdrantNotFoundError,
+  qdrantCollectionExists,
+  qdrantDocumentFilter,
+  qdrantDocumentPage,
+  qdrantMutationRequest,
+  qdrantPoints,
+  validateQdrantCollection,
+} from "./helpers.js";
 import { QdrantVectorIndex } from "./search-index.js";
 import {
   defaultDenseVectorName,
@@ -7,6 +17,7 @@ import {
   isQdrantHybridIndexOptions,
   type QdrantClientLike,
   type QdrantIndexOptions,
+  type QdrantMutationOptions,
   type QdrantVectorStoreConnectOptions,
 } from "./types.js";
 
@@ -24,45 +35,60 @@ export class QdrantVectorStore<T, Metadata extends VectorMetadata = VectorMetada
   static async connect<T, Metadata extends VectorMetadata = VectorMetadata>(
     options: QdrantVectorStoreConnectOptions,
   ): Promise<QdrantVectorStore<T, Metadata>> {
-    const client = options.client ?? (await defaultQdrantClient());
+    if (options.client !== undefined && options.clientOptions !== undefined) {
+      throw new TypeError("Qdrant connect accepts either client or clientOptions, but not both.");
+    }
+    const client = options.client ?? (await defaultQdrantClient(options.clientOptions));
     const hybrid = options.hybrid === true;
     const denseVectorName = options.denseVectorName ?? defaultDenseVectorName;
     const sparseVectorName = options.sparseVectorName ?? defaultSparseVectorName;
     const storeOptions = { hybrid, denseVectorName, sparseVectorName };
+    const collectionOptions = {
+      vectorSize: options.vectorSize,
+      distance: options.distance ?? ("Cosine" as const),
+      ...storeOptions,
+    };
 
     if (options.createIfMissing === false) {
-      await client.getCollection(options.collectionName);
+      validateQdrantCollection(
+        await client.getCollection(options.collectionName),
+        collectionOptions,
+      );
       return new QdrantVectorStore<T, Metadata>(client, options.collectionName, storeOptions);
     }
 
-    try {
-      await client.getCollection(options.collectionName);
-    } catch {
-      if (hybrid) {
-        await client.createCollection(options.collectionName, {
-          vectors: {
-            [denseVectorName]: {
-              size: options.vectorSize,
-              distance: options.distance ?? "Cosine",
-            },
-          },
-          sparse_vectors: {
-            [sparseVectorName]: {},
-          },
-        });
-      } else {
-        await client.createCollection(options.collectionName, {
-          vectors: {
-            size: options.vectorSize,
-            distance: options.distance ?? "Cosine",
-          },
-        });
+    let exists: boolean | undefined;
+    if (typeof client.collectionExists === "function") {
+      exists = qdrantCollectionExists(await client.collectionExists(options.collectionName));
+    }
+
+    if (exists === true) {
+      validateQdrantCollection(
+        await client.getCollection(options.collectionName),
+        collectionOptions,
+      );
+    } else if (exists === false) {
+      await createCollection(client, options, storeOptions);
+    } else {
+      try {
+        validateQdrantCollection(
+          await client.getCollection(options.collectionName),
+          collectionOptions,
+        );
+      } catch (error) {
+        if (!isQdrantNotFoundError(error)) {
+          throw error;
+        }
+        await createCollection(client, options, storeOptions);
       }
     }
     return new QdrantVectorStore<T, Metadata>(client, options.collectionName, storeOptions);
   }
 
-  async upsertDocuments(documents: Array<EmbeddedDocument<T, Metadata>>): Promise<void> {
+  async upsertDocuments(
+    documents: Array<EmbeddedDocument<T, Metadata>>,
+    mutationOptions: QdrantMutationOptions = {},
+  ): Promise<void> {
     const points = documents.flatMap((document) =>
       qdrantPoints(document, {
         hybrid: this.options.hybrid,
@@ -70,7 +96,66 @@ export class QdrantVectorStore<T, Metadata extends VectorMetadata = VectorMetada
         sparseVectorName: this.options.sparseVectorName,
       }),
     );
-    await this.client.upsert(this.collectionName, { points });
+    if (points.length === 0) {
+      return;
+    }
+
+    const documentIds = [...new Set(documents.map((document) => document.id))];
+    const filter = qdrantDocumentFilter(documentIds);
+    const requestOptions = qdrantMutationRequest(mutationOptions);
+    if (typeof this.client.batchUpdate === "function") {
+      await this.client.batchUpdate(this.collectionName, {
+        ...requestOptions,
+        operations: [{ delete: { filter } }, { upsert: { points } }],
+      });
+      return;
+    }
+
+    // Older custom clients may not implement batchUpdate. Delete first so replacing a document with
+    // fewer embeddings does not leave stale points behind. The delete must finish before the upsert
+    // when the operations cannot be submitted as one ordered batch.
+    if (typeof this.client.delete !== "function") {
+      throw new TypeError(
+        "Qdrant document replacement requires a client that implements batchUpdate(...) or delete(...).",
+      );
+    }
+    await this.client.delete(this.collectionName, { ...requestOptions, wait: true, filter });
+    await this.client.upsert(this.collectionName, { ...requestOptions, points });
+  }
+
+  async deleteDocuments(
+    documentIds: string[],
+    mutationOptions: QdrantMutationOptions = {},
+  ): Promise<void> {
+    const ids = [...new Set(documentIds)];
+    if (ids.length === 0) {
+      return;
+    }
+    if (typeof this.client.delete !== "function") {
+      throw new TypeError(
+        "Qdrant document deletion requires a client that implements delete(...).",
+      );
+    }
+    await this.client.delete(this.collectionName, {
+      ...qdrantMutationRequest(mutationOptions),
+      filter: qdrantDocumentFilter(ids),
+    });
+  }
+
+  async getDocuments(documentIds: string[]): Promise<Array<VectorInspectItem<T, Metadata>>> {
+    const ids = [...new Set(documentIds)];
+    if (ids.length === 0) {
+      return [];
+    }
+    const page = await qdrantDocumentPage<T, Metadata>(this.client, this.collectionName, {
+      limit: ids.length,
+      filter: qdrantDocumentFilter(ids),
+    });
+    const byId = new Map(page.items.map((item) => [item.id, item]));
+    return ids.flatMap((id) => {
+      const item = byId.get(id);
+      return item === undefined ? [] : [item];
+    });
   }
 
   index(options: QdrantIndexOptions): QdrantVectorIndex<T, Metadata> {
@@ -94,5 +179,36 @@ export class QdrantVectorStore<T, Metadata extends VectorMetadata = VectorMetada
       );
     }
     return new QdrantVectorIndex(options as EmbeddingModel, this.client, this.collectionName);
+  }
+}
+
+async function createCollection(
+  client: QdrantClientLike,
+  options: QdrantVectorStoreConnectOptions,
+  storeOptions: {
+    hybrid: boolean;
+    denseVectorName: string;
+    sparseVectorName: string;
+  },
+): Promise<void> {
+  if (storeOptions.hybrid) {
+    await client.createCollection(options.collectionName, {
+      vectors: {
+        [storeOptions.denseVectorName]: {
+          size: options.vectorSize,
+          distance: options.distance ?? "Cosine",
+        },
+      },
+      sparse_vectors: {
+        [storeOptions.sparseVectorName]: {},
+      },
+    });
+  } else {
+    await client.createCollection(options.collectionName, {
+      vectors: {
+        size: options.vectorSize,
+        distance: options.distance ?? "Cosine",
+      },
+    });
   }
 }

--- a/packages/vector-qdrant/src/store.ts
+++ b/packages/vector-qdrant/src/store.ts
@@ -113,7 +113,8 @@ export class QdrantVectorStore<T, Metadata extends VectorMetadata = VectorMetada
 
     // Older custom clients may not implement batchUpdate. Delete first so replacing a document with
     // fewer embeddings does not leave stale points behind. The delete must finish before the upsert
-    // when the operations cannot be submitted as one ordered batch.
+    // when the operations cannot be submitted as one ordered batch. This path is not atomic: if the
+    // upsert fails, the previous points have already been deleted.
     if (typeof this.client.delete !== "function") {
       throw new TypeError(
         "Qdrant document replacement requires a client that implements batchUpdate(...) or delete(...).",

--- a/packages/vector-qdrant/src/types.ts
+++ b/packages/vector-qdrant/src/types.ts
@@ -1,4 +1,5 @@
 import type { EmbeddingModel, SparseEmbeddingModel } from "@anvia/core/embeddings";
+import type { QdrantClientParams } from "@qdrant/js-client-rest";
 
 export const documentIdPayloadKey = "__anvia_document_id";
 export const documentPayloadKey = "__anvia_document";
@@ -7,7 +8,7 @@ export const reservedPayloadPrefix = "__anvia_";
 export const defaultDenseVectorName = "dense";
 export const defaultSparseVectorName = "sparse";
 
-export type QdrantDistance = "Cosine" | "Dot" | "Euclid";
+export type QdrantDistance = "Cosine" | "Dot" | "Euclid" | "Manhattan";
 
 export type QdrantFusion = "rrf" | "dbsf";
 
@@ -15,12 +16,15 @@ export type QdrantClientLike = {
   getCollection(collectionName: string): Promise<unknown>;
   createCollection(collectionName: string, options: Record<string, unknown>): Promise<unknown>;
   upsert(collectionName: string, options: Record<string, unknown>): Promise<unknown>;
+  batchUpdate?(collectionName: string, options: Record<string, unknown>): Promise<unknown>;
+  collectionExists?(collectionName: string): Promise<unknown>;
+  delete?(collectionName: string, options: Record<string, unknown>): Promise<unknown>;
+  scroll?(collectionName: string, options: Record<string, unknown>): Promise<unknown>;
   search?(collectionName: string, options: Record<string, unknown>): Promise<unknown>;
   query?(collectionName: string, options: Record<string, unknown>): Promise<unknown>;
 };
 
-export type QdrantVectorStoreConnectOptions = {
-  client?: QdrantClientLike | undefined;
+type QdrantVectorStoreBaseConnectOptions = {
   collectionName: string;
   vectorSize: number;
   createIfMissing?: boolean | undefined;
@@ -29,6 +33,25 @@ export type QdrantVectorStoreConnectOptions = {
   hybrid?: boolean | undefined;
   denseVectorName?: string | undefined;
   sparseVectorName?: string | undefined;
+};
+
+export type QdrantVectorStoreConnectOptions = QdrantVectorStoreBaseConnectOptions &
+  (
+    | {
+        client: QdrantClientLike;
+        clientOptions?: never;
+      }
+    | {
+        client?: undefined;
+        clientOptions?: QdrantClientParams | undefined;
+      }
+  );
+
+export type QdrantMutationOptions = {
+  /** Wait until Qdrant has applied the mutation. Defaults to true. */
+  wait?: boolean | undefined;
+  ordering?: "weak" | "medium" | "strong" | undefined;
+  timeout?: number | undefined;
 };
 
 export type QdrantHybridIndexOptions = {

--- a/packages/vector-qdrant/test/qdrant-vector-store.test.ts
+++ b/packages/vector-qdrant/test/qdrant-vector-store.test.ts
@@ -1,8 +1,9 @@
 import type { SparseEmbedding, SparseEmbeddingModel } from "@anvia/core/embeddings";
 import { type Embedding, type EmbeddingModel, embedDocuments } from "@anvia/core/embeddings";
 import { vectorFilter } from "@anvia/core/vector-store";
-import { describe, expect, it } from "vitest";
-import { filterToQdrantFilter, QdrantVectorStore } from "../src/index";
+import type { QdrantClient } from "@qdrant/js-client-rest";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { filterToQdrantFilter, type QdrantClientLike, QdrantVectorStore } from "../src/index";
 
 class MockEmbeddingModel implements EmbeddingModel {
   async embedTexts(texts: string[]): Promise<Embedding[]> {
@@ -29,9 +30,12 @@ class MockSparseEmbeddingModel implements SparseEmbeddingModel {
 class MockQdrantClient {
   readonly collections = new Set<string>();
   readonly creates: unknown[] = [];
+  readonly deletes: unknown[] = [];
   readonly upserts: unknown[] = [];
   readonly searches: unknown[] = [];
   readonly queries: unknown[] = [];
+  readonly scrolls: unknown[] = [];
+  scrollResponse: unknown = { points: [] };
 
   async getCollection(collectionName: string): Promise<unknown> {
     if (!this.collections.has(collectionName)) {
@@ -49,6 +53,16 @@ class MockQdrantClient {
   async upsert(collectionName: string, options: unknown): Promise<unknown> {
     this.upserts.push({ collectionName, options });
     return {};
+  }
+
+  async delete(collectionName: string, options: unknown): Promise<unknown> {
+    this.deletes.push({ collectionName, options });
+    return {};
+  }
+
+  async scroll(collectionName: string, options: unknown): Promise<unknown> {
+    this.scrolls.push({ collectionName, options });
+    return this.scrollResponse;
   }
 
   async search(collectionName: string, options: unknown): Promise<unknown> {
@@ -107,6 +121,10 @@ class MockQdrantClient {
 }
 
 describe("QdrantVectorStore", () => {
+  it("accepts the official Qdrant client type", () => {
+    expectTypeOf<QdrantClient>().toMatchTypeOf<QdrantClientLike>();
+  });
+
   it("creates a missing collection with vector size and default cosine distance", async () => {
     const client = new MockQdrantClient();
 
@@ -148,6 +166,26 @@ describe("QdrantVectorStore", () => {
         },
         sparse_vectors: {
           sparse: {},
+        },
+      },
+    });
+  });
+
+  it("supports Manhattan distance", async () => {
+    const client = new MockQdrantClient();
+
+    await QdrantVectorStore.connect({
+      client,
+      collectionName: "docs",
+      vectorSize: 2,
+      distance: "Manhattan",
+    });
+
+    expect(client.creates[0]).toMatchObject({
+      options: {
+        vectors: {
+          size: 2,
+          distance: "Manhattan",
         },
       },
     });
@@ -320,6 +358,7 @@ describe("QdrantVectorStore", () => {
       options: {
         query: [1, 0],
         limit: 2,
+        score_threshold: 0.5,
         filter: { must: [{ key: "kind", match: { value: "animal" } }] },
         with_payload: true,
       },
@@ -389,6 +428,265 @@ describe("QdrantVectorStore", () => {
     expect(points[1]?.id).toMatch(/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/);
     expect(points[0]?.id).not.toBe(points[1]?.id);
     expect(points.map((point) => point.payload.__anvia_document_id)).toEqual(["doc1", "doc1"]);
+  });
+
+  it("replaces existing document points and waits for mutations by default", async () => {
+    const client = new MockQdrantClient();
+    const store = await QdrantVectorStore.connect<string>({
+      client,
+      collectionName: "docs",
+      vectorSize: 2,
+    });
+
+    await store.upsertDocuments(
+      [
+        {
+          id: "doc1",
+          document: "replacement",
+          embeddings: [{ document: "replacement", vector: [1, 0] }],
+        },
+      ],
+      { ordering: "strong", timeout: 10 },
+    );
+
+    expect(client.deletes[0]).toEqual({
+      collectionName: "docs",
+      options: {
+        wait: true,
+        ordering: "strong",
+        timeout: 10,
+        filter: {
+          must: [
+            {
+              key: "__anvia_document_id",
+              match: { any: ["doc1"] },
+            },
+          ],
+        },
+      },
+    });
+    expect(client.upserts[0]).toMatchObject({
+      collectionName: "docs",
+      options: { wait: true, ordering: "strong", timeout: 10 },
+    });
+  });
+
+  it("uses a single batch update when the client supports it", async () => {
+    const backend = new MockQdrantClient();
+    const batches: unknown[] = [];
+    const client = {
+      getCollection: backend.getCollection.bind(backend),
+      createCollection: backend.createCollection.bind(backend),
+      upsert: backend.upsert.bind(backend),
+      batchUpdate: async (collectionName: string, options: unknown) => {
+        batches.push({ collectionName, options });
+        return {};
+      },
+    };
+    const store = await QdrantVectorStore.connect<string>({
+      client,
+      collectionName: "docs",
+      vectorSize: 2,
+    });
+
+    await store.upsertDocuments([
+      {
+        id: "doc1",
+        document: "replacement",
+        embeddings: [{ document: "replacement", vector: [1, 0] }],
+      },
+    ]);
+
+    expect(batches[0]).toMatchObject({
+      collectionName: "docs",
+      options: {
+        wait: true,
+        operations: [
+          {
+            delete: {
+              filter: {
+                must: [{ key: "__anvia_document_id", match: { any: ["doc1"] } }],
+              },
+            },
+          },
+          { upsert: { points: [{ payload: { __anvia_document_id: "doc1" } }] } },
+        ],
+      },
+    });
+    expect(backend.upserts).toEqual([]);
+  });
+
+  it("deletes every point belonging to logical document ids", async () => {
+    const client = new MockQdrantClient();
+    const store = await QdrantVectorStore.connect({
+      client,
+      collectionName: "docs",
+      vectorSize: 2,
+    });
+
+    await store.deleteDocuments(["doc1", "doc1", "doc2"], { wait: false });
+    await store.deleteDocuments([]);
+
+    expect(client.deletes).toEqual([
+      {
+        collectionName: "docs",
+        options: {
+          wait: false,
+          filter: {
+            must: [
+              {
+                key: "__anvia_document_id",
+                match: { any: ["doc1", "doc2"] },
+              },
+            ],
+          },
+        },
+      },
+    ]);
+  });
+
+  it("gets logical documents in requested order and deduplicates their points", async () => {
+    const client = new MockQdrantClient();
+    client.scrollResponse = {
+      points: [
+        {
+          id: "point-doc1-a",
+          payload: {
+            __anvia_document_id: "doc1",
+            __anvia_document: JSON.stringify({ title: "Cat guide" }),
+            kind: "animal",
+          },
+        },
+        {
+          id: "point-doc1-b",
+          payload: {
+            __anvia_document_id: "doc1",
+            __anvia_document: JSON.stringify({ title: "Cat guide" }),
+            kind: "animal",
+          },
+        },
+        {
+          id: "point-doc2",
+          payload: {
+            __anvia_document_id: "doc2",
+            __anvia_document: "Dog note",
+          },
+        },
+      ],
+    };
+    const store = await QdrantVectorStore.connect<{ title: string } | string>({
+      client,
+      collectionName: "docs",
+      vectorSize: 2,
+    });
+
+    const documents = await store.getDocuments(["doc2", "missing", "doc1"]);
+
+    expect(documents).toEqual([
+      { id: "doc2", document: "Dog note" },
+      { id: "doc1", document: { title: "Cat guide" }, metadata: { kind: "animal" } },
+    ]);
+    expect(client.scrolls[0]).toMatchObject({
+      collectionName: "docs",
+      options: {
+        filter: {
+          must: [
+            {
+              key: "__anvia_document_id",
+              match: { any: ["doc2", "missing", "doc1"] },
+            },
+          ],
+        },
+        with_payload: true,
+        with_vector: false,
+      },
+    });
+  });
+
+  it("inspects logical documents with deduplicated cursor pagination", async () => {
+    const client = new MockQdrantClient();
+    client.scrollResponse = {
+      points: [
+        {
+          id: "point-doc1-a",
+          payload: { __anvia_document_id: "doc1", __anvia_document: "one" },
+        },
+        {
+          id: "point-doc1-b",
+          payload: { __anvia_document_id: "doc1", __anvia_document: "one" },
+        },
+        {
+          id: "point-doc2",
+          payload: { __anvia_document_id: "doc2", __anvia_document: "two", rank: 2 },
+        },
+        {
+          id: "point-doc3",
+          payload: { __anvia_document_id: "doc3", __anvia_document: "three" },
+        },
+      ],
+    };
+    const store = await QdrantVectorStore.connect<string>({
+      client,
+      collectionName: "docs",
+      vectorSize: 2,
+    });
+    const index = store.index(new MockEmbeddingModel());
+
+    const first = await index.inspect({
+      limit: 2,
+      filter: vectorFilter.gt("rank", 1),
+    });
+    const second = await index.inspect({ limit: 2, cursor: first.nextCursor });
+
+    expect(first).toEqual({
+      items: [
+        { id: "doc1", document: "one" },
+        { id: "doc2", document: "two", metadata: { rank: 2 } },
+      ],
+      nextCursor: "2",
+    });
+    expect(second).toEqual({ items: [{ id: "doc3", document: "three" }] });
+    expect(client.scrolls[0]).toMatchObject({
+      options: { filter: { must: [{ key: "rank", range: { gt: 1 } }] } },
+    });
+  });
+
+  it("validates existing collection dimensions", async () => {
+    const client = new MockQdrantClient();
+    client.collections.add("docs");
+    client.getCollection = async () => ({
+      config: {
+        params: {
+          vectors: { size: 3, distance: "Cosine" },
+        },
+      },
+    });
+
+    await expect(
+      QdrantVectorStore.connect({
+        client,
+        collectionName: "docs",
+        vectorSize: 2,
+      }),
+    ).rejects.toThrow("vector size 3 does not match requested size 2");
+  });
+
+  it("does not treat unrelated collection lookup failures as missing collections", async () => {
+    const client = {
+      getCollection: async () => {
+        throw new Error("permission denied");
+      },
+      createCollection: async () => ({}),
+      upsert: async () => ({}),
+    };
+
+    await expect(
+      QdrantVectorStore.connect({
+        client,
+        collectionName: "docs",
+        vectorSize: 2,
+      }),
+    ).rejects.toThrow("permission denied");
   });
 
   it("translates compound filters", () => {

--- a/packages/vector-qdrant/test/qdrant-vector-store.test.ts
+++ b/packages/vector-qdrant/test/qdrant-vector-store.test.ts
@@ -217,6 +217,7 @@ describe("QdrantVectorStore", () => {
     const results = await store.index({ dense, sparse }).search({
       query: "cat",
       topK: 2,
+      threshold: 1,
     });
 
     expect(client.upserts[0]).toMatchObject({
@@ -244,6 +245,9 @@ describe("QdrantVectorStore", () => {
         with_payload: true,
       },
     });
+    expect((client.queries[0] as { options: Record<string, unknown> }).options).not.toHaveProperty(
+      "score_threshold",
+    );
     expect(results).toEqual([
       {
         id: "doc1",
@@ -605,25 +609,39 @@ describe("QdrantVectorStore", () => {
 
   it("inspects logical documents with deduplicated cursor pagination", async () => {
     const client = new MockQdrantClient();
-    client.scrollResponse = {
-      points: [
-        {
-          id: "point-doc1-a",
-          payload: { __anvia_document_id: "doc1", __anvia_document: "one" },
-        },
-        {
-          id: "point-doc1-b",
-          payload: { __anvia_document_id: "doc1", __anvia_document: "one" },
-        },
-        {
-          id: "point-doc2",
-          payload: { __anvia_document_id: "doc2", __anvia_document: "two", rank: 2 },
-        },
-        {
-          id: "point-doc3",
-          payload: { __anvia_document_id: "doc3", __anvia_document: "three" },
-        },
-      ],
+    client.scroll = async (collectionName: string, options: unknown) => {
+      client.scrolls.push({ collectionName, options });
+      const offset = (options as { offset?: unknown }).offset;
+      return offset === "page-2"
+        ? {
+            points: [
+              {
+                id: "point-doc2",
+                payload: { __anvia_document_id: "doc2", __anvia_document: "two", rank: 2 },
+              },
+              {
+                id: "point-doc1-c",
+                payload: { __anvia_document_id: "doc1", __anvia_document: "one" },
+              },
+              {
+                id: "point-doc3",
+                payload: { __anvia_document_id: "doc3", __anvia_document: "three" },
+              },
+            ],
+          }
+        : {
+            points: [
+              {
+                id: "point-doc1-a",
+                payload: { __anvia_document_id: "doc1", __anvia_document: "one" },
+              },
+              {
+                id: "point-doc1-b",
+                payload: { __anvia_document_id: "doc1", __anvia_document: "one" },
+              },
+            ],
+            next_page_offset: "page-2",
+          };
     };
     const store = await QdrantVectorStore.connect<string>({
       client,
@@ -643,12 +661,26 @@ describe("QdrantVectorStore", () => {
         { id: "doc1", document: "one" },
         { id: "doc2", document: "two", metadata: { rank: 2 } },
       ],
-      nextCursor: "2",
+      nextCursor: expect.any(String),
     });
     expect(second).toEqual({ items: [{ id: "doc3", document: "three" }] });
     expect(client.scrolls[0]).toMatchObject({
       options: { filter: { must: [{ key: "rank", range: { gt: 1 } }] } },
     });
+    expect(client.scrolls[2]).toMatchObject({ options: { offset: "page-2" } });
+  });
+
+  it("rejects invalid inspect cursors", async () => {
+    const client = new MockQdrantClient();
+    const store = await QdrantVectorStore.connect<string>({
+      client,
+      collectionName: "docs",
+      vectorSize: 2,
+    });
+
+    await expect(
+      store.index(new MockEmbeddingModel()).inspect({ limit: 2, cursor: "invalid" }),
+    ).rejects.toThrow("Invalid Qdrant inspect cursor");
   });
 
   it("validates existing collection dimensions", async () => {


### PR DESCRIPTION
## Summary

- add logical document deletion, retrieval, and inspection to `@anvia/qdrant`
- replace stale multi-embedding points through ordered delete-and-upsert batches
- expose mutation consistency and hosted-client options
- validate existing collection configuration, support Manhattan distance, and forward score thresholds
- document the focused adapter surface and add a minor changeset

## Why

The adapter supported upsert and search but lacked the common document lifecycle operations needed by applications and Studio inspection. Re-upserting a document with fewer embeddings could also leave stale Qdrant points behind.

Advanced collection administration remains available through a retained native Qdrant client instead of being duplicated in Anvia.

## Validation

- `pnpm exec biome check packages/vector-qdrant/src/types.ts packages/vector-qdrant/src/helpers.ts packages/vector-qdrant/src/store.ts packages/vector-qdrant/src/search-index.ts packages/vector-qdrant/src/index.ts packages/vector-qdrant/test/qdrant-vector-store.test.ts`
- `pnpm --filter @anvia/qdrant typecheck`
- `pnpm --filter @anvia/qdrant test` (25 tests)
- `pnpm --filter @anvia/qdrant build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added document deletion, retrieval, replacement, and paginated inspection.
  * Added configurable mutation controls, including waiting, ordering, and timeouts.
  * Added hosted Qdrant client configuration with URL and API key support.
  * Added Manhattan distance and server-side search score thresholds.
  * Added collection validation and improved stale-data cleanup during replacement.

* **Documentation**
  * Expanded Qdrant usage examples and guidance for advanced client operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->