### PR TITLE
security(scripts): parameterize Lens integration SQL

### DIFF
--- a/scripts/test-lens-integration.mjs
+++ b/scripts/test-lens-integration.mjs
@@ -23,6 +23,8 @@ if (!/^[A-Za-z0-9_-]+$/.test(environment.ANVIA_LENS_PUBLIC_KEY)) {
   throw new Error("ANVIA_LENS_PUBLIC_KEY contains unsupported characters");
 }
 
+const publicKey = sqlLiteral(environment.ANVIA_LENS_PUBLIC_KEY);
+
 if (options.has("--rebuild")) {
   run("docker", ["compose", "up", "-d", "--build"], { cwd: lensRoot });
 } else {
@@ -41,11 +43,12 @@ const projectId = compose([
   "-d",
   "lens",
   "-Atc",
-  `SELECT project_id FROM project_api_keys WHERE public_key = '${environment.ANVIA_LENS_PUBLIC_KEY}' AND revoked_at IS NULL LIMIT 1`,
+  `SELECT project_id FROM project_api_keys WHERE public_key = ${publicKey} AND revoked_at IS NULL LIMIT 1`,
 ]).trim();
 if (!/^[0-9a-f-]{36}$/.test(projectId)) {
   throw new Error("The configured public key does not resolve to an active Lens project");
 }
+const projectIdLiteral = sqlLiteral(projectId);
 
 const smoke = run("pnpm", ["--filter", "cookbook", "integrations:08"], {
   cwd: root,
@@ -65,6 +68,8 @@ if (!/^[0-9a-f]{32}$/.test(traceId ?? "") || !/^[0-9a-f]{16}$/.test(observationI
 if (typeof runId !== "string" || !/^[A-Za-z0-9_-]{1,128}$/.test(runId)) {
   throw new Error("The native smoke example did not return an evaluation run ID");
 }
+const traceIdLiteral = sqlLiteral(traceId);
+const runIdLiteral = sqlLiteral(runId);
 if (payload.outcome !== "pass")
   throw new Error(`Expected a passing evaluation, got ${payload.outcome}`);
 
@@ -72,11 +77,11 @@ await waitFor(async () => {
   const [traces, evaluations, runs] = clickhouse(
     `SELECT
       (SELECT count() FROM trace_summaries FINAL
-        WHERE project_id='${projectId}' AND trace_id='${traceId}'),
+        WHERE project_id=${projectIdLiteral} AND trace_id=${traceIdLiteral}),
       (SELECT count() FROM evaluation_results FINAL
-        WHERE project_id='${projectId}' AND trace_id='${traceId}' AND run_id='${runId}'),
+        WHERE project_id=${projectIdLiteral} AND trace_id=${traceIdLiteral} AND run_id=${runIdLiteral}),
       (SELECT count() FROM evaluation_runs FINAL
-        WHERE project_id='${projectId}' AND id='${runId}' AND status='completed')
+        WHERE project_id=${projectIdLiteral} AND id=${runIdLiteral} AND status='completed')
       FORMAT TabSeparatedRaw`,
   )
     .trim()
@@ -90,7 +95,7 @@ const evaluation = JSON.parse(
     `SELECT run_id, trace_id, observation_id, suite_name, case_id, metric_name, outcome,
       service_name, environment, release, payload, payload_status
       FROM evaluation_results FINAL
-      WHERE project_id='${projectId}' AND trace_id='${traceId}'
+      WHERE project_id=${projectIdLiteral} AND trace_id=${traceIdLiteral}
       ORDER BY timestamp DESC LIMIT 1
       FORMAT JSONEachRow`,
   ).trim(),
@@ -116,7 +121,7 @@ if (
 
 const capturedPayloads = Number(
   clickhouse(
-    `SELECT countIf(input IS NOT NULL OR output IS NOT NULL) FROM spans FINAL WHERE project_id='${projectId}' AND trace_id='${traceId}' FORMAT TabSeparatedRaw`,
+    `SELECT countIf(input IS NOT NULL OR output IS NOT NULL) FROM spans FINAL WHERE project_id=${projectIdLiteral} AND trace_id=${traceIdLiteral} FORMAT TabSeparatedRaw`,
   ).trim(),
 );
 if (capturedPayloads !== 0) throw new Error("Safe capture exported an input or output payload");
@@ -130,7 +135,7 @@ if (options.has("--durability")) {
     async () =>
       Number(
         clickhouse(
-          `SELECT count() FROM evaluation_results FINAL WHERE project_id='${projectId}' AND trace_id='${traceId}' FORMAT TabSeparatedRaw`,
+          `SELECT count() FROM evaluation_results FINAL WHERE project_id=${projectIdLiteral} AND trace_id=${traceIdLiteral} FORMAT TabSeparatedRaw`,
         ).trim(),
       ) === 1,
     "evaluation durability after ClickHouse restart",
@@ -239,6 +244,13 @@ async function waitFor(check, label) {
     await new Promise((resolvePromise) => setTimeout(resolvePromise, 500));
   }
   throw new Error(`Timed out waiting for ${label}`, { cause: lastError });
+}
+
+function sqlLiteral(value) {
+  if (typeof value !== "string") {
+    throw new Error("SQL literal must be a string");
+  }
+  return `'${value.replaceAll("'", "''")}'`;
 }
 
 function loadEnvironment(source) {

--- a/scripts/test-lens-integration.mjs
+++ b/scripts/test-lens-integration.mjs
@@ -23,8 +23,6 @@ if (!/^[A-Za-z0-9_-]+$/.test(environment.ANVIA_LENS_PUBLIC_KEY)) {
   throw new Error("ANVIA_LENS_PUBLIC_KEY contains unsupported characters");
 }
 
-const publicKey = sqlLiteral(environment.ANVIA_LENS_PUBLIC_KEY);
-
 if (options.has("--rebuild")) {
   run("docker", ["compose", "up", "-d", "--build"], { cwd: lensRoot });
 } else {
@@ -42,13 +40,14 @@ const projectId = compose([
   "lens",
   "-d",
   "lens",
+  "--set",
+  `public_key=${environment.ANVIA_LENS_PUBLIC_KEY}`,
   "-Atc",
-  `SELECT project_id FROM project_api_keys WHERE public_key = ${publicKey} AND revoked_at IS NULL LIMIT 1`,
+  "SELECT project_id FROM project_api_keys WHERE public_key = :'public_key' AND revoked_at IS NULL LIMIT 1",
 ]).trim();
 if (!/^[0-9a-f-]{36}$/.test(projectId)) {
   throw new Error("The configured public key does not resolve to an active Lens project");
 }
-const projectIdLiteral = sqlLiteral(projectId);
 
 const smoke = run("pnpm", ["--filter", "cookbook", "integrations:08"], {
   cwd: root,
@@ -68,8 +67,6 @@ if (!/^[0-9a-f]{32}$/.test(traceId ?? "") || !/^[0-9a-f]{16}$/.test(observationI
 if (typeof runId !== "string" || !/^[A-Za-z0-9_-]{1,128}$/.test(runId)) {
   throw new Error("The native smoke example did not return an evaluation run ID");
 }
-const traceIdLiteral = sqlLiteral(traceId);
-const runIdLiteral = sqlLiteral(runId);
 if (payload.outcome !== "pass")
   throw new Error(`Expected a passing evaluation, got ${payload.outcome}`);
 
@@ -77,12 +74,14 @@ await waitFor(async () => {
   const [traces, evaluations, runs] = clickhouse(
     `SELECT
       (SELECT count() FROM trace_summaries FINAL
-        WHERE project_id=${projectIdLiteral} AND trace_id=${traceIdLiteral}),
+        WHERE project_id={project_id:String} AND trace_id={trace_id:String}),
       (SELECT count() FROM evaluation_results FINAL
-        WHERE project_id=${projectIdLiteral} AND trace_id=${traceIdLiteral} AND run_id=${runIdLiteral}),
+        WHERE project_id={project_id:String} AND trace_id={trace_id:String}
+          AND run_id={run_id:String}),
       (SELECT count() FROM evaluation_runs FINAL
-        WHERE project_id=${projectIdLiteral} AND id=${runIdLiteral} AND status='completed')
+        WHERE project_id={project_id:String} AND id={run_id:String} AND status='completed')
       FORMAT TabSeparatedRaw`,
+    { project_id: projectId, trace_id: traceId, run_id: runId },
   )
     .trim()
     .split("\t")
@@ -95,9 +94,10 @@ const evaluation = JSON.parse(
     `SELECT run_id, trace_id, observation_id, suite_name, case_id, metric_name, outcome,
       service_name, environment, release, payload, payload_status
       FROM evaluation_results FINAL
-      WHERE project_id=${projectIdLiteral} AND trace_id=${traceIdLiteral}
+      WHERE project_id={project_id:String} AND trace_id={trace_id:String}
       ORDER BY timestamp DESC LIMIT 1
       FORMAT JSONEachRow`,
+    { project_id: projectId, trace_id: traceId },
   ).trim(),
 );
 if (evaluation.observation_id !== observationId) {
@@ -121,7 +121,10 @@ if (
 
 const capturedPayloads = Number(
   clickhouse(
-    `SELECT countIf(input IS NOT NULL OR output IS NOT NULL) FROM spans FINAL WHERE project_id=${projectIdLiteral} AND trace_id=${traceIdLiteral} FORMAT TabSeparatedRaw`,
+    `SELECT countIf(input IS NOT NULL OR output IS NOT NULL) FROM spans FINAL
+      WHERE project_id={project_id:String} AND trace_id={trace_id:String}
+      FORMAT TabSeparatedRaw`,
+    { project_id: projectId, trace_id: traceId },
   ).trim(),
 );
 if (capturedPayloads !== 0) throw new Error("Safe capture exported an input or output payload");
@@ -135,7 +138,10 @@ if (options.has("--durability")) {
     async () =>
       Number(
         clickhouse(
-          `SELECT count() FROM evaluation_results FINAL WHERE project_id=${projectIdLiteral} AND trace_id=${traceIdLiteral} FORMAT TabSeparatedRaw`,
+          `SELECT count() FROM evaluation_results FINAL
+            WHERE project_id={project_id:String} AND trace_id={trace_id:String}
+            FORMAT TabSeparatedRaw`,
+          { project_id: projectId, trace_id: traceId },
         ).trim(),
       ) === 1,
     "evaluation durability after ClickHouse restart",
@@ -178,7 +184,10 @@ function composeServiceUrl(service, port) {
   return `http://127.0.0.1:${hostPort}`;
 }
 
-function clickhouse(query) {
+function clickhouse(query, parameters) {
+  const parameterArgs = Object.entries(parameters).map(
+    ([name, value]) => `--param_${name}=${value}`,
+  );
   return compose([
     "exec",
     "-T",
@@ -186,6 +195,7 @@ function clickhouse(query) {
     "clickhouse-client",
     "--database",
     "lens",
+    ...parameterArgs,
     "--query",
     query,
   ]);
@@ -244,24 +254,6 @@ async function waitFor(check, label) {
     await new Promise((resolvePromise) => setTimeout(resolvePromise, 500));
   }
   throw new Error(`Timed out waiting for ${label}`, { cause: lastError });
-}
-
-/**
- * Escape a value for safe interpolation into a SQL string literal.
- *
- * Wraps the input in single quotes and doubles any internal single quotes
- * using the standard SQL escaping rule (`'` → `''`), so the result can be
- * embedded directly into a query without risk of breaking out of the literal.
- *
- * @param {string} value - The value to escape.
- * @returns {string} A safely-quoted SQL string literal (e.g. `'hello'`, `'it''s'`).
- * @throws {Error} If `value` is not a string.
- */
-function sqlLiteral(value) {
-  if (typeof value !== "string") {
-    throw new Error("SQL literal must be a string");
-  }
-  return `'${value.replaceAll("'", "''")}'`;
 }
 
 function loadEnvironment(source) {

--- a/scripts/test-lens-integration.mjs
+++ b/scripts/test-lens-integration.mjs
@@ -246,6 +246,17 @@ async function waitFor(check, label) {
   throw new Error(`Timed out waiting for ${label}`, { cause: lastError });
 }
 
+/**
+ * Escape a value for safe interpolation into a SQL string literal.
+ *
+ * Wraps the input in single quotes and doubles any internal single quotes
+ * using the standard SQL escaping rule (`'` → `''`), so the result can be
+ * embedded directly into a query without risk of breaking out of the literal.
+ *
+ * @param {string} value - The value to escape.
+ * @returns {string} A safely-quoted SQL string literal (e.g. `'hello'`, `'it''s'`).
+ * @throws {Error} If `value` is not a string.
+ */
 function sqlLiteral(value) {
   if (typeof value !== "string") {
     throw new Error("SQL literal must be a string");


### PR DESCRIPTION
## Summary

- prevent Lens integration values from being interpolated into PostgreSQL and ClickHouse SQL text
- pass the public key through a safely quoted `psql` variable
- pass project, trace, and run identifiers through typed ClickHouse query parameters
- retain the existing input validation as an additional boundary check

This supersedes the initial shared SQL-literal helper with each database client native parameter mechanism, avoiding dialect-specific escaping gaps.

Initial report and implementation by @DeryFerd; maintainer follow-up in `598af4e9` preserves the contributor commits and attribution.

## Validation

- `node --check scripts/test-lens-integration.mjs`
- `pnpm check`
- `git diff --check`
- static verification that no database value remains manually interpolated into SQL

The Docker Lens end-to-end test was not run for the maintainer follow-up because the local workspace does not have the adjacent Lens checkout or required `.env`. GitHub CI is expected to rerun against the updated branch.

No changeset is required because this modifies an internal integration-test script and no public package behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integration test reliability when project, trace, and run identifiers contain special characters.
  * Prevented query-related failures caused by unsafe value handling during integration checks.
  * Preserved existing validation and data-ingestion coverage while improving the consistency of test results across supported database systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->