### PR TITLE
chore: prepare 1.0.0-rc.5

### DIFF
--- a/.changeset/fix-browser-interaction-boundary.md
+++ b/.changeset/fix-browser-interaction-boundary.md
@@ -1,0 +1,11 @@
+---
+"@anvia/core": patch
+"@anvia/client": patch
+"@anvia/react": patch
+"@anvia/react-ui": patch
+"@anvia/studio": patch
+---
+
+Move Agent interaction contracts and parsers to the browser-safe
+`@anvia/core/agent/interactions` subpath. Prevent Client and React bundles from loading the Agent
+runtime, MCP stdio, Node built-ins, or undici through Core's server barrels.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -45,6 +45,7 @@
     "add-neo4j-graphrag",
     "anvia-v1-release-train",
     "explicit-client-stream-boundary",
+    "fix-browser-interaction-boundary",
     "fix-lancedb-metadata-filters",
     "public-rc-ready",
     "redesign-agent-interactions",
@@ -59,6 +60,7 @@
     "redesign-provider-model-construction",
     "redesign-type-safe-message-boundaries",
     "redesign-vector-clients",
+    "robust-structured-output",
     "tidy-agent-builder-registration",
     "unify-generation-public-api",
     "update-upstream-runtime-dependencies"

--- a/.changeset/robust-structured-output.md
+++ b/.changeset/robust-structured-output.md
@@ -1,0 +1,10 @@
+---
+"@anvia/core": patch
+"@anvia/logger": patch
+---
+
+Accept only complete outer JSON Markdown fences as a strict structured-output compatibility
+fallback, retry Agent parsing and schema failures within the configured total-attempt budget, and
+surface phase-aware errors without embedding rejected output. Preserve nested Error cause details
+in logger observer records with bounded traversal and redact parser/schema causes that may contain
+rejected structured output.

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @anvia/client
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- e96d038: Move Agent interaction contracts and parsers to the browser-safe
+  `@anvia/core/agent/interactions` subpath. Prevent Client and React bundles from loading the Agent
+  runtime, MCP stdio, Node built-ins, or undici through Core's server barrels.
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -19,6 +19,8 @@ The request carries core `Message[]`; client-side `UIMessage[]` never crosses th
 The response uses `ClientStreamEvent` records inside an always-framed `anvia.client.v3` stream.
 Agent endpoints accept either a `messages` request or an `interaction_response` request, while
 keeping the matching `AgentContinuation` exclusively on the server.
+Agent interaction wire contracts come from the browser-safe `@anvia/core/agent/interactions`
+subpath; importing Client does not load the Agent runtime or its infrastructure dependencies.
 
 ## Public API
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/client",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "Framework-neutral client protocol, transports, and UI message state for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/client/src/protocol.ts
+++ b/packages/client/src/protocol.ts
@@ -1,4 +1,7 @@
-import { parseAgentInteractionRequest, parseAgentInteractionResponse } from "@anvia/core/agent";
+import {
+  parseAgentInteractionRequest,
+  parseAgentInteractionResponse,
+} from "@anvia/core/agent/interactions";
 import type { JsonObject, JsonValue, Message } from "@anvia/core/completion";
 import { isJsonValue, parseMessages } from "@anvia/core/completion";
 import {

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -1,4 +1,7 @@
-import type { AgentInteractionRequest, AgentInteractionResponse } from "@anvia/core/agent";
+import type {
+  AgentInteractionRequest,
+  AgentInteractionResponse,
+} from "@anvia/core/agent/interactions";
 import type {
   CompletionSource,
   ContextUsage,

--- a/packages/client/vitest.config.ts
+++ b/packages/client/vitest.config.ts
@@ -3,6 +3,10 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   resolve: {
     alias: {
+      "@anvia/core/agent/interactions": new URL(
+        "../core/src/agent/interactions/index.ts",
+        import.meta.url,
+      ).pathname,
       "@anvia/core/agent": new URL("../core/src/agent/index.ts", import.meta.url).pathname,
       "@anvia/core/completion": new URL("../core/src/completion/index.ts", import.meta.url)
         .pathname,

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @anvia/core
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- e96d038: Move Agent interaction contracts and parsers to the browser-safe
+  `@anvia/core/agent/interactions` subpath. Prevent Client and React bundles from loading the Agent
+  runtime, MCP stdio, Node built-ins, or undici through Core's server barrels.
+- e96d038: Accept only complete outer JSON Markdown fences as a strict structured-output compatibility
+  fallback, retry Agent parsing and schema failures within the configured total-attempt budget, and
+  surface phase-aware errors without embedding rejected output. Preserve nested Error cause details
+  in logger observer records with bounded traversal and redact parser/schema causes that may contain
+  rejected structured output.
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -191,7 +191,9 @@ keys. Cancellation is forwarded to provider SDK calls and is never retried.
 
 Agents own their default retry policy. A run with no `retries` value inherits the Agent setting;
 `false` disables it for that run; an object replaces it for that run. Retries apply to the current
-provider call only, so completed tools and earlier turns are never replayed.
+completion only, so completed tools and earlier turns are never replayed. `maxAttempts` is the
+total number of model attempts for that completion, including the initial attempt; it is not the
+number of additional retries.
 
 ```ts
 const agent = new Agent({
@@ -207,6 +209,19 @@ await agent.generate({
   retries: { maxAttempts: 2, initialDelayMs: 0, maxDelayMs: 0 },
 });
 ```
+
+When an Agent has `outputSchema`, JSON parsing and schema-validation failures use the same retry
+budget when retries are explicitly enabled. A correction request includes the rejected response in
+the provider transcript and asks for raw JSON matching the schema, without Markdown or commentary.
+Transport failures and structured-output failures therefore cannot exceed `maxAttempts` in total.
+
+Structured output remains strict: Core trims surrounding whitespace, parses JSON, and validates the
+result with the configured Zod schema. As a compatibility fallback for OpenAI-compatible providers
+that violate strict JSON mode, Core also accepts a response consisting entirely of one lowercase
+`json` Markdown fence or one unlabeled Markdown fence. It does not search prose for JSON, accept
+content before or after a fence, or bypass schema validation. `AgentStructuredOutputError` reports
+the `parse` or `schema` phase, attempt counts, output length/format metadata, cumulative attempt
+usage, and the original `cause`; its message never contains the rejected model response.
 
 Agent results are discriminated by `status`. Completed results include typed `output` and `text`;
 guardrail blocks return `status: "blocked"`, `stage`, and `text`; tool approvals and first-class
@@ -239,6 +254,17 @@ Keep continuations server-side. A resumed phase receives a new `runId`; Core val
 continuation and current Agent/tool registration but does not provide a durable continuation store
 or exactly-once execution. Use `createQuestionTool({ name, description })` when a model must ask for
 structured free-text or choice answers.
+
+Import JSON-safe interaction contracts and parsers from their browser-safe subpath. This entrypoint
+does not load the Agent runtime, MCP clients, or Node infrastructure:
+
+```ts
+import {
+  type AgentInteractionResponse,
+  parseAgentInteractionRequest,
+  parseAgentInteractionResponse,
+} from "@anvia/core/agent/interactions";
+```
 
 An Agent with `outputSchema` carries that output type through `generate`, `stream`, `asTool`, and
 Pipeline Agent stages. Agent stream finals use the same result shape:
@@ -504,7 +530,8 @@ added to Agent instructions.
 
 ## Public Areas
 
-- `agent`: typed Agent runtime, continuations, interactions, retries, and stream events
+- `agent`: typed Agent runtime, retries, and stream events
+- `agent/interactions`: browser-safe interaction contracts, schemas, assertions, and parsers
 - `tool`: typed tool creation and tool sets
 - `completion`: direct completion helpers and provider-neutral model contracts
 - `memory`: durable session memory interfaces and in-memory store

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/core",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "Core runtime primitives for context-aware Anvia agents.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,6 +29,10 @@
       "types": "./dist/agent/index.d.ts",
       "import": "./dist/agent/index.js"
     },
+    "./agent/interactions": {
+      "types": "./dist/agent/interactions/index.d.ts",
+      "import": "./dist/agent/interactions/index.js"
+    },
     "./internal/agent": {
       "types": "./dist/internal/agent.d.ts",
       "import": "./dist/internal/agent.js"
@@ -107,7 +111,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts src/agent/index.ts src/internal/agent.ts src/speech-generation/index.ts src/completion/index.ts src/embeddings/index.ts src/evals/index.ts src/image-generation/index.ts src/documents/index.ts src/extractor/index.ts src/guardrails/index.ts src/mcp/index.ts src/memory/index.ts src/model-listing/index.ts src/observability/index.ts src/pipeline/index.ts src/skills/index.ts src/streaming/index.ts src/tool/index.ts src/transcription/index.ts src/vector-store/index.ts --format esm --dts --sourcemap --clean",
+    "build": "tsup src/index.ts src/agent/index.ts src/agent/interactions/index.ts src/internal/agent.ts src/speech-generation/index.ts src/completion/index.ts src/embeddings/index.ts src/evals/index.ts src/image-generation/index.ts src/documents/index.ts src/extractor/index.ts src/guardrails/index.ts src/mcp/index.ts src/memory/index.ts src/model-listing/index.ts src/observability/index.ts src/pipeline/index.ts src/skills/index.ts src/streaming/index.ts src/tool/index.ts src/transcription/index.ts src/vector-store/index.ts --format esm --dts --sourcemap --clean",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/core/src/agent/errors.ts
+++ b/packages/core/src/agent/errors.ts
@@ -1,5 +1,44 @@
-import type { Message } from "../completion/index";
+import type { Message, Usage } from "../completion/index";
 import type { AgentBlockedResult, AgentSuspendedResult } from "./run-types";
+
+export type AgentStructuredOutputPhase = "parse" | "schema";
+
+export type AgentStructuredOutputFormat = "raw" | "json-fence" | "unlabeled-fence";
+
+export class AgentStructuredOutputError extends Error {
+  readonly phase: AgentStructuredOutputPhase;
+  readonly attempt: number;
+  readonly maxAttempts: number;
+  readonly outputLength: number;
+  readonly normalizedLength: number;
+  readonly outputFormat: AgentStructuredOutputFormat;
+  readonly usage: Usage;
+
+  constructor(options: {
+    phase: AgentStructuredOutputPhase;
+    attempt: number;
+    maxAttempts: number;
+    outputLength: number;
+    normalizedLength: number;
+    outputFormat: AgentStructuredOutputFormat;
+    usage: Usage;
+    cause: unknown;
+  }) {
+    const failure = options.phase === "parse" ? "JSON parsing" : "schema validation";
+    super(
+      `Agent structured output failed ${failure} on attempt ${options.attempt} of ${options.maxAttempts}.`,
+      { cause: options.cause },
+    );
+    this.name = "AgentStructuredOutputError";
+    this.phase = options.phase;
+    this.attempt = options.attempt;
+    this.maxAttempts = options.maxAttempts;
+    this.outputLength = options.outputLength;
+    this.normalizedLength = options.normalizedLength;
+    this.outputFormat = options.outputFormat;
+    this.usage = options.usage;
+  }
+}
 
 export class MaxTurnsError extends Error {
   constructor(

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -1,32 +1,15 @@
 export type { ModelCallOptions } from "../model-call-options";
 export type { RetryContext, RetryOptions, RetrySetting } from "../retry";
 export { Agent } from "./agent";
+export type { AgentStructuredOutputFormat, AgentStructuredOutputPhase } from "./errors";
 export {
   AgentRunBlockedError,
   AgentRunCancelledError,
   AgentStreamClosedError,
+  AgentStructuredOutputError,
   AgentToolSuspensionError,
   MaxTurnsError,
 } from "./errors";
-export type {
-  AgentContinuation,
-  AgentInteractionRequest,
-  AgentInteractionResponse,
-  AgentQuestionAnswer,
-  AgentQuestionChoice,
-  AgentQuestionPrompt,
-  AgentToolApprovalRequest,
-  AgentToolQuestionRequest,
-} from "./interactions";
-export {
-  agentContinuationSchema,
-  agentInteractionRequestSchema,
-  agentInteractionResponseSchema,
-  assertAgentInteractionResponse,
-  parseAgentContinuation,
-  parseAgentInteractionRequest,
-  parseAgentInteractionResponse,
-} from "./interactions";
 export type {
   AgentErrorEvent,
   AgentFinishEvent,

--- a/packages/core/src/agent/interactions.ts
+++ b/packages/core/src/agent/interactions.ts
@@ -1,10 +1,6 @@
 import { z } from "zod";
-import {
-  isJsonValue,
-  type JsonObject,
-  type JsonValue,
-  type ToolQuestionAnswer,
-} from "../completion";
+import { isJsonValue } from "../completion/json";
+import type { JsonObject, JsonValue, ToolQuestionAnswer } from "../completion/types";
 
 export type AgentQuestionChoice = Readonly<{
   label: string;

--- a/packages/core/src/agent/interactions/index.ts
+++ b/packages/core/src/agent/interactions/index.ts
@@ -1,0 +1,19 @@
+export type {
+  AgentContinuation,
+  AgentInteractionRequest,
+  AgentInteractionResponse,
+  AgentQuestionAnswer,
+  AgentQuestionChoice,
+  AgentQuestionPrompt,
+  AgentToolApprovalRequest,
+  AgentToolQuestionRequest,
+} from "../interactions";
+export {
+  agentContinuationSchema,
+  agentInteractionRequestSchema,
+  agentInteractionResponseSchema,
+  assertAgentInteractionResponse,
+  parseAgentContinuation,
+  parseAgentInteractionRequest,
+  parseAgentInteractionResponse,
+} from "../interactions";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,29 +1,13 @@
 export { Agent } from "./agent/agent";
+export type { AgentStructuredOutputFormat, AgentStructuredOutputPhase } from "./agent/errors";
 export {
   AgentRunBlockedError,
   AgentRunCancelledError,
   AgentStreamClosedError,
+  AgentStructuredOutputError,
   AgentToolSuspensionError,
   MaxTurnsError,
 } from "./agent/errors";
-export type {
-  AgentContinuation,
-  AgentInteractionRequest,
-  AgentInteractionResponse,
-  AgentQuestionAnswer,
-  AgentQuestionChoice,
-  AgentQuestionPrompt,
-  AgentToolApprovalRequest,
-  AgentToolQuestionRequest,
-} from "./agent/interactions";
-export {
-  agentContinuationSchema,
-  agentInteractionRequestSchema,
-  agentInteractionResponseSchema,
-  parseAgentContinuation,
-  parseAgentInteractionRequest,
-  parseAgentInteractionResponse,
-} from "./agent/interactions";
 export type {
   AgentErrorEvent,
   AgentFinishEvent,

--- a/packages/core/src/internal/agent-runtime/agent-run.ts
+++ b/packages/core/src/internal/agent-runtime/agent-run.ts
@@ -1,5 +1,10 @@
 import type { Agent } from "../../agent/agent";
-import { AgentRunCancelledError, AgentStreamClosedError, MaxTurnsError } from "../../agent/errors";
+import {
+  AgentRunCancelledError,
+  AgentStreamClosedError,
+  AgentStructuredOutputError,
+  MaxTurnsError,
+} from "../../agent/errors";
 import {
   type AgentInteractionResponse,
   assertAgentInteractionResponse,
@@ -104,6 +109,7 @@ import { getInternalAgentRunOptions, type InternalAgentRunOptions } from "./run-
 import { assertNonnegativeSafeInteger, assertPositiveSafeInteger } from "./run-validation";
 import { CompletionStreamAccumulator } from "./stream-accumulator";
 import { addTurn, addTurnToToolCallDelta, isGenerationDeltaEvent } from "./stream-events";
+import { normalizeStructuredOutput, STRUCTURED_OUTPUT_RETRY_PROMPT } from "./structured-output";
 import {
   type AgentToolEventPayload,
   ToolCallExecutor,
@@ -169,6 +175,8 @@ export class AgentRun<Output = string, M extends CompletionModel = CompletionMod
   private currentMessages: MessageType[] = [];
   private cancellationError: AgentRunCancelledError | undefined;
   private activeGeneration: { turn: number; observers: ActiveGenerationObservers } | undefined;
+  private validatedStructuredOutput: { text: string; output: Output } | undefined;
+  private failedCompletionUsage = Usage.empty();
   private readonly abortController = new AbortController();
   private removeExternalAbortListener: (() => void) | undefined;
 
@@ -548,6 +556,12 @@ export class AgentRun<Output = string, M extends CompletionModel = CompletionMod
       if (error instanceof MemoryCompactionError && error.usage !== undefined) {
         usage = Usage.add(usage, error.usage);
       }
+      const failedCompletionUsage = this.takeFailedCompletionUsage();
+      if (error instanceof AgentStructuredOutputError) {
+        usage = Usage.add(usage, error.usage);
+      } else {
+        usage = Usage.add(usage, failedCompletionUsage);
+      }
       this.runState = "closing";
       const runError = this.normalizeRunError(error);
       const reportedError = await this.reportRunFailure(
@@ -731,7 +745,8 @@ export class AgentRun<Output = string, M extends CompletionModel = CompletionMod
           request,
           modelInfo: generationStartArgs.modelInfo,
         };
-        const bufferResponseEvents = this.shouldBufferStreamResponseEvents();
+        const bufferResponseEvents =
+          this.shouldBufferStreamResponseEvents() || this.agent.outputSchema !== undefined;
         const completionState: StreamingCompletionState = {
           response: undefined,
           firstDeltaMs: undefined,
@@ -925,6 +940,9 @@ export class AgentRun<Output = string, M extends CompletionModel = CompletionMod
       if (error instanceof MemoryCompactionError && error.usage !== undefined) {
         usage = Usage.add(usage, error.usage);
       }
+      if (error instanceof AgentStructuredOutputError) {
+        usage = Usage.add(usage, error.usage);
+      }
       this.runState = "closing";
       const runError = this.normalizeRunError(error);
       const reportedError = await this.reportRunFailure(
@@ -959,16 +977,20 @@ export class AgentRun<Output = string, M extends CompletionModel = CompletionMod
     runObservers: ActiveAgentRunObservers,
   ): Promise<CompletionResponse> {
     assertCompletionRequestSupported(this.agent.model, request);
+    this.validatedStructuredOutput = undefined;
+    this.failedCompletionUsage = Usage.empty();
     const providerRequest = this.providerTraceRequest(request);
     const generationObservers = await runObservers.startGeneration(
       this.generationStartArgs(turn, request, providerRequest),
     );
+    let currentRequest = request;
+    let structuredRetryUsage = Usage.empty();
     try {
       for (let attempt = 1; ; attempt += 1) {
         let response: CompletionResponse;
         try {
           this.throwIfCancelled();
-          response = await this.agent.model.completion(request, this.modelCallOptions());
+          response = await this.agent.model.completion(currentRequest, this.modelCallOptions());
         } catch (error) {
           const retryOptions = this.retryOptionsForFailure(error, attempt, turn, false);
           if (retryOptions === undefined) {
@@ -984,8 +1006,36 @@ export class AgentRun<Output = string, M extends CompletionModel = CompletionMod
           );
           continue;
         }
-        await generationObservers.end({ turn, response });
-        return response;
+
+        const cumulativeUsage = Usage.add(structuredRetryUsage, response.usage);
+        try {
+          this.validateStructuredResponse(response, attempt, cumulativeUsage);
+        } catch (error) {
+          const retryOptions = this.retryOptionsForFailure(error, attempt, turn, false);
+          if (retryOptions === undefined) {
+            throw error;
+          }
+          structuredRetryUsage = cumulativeUsage;
+          this.failedCompletionUsage = structuredRetryUsage;
+          currentRequest = structuredOutputRetryRequest(currentRequest, response);
+          await this.scheduleCompletionRetry(
+            error,
+            attempt,
+            turn,
+            false,
+            retryOptions,
+            runObservers,
+          );
+          continue;
+        }
+
+        const finalResponse =
+          structuredRetryUsage.totalTokens === 0
+            ? response
+            : { ...response, usage: cumulativeUsage };
+        await generationObservers.end({ turn, response: finalResponse });
+        this.failedCompletionUsage = Usage.empty();
+        return finalResponse;
       }
     } catch (error) {
       await settleFailureCleanup([() => generationObservers.error({ turn, error })]);
@@ -1029,12 +1079,14 @@ export class AgentRun<Output = string, M extends CompletionModel = CompletionMod
     if (!isStreamingCompletionModel(model)) {
       throw new TypeError("Streaming completion requires a streaming-capable model.");
     }
-    const accumulator = new CompletionStreamAccumulator();
+    this.validatedStructuredOutput = undefined;
+    let currentRequest = args.request;
     for (let attempt = 1; ; attempt += 1) {
+      const accumulator = new CompletionStreamAccumulator();
       let hasProviderProgress = false;
       try {
         this.throwIfCancelled();
-        for await (const event of model.streamCompletion(args.request, this.modelCallOptions())) {
+        for await (const event of model.streamCompletion(currentRequest, this.modelCallOptions())) {
           if (event.type === "error") {
             if (event.usage !== undefined) {
               args.state.providerErrorUsage = Usage.add(args.state.providerErrorUsage, event.usage);
@@ -1063,7 +1115,37 @@ export class AgentRun<Output = string, M extends CompletionModel = CompletionMod
             }
           }
         }
-        args.state.response = accumulator.response();
+        const response = accumulator.response();
+        const cumulativeStructuredUsage = Usage.add(args.state.providerErrorUsage, response.usage);
+        try {
+          this.validateStructuredResponse(response, attempt, cumulativeStructuredUsage);
+        } catch (error) {
+          const retryOptions = this.retryOptionsForFailure(error, attempt, args.turn, true);
+          if (retryOptions === undefined) {
+            if (error instanceof AgentStructuredOutputError) {
+              args.state.providerErrorUsage = Usage.empty();
+            }
+            throw error;
+          }
+          args.state.providerErrorUsage = Usage.add(args.state.providerErrorUsage, response.usage);
+          args.state.firstDeltaMs = undefined;
+          args.state.emittedToolCallIds.clear();
+          currentRequest = structuredOutputRetryRequest(currentRequest, response);
+          await this.scheduleCompletionRetry(
+            error,
+            attempt,
+            args.turn,
+            true,
+            retryOptions,
+            args.runObservers,
+          );
+          continue;
+        }
+        args.state.response =
+          args.state.providerErrorUsage.totalTokens === 0
+            ? response
+            : { ...response, usage: cumulativeStructuredUsage };
+        args.state.providerErrorUsage = Usage.empty();
         return;
       } catch (error) {
         const retryOptions = hasProviderProgress
@@ -1640,16 +1722,66 @@ export class AgentRun<Output = string, M extends CompletionModel = CompletionMod
     };
   }
 
-  private parseOutput(text: string): Output {
+  private validateStructuredResponse(
+    response: CompletionResponse,
+    attempt: number,
+    usage: Usage,
+  ): void {
+    if (this.agent.outputSchema === undefined) return;
+    if (response.choice.some((item) => item.type === "tool-call")) return;
+    const text = textFromAssistantContent(response.choice);
+    const output = this.parseOutput(text, attempt, usage, { useValidatedOutput: false });
+    this.validatedStructuredOutput = { text, output };
+  }
+
+  private takeFailedCompletionUsage(): Usage {
+    const usage = this.failedCompletionUsage;
+    this.failedCompletionUsage = Usage.empty();
+    return usage;
+  }
+
+  private parseOutput(
+    text: string,
+    attempt = 1,
+    usage = Usage.empty(),
+    options: { useValidatedOutput?: boolean } = {},
+  ): Output {
     const schema = this.agent.outputSchema;
     if (schema === undefined) return text as Output;
+    if (options.useValidatedOutput !== false && this.validatedStructuredOutput?.text === text) {
+      return this.validatedStructuredOutput.output;
+    }
+    const normalized = normalizeStructuredOutput(text);
+    const maxAttempts = this.completionRetryOptions?.maxAttempts ?? 1;
     let json: unknown;
     try {
-      json = JSON.parse(text);
+      json = JSON.parse(normalized.text);
     } catch (error) {
-      throw new Error("Agent expected the model response to be valid JSON.", { cause: error });
+      throw new AgentStructuredOutputError({
+        phase: "parse",
+        attempt,
+        maxAttempts,
+        outputLength: text.length,
+        normalizedLength: normalized.text.length,
+        outputFormat: normalized.format,
+        usage,
+        cause: error,
+      });
     }
-    return schema.parse(json);
+    try {
+      return schema.parse(json);
+    } catch (error) {
+      throw new AgentStructuredOutputError({
+        phase: "schema",
+        attempt,
+        maxAttempts,
+        outputLength: text.length,
+        normalizedLength: normalized.text.length,
+        outputFormat: normalized.format,
+        usage,
+        cause: error,
+      });
+    }
   }
 
   private memoryCompactionResult(): {
@@ -2322,6 +2454,24 @@ function latestAssistantText(messages: readonly MessageType[]): string {
     }
   }
   return "";
+}
+
+function structuredOutputRetryRequest(
+  request: CompletionRequest,
+  response: CompletionResponse,
+): CompletionRequest {
+  const invalidResponse: MessageType = {
+    role: "assistant",
+    content: [...response.choice],
+  };
+  const correction: MessageType = {
+    role: "user",
+    content: STRUCTURED_OUTPUT_RETRY_PROMPT,
+  };
+  return {
+    ...request,
+    chatHistory: [...request.chatHistory, invalidResponse, correction],
+  };
 }
 
 function providerMessages(messages: readonly MessageType[]): MessageType[] {

--- a/packages/core/src/internal/agent-runtime/structured-output.ts
+++ b/packages/core/src/internal/agent-runtime/structured-output.ts
@@ -1,0 +1,50 @@
+import type { AgentStructuredOutputFormat } from "../../agent/errors";
+
+const JSON_FENCE_START = "```json\n";
+const JSON_FENCE_CRLF_START = "```json\r\n";
+const UNLABELED_FENCE_START = "```\n";
+const UNLABELED_FENCE_CRLF_START = "```\r\n";
+const FENCE_END = "\n```";
+
+export const STRUCTURED_OUTPUT_RETRY_PROMPT =
+  "Your previous response was invalid structured output. Return only raw JSON that matches the supplied JSON schema. Do not use Markdown fences or include commentary.";
+
+export type NormalizedStructuredOutput = Readonly<{
+  text: string;
+  format: AgentStructuredOutputFormat;
+}>;
+
+export function normalizeStructuredOutput(text: string): NormalizedStructuredOutput {
+  const trimmed = text.trim();
+  const opening = fenceOpening(trimmed);
+  if (opening === undefined || !trimmed.endsWith(FENCE_END)) {
+    return { text: trimmed, format: "raw" };
+  }
+
+  const closingStart = trimmed.length - 3;
+  const precedingNewline = closingStart - 1;
+  const contentEnd =
+    trimmed[precedingNewline - 1] === "\r" ? precedingNewline - 1 : precedingNewline;
+  return {
+    text: trimmed.slice(opening.length, contentEnd).trim(),
+    format: opening.format,
+  };
+}
+
+function fenceOpening(
+  text: string,
+): Readonly<{ length: number; format: Exclude<AgentStructuredOutputFormat, "raw"> }> | undefined {
+  if (text.startsWith(JSON_FENCE_START)) {
+    return { length: JSON_FENCE_START.length, format: "json-fence" };
+  }
+  if (text.startsWith(JSON_FENCE_CRLF_START)) {
+    return { length: JSON_FENCE_CRLF_START.length, format: "json-fence" };
+  }
+  if (text.startsWith(UNLABELED_FENCE_START)) {
+    return { length: UNLABELED_FENCE_START.length, format: "unlabeled-fence" };
+  }
+  if (text.startsWith(UNLABELED_FENCE_CRLF_START)) {
+    return { length: UNLABELED_FENCE_CRLF_START.length, format: "unlabeled-fence" };
+  }
+  return undefined;
+}

--- a/packages/core/src/retry.ts
+++ b/packages/core/src/retry.ts
@@ -33,6 +33,7 @@ const MAX_TIMER_DELAY_MS = 2_147_483_647;
 const RETRYABLE_STATUS_CODES = new Set([408, 409, 425, 429]);
 const RETRYABLE_NUMERIC_ERROR_CODES = new Set([4, 8, 14]);
 const RETRYABLE_ERROR_NAMES = new Set([
+  "AgentStructuredOutputError",
   "APIConnectionError",
   "APIConnectionTimeoutError",
   "TimeoutError",

--- a/packages/core/test/helpers/imports.ts
+++ b/packages/core/test/helpers/imports.ts
@@ -1,4 +1,5 @@
 export * from "../../src/agent";
+export * from "../../src/agent/interactions/index";
 export * from "../../src/completion";
 export * from "../../src/embeddings";
 export * from "../../src/evals";

--- a/packages/core/test/public-exports.test.ts
+++ b/packages/core/test/public-exports.test.ts
@@ -1,3 +1,4 @@
+import { readFile } from "node:fs/promises";
 import { describe, expect, expectTypeOf, it } from "vitest";
 import type {
   AgentContextInput,
@@ -15,6 +16,12 @@ import type {
   VectorContext,
 } from "../src/agent";
 import * as publicAgent from "../src/agent";
+import type {
+  AgentContinuation as PublicAgentContinuation,
+  AgentInteractionRequest as PublicAgentInteractionRequest,
+  AgentInteractionResponse as PublicAgentInteractionResponse,
+} from "../src/agent/interactions/index";
+import * as publicAgentInteractions from "../src/agent/interactions/index";
 import * as completion from "../src/completion";
 import * as documents from "../src/documents";
 import * as embeddings from "../src/embeddings";
@@ -92,6 +99,10 @@ type RemovedPdfFileLoader = import("../src/documents").PdfFileLoader;
 type RemovedApprovalRequiredResult = import("../src/agent").AgentApprovalRequiredResult;
 // @ts-expect-error Approval decisions were replaced by AgentInteractionResponse.
 type RemovedApprovalDecision = import("../src/agent").AgentApprovalDecision;
+// @ts-expect-error Agent interaction contracts have a dedicated browser-safe subpath.
+type RemovedAgentInteractionResponse = import("../src/agent").AgentInteractionResponse;
+// @ts-expect-error Agent interaction contracts are not exported from the root server barrel.
+type RemovedRootAgentInteractionResponse = import("../src/index").AgentInteractionResponse;
 
 describe("public exports", () => {
   it("exposes public agent type exports", () => {
@@ -106,6 +117,11 @@ describe("public exports", () => {
     expectTypeOf<RemovedRootAgentSession>().toBeAny();
     expectTypeOf<RemovedApprovalRequiredResult>().toBeAny();
     expectTypeOf<RemovedApprovalDecision>().toBeAny();
+    expectTypeOf<RemovedAgentInteractionResponse>().toBeAny();
+    expectTypeOf<RemovedRootAgentInteractionResponse>().toBeAny();
+    expectTypeOf<PublicAgentContinuation>().not.toBeNever();
+    expectTypeOf<PublicAgentInteractionRequest>().not.toBeNever();
+    expectTypeOf<PublicAgentInteractionResponse>().not.toBeNever();
     expectTypeOf<RootAgentToolOptions>().toEqualTypeOf<AgentToolOptions>();
     expectTypeOf<Parameters<PublicAgentType["generate"]>["length"]>().toEqualTypeOf<1>();
     expectTypeOf<Parameters<PublicAgentType["stream"]>["length"]>().toEqualTypeOf<1>();
@@ -117,7 +133,7 @@ describe("public exports", () => {
       agent.stream("hello");
       // @ts-expect-error Continuation runs cannot override prompt or session.
       agent.generate({
-        continuation: {} as import("../src/agent").AgentContinuation,
+        continuation: {} as PublicAgentContinuation,
         response: { type: "tool-approval" as const, approved: true },
         prompt: "not allowed",
       });
@@ -156,8 +172,29 @@ describe("public exports", () => {
     expect("AgentSession" in publicAgent).toBe(false);
     expect(publicAgent.Agent.prototype).not.toHaveProperty("session");
     expect(publicAgent.Agent.prototype).not.toHaveProperty("resume");
-    expect(publicAgent).toHaveProperty("parseAgentContinuation");
-    expect(publicAgent).toHaveProperty("parseAgentInteractionResponse");
+    expect(publicAgent).not.toHaveProperty("parseAgentContinuation");
+    expect(publicAgent).not.toHaveProperty("parseAgentInteractionResponse");
+    expect(publicCore).not.toHaveProperty("parseAgentContinuation");
+    expect(publicCore).not.toHaveProperty("parseAgentInteractionResponse");
+  });
+
+  it("isolates Agent interaction contracts on the browser-safe subpath", async () => {
+    expect(Object.keys(publicAgentInteractions).sort()).toEqual([
+      "agentContinuationSchema",
+      "agentInteractionRequestSchema",
+      "agentInteractionResponseSchema",
+      "assertAgentInteractionResponse",
+      "parseAgentContinuation",
+      "parseAgentInteractionRequest",
+      "parseAgentInteractionResponse",
+    ]);
+    const packageJson = JSON.parse(
+      await readFile(new URL("../package.json", import.meta.url), "utf8"),
+    ) as { exports?: Record<string, unknown> };
+    expect(packageJson.exports).toHaveProperty("./agent/interactions", {
+      types: "./dist/agent/interactions/index.d.ts",
+      import: "./dist/agent/interactions/index.js",
+    });
   });
 
   it("exposes only the internal Agent integration contract", () => {
@@ -178,6 +215,8 @@ describe("public exports", () => {
     expect("skipTool" in publicAgent).toBe(false);
     expect("AgentRunCancelledError" in publicAgent).toBe(true);
     expect("AgentRunBlockedError" in publicAgent).toBe(true);
+    expect("AgentStructuredOutputError" in publicAgent).toBe(true);
+    expect("AgentStructuredOutputError" in publicCore).toBe(true);
     expect("MaxTurnsError" in publicAgent).toBe(true);
     expect("ToolApprovalRequiredError" in publicAgent).toBe(false);
     expect("AgentToolSuspensionError" in publicAgent).toBe(true);

--- a/packages/core/test/structured-output.test.ts
+++ b/packages/core/test/structured-output.test.ts
@@ -1,0 +1,375 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+  Agent,
+  AgentRunCancelledError,
+  AgentStructuredOutputError,
+  AssistantContent,
+  type CompletionModel,
+  type CompletionModelCapabilities,
+  type CompletionModelStreamEvent,
+  type CompletionRequest,
+  type CompletionResponse,
+  createTool,
+  type ModelCallOptions,
+  type StreamingCompletionModel,
+} from "./helpers/imports";
+
+const structuredSchema = z.object({
+  phase: z.literal("hypotheses"),
+  hypotheses: z.array(z.string()),
+});
+
+const rawJson = '{"phase":"hypotheses","hypotheses":[]}';
+const fencedJson = `\`\`\`json
+{
+  "phase": "hypotheses",
+  "hypotheses": []
+}
+\`\`\``;
+
+class QueueModel implements CompletionModel {
+  readonly provider = "test";
+  readonly modelId = "structured-output";
+  readonly capabilities: CompletionModelCapabilities = {
+    streaming: false,
+    tools: true,
+    toolChoice: true,
+    imageInput: true,
+    documentInput: true,
+    outputSchema: true,
+    reasoning: true,
+  };
+  readonly requests: CompletionRequest[] = [];
+
+  constructor(private readonly outputs: Array<string | Error>) {}
+
+  async completion(request: CompletionRequest): Promise<CompletionResponse> {
+    this.requests.push(request);
+    const output = this.outputs.shift();
+    if (output === undefined) throw new Error("No queued model output.");
+    if (output instanceof Error) throw output;
+    return response(output);
+  }
+}
+
+class StreamingQueueModel extends QueueModel implements StreamingCompletionModel {
+  constructor(
+    private readonly streamingOutputs: Array<string | readonly CompletionModelStreamEvent[]>,
+  ) {
+    super([]);
+  }
+
+  override readonly capabilities: CompletionModelCapabilities = {
+    streaming: true,
+    tools: true,
+    toolChoice: true,
+    imageInput: true,
+    documentInput: true,
+    outputSchema: true,
+    reasoning: true,
+  };
+
+  async *streamCompletion(request: CompletionRequest): AsyncIterable<CompletionModelStreamEvent> {
+    this.requests.push(request);
+    const output = this.streamingOutputs.shift();
+    if (output === undefined) throw new Error("No queued streaming model output.");
+    if (typeof output === "string") {
+      yield { type: "final", response: response(output) };
+      return;
+    }
+    yield* output;
+  }
+}
+
+describe("Agent structured output", () => {
+  it.each([
+    ["raw JSON", rawJson],
+    ["a lowercase json fence", fencedJson],
+    ["an unlabeled fence", `\`\`\`\n${rawJson}\n\`\`\``],
+    ["surrounding whitespace around a complete fence", ` \n${fencedJson}\n\t`],
+  ])("accepts %s and preserves schema validation", async (_name, output) => {
+    const agent = new Agent({
+      id: "structured",
+      model: new QueueModel([output]),
+      outputSchema: structuredSchema,
+    });
+
+    await expect(agent.generate({ prompt: "Create hypotheses." })).resolves.toMatchObject({
+      status: "completed",
+      output: { phase: "hypotheses", hypotheses: [] },
+      text: output,
+    });
+  });
+
+  it.each([
+    ["prose before a fence", `Here is the result:\n${fencedJson}`],
+    ["prose after a fence", `${fencedJson}\nHope this helps.`],
+    ["malformed JSON inside a fence", '```json\n{"phase":\n```'],
+  ])("rejects %s without extracting an embedded object", async (_name, output) => {
+    const agent = new Agent({
+      id: "structured",
+      model: new QueueModel([output]),
+      outputSchema: structuredSchema,
+    });
+
+    const error = await agent.generate({ prompt: "Create hypotheses." }).catch((value) => value);
+
+    expect(error).toBeInstanceOf(AgentStructuredOutputError);
+    expect(error).toMatchObject({
+      name: "AgentStructuredOutputError",
+      phase: "parse",
+      attempt: 1,
+      maxAttempts: 1,
+      outputLength: output.length,
+    });
+    expect(error.cause).toBeInstanceOf(SyntaxError);
+    expect(error.message).not.toContain(output);
+  });
+
+  it("rejects valid JSON that fails the configured schema", async () => {
+    const output = '{"phase":"final","hypotheses":[]}';
+    const agent = new Agent({
+      id: "structured",
+      model: new QueueModel([output]),
+      outputSchema: structuredSchema,
+    });
+
+    const error = await agent.generate({ prompt: "Create hypotheses." }).catch((value) => value);
+
+    expect(error).toBeInstanceOf(AgentStructuredOutputError);
+    expect(error).toMatchObject({ phase: "schema", attempt: 1, maxAttempts: 1 });
+    expect(error.cause).toBeInstanceOf(z.ZodError);
+    expect(error.message).not.toContain(output);
+  });
+
+  it.each([
+    ["malformed JSON", "not json"],
+    ["schema-invalid JSON", '{"phase":"final","hypotheses":[]}'],
+  ])("retries %s and succeeds on a later valid response", async (_name, invalidOutput) => {
+    const model = new QueueModel([invalidOutput, rawJson]);
+    const agent = new Agent({
+      id: "structured",
+      model,
+      outputSchema: structuredSchema,
+      retries: { maxAttempts: 2, initialDelayMs: 0, maxDelayMs: 0 },
+    });
+
+    await expect(agent.generate({ prompt: "Create hypotheses." })).resolves.toMatchObject({
+      output: { phase: "hypotheses", hypotheses: [] },
+      usage: { totalTokens: 2 },
+    });
+    expect(model.requests).toHaveLength(2);
+    expect(model.requests[1]?.chatHistory.slice(-2)).toEqual([
+      { role: "assistant", content: [AssistantContent.text(invalidOutput)] },
+      {
+        role: "user",
+        content:
+          "Your previous response was invalid structured output. Return only raw JSON that matches the supplied JSON schema. Do not use Markdown fences or include commentary.",
+      },
+    ]);
+  });
+
+  it("stops at the exact total-attempt limit and preserves the final cause", async () => {
+    const first = Object.assign(new Error("temporarily unavailable"), { status: 503 });
+    const model = new QueueModel([first, "still not json", rawJson]);
+    const agent = new Agent({
+      id: "structured",
+      model,
+      outputSchema: structuredSchema,
+      retries: { maxAttempts: 2, initialDelayMs: 0, maxDelayMs: 0 },
+    });
+
+    const error = await agent.generate({ prompt: "Create hypotheses." }).catch((value) => value);
+
+    expect(model.requests).toHaveLength(2);
+    expect(error).toBeInstanceOf(AgentStructuredOutputError);
+    expect(error).toMatchObject({ phase: "parse", attempt: 2, maxAttempts: 2 });
+    expect(error.cause).toBeInstanceOf(SyntaxError);
+  });
+
+  it("retains rejected-output usage when the retry ends in a provider failure", async () => {
+    const providerError = new Error("provider rejected retry");
+    const observedUsage: number[] = [];
+    const model = new QueueModel(["not json", providerError]);
+    const agent = new Agent({
+      id: "structured",
+      model,
+      outputSchema: structuredSchema,
+      retries: { maxAttempts: 2, initialDelayMs: 0, maxDelayMs: 0 },
+      lifecycle: {
+        onError({ usage }) {
+          observedUsage.push(usage.totalTokens);
+        },
+      },
+    });
+
+    await expect(agent.generate({ prompt: "Create hypotheses." })).rejects.toBe(providerError);
+    expect(model.requests).toHaveLength(2);
+    expect(observedUsage).toEqual([1]);
+  });
+
+  it("retains rejected-output usage when the retry is aborted", async () => {
+    const controller = new AbortController();
+    const observedUsage: number[] = [];
+    let calls = 0;
+    let markRetryStarted: (() => void) | undefined;
+    const retryStarted = new Promise<void>((resolve) => {
+      markRetryStarted = resolve;
+    });
+    const model: CompletionModel = {
+      provider: "test",
+      modelId: "structured-abort",
+      capabilities: new QueueModel([]).capabilities,
+      async completion(
+        _request: CompletionRequest,
+        options?: ModelCallOptions,
+      ): Promise<CompletionResponse> {
+        calls += 1;
+        if (calls === 1) return response("not json");
+        const abortSignal = options?.abortSignal;
+        if (abortSignal === undefined) throw new Error("Expected Agent abort signal.");
+        markRetryStarted?.();
+        return new Promise((_, reject) => {
+          abortSignal.addEventListener("abort", () => reject(abortSignal.reason), { once: true });
+        });
+      },
+    };
+    const agent = new Agent({
+      id: "structured",
+      model,
+      outputSchema: structuredSchema,
+      retries: { maxAttempts: 2, initialDelayMs: 0, maxDelayMs: 0 },
+      lifecycle: {
+        onError({ usage }) {
+          observedUsage.push(usage.totalTokens);
+        },
+      },
+    });
+
+    const result = agent.generate({ prompt: "Create hypotheses.", abortSignal: controller.signal });
+    await retryStarted;
+    controller.abort("stop retry");
+
+    await expect(result).rejects.toBeInstanceOf(AgentRunCancelledError);
+    expect(calls).toBe(2);
+    expect(observedUsage).toEqual([1]);
+  });
+
+  it("does not retry structured failures unless retries are configured", async () => {
+    const model = new QueueModel(["not json", rawJson]);
+    const agent = new Agent({ id: "structured", model, outputSchema: structuredSchema });
+
+    await expect(agent.generate({ prompt: "Create hypotheses." })).rejects.toBeInstanceOf(
+      AgentStructuredOutputError,
+    );
+    expect(model.requests).toHaveLength(1);
+  });
+
+  it("buffers invalid structured streams and retries without exposing their text", async () => {
+    const model = new StreamingQueueModel(["not json", rawJson]);
+    const agent = new Agent({
+      id: "structured",
+      model,
+      outputSchema: structuredSchema,
+      retries: { maxAttempts: 2, initialDelayMs: 0, maxDelayMs: 0 },
+    });
+    const events = [];
+
+    for await (const event of agent.stream({ prompt: "Create hypotheses." })) {
+      events.push(event);
+    }
+
+    expect(model.requests).toHaveLength(2);
+    expect(events).not.toContainEqual(expect.objectContaining({ delta: "not json" }));
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "turn_end",
+        response: expect.objectContaining({ usage: expect.objectContaining({ totalTokens: 2 }) }),
+      }),
+    );
+    const final = events.at(-1);
+    expect(final).toMatchObject({
+      type: "final",
+      result: {
+        output: { phase: "hypotheses", hypotheses: [] },
+        usage: { totalTokens: 2 },
+      },
+    });
+    if (final?.type !== "final") throw new Error("Expected final Agent event.");
+    expect(final.result.messages.at(-1)?.metadata).toMatchObject({
+      anvia: { generation: { usage: { totalTokens: 2 } } },
+    });
+  });
+
+  it("replays buffered reasoning and text on structured tool-call turns", async () => {
+    const toolCall = AssistantContent.toolCall("call_1", "lookup", {});
+    const model = new StreamingQueueModel([
+      [
+        { type: "reasoning_delta", delta: "checking" },
+        { type: "text_delta", delta: "working" },
+        { type: "tool_call", toolCall },
+      ],
+      rawJson,
+    ]);
+    const lookup = createTool({
+      name: "lookup",
+      description: "Look up data.",
+      inputSchema: z.object({}),
+      execute: () => "found",
+    });
+    const agent = new Agent({
+      id: "structured",
+      model,
+      outputSchema: structuredSchema,
+      tools: [lookup],
+    });
+    const events = [];
+
+    for await (const event of agent.stream({ prompt: "Create hypotheses." })) {
+      events.push(event);
+    }
+
+    expect(events.map((event) => event.type)).toEqual([
+      "turn_start",
+      "generation_start",
+      "reasoning_delta",
+      "text_delta",
+      "tool_call",
+      "turn_end",
+      "tool_result",
+      "turn_start",
+      "generation_start",
+      "text_delta",
+      "turn_end",
+      "final",
+    ]);
+    expect(events).toContainEqual({ type: "reasoning_delta", turn: 1, delta: "checking" });
+    expect(events).toContainEqual({ type: "text_delta", turn: 1, delta: "working" });
+  });
+
+  it("leaves ordinary non-structured Agent output unchanged", async () => {
+    const model = new QueueModel([fencedJson]);
+    const agent = new Agent({ id: "ordinary", model });
+
+    await expect(agent.generate({ prompt: "Answer normally." })).resolves.toMatchObject({
+      output: fencedJson,
+      text: fencedJson,
+    });
+    expect(model.requests).toHaveLength(1);
+  });
+});
+
+function response(text: string): CompletionResponse {
+  return {
+    choice: [AssistantContent.text(text)],
+    usage: {
+      inputTokens: 0,
+      outputTokens: 1,
+      totalTokens: 1,
+      cachedInputTokens: 0,
+      cacheCreationInputTokens: 0,
+    },
+    rawResponse: {},
+  };
+}

--- a/packages/embedding-fastembed/CHANGELOG.md
+++ b/packages/embedding-fastembed/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/fastembed
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/embedding-fastembed/package.json
+++ b/packages/embedding-fastembed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/fastembed",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "FastEmbed embedding model adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/embedding-transformers/CHANGELOG.md
+++ b/packages/embedding-transformers/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/transformers
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/embedding-transformers/package.json
+++ b/packages/embedding-transformers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/transformers",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "Transformers.js embedding model adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/graph-neo4j/CHANGELOG.md
+++ b/packages/graph-neo4j/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/neo4j
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/graph-neo4j/package.json
+++ b/packages/graph-neo4j/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/neo4j",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "Schema-first Neo4j GraphRAG integration for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @anvia/logger
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- e96d038: Accept only complete outer JSON Markdown fences as a strict structured-output compatibility
+  fallback, retry Agent parsing and schema failures within the configured total-attempt budget, and
+  surface phase-aware errors without embedding rejected output. Preserve nested Error cause details
+  in logger observer records with bounded traversal and redact parser/schema causes that may contain
+  rejected structured output.
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -49,6 +49,12 @@ if (result.status === "completed") console.log(result.output);
 
 The logger observer omits final outputs, full model requests, model responses, and tool results by default. Pass `LoggerObserverOptions` to opt in when your data policy allows those payloads in logs.
 
+Agent errors are serialized before reaching the configured logger. Nested `Error.cause` chains keep
+their `name`, `message`, and `stack`, including when the destination is Pino. Cause traversal is
+bounded. Structured-output causes are reduced to safe type metadata because parser and schema error
+messages can contain rejected model content; the outer error still records its phase, attempts,
+lengths, and detected format.
+
 For local development without Pino output, use the console logger:
 
 ```ts

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/logger",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "Structured logger adapters for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/logger/src/observer.ts
+++ b/packages/logger/src/observer.ts
@@ -191,15 +191,62 @@ function generationEndContext(
   return context;
 }
 
-function serializeError(error: unknown): unknown {
+const MAX_SERIALIZED_ERROR_CAUSE_DEPTH = 16;
+
+function serializeError(error: unknown, seen = new Set<object>(), depth = 0): unknown {
   if (error instanceof Error) {
-    return {
+    if (seen.has(error)) return "[Circular error cause]";
+    if (depth >= MAX_SERIALIZED_ERROR_CAUSE_DEPTH) return "[Error cause depth limit]";
+    seen.add(error);
+    const serialized: Record<string, unknown> = {
       name: error.name,
       message: error.message,
       stack: error.stack,
-      cause: error.cause,
     };
+    if (error.name === "AgentStructuredOutputError") {
+      addStructuredOutputMetadata(serialized, error);
+    }
+    if (error.cause !== undefined) {
+      if (error.name === "AgentStructuredOutputError") {
+        serialized.cause = structuredOutputCauseMetadata(error.cause);
+      } else {
+        serialized.cause = serializeError(error.cause, seen, depth + 1);
+      }
+    }
+    return serialized;
   }
 
   return error;
+}
+
+function addStructuredOutputMetadata(serialized: Record<string, unknown>, error: Error): void {
+  const details = error as unknown as Record<string, unknown>;
+  if (details.phase === "parse" || details.phase === "schema") {
+    serialized.phase = details.phase;
+  }
+  for (const name of ["attempt", "maxAttempts", "outputLength", "normalizedLength"] as const) {
+    const value = details[name];
+    if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0) {
+      serialized[name] = value;
+    }
+  }
+  if (
+    details.outputFormat === "raw" ||
+    details.outputFormat === "json-fence" ||
+    details.outputFormat === "unlabeled-fence"
+  ) {
+    serialized.outputFormat = details.outputFormat;
+  }
+}
+
+function structuredOutputCauseMetadata(cause: unknown): Record<string, unknown> {
+  const metadata: Record<string, unknown> = {
+    message: "Structured-output cause details redacted.",
+  };
+  if (cause instanceof Error) {
+    metadata.name = cause.name;
+  } else {
+    metadata.type = cause === null ? "null" : typeof cause;
+  }
+  return metadata;
 }

--- a/packages/logger/test/logger.test.ts
+++ b/packages/logger/test/logger.test.ts
@@ -1,3 +1,4 @@
+import { AgentStructuredOutputError, Usage } from "@anvia/core";
 import type { AgentRunObserver, AgentToolObserver } from "@anvia/core/observability";
 import { describe, expect, it } from "vitest";
 import { createConsoleLogger, createLoggerObserver, createPinoLogger, type Logger } from "../src";
@@ -192,7 +193,124 @@ describe("createLoggerObserver", () => {
     });
     expect(logger.records[5]?.context).not.toHaveProperty("output");
   });
+
+  it("serializes nested Error causes before handing them to Pino", async () => {
+    const lines: Array<Record<string, unknown>> = [];
+    const logger = createPinoLogger({
+      level: "error",
+      destination: {
+        write: (line: string) => {
+          lines.push(JSON.parse(line) as Record<string, unknown>);
+        },
+      },
+    });
+    const observer = createLoggerObserver({ logger });
+    const run = (await observer.startRun({
+      runId: "run_error",
+      prompt: { role: "user", content: "hello" },
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+    const rootCause = new SyntaxError("Unexpected token");
+    const nestedCause = new Error("Invalid JSON", { cause: rootCause });
+    const error = new Error("Structured output failed", { cause: nestedCause });
+
+    run.error?.({
+      error,
+      usage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        cachedInputTokens: 0,
+        cacheCreationInputTokens: 0,
+      },
+      messages: [],
+    });
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]?.error).toMatchObject({
+      name: "Error",
+      message: "Structured output failed",
+      stack: expect.any(String),
+      cause: {
+        name: "Error",
+        message: "Invalid JSON",
+        stack: expect.any(String),
+        cause: {
+          name: "SyntaxError",
+          message: "Unexpected token",
+          stack: expect.any(String),
+        },
+      },
+    });
+  });
+
+  it("redacts structured-output cause details while retaining safe diagnostics", async () => {
+    const rejectedOutput = "customer-secret-structured-output";
+    const error = new AgentStructuredOutputError({
+      phase: "parse",
+      attempt: 2,
+      maxAttempts: 2,
+      outputLength: rejectedOutput.length,
+      normalizedLength: rejectedOutput.length,
+      outputFormat: "raw",
+      usage: Usage.empty(),
+      cause: new SyntaxError(`Unexpected token in ${rejectedOutput}`),
+    });
+
+    const record = await recordPinoRunError(error);
+
+    expect(JSON.stringify(record)).not.toContain(rejectedOutput);
+    expect(record.error).toMatchObject({
+      name: "AgentStructuredOutputError",
+      phase: "parse",
+      attempt: 2,
+      maxAttempts: 2,
+      outputLength: rejectedOutput.length,
+      normalizedLength: rejectedOutput.length,
+      outputFormat: "raw",
+      cause: {
+        name: "SyntaxError",
+        message: "Structured-output cause details redacted.",
+      },
+    });
+  });
+
+  it("bounds deeply nested error-cause serialization", async () => {
+    let error: Error = new Error("root cause");
+    for (let depth = 0; depth < 100; depth += 1) {
+      error = new Error(`cause ${depth}`, { cause: error });
+    }
+
+    const record = await recordPinoRunError(error);
+
+    expect(JSON.stringify(record)).toContain("[Error cause depth limit]");
+  });
 });
+
+async function recordPinoRunError(error: Error): Promise<Record<string, unknown>> {
+  const lines: Array<Record<string, unknown>> = [];
+  const observer = createLoggerObserver({
+    logger: createPinoLogger({
+      level: "error",
+      destination: {
+        write: (line: string) => {
+          lines.push(JSON.parse(line) as Record<string, unknown>);
+        },
+      },
+    }),
+  });
+  const run = (await observer.startRun({
+    runId: "run_error",
+    prompt: { role: "user", content: "hello" },
+    history: [],
+    maxTurns: 1,
+  })) as AgentRunObserver;
+  run.error?.({ error, usage: Usage.empty(), messages: [] });
+  const record = lines[0];
+  if (record === undefined) throw new Error("Expected Pino error record.");
+  return record;
+}
 
 class RecordingLogger implements Logger {
   readonly records: { level: string; message: string; context: Record<string, unknown> }[];

--- a/packages/memory-drizzle/CHANGELOG.md
+++ b/packages/memory-drizzle/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/memory-drizzle
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/memory-drizzle/package.json
+++ b/packages/memory-drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/memory-drizzle",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "Drizzle-backed durable session memory store for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/memory-postgres/CHANGELOG.md
+++ b/packages/memory-postgres/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/memory-postgres
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/memory-postgres/package.json
+++ b/packages/memory-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/memory-postgres",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "Postgres-backed durable session memory store for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/memory-prisma/CHANGELOG.md
+++ b/packages/memory-prisma/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/memory-prisma
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/memory-prisma/package.json
+++ b/packages/memory-prisma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/memory-prisma",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "Prisma-backed durable session memory store for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/memory-sqlite/CHANGELOG.md
+++ b/packages/memory-sqlite/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/memory-sqlite
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/memory-sqlite/package.json
+++ b/packages/memory-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/memory-sqlite",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "SQLite-backed durable session memory store for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/observability-langfuse/CHANGELOG.md
+++ b/packages/observability-langfuse/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/langfuse
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/observability-langfuse/package.json
+++ b/packages/observability-langfuse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/langfuse",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "Langfuse tracing adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/observability-lens/CHANGELOG.md
+++ b/packages/observability-lens/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @anvia/lens
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+  - @anvia/otel@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/observability-lens/package.json
+++ b/packages/observability-lens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/lens",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "Native Anvia Lens tracing and evaluation adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/observability-otel/CHANGELOG.md
+++ b/packages/observability-otel/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/otel
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/observability-otel/package.json
+++ b/packages/observability-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/otel",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "OpenTelemetry tracing and eval reporting adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/provider-anthropic/CHANGELOG.md
+++ b/packages/provider-anthropic/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/anthropic
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/provider-anthropic/package.json
+++ b/packages/provider-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/anthropic",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "Anthropic provider adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/provider-anthropic/vitest.config.ts
+++ b/packages/provider-anthropic/vitest.config.ts
@@ -3,6 +3,10 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   resolve: {
     alias: {
+      "@anvia/core/agent/interactions": new URL(
+        "../core/src/agent/interactions/index.ts",
+        import.meta.url,
+      ).pathname,
       "@anvia/core/agent": new URL("../core/src/agent/index.ts", import.meta.url).pathname,
       "@anvia/core/completion": new URL("../core/src/completion/index.ts", import.meta.url)
         .pathname,

--- a/packages/provider-gemini/CHANGELOG.md
+++ b/packages/provider-gemini/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/gemini
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/provider-gemini/package.json
+++ b/packages/provider-gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/gemini",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "Gemini provider adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/provider-grok/CHANGELOG.md
+++ b/packages/provider-grok/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @anvia/grok
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+  - @anvia/openai@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/provider-grok/package.json
+++ b/packages/provider-grok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/grok",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "Grok provider adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/provider-mistral/CHANGELOG.md
+++ b/packages/provider-mistral/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/mistral
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/provider-mistral/package.json
+++ b/packages/provider-mistral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/mistral",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "Mistral provider adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/provider-openai/CHANGELOG.md
+++ b/packages/provider-openai/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/openai
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/provider-openai/package.json
+++ b/packages/provider-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/openai",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "OpenAI provider adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/provider-openai/test/openai-chat-completion.test.ts
+++ b/packages/provider-openai/test/openai-chat-completion.test.ts
@@ -179,6 +179,32 @@ describe("OpenAI chat-completions client path", () => {
     expect(params.messages).toEqual([{ role: "assistant", content: "visible response" }]);
   });
 
+  it("keeps strict json_schema response formatting for structured output", () => {
+    const schema = {
+      type: "object",
+      properties: { phase: { type: "string" } },
+      required: ["phase"],
+      additionalProperties: false,
+      title: "hypothesis_response",
+    };
+
+    const params = toOpenAIChatCompletionParams("custom-chat-model", {
+      chatHistory: [Message.user("Create hypotheses")],
+      documents: [],
+      tools: [],
+      outputSchema: schema,
+    });
+
+    expect(params.response_format).toEqual({
+      type: "json_schema",
+      json_schema: {
+        name: "hypothesis_response",
+        strict: true,
+        schema,
+      },
+    });
+  });
+
   it("adds compatible content to empty assistant history", () => {
     const params = toOpenAIChatCompletionParams("deepseek-v4-flash", {
       chatHistory: [Message.assistant([])],

--- a/packages/react-ui/CHANGELOG.md
+++ b/packages/react-ui/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @anvia/react-ui
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- e96d038: Move Agent interaction contracts and parsers to the browser-safe
+  `@anvia/core/agent/interactions` subpath. Prevent Client and React bundles from loading the Agent
+  runtime, MCP stdio, Node built-ins, or undici through Core's server barrels.
+- Updated dependencies [e96d038]
+  - @anvia/client@1.0.0-rc.5
+  - @anvia/react@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/react-ui",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "Composable React UI primitives for Anvia chat and completion experiences.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/react-ui/src/contexts/chat.tsx
+++ b/packages/react-ui/src/contexts/chat.tsx
@@ -4,7 +4,10 @@ import type {
   ClientStreamRequest,
   ClientTransport,
 } from "@anvia/client";
-import type { AgentToolApprovalRequest, AgentToolQuestionRequest } from "@anvia/core/agent";
+import type {
+  AgentToolApprovalRequest,
+  AgentToolQuestionRequest,
+} from "@anvia/core/agent/interactions";
 import type { UseChatResult } from "@anvia/react";
 import { createContext, createElement, type ReactElement, type ReactNode, useContext } from "react";
 

--- a/packages/react-ui/src/contexts/human-input.tsx
+++ b/packages/react-ui/src/contexts/human-input.tsx
@@ -4,7 +4,7 @@ import type {
   AgentQuestionPrompt,
   AgentToolApprovalRequest,
   AgentToolQuestionRequest,
-} from "@anvia/core/agent";
+} from "@anvia/core/agent/interactions";
 import {
   createContext,
   createElement,

--- a/packages/react-ui/src/human-input/questions.tsx
+++ b/packages/react-ui/src/human-input/questions.tsx
@@ -1,4 +1,4 @@
-import type { AgentQuestionAnswer, AgentQuestionPrompt } from "@anvia/core/agent";
+import type { AgentQuestionAnswer, AgentQuestionPrompt } from "@anvia/core/agent/interactions";
 import {
   type ChangeEvent,
   forwardRef,

--- a/packages/react-ui/test/helpers.tsx
+++ b/packages/react-ui/test/helpers.tsx
@@ -1,5 +1,8 @@
 import type { ClientInteraction, UIMessage } from "@anvia/client";
-import type { AgentToolApprovalRequest, AgentToolQuestionRequest } from "@anvia/core/agent";
+import type {
+  AgentToolApprovalRequest,
+  AgentToolQuestionRequest,
+} from "@anvia/core/agent/interactions";
 import type { UseChatResult, UseCompletionResult } from "@anvia/react";
 import { vi } from "vitest";
 

--- a/packages/react-ui/vitest.config.ts
+++ b/packages/react-ui/vitest.config.ts
@@ -4,6 +4,10 @@ export default defineConfig({
   resolve: {
     alias: {
       "@anvia/client": new URL("../client/src/index.ts", import.meta.url).pathname,
+      "@anvia/core/agent/interactions": new URL(
+        "../core/src/agent/interactions/index.ts",
+        import.meta.url,
+      ).pathname,
       "@anvia/core/agent": new URL("../core/src/agent/index.ts", import.meta.url).pathname,
       "@anvia/core/completion": new URL("../core/src/completion/index.ts", import.meta.url)
         .pathname,

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @anvia/react
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- e96d038: Move Agent interaction contracts and parsers to the browser-safe
+  `@anvia/core/agent/interactions` subpath. Prevent Client and React bundles from loading the Agent
+  runtime, MCP stdio, Node built-ins, or undici through Core's server barrels.
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+  - @anvia/client@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -47,6 +47,8 @@ useChat({
 
 Import transports, protocol types, `UIMessage`, and conversion helpers from `@anvia/client`.
 `@anvia/react` deliberately does not re-export them.
+Import Agent interaction types directly from `@anvia/core/agent/interactions` when an application
+needs to name them.
 
 `useChat`:
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -44,6 +44,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitest/coverage-v8": "4.1.5",
+    "esbuild": "^0.27.7",
     "happy-dom": "20.9.0",
     "react": "^19.2.6",
     "react-dom": "19.2.6",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/react",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "React hooks for the explicit Anvia client stream protocol.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/react/src/resume.ts
+++ b/packages/react/src/resume.ts
@@ -6,7 +6,7 @@ import {
   parseClientStreamRequest,
   parseUIMessages,
 } from "@anvia/client";
-import { parseAgentInteractionRequest } from "@anvia/core/agent";
+import { parseAgentInteractionRequest } from "@anvia/core/agent/interactions";
 import type { ChatResumeOptions, ChatResumeState } from "./types";
 
 const storageKeyPrefix = "anvia:chat-resume:";

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -9,7 +9,7 @@ import type {
   CreateUIAttachment,
   UIMessage,
 } from "@anvia/client";
-import type { AgentInteractionResponse } from "@anvia/core/agent";
+import type { AgentInteractionResponse } from "@anvia/core/agent/interactions";
 import type { ContextUsage } from "@anvia/core/completion";
 
 export type AnyClientTransport = ClientTransport<

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -15,7 +15,7 @@ import {
   type AgentInteractionResponse,
   assertAgentInteractionResponse,
   parseAgentInteractionResponse,
-} from "@anvia/core/agent";
+} from "@anvia/core/agent/interactions";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { contextUsageFromMessages, contextUsageUpdateFromEvent } from "./context-usage";
 import { clearChatResumeState, loadChatResumeState, saveChatResumeState } from "./resume";

--- a/packages/react/test/browser-boundary.test.ts
+++ b/packages/react/test/browser-boundary.test.ts
@@ -1,0 +1,31 @@
+import { resolve } from "node:path";
+import { build } from "esbuild";
+import { describe, expect, it } from "vitest";
+
+describe("browser package boundary", () => {
+  it("bundles React and Client without loading the Agent runtime or Node infrastructure", async () => {
+    const result = await build({
+      bundle: true,
+      entryPoints: [resolve("src/index.ts")],
+      external: ["react", "react/*"],
+      format: "esm",
+      metafile: true,
+      platform: "browser",
+      tsconfig: resolve("tsconfig.json"),
+      write: false,
+    });
+
+    const inputs = Object.keys(result.metafile.inputs).map((input) => input.replaceAll("\\", "/"));
+    expect(inputs.some((input) => input.endsWith("core/src/agent/interactions.ts"))).toBe(true);
+    expect(
+      inputs.filter(
+        (input) =>
+          input.includes("node_modules/.pnpm/undici@") ||
+          input.includes("node_modules/@modelcontextprotocol/") ||
+          input.includes("core/src/agent/agent.ts") ||
+          input.includes("core/src/internal/agent-runtime/") ||
+          input.includes("core/src/mcp/"),
+      ),
+    ).toEqual([]);
+  });
+});

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -4,6 +4,10 @@ export default defineConfig({
   resolve: {
     alias: {
       "@anvia/client": new URL("../client/src/index.ts", import.meta.url).pathname,
+      "@anvia/core/agent/interactions": new URL(
+        "../core/src/agent/interactions/index.ts",
+        import.meta.url,
+      ).pathname,
       "@anvia/core/agent": new URL("../core/src/agent/index.ts", import.meta.url).pathname,
       "@anvia/core/completion": new URL("../core/src/completion/index.ts", import.meta.url)
         .pathname,

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/server
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- Updated dependencies [e96d038]
+  - @anvia/client@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/server",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "Server-side client protocol and generic event stream responses for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -4,6 +4,10 @@ export default defineConfig({
   resolve: {
     alias: {
       "@anvia/client": new URL("../client/src/index.ts", import.meta.url).pathname,
+      "@anvia/core/agent/interactions": new URL(
+        "../core/src/agent/interactions/index.ts",
+        import.meta.url,
+      ).pathname,
       "@anvia/core/agent": new URL("../core/src/agent/index.ts", import.meta.url).pathname,
       "@anvia/core/completion": new URL("../core/src/completion/index.ts", import.meta.url)
         .pathname,

--- a/packages/tool-browser/CHANGELOG.md
+++ b/packages/tool-browser/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @anvia/browser
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+  - @anvia/sandbox@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/tool-browser/package.json
+++ b/packages/tool-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/browser",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "Visible Chromium runtime and semantic browser tools for Anvia agents.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/tool-sandbox/CHANGELOG.md
+++ b/packages/tool-sandbox/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/sandbox
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/tool-sandbox/package.json
+++ b/packages/tool-sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/sandbox",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "Sandboxed workspace tools for Anvia agents.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/tool-studio/CHANGELOG.md
+++ b/packages/tool-studio/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @anvia/studio
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- e96d038: Move Agent interaction contracts and parsers to the browser-safe
+  `@anvia/core/agent/interactions` subpath. Prevent Client and React bundles from loading the Agent
+  runtime, MCP stdio, Node built-ins, or undici through Core's server barrels.
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+  - @anvia/client@1.0.0-rc.5
+  - @anvia/react@1.0.0-rc.5
+  - @anvia/react-ui@1.0.0-rc.5
+  - @anvia/server@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/tool-studio/package.json
+++ b/packages/tool-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/studio",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "Studio UI and HTTP runtime for Anvia agents.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/tool-studio/src/runtime/interactions.ts
+++ b/packages/tool-studio/src/runtime/interactions.ts
@@ -2,7 +2,7 @@ import {
   type AgentContinuation,
   type AgentInteractionResponse,
   assertAgentInteractionResponse,
-} from "@anvia/core/agent";
+} from "@anvia/core/agent/interactions";
 
 export type StudioContinuationRegistration<Context> = Readonly<{
   continuation: AgentContinuation;

--- a/packages/tool-studio/src/runtime/runs.ts
+++ b/packages/tool-studio/src/runtime/runs.ts
@@ -4,7 +4,7 @@ import {
   customAgentEventsToClientStream,
 } from "@anvia/client";
 import type { AgentStreamEvent } from "@anvia/core/agent";
-import { parseAgentInteractionResponse } from "@anvia/core/agent";
+import { parseAgentInteractionResponse } from "@anvia/core/agent/interactions";
 import {
   isJsonValue,
   type JsonObject,

--- a/packages/tool-studio/src/types.ts
+++ b/packages/tool-studio/src/types.ts
@@ -1,10 +1,5 @@
-import type {
-  Agent,
-  AgentInteractionResponse,
-  AgentResult,
-  AgentStreamEvent,
-  AgentSuspendedResult,
-} from "@anvia/core/agent";
+import type { Agent, AgentResult, AgentStreamEvent, AgentSuspendedResult } from "@anvia/core/agent";
+import type { AgentInteractionResponse } from "@anvia/core/agent/interactions";
 import type {
   CompletionModel,
   CompletionModelCapabilities,

--- a/packages/tool-studio/vitest.config.ts
+++ b/packages/tool-studio/vitest.config.ts
@@ -10,6 +10,10 @@ export default defineConfig({
       "@anvia/react-ui/stream": new URL("../react-ui/src/stream/index.ts", import.meta.url)
         .pathname,
       "@anvia/react": new URL("../react/src/index.ts", import.meta.url).pathname,
+      "@anvia/core/agent/interactions": new URL(
+        "../core/src/agent/interactions/index.ts",
+        import.meta.url,
+      ).pathname,
       "@anvia/core/agent": new URL("../core/src/agent/index.ts", import.meta.url).pathname,
       "@anvia/core/completion": new URL("../core/src/completion/index.ts", import.meta.url)
         .pathname,

--- a/packages/vector-chroma/CHANGELOG.md
+++ b/packages/vector-chroma/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/chroma
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/vector-chroma/package.json
+++ b/packages/vector-chroma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/chroma",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "ChromaDB vector store adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/vector-lancedb/CHANGELOG.md
+++ b/packages/vector-lancedb/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/lancedb
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/vector-lancedb/package.json
+++ b/packages/vector-lancedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/lancedb",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "LanceDB vector store adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/vector-milvus/CHANGELOG.md
+++ b/packages/vector-milvus/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/milvus
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/vector-milvus/package.json
+++ b/packages/vector-milvus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/milvus",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "Milvus vector store adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/vector-pgvector/CHANGELOG.md
+++ b/packages/vector-pgvector/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/pgvector
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/vector-pgvector/package.json
+++ b/packages/vector-pgvector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/pgvector",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "Postgres pgvector store adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/vector-pinecone/CHANGELOG.md
+++ b/packages/vector-pinecone/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/pinecone
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/vector-pinecone/package.json
+++ b/packages/vector-pinecone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/pinecone",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "Pinecone vector store adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/vector-qdrant/CHANGELOG.md
+++ b/packages/vector-qdrant/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/qdrant
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/vector-qdrant/package.json
+++ b/packages/vector-qdrant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/qdrant",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "Qdrant vector store adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/vector-redis/CHANGELOG.md
+++ b/packages/vector-redis/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/redis
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/vector-redis/package.json
+++ b/packages/vector-redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/redis",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "Redis vector store adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/vector-weaviate/CHANGELOG.md
+++ b/packages/vector-weaviate/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/weaviate
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- Updated dependencies [e96d038]
+- Updated dependencies [e96d038]
+  - @anvia/core@1.0.0-rc.5
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/packages/vector-weaviate/package.json
+++ b/packages/vector-weaviate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/weaviate",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "Weaviate vector store adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -774,6 +774,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 4.1.5
         version: 4.1.5(vitest@4.1.5)
+      esbuild:
+        specifier: ^0.27.7
+        version: 0.27.7
       happy-dom:
         specifier: 20.9.0
         version: 20.9.0


### PR DESCRIPTION
## Summary

- keep browser-safe React and Client imports from pulling the server Agent runtime, MCP stdio, Node built-ins, or undici into browser bundles
- harden structured-output parsing, retries, usage accounting, streaming replay, errors, and logger redaction
- synchronize all public packages and changelogs at `1.0.0-rc.5`

## Root causes fixed

The RC4 browser entrypoints imported parsers from server barrels, allowing Node-only runtime dependencies into browser bundles. Structured-output handling also accepted overly broad fences, exposed rejected payloads through nested errors, lost usage across some retry terminal paths, and dropped buffered response events on tool-call turns.

## Validation

- release-train state validation for `v1.0.0-rc.5`
- release script tests
- `pnpm check`
- Core build, then every remaining package build
- release pack verification
- all package typechecks
- all example typechecks
- all package tests
- Bugbot review completed; all five concrete findings fixed
