### PR TITLE
Fix Core peer dependency packaging

### DIFF
--- a/.changeset/shy-spiders-share.md
+++ b/.changeset/shy-spiders-share.md
@@ -1,0 +1,8 @@
+---
+"@anvia/react": patch
+"@anvia/server": patch
+"@anvia/studio": patch
+---
+
+Use the consumer's `@anvia/core` installation from React and Server so Studio targets do not
+resolve incompatible Agent and Pipeline class declarations from nested Core versions.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,12 +32,11 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
+    "@anvia/core": ">=0.25.0 <1.0.0",
     "react": ">=18"
   },
-  "dependencies": {
-    "@anvia/core": "workspace:*"
-  },
   "devDependencies": {
+    "@anvia/core": "workspace:*",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^24.9.1",
     "@types/react": "^19.2.14",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -31,14 +31,15 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
-  "dependencies": {
-    "@anvia/core": "workspace:*"
-  },
   "devDependencies": {
+    "@anvia/core": "workspace:*",
     "@types/node": "^24.9.1",
     "@vitest/coverage-v8": "4.1.5",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.8"
+  },
+  "peerDependencies": {
+    "@anvia/core": ">=0.25.0 <1.0.0"
   }
 }

--- a/packages/tool-studio/test/core-peer-dependencies.test.ts
+++ b/packages/tool-studio/test/core-peer-dependencies.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+type PackageManifest = {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+};
+
+function readPackageManifest(relativePath: string): PackageManifest {
+  return JSON.parse(
+    readFileSync(new URL(relativePath, import.meta.url), "utf8"),
+  ) as PackageManifest;
+}
+
+describe("Studio Core peer dependency boundaries", () => {
+  it.each([
+    "../../react/package.json",
+    "../../server/package.json",
+  ])("keeps Core as a peer of %s", (relativePath) => {
+    const packageManifest = readPackageManifest(relativePath);
+
+    expect(packageManifest.dependencies?.["@anvia/core"]).toBeUndefined();
+    expect(packageManifest.devDependencies?.["@anvia/core"]).toBe("workspace:*");
+    expect(packageManifest.peerDependencies?.["@anvia/core"]).toBe(">=0.25.0 <1.0.0");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -697,11 +697,10 @@ importers:
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/react:
-    dependencies:
+    devDependencies:
       '@anvia/core':
         specifier: workspace:*
         version: link:../core
-    devDependencies:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -819,11 +818,10 @@ importers:
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/server:
-    dependencies:
+    devDependencies:
       '@anvia/core':
         specifier: workspace:*
         version: link:../core
-    devDependencies:
       '@types/node':
         specifier: ^24.9.1
         version: 24.12.2


### PR DESCRIPTION
## Summary

- move `@anvia/core` from a runtime dependency to a peer dependency in `@anvia/react` and `@anvia/server`
- keep Core as a workspace dev dependency for local builds and tests
- add a Studio regression test for the Core peer boundary
- add patch changesets for React, Server, and Studio

## Root cause

Published React and Server packages converted `workspace:*` into exact `@anvia/core` runtime
dependencies. A consumer could therefore install nested Core versions alongside Studio's
peer-resolved Core version. Because Agent and Pipeline contain types with private members,
TypeScript treats declarations from separate Core installations as incompatible.

## Impact

React, Server, Studio, and consumer-created targets now resolve the consumer's single Core
installation, preventing nominal type errors such as separate declarations of the private
`tools` property.

## Validation

- `pnpm check`
- `pnpm --filter @anvia/react typecheck`
- `pnpm --filter @anvia/react test` (99 tests)
- `pnpm --filter @anvia/react build`
- `pnpm --filter @anvia/server typecheck`
- `pnpm --filter @anvia/server test` (26 tests)
- `pnpm --filter @anvia/server build`
- `pnpm --filter @anvia/studio typecheck`
- `pnpm --filter @anvia/studio test` (175 tests)
- `pnpm --filter @anvia/studio build`
- packed-package consumer typecheck with Agent and Pipeline targets
- confirmed the packed consumer installs only `@anvia/core@0.26.0`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility across React, Server, and Studio integrations by consistently using the application’s installed core version.
  * Prevented conflicts caused by multiple incompatible core versions being installed.
  * Added compatible version requirements to help ensure reliable Agent and Pipeline declarations.

* **Tests**
  * Added coverage to verify package installation and compatibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->