### PR TITLE
chore: prepare 1.0.0-rc.6

### DIFF
--- a/.changeset/fix-structured-output-truncation.md
+++ b/.changeset/fix-structured-output-truncation.md
@@ -1,0 +1,14 @@
+---
+"@anvia/core": patch
+"@anvia/logger": patch
+"@anvia/openai": patch
+"@anvia/anthropic": patch
+"@anvia/gemini": patch
+"@anvia/mistral": patch
+"@anvia/grok": patch
+---
+
+Preserve normalized and provider-native completion finish reasons across first-party adapters,
+identify output-limit truncation before structured parsing, rebuild Agent repairs from the original
+request with omitted or bounded text-only output, and log safe per-attempt retry diagnostics through
+named observer events.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -47,6 +47,7 @@
     "explicit-client-stream-boundary",
     "fix-browser-interaction-boundary",
     "fix-lancedb-metadata-filters",
+    "fix-structured-output-truncation",
     "public-rc-ready",
     "redesign-agent-interactions",
     "redesign-agent-memory-compaction",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/client
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/client",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Framework-neutral client protocol, transports, and UI message state for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @anvia/core
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- 706b321: Preserve normalized and provider-native completion finish reasons across first-party adapters,
+  identify output-limit truncation before structured parsing, rebuild Agent repairs from the original
+  request with omitted or bounded text-only output, and log safe per-attempt retry diagnostics through
+  named observer events.
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -126,7 +126,17 @@ console.log(result.output.priority); // fully typed
 ```
 
 `CompletionResult` consistently contains `output`, the original `text`, normalized `content`,
-`usage`, and `rawResponse`, plus optional message, context, source, and provider-tool metadata.
+`usage`, and `rawResponse`, plus optional message, context, source, provider-tool, and finish-reason
+metadata. First-party adapters normalize provider termination into `finishReason` (`stop`, `length`,
+`content-filter`, `tool-calls`, or `other`) while preserving the provider value separately as
+`providerFinishReason`.
+
+Schema-backed completion detects `finishReason: "length"` before JSON parsing and throws
+`CompletionStructuredOutputError` with `phase: "truncated"`. Ordinary text completion remains
+intentional: partial text is returned unchanged with its finish reason so the application decides
+whether to display, continue, or discard it. A direct structured stream can similarly end with one
+typed error event after any already-emitted deltas; it does not silently retract public stream
+progress.
 
 Use `streamCompletion` for the streaming form:
 
@@ -210,18 +220,24 @@ await agent.generate({
 });
 ```
 
-When an Agent has `outputSchema`, JSON parsing and schema-validation failures use the same retry
-budget when retries are explicitly enabled. A correction request includes the rejected response in
-the provider transcript and asks for raw JSON matching the schema, without Markdown or commentary.
+When an Agent has `outputSchema`, truncation, JSON parsing, and schema-validation failures use the
+same retry budget when retries are explicitly enabled. Each retry starts from the original request
+rather than recursively accumulating failed attempts. Truncated output and reasoning are omitted;
+parse and schema repairs include only a bounded, text-only preview of the latest failed response.
+The correction asks for shorter raw JSON matching the schema, without Markdown or commentary.
 Transport failures and structured-output failures therefore cannot exceed `maxAttempts` in total.
+Completed Agent results expose the last generation's `finishReason` and `providerFinishReason`, and
+the same fields remain attached to each assistant message's Anvia generation metadata.
 
 Structured output remains strict: Core trims surrounding whitespace, parses JSON, and validates the
 result with the configured Zod schema. As a compatibility fallback for OpenAI-compatible providers
 that violate strict JSON mode, Core also accepts a response consisting entirely of one lowercase
 `json` Markdown fence or one unlabeled Markdown fence. It does not search prose for JSON, accept
 content before or after a fence, or bypass schema validation. `AgentStructuredOutputError` reports
-the `parse` or `schema` phase, attempt counts, output length/format metadata, cumulative attempt
-usage, and the original `cause`; its message never contains the rejected model response.
+the `truncated`, `parse`, or `schema` phase, attempt counts, output length/format metadata, per-attempt
+and cumulative usage, finish reasons, and the original `cause` when one exists; its message never
+contains the rejected model response. The `completion.retry` observer event records the same safe
+diagnostics and whether failed output was omitted or previewed, never the model output itself.
 
 Agent results are discriminated by `status`. Completed results include typed `output` and `text`;
 guardrail blocks return `status: "blocked"`, `stage`, and `text`; tool approvals and first-class

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/core",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Core runtime primitives for context-aware Anvia agents.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/core/src/agent/errors.ts
+++ b/packages/core/src/agent/errors.ts
@@ -1,7 +1,7 @@
-import type { Message, Usage } from "../completion/index";
+import type { CompletionFinishReason, Message, Usage } from "../completion/index";
 import type { AgentBlockedResult, AgentSuspendedResult } from "./run-types";
 
-export type AgentStructuredOutputPhase = "parse" | "schema";
+export type AgentStructuredOutputPhase = "truncated" | "parse" | "schema";
 
 export type AgentStructuredOutputFormat = "raw" | "json-fence" | "unlabeled-fence";
 
@@ -12,7 +12,10 @@ export class AgentStructuredOutputError extends Error {
   readonly outputLength: number;
   readonly normalizedLength: number;
   readonly outputFormat: AgentStructuredOutputFormat;
+  readonly attemptUsage: Usage;
   readonly usage: Usage;
+  readonly finishReason: CompletionFinishReason | undefined;
+  readonly providerFinishReason: string | undefined;
 
   constructor(options: {
     phase: AgentStructuredOutputPhase;
@@ -21,13 +24,22 @@ export class AgentStructuredOutputError extends Error {
     outputLength: number;
     normalizedLength: number;
     outputFormat: AgentStructuredOutputFormat;
+    attemptUsage: Usage;
     usage: Usage;
-    cause: unknown;
+    finishReason?: CompletionFinishReason | undefined;
+    providerFinishReason?: string | undefined;
+    cause?: unknown;
   }) {
-    const failure = options.phase === "parse" ? "JSON parsing" : "schema validation";
+    const failure =
+      options.phase === "truncated"
+        ? "because the provider reached its output limit"
+        : options.phase === "parse"
+          ? "during JSON parsing"
+          : "during schema validation";
+    const errorOptions = options.cause === undefined ? undefined : { cause: options.cause };
     super(
       `Agent structured output failed ${failure} on attempt ${options.attempt} of ${options.maxAttempts}.`,
-      { cause: options.cause },
+      errorOptions,
     );
     this.name = "AgentStructuredOutputError";
     this.phase = options.phase;
@@ -36,7 +48,10 @@ export class AgentStructuredOutputError extends Error {
     this.outputLength = options.outputLength;
     this.normalizedLength = options.normalizedLength;
     this.outputFormat = options.outputFormat;
+    this.attemptUsage = options.attemptUsage;
     this.usage = options.usage;
+    this.finishReason = options.finishReason;
+    this.providerFinishReason = options.providerFinishReason;
   }
 }
 

--- a/packages/core/src/agent/run-types.ts
+++ b/packages/core/src/agent/run-types.ts
@@ -1,4 +1,5 @@
 import type {
+  CompletionFinishReason,
   CompletionRequest,
   CompletionResponse,
   CompletionSource,
@@ -82,6 +83,8 @@ export type AgentResultBase = {
   runId: string;
   text: string;
   usage: Usage;
+  finishReason?: CompletionFinishReason | undefined;
+  providerFinishReason?: string | undefined;
   contextUsage?: ContextUsage | undefined;
   messages: MessageType[];
   trace?: AgentTraceInfo | undefined;

--- a/packages/core/src/completion/generate-completion.ts
+++ b/packages/core/src/completion/generate-completion.ts
@@ -27,6 +27,39 @@ import type {
 } from "./types";
 import { assertCompletionRequestSupported, textFromAssistantContent, Usage } from "./types";
 
+export type CompletionStructuredOutputPhase = "truncated" | "parse" | "schema";
+
+export class CompletionStructuredOutputError extends Error {
+  readonly phase: CompletionStructuredOutputPhase;
+  readonly outputLength: number;
+  readonly usage: Usage;
+  readonly finishReason: CompletionResponse["finishReason"];
+  readonly providerFinishReason: string | undefined;
+
+  constructor(options: {
+    phase: CompletionStructuredOutputPhase;
+    outputLength: number;
+    usage: Usage;
+    finishReason?: CompletionResponse["finishReason"];
+    providerFinishReason?: string | undefined;
+    cause?: unknown;
+  }) {
+    const failure =
+      options.phase === "truncated"
+        ? "because the provider reached its output limit"
+        : options.phase === "parse"
+          ? "during JSON parsing"
+          : "during schema validation";
+    super(`Structured completion output failed ${failure}.`, { cause: options.cause });
+    this.name = "CompletionStructuredOutputError";
+    this.phase = options.phase;
+    this.outputLength = options.outputLength;
+    this.usage = options.usage;
+    this.finishReason = options.finishReason;
+    this.providerFinishReason = options.providerFinishReason;
+  }
+}
+
 export type CompletionInput =
   | { prompt: string; messages?: never }
   | { messages: readonly MessageType[]; prompt?: never };
@@ -286,12 +319,16 @@ function resultFromResponse<Output, RawResponse>(
 ): CompletionResult<Output | string, RawResponse> {
   const text = textFromAssistantContent(response.choice);
   const result: CompletionResult<Output | string, RawResponse> = {
-    output: outputSchema === undefined ? text : parseCompletionOutput(text, outputSchema),
+    output: outputSchema === undefined ? text : parseCompletionOutput(text, outputSchema, response),
     text,
     content: [...response.choice],
     usage: response.usage,
     rawResponse: response.rawResponse,
   };
+  if (response.finishReason !== undefined) result.finishReason = response.finishReason;
+  if (response.providerFinishReason !== undefined) {
+    result.providerFinishReason = response.providerFinishReason;
+  }
   if (response.contextUsage !== undefined) result.contextUsage = response.contextUsage;
   if (response.messageId !== undefined) result.messageId = response.messageId;
   if (response.sources !== undefined) result.sources = [...response.sources];
@@ -301,16 +338,45 @@ function resultFromResponse<Output, RawResponse>(
   return result;
 }
 
-function parseCompletionOutput<Output>(text: string, schema: ZodSchema<Output>): Output {
+function parseCompletionOutput<Output, RawResponse>(
+  text: string,
+  schema: ZodSchema<Output>,
+  response: CompletionResponse<RawResponse>,
+): Output {
+  if (response.finishReason === "length") {
+    throw new CompletionStructuredOutputError({
+      phase: "truncated",
+      outputLength: text.length,
+      usage: response.usage,
+      finishReason: response.finishReason,
+      providerFinishReason: response.providerFinishReason,
+    });
+  }
   let json: unknown;
   try {
     json = JSON.parse(text);
   } catch (error) {
-    throw new Error("generateCompletion expected the model response to be valid JSON.", {
+    throw new CompletionStructuredOutputError({
+      phase: "parse",
+      outputLength: text.length,
+      usage: response.usage,
+      finishReason: response.finishReason,
+      providerFinishReason: response.providerFinishReason,
       cause: error,
     });
   }
-  return schema.parse(json);
+  try {
+    return schema.parse(json);
+  } catch (error) {
+    throw new CompletionStructuredOutputError({
+      phase: "schema",
+      outputLength: text.length,
+      usage: response.usage,
+      finishReason: response.finishReason,
+      providerFinishReason: response.providerFinishReason,
+      cause: error,
+    });
+  }
 }
 
 function modelCallOptions(abortSignal: AbortSignal | undefined): ModelCallOptions | undefined {

--- a/packages/core/src/completion/types.ts
+++ b/packages/core/src/completion/types.ts
@@ -317,6 +317,8 @@ export type AssistantGenerationMetadata = {
   provider: string;
   modelId: string;
   usage: Usage;
+  finishReason?: CompletionFinishReason;
+  providerFinishReason?: string;
   contextUsage?: ContextUsage;
   sources?: CompletionSource[];
   providerToolCalls?: ProviderToolCall[];
@@ -403,6 +405,12 @@ export function getAssistantGenerationMetadata(
     modelId: generation.modelId,
     usage,
   };
+  if (isCompletionFinishReason(generation.finishReason)) {
+    metadata.finishReason = generation.finishReason;
+  }
+  if (typeof generation.providerFinishReason === "string") {
+    metadata.providerFinishReason = generation.providerFinishReason;
+  }
   if (isContextUsageValue(generation.contextUsage)) {
     metadata.contextUsage = {
       ...generation.contextUsage,
@@ -560,9 +568,13 @@ export type CompletionRequest = {
   outputSchema?: JsonObject;
 };
 
+export type CompletionFinishReason = "stop" | "length" | "content-filter" | "tool-calls" | "other";
+
 export type CompletionResponse<RawResponse = unknown> = {
   choice: AssistantContentPart[];
   usage: Usage;
+  finishReason?: CompletionFinishReason;
+  providerFinishReason?: string;
   contextUsage?: ContextUsage;
   rawResponse: RawResponse;
   messageId?: string;
@@ -575,12 +587,24 @@ export type CompletionResult<Output = string, RawResponse = unknown> = {
   text: string;
   content: readonly AssistantContentPart[];
   usage: Usage;
+  finishReason?: CompletionFinishReason;
+  providerFinishReason?: string;
   contextUsage?: ContextUsage;
   rawResponse: RawResponse;
   messageId?: string;
   sources?: readonly CompletionSource[];
   providerToolCalls?: readonly ProviderToolCall[];
 };
+
+function isCompletionFinishReason(value: JsonValue | undefined): value is CompletionFinishReason {
+  return (
+    value === "stop" ||
+    value === "length" ||
+    value === "content-filter" ||
+    value === "tool-calls" ||
+    value === "other"
+  );
+}
 
 export type CompletionModelCapabilities = {
   streaming: boolean;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,6 +56,7 @@ export type {
   AssistantGenerationMetadata,
   AssistantMessage,
   CompletionBaseOptions,
+  CompletionFinishReason,
   CompletionInput,
   CompletionModel,
   CompletionModelInfo,
@@ -65,6 +66,7 @@ export type {
   CompletionResult,
   CompletionSource,
   CompletionStreamEvent,
+  CompletionStructuredOutputPhase,
   CompletionTool,
   ContextUsage,
   Document,
@@ -100,6 +102,7 @@ export type {
   UserMessage,
 } from "./completion/index";
 export {
+  CompletionStructuredOutputError,
   calculateContextUsage,
   createMessageSchema,
   generateCompletion,

--- a/packages/core/src/internal/agent-runtime/agent-run.ts
+++ b/packages/core/src/internal/agent-runtime/agent-run.ts
@@ -34,6 +34,7 @@ import { getAgentToolState } from "../../agent/tool-state";
 import { isStreamingCompletionModel } from "../../completion/generate-completion";
 import {
   assertCompletionRequestSupported,
+  type CompletionFinishReason,
   type CompletionModel,
   type CompletionRequest,
   type CompletionResponse,
@@ -109,7 +110,12 @@ import { getInternalAgentRunOptions, type InternalAgentRunOptions } from "./run-
 import { assertNonnegativeSafeInteger, assertPositiveSafeInteger } from "./run-validation";
 import { CompletionStreamAccumulator } from "./stream-accumulator";
 import { addTurn, addTurnToToolCallDelta, isGenerationDeltaEvent } from "./stream-events";
-import { normalizeStructuredOutput, STRUCTURED_OUTPUT_RETRY_PROMPT } from "./structured-output";
+import {
+  normalizeStructuredOutput,
+  STRUCTURED_OUTPUT_RETRY_PROMPT,
+  STRUCTURED_OUTPUT_TRUNCATED_RETRY_PROMPT,
+  structuredOutputRepairPreview,
+} from "./structured-output";
 import {
   type AgentToolEventPayload,
   ToolCallExecutor,
@@ -132,6 +138,12 @@ type StreamingCompletionState = {
   emittedToolCallIds: Set<string>;
   providerErrorUsage: Usage;
 };
+
+type StructuredOutputRetryRequest = Readonly<{
+  request: CompletionRequest;
+  previousResponse: "omitted" | "preview";
+  includedOutputLength: number;
+}>;
 
 async function settleFailureCleanup(
   operations: Array<() => void | Promise<void> | undefined>,
@@ -1017,7 +1029,8 @@ export class AgentRun<Output = string, M extends CompletionModel = CompletionMod
           }
           structuredRetryUsage = cumulativeUsage;
           this.failedCompletionUsage = structuredRetryUsage;
-          currentRequest = structuredOutputRetryRequest(currentRequest, response);
+          const retryRequest = structuredOutputRetryRequest(request, response, error);
+          currentRequest = retryRequest.request;
           await this.scheduleCompletionRetry(
             error,
             attempt,
@@ -1025,6 +1038,7 @@ export class AgentRun<Output = string, M extends CompletionModel = CompletionMod
             false,
             retryOptions,
             runObservers,
+            structuredOutputRetryEventAttributes(error, retryRequest),
           );
           continue;
         }
@@ -1130,7 +1144,8 @@ export class AgentRun<Output = string, M extends CompletionModel = CompletionMod
           args.state.providerErrorUsage = Usage.add(args.state.providerErrorUsage, response.usage);
           args.state.firstDeltaMs = undefined;
           args.state.emittedToolCallIds.clear();
-          currentRequest = structuredOutputRetryRequest(currentRequest, response);
+          const retryRequest = structuredOutputRetryRequest(args.request, response, error);
+          currentRequest = retryRequest.request;
           await this.scheduleCompletionRetry(
             error,
             attempt,
@@ -1138,6 +1153,7 @@ export class AgentRun<Output = string, M extends CompletionModel = CompletionMod
             true,
             retryOptions,
             args.runObservers,
+            structuredOutputRetryEventAttributes(error, retryRequest),
           );
           continue;
         }
@@ -1321,6 +1337,10 @@ export class AgentRun<Output = string, M extends CompletionModel = CompletionMod
       modelId: this.agent.model.modelId,
       usage: { ...response.usage },
     };
+    if (response.finishReason !== undefined) generation.finishReason = response.finishReason;
+    if (response.providerFinishReason !== undefined) {
+      generation.providerFinishReason = response.providerFinishReason;
+    }
     if (response.contextUsage !== undefined) generation.contextUsage = response.contextUsage;
     if (response.sources !== undefined) generation.sources = response.sources;
     if (response.providerToolCalls !== undefined) {
@@ -1389,20 +1409,25 @@ export class AgentRun<Output = string, M extends CompletionModel = CompletionMod
     streaming: boolean,
     options: ResolvedRetryOptions,
     runObservers: ActiveAgentRunObservers,
+    additionalAttributes?: JsonObject | undefined,
   ): Promise<void> {
     const delayMs = retryDelayMs(options, attempt);
+    const attributes: JsonObject = {
+      turn,
+      attempt,
+      nextAttempt: attempt + 1,
+      maxAttempts: options.maxAttempts,
+      delayMs,
+      streaming,
+      ...retryErrorAttributes(error),
+    };
+    if (additionalAttributes !== undefined) {
+      Object.assign(attributes, additionalAttributes);
+    }
     await runObservers.event({
       name: "completion.retry",
       level: "WARNING",
-      attributes: {
-        turn,
-        attempt,
-        nextAttempt: attempt + 1,
-        maxAttempts: options.maxAttempts,
-        delayMs,
-        streaming,
-        ...retryErrorAttributes(error),
-      },
+      attributes,
     });
     await waitForRetry(delayMs, this.abortController.signal);
   }
@@ -1730,7 +1755,27 @@ export class AgentRun<Output = string, M extends CompletionModel = CompletionMod
     if (this.agent.outputSchema === undefined) return;
     if (response.choice.some((item) => item.type === "tool-call")) return;
     const text = textFromAssistantContent(response.choice);
-    const output = this.parseOutput(text, attempt, usage, { useValidatedOutput: false });
+    const normalized = normalizeStructuredOutput(text);
+    if (response.finishReason === "length") {
+      throw new AgentStructuredOutputError({
+        phase: "truncated",
+        attempt,
+        maxAttempts: this.completionRetryOptions?.maxAttempts ?? 1,
+        outputLength: text.length,
+        normalizedLength: normalized.text.length,
+        outputFormat: normalized.format,
+        attemptUsage: response.usage,
+        usage,
+        finishReason: response.finishReason,
+        providerFinishReason: response.providerFinishReason,
+      });
+    }
+    const output = this.parseOutput(text, attempt, usage, {
+      useValidatedOutput: false,
+      attemptUsage: response.usage,
+      finishReason: response.finishReason,
+      providerFinishReason: response.providerFinishReason,
+    });
     this.validatedStructuredOutput = { text, output };
   }
 
@@ -1744,7 +1789,12 @@ export class AgentRun<Output = string, M extends CompletionModel = CompletionMod
     text: string,
     attempt = 1,
     usage = Usage.empty(),
-    options: { useValidatedOutput?: boolean } = {},
+    options: {
+      useValidatedOutput?: boolean;
+      attemptUsage?: Usage;
+      finishReason?: CompletionFinishReason | undefined;
+      providerFinishReason?: string | undefined;
+    } = {},
   ): Output {
     const schema = this.agent.outputSchema;
     if (schema === undefined) return text as Output;
@@ -1764,7 +1814,10 @@ export class AgentRun<Output = string, M extends CompletionModel = CompletionMod
         outputLength: text.length,
         normalizedLength: normalized.text.length,
         outputFormat: normalized.format,
+        attemptUsage: options.attemptUsage ?? usage,
         usage,
+        finishReason: options.finishReason,
+        providerFinishReason: options.providerFinishReason,
         cause: error,
       });
     }
@@ -1778,7 +1831,10 @@ export class AgentRun<Output = string, M extends CompletionModel = CompletionMod
         outputLength: text.length,
         normalizedLength: normalized.text.length,
         outputFormat: normalized.format,
+        attemptUsage: options.attemptUsage ?? usage,
         usage,
+        finishReason: options.finishReason,
+        providerFinishReason: options.providerFinishReason,
         cause: error,
       });
     }
@@ -2365,14 +2421,20 @@ function responseStreamEvents(
 function generationArtifacts(messages: MessageType[]): {
   sources?: CompletionSource[];
   providerToolCalls?: ProviderToolCall[];
+  finishReason?: CompletionFinishReason;
+  providerFinishReason?: string;
   contextUsage?: import("../../completion/index").ContextUsage;
 } {
   const sources = new Map<string, CompletionSource>();
   const providerToolCalls = new Map<string, ProviderToolCall>();
+  let finishReason: CompletionFinishReason | undefined;
+  let providerFinishReason: string | undefined;
   let contextUsage: import("../../completion/index").ContextUsage | undefined;
   for (const message of messages) {
     const metadata = getAssistantGenerationMetadata(message);
     if (metadata !== undefined) {
+      finishReason = metadata.finishReason;
+      providerFinishReason = metadata.providerFinishReason;
       contextUsage = metadata.contextUsage;
     }
     for (const source of metadata?.sources ?? []) {
@@ -2386,11 +2448,17 @@ function generationArtifacts(messages: MessageType[]): {
   const artifacts: {
     sources?: CompletionSource[];
     providerToolCalls?: ProviderToolCall[];
+    finishReason?: CompletionFinishReason;
+    providerFinishReason?: string;
     contextUsage?: import("../../completion/index").ContextUsage;
   } = {};
   if (sources.size > 0) artifacts.sources = [...sources.values()];
   if (providerToolCalls.size > 0) {
     artifacts.providerToolCalls = [...providerToolCalls.values()];
+  }
+  if (finishReason !== undefined) artifacts.finishReason = finishReason;
+  if (providerFinishReason !== undefined) {
+    artifacts.providerFinishReason = providerFinishReason;
   }
   if (contextUsage !== undefined) artifacts.contextUsage = contextUsage;
   return artifacts;
@@ -2459,19 +2527,81 @@ function latestAssistantText(messages: readonly MessageType[]): string {
 function structuredOutputRetryRequest(
   request: CompletionRequest,
   response: CompletionResponse,
-): CompletionRequest {
-  const invalidResponse: MessageType = {
-    role: "assistant",
-    content: [...response.choice],
-  };
+  error: unknown,
+): StructuredOutputRetryRequest {
+  const truncated = error instanceof AgentStructuredOutputError && error.phase === "truncated";
   const correction: MessageType = {
     role: "user",
-    content: STRUCTURED_OUTPUT_RETRY_PROMPT,
+    content: truncated ? STRUCTURED_OUTPUT_TRUNCATED_RETRY_PROMPT : STRUCTURED_OUTPUT_RETRY_PROMPT,
+  };
+  if (truncated) {
+    return {
+      request: {
+        ...request,
+        chatHistory: [...request.chatHistory, correction],
+      },
+      previousResponse: "omitted",
+      includedOutputLength: 0,
+    };
+  }
+  const preview = structuredOutputRepairPreview(textFromAssistantContent(response.choice));
+  if (preview.includedOutputLength === 0) {
+    return {
+      request: {
+        ...request,
+        chatHistory: [...request.chatHistory, correction],
+      },
+      previousResponse: "omitted",
+      includedOutputLength: 0,
+    };
+  }
+  const invalidResponse: MessageType = {
+    role: "assistant",
+    content: [{ type: "text", text: preview.text }],
   };
   return {
-    ...request,
-    chatHistory: [...request.chatHistory, invalidResponse, correction],
+    request: {
+      ...request,
+      chatHistory: [...request.chatHistory, invalidResponse, correction],
+    },
+    previousResponse: "preview",
+    includedOutputLength: preview.includedOutputLength,
   };
+}
+
+function structuredOutputRetryEventAttributes(
+  error: unknown,
+  retryRequest: StructuredOutputRetryRequest,
+): JsonObject {
+  const attributes: JsonObject = {
+    previousResponse: retryRequest.previousResponse,
+    includedOutputLength: retryRequest.includedOutputLength,
+  };
+  if (!(error instanceof AgentStructuredOutputError)) return attributes;
+  Object.assign(attributes, {
+    failurePhase: error.phase,
+    outputLength: error.outputLength,
+    normalizedLength: error.normalizedLength,
+    attemptUsage: usageEventValue(error.attemptUsage),
+    cumulativeUsage: usageEventValue(error.usage),
+  });
+  if (error.finishReason !== undefined) attributes.finishReason = error.finishReason;
+  if (error.providerFinishReason !== undefined) {
+    attributes.providerFinishReason = error.providerFinishReason;
+  }
+  return attributes;
+}
+
+function usageEventValue(usage: Usage): JsonObject {
+  const value: JsonObject = {
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    totalTokens: usage.totalTokens,
+    cachedInputTokens: usage.cachedInputTokens,
+    cacheCreationInputTokens: usage.cacheCreationInputTokens,
+  };
+  if (usage.details !== undefined) value.details = { ...usage.details };
+  return value;
 }
 
 function providerMessages(messages: readonly MessageType[]): MessageType[] {

--- a/packages/core/src/internal/agent-runtime/stream-accumulator.ts
+++ b/packages/core/src/internal/agent-runtime/stream-accumulator.ts
@@ -185,6 +185,12 @@ export class CompletionStreamAccumulator<RawResponse = unknown> {
         usage: finalResponse.usage,
         rawResponse: finalResponse.rawResponse,
       };
+      if (finalResponse.finishReason !== undefined) {
+        mergedResponse.finishReason = finalResponse.finishReason;
+      }
+      if (finalResponse.providerFinishReason !== undefined) {
+        mergedResponse.providerFinishReason = finalResponse.providerFinishReason;
+      }
       if (finalResponse.messageId !== undefined) {
         mergedResponse.messageId = finalResponse.messageId;
       }

--- a/packages/core/src/internal/agent-runtime/structured-output.ts
+++ b/packages/core/src/internal/agent-runtime/structured-output.ts
@@ -9,6 +9,31 @@ const FENCE_END = "\n```";
 export const STRUCTURED_OUTPUT_RETRY_PROMPT =
   "Your previous response was invalid structured output. Return only raw JSON that matches the supplied JSON schema. Do not use Markdown fences or include commentary.";
 
+export const STRUCTURED_OUTPUT_TRUNCATED_RETRY_PROMPT =
+  "Your previous response exceeded the provider output limit. Return substantially shorter raw JSON that matches the supplied JSON schema. Do not use Markdown fences or include commentary.";
+
+const STRUCTURED_OUTPUT_REPAIR_PREVIEW_MAX_LENGTH = 8_192;
+const STRUCTURED_OUTPUT_REPAIR_PREVIEW_MARKER = "\n...[output omitted]...\n";
+
+export type StructuredOutputRepairPreview = Readonly<{
+  text: string;
+  includedOutputLength: number;
+}>;
+
+export function structuredOutputRepairPreview(text: string): StructuredOutputRepairPreview {
+  if (text.length <= STRUCTURED_OUTPUT_REPAIR_PREVIEW_MAX_LENGTH) {
+    return { text, includedOutputLength: text.length };
+  }
+  const availableLength =
+    STRUCTURED_OUTPUT_REPAIR_PREVIEW_MAX_LENGTH - STRUCTURED_OUTPUT_REPAIR_PREVIEW_MARKER.length;
+  const headLength = Math.ceil(availableLength / 2);
+  const tailLength = availableLength - headLength;
+  return {
+    text: `${text.slice(0, headLength)}${STRUCTURED_OUTPUT_REPAIR_PREVIEW_MARKER}${text.slice(-tailLength)}`,
+    includedOutputLength: headLength + tailLength,
+  };
+}
+
 export type NormalizedStructuredOutput = Readonly<{
   text: string;
   format: AgentStructuredOutputFormat;

--- a/packages/core/test/completion-capabilities.test.ts
+++ b/packages/core/test/completion-capabilities.test.ts
@@ -341,7 +341,7 @@ describe("generateCompletion", () => {
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({
       type: "error",
-      error: { message: "generateCompletion expected the model response to be valid JSON." },
+      error: { name: "CompletionStructuredOutputError", phase: "parse" },
     });
   });
 
@@ -437,7 +437,7 @@ describe("generateCompletion", () => {
         prompt: "hello",
         outputSchema: z.object({ title: z.string() }),
       }),
-    ).rejects.toThrow("generateCompletion expected the model response to be valid JSON.");
+    ).rejects.toMatchObject({ name: "CompletionStructuredOutputError", phase: "parse" });
   });
 });
 

--- a/packages/core/test/direct-completion-retry.test.ts
+++ b/packages/core/test/direct-completion-retry.test.ts
@@ -7,6 +7,7 @@ import {
   type CompletionModelStreamEvent,
   type CompletionRequest,
   type CompletionResponse,
+  CompletionStructuredOutputError,
   generateCompletion,
   type StreamingCompletionModel,
   streamCompletion,
@@ -92,8 +93,42 @@ describe("direct completion retries", () => {
         outputSchema: z.object({ ok: z.boolean() }),
         retries: { initialDelayMs: 0, maxDelayMs: 0 },
       }),
-    ).rejects.toThrow("valid JSON");
+    ).rejects.toMatchObject({
+      name: "CompletionStructuredOutputError",
+      phase: "parse",
+    });
     expect(model.requests).toHaveLength(1);
+  });
+
+  it("reports truncated structured output distinctly and preserves ordinary partial text", async () => {
+    const partial = response('{"ok":');
+    partial.finishReason = "length";
+    partial.providerFinishReason = "length";
+    const structuredModel = new CompletionQueueModel([partial]);
+
+    const error = await generateCompletion({
+      model: structuredModel,
+      prompt: "hello",
+      outputSchema: z.object({ ok: z.boolean() }),
+    }).catch((value) => value);
+
+    expect(error).toBeInstanceOf(CompletionStructuredOutputError);
+    expect(error).toMatchObject({
+      phase: "truncated",
+      outputLength: 6,
+      finishReason: "length",
+      providerFinishReason: "length",
+    });
+
+    const ordinaryModel = new CompletionQueueModel([partial]);
+    await expect(
+      generateCompletion({ model: ordinaryModel, prompt: "hello" }),
+    ).resolves.toMatchObject({
+      text: '{"ok":',
+      output: '{"ok":',
+      finishReason: "length",
+      providerFinishReason: "length",
+    });
   });
 
   it("retries a stream error before exposing events and aggregates usage", async () => {
@@ -120,6 +155,31 @@ describe("direct completion retries", () => {
     });
     expect(model.requests).toHaveLength(2);
     expect(model.requests[1]).toBe(model.requests[0]);
+  });
+
+  it("emits a dedicated error for a length-terminated structured stream", async () => {
+    const partial = response('{"ok":');
+    partial.finishReason = "length";
+    partial.providerFinishReason = "length";
+    const model = new StreamQueueModel([[{ type: "final", response: partial }]]);
+
+    const events = await collect(
+      streamCompletion({
+        model,
+        prompt: "hello",
+        outputSchema: z.object({ ok: z.boolean() }),
+      }),
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "error",
+      error: {
+        name: "CompletionStructuredOutputError",
+        phase: "truncated",
+        finishReason: "length",
+      },
+    });
   });
 
   it("closes a failed stream attempt before waiting to retry", async () => {

--- a/packages/core/test/message-content.test.ts
+++ b/packages/core/test/message-content.test.ts
@@ -255,6 +255,8 @@ describe("generation metadata", () => {
           generation: {
             provider: "test",
             modelId: "test-model",
+            finishReason: "length",
+            providerFinishReason: "max_output_tokens",
             usage: {
               inputTokens: 7,
               outputTokens: 2,
@@ -269,6 +271,8 @@ describe("generation metadata", () => {
     expect(getAssistantGenerationMetadata(valid)).toMatchObject({
       provider: "test",
       modelId: "test-model",
+      finishReason: "length",
+      providerFinishReason: "max_output_tokens",
       usage: { totalTokens: 9 },
     });
 

--- a/packages/core/test/observability.test.ts
+++ b/packages/core/test/observability.test.ts
@@ -297,6 +297,65 @@ describe("agent observability", () => {
     expect(JSON.stringify(observer.events[2])).not.toContain("private provider detail");
   });
 
+  it("records structured truncation retry diagnostics without response content", async () => {
+    const observer = new RecordingObserver();
+    const truncated = response([AssistantContent.text('{"answer":"private partial')]);
+    truncated.finishReason = "length";
+    truncated.providerFinishReason = "length";
+    truncated.usage = {
+      ...Usage.empty(),
+      inputTokens: 10,
+      outputTokens: 20,
+      totalTokens: 30,
+    };
+    const model = new QueueModel([
+      truncated,
+      response([AssistantContent.text('{"answer":"short"}')]),
+    ]);
+    const agent = new Agent({
+      id: "test-agent",
+      model,
+      outputSchema: z.object({ answer: z.string() }),
+      observability: { observers: { test: observer }, primaryTrace: "test" },
+      retries: { maxAttempts: 2, initialDelayMs: 0, maxDelayMs: 0 },
+    });
+
+    await agent.generate({ prompt: "hello" });
+
+    const retry = observer.events.find(
+      (event): event is { type: "run_event"; args: AgentRunEventArgs } =>
+        typeof event === "object" &&
+        event !== null &&
+        "type" in event &&
+        event.type === "run_event" &&
+        "args" in event &&
+        typeof event.args === "object" &&
+        event.args !== null &&
+        "name" in event.args &&
+        event.args.name === "completion.retry",
+    );
+    expect(retry).toMatchObject({
+      type: "run_event",
+      args: {
+        level: "WARNING",
+        attributes: {
+          attempt: 1,
+          maxAttempts: 2,
+          failurePhase: "truncated",
+          finishReason: "length",
+          providerFinishReason: "length",
+          outputLength: 26,
+          normalizedLength: 26,
+          attemptUsage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          cumulativeUsage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          previousResponse: "omitted",
+          includedOutputLength: 0,
+        },
+      },
+    });
+    expect(JSON.stringify(retry)).not.toContain("private partial");
+  });
+
   it("records multiple turns and tool calls", async () => {
     const observer = new RecordingObserver();
     const model = new QueueModel([

--- a/packages/core/test/public-exports.test.ts
+++ b/packages/core/test/public-exports.test.ts
@@ -274,6 +274,8 @@ describe("public exports", () => {
     expect(completion).not.toHaveProperty("CompletionRequestBuilder");
     expect(completion).toHaveProperty("generateCompletion");
     expect(completion).toHaveProperty("streamCompletion");
+    expect(completion).toHaveProperty("CompletionStructuredOutputError");
+    expect(publicCore).toHaveProperty("CompletionStructuredOutputError");
     expect(completion).not.toHaveProperty("createCompletion");
     expect(completion).not.toHaveProperty("createParsedCompletion");
     expect(completion).not.toHaveProperty("createCompletionStream");

--- a/packages/core/test/structured-output.test.ts
+++ b/packages/core/test/structured-output.test.ts
@@ -42,14 +42,14 @@ class QueueModel implements CompletionModel {
   };
   readonly requests: CompletionRequest[] = [];
 
-  constructor(private readonly outputs: Array<string | Error>) {}
+  constructor(private readonly outputs: Array<string | Error | CompletionResponse>) {}
 
   async completion(request: CompletionRequest): Promise<CompletionResponse> {
     this.requests.push(request);
     const output = this.outputs.shift();
     if (output === undefined) throw new Error("No queued model output.");
     if (output instanceof Error) throw output;
-    return response(output);
+    return typeof output === "string" ? response(output) : output;
   }
 }
 
@@ -100,6 +100,93 @@ describe("Agent structured output", () => {
       output: { phase: "hypotheses", hypotheses: [] },
       text: output,
     });
+  });
+
+  it("reports provider truncation before attempting to parse partial JSON", async () => {
+    const partial = '{"phase":"hypotheses","hypotheses":["unfinished';
+    const modelResponse = response(partial);
+    modelResponse.finishReason = "length";
+    modelResponse.providerFinishReason = "length";
+    const agent = new Agent({
+      id: "structured",
+      model: new QueueModel([modelResponse]),
+      outputSchema: structuredSchema,
+    });
+
+    const error = await agent.generate({ prompt: "Create hypotheses." }).catch((value) => value);
+
+    expect(error).toBeInstanceOf(AgentStructuredOutputError);
+    expect(error).toMatchObject({
+      phase: "truncated",
+      outputLength: partial.length,
+      normalizedLength: partial.length,
+      finishReason: "length",
+      providerFinishReason: "length",
+      attemptUsage: { totalTokens: 1 },
+      usage: { totalTokens: 1 },
+    });
+    expect(error.cause).toBeUndefined();
+  });
+
+  it("retries truncation from the original request without replaying partial output", async () => {
+    const partial = '{"phase":"hypotheses","hypotheses":["private partial';
+    const truncated = response(partial);
+    truncated.finishReason = "length";
+    truncated.providerFinishReason = "length";
+    const model = new QueueModel([truncated, rawJson]);
+    const agent = new Agent({
+      id: "structured",
+      model,
+      outputSchema: structuredSchema,
+      retries: { maxAttempts: 2, initialDelayMs: 0, maxDelayMs: 0 },
+    });
+
+    await expect(agent.generate({ prompt: "Create hypotheses." })).resolves.toMatchObject({
+      output: { phase: "hypotheses", hypotheses: [] },
+      usage: { totalTokens: 2 },
+    });
+    expect(JSON.stringify(model.requests[1])).not.toContain("private partial");
+    expect(model.requests[1]?.chatHistory).toEqual([
+      { role: "user", content: "Create hypotheses." },
+      {
+        role: "user",
+        content:
+          "Your previous response exceeded the provider output limit. Return substantially shorter raw JSON that matches the supplied JSON schema. Do not use Markdown fences or include commentary.",
+      },
+    ]);
+  });
+
+  it("bounds repair previews, excludes reasoning, and never accumulates failed attempts", async () => {
+    const firstText = `first-private-${"a".repeat(12_000)}`;
+    const secondText = `second-private-${"b".repeat(12_000)}`;
+    const first = response(firstText);
+    first.choice.unshift({ type: "reasoning", text: "first-secret-reasoning" });
+    const second = response(secondText);
+    second.choice.unshift({ type: "reasoning", text: "second-secret-reasoning" });
+    const model = new QueueModel([first, second, rawJson]);
+    const agent = new Agent({
+      id: "structured",
+      model,
+      outputSchema: structuredSchema,
+      retries: { maxAttempts: 3, initialDelayMs: 0, maxDelayMs: 0 },
+    });
+
+    await agent.generate({ prompt: "Create hypotheses." });
+
+    expect(model.requests).toHaveLength(3);
+    for (const request of model.requests.slice(1)) {
+      expect(request.chatHistory).toHaveLength(3);
+      expect(JSON.stringify(request)).not.toContain("secret-reasoning");
+      const repair = request.chatHistory[1];
+      expect(repair?.role).toBe("assistant");
+      if (repair?.role !== "assistant" || typeof repair.content === "string") {
+        throw new Error("Expected a text-only repair preview.");
+      }
+      const text = repair.content.find((part) => part.type === "text")?.text;
+      expect(text?.length).toBeLessThanOrEqual(8_192);
+    }
+    expect(JSON.stringify(model.requests[2])).toContain("second-private");
+    expect(JSON.stringify(model.requests[2])).not.toContain("first-private");
   });
 
   it.each([
@@ -302,6 +389,31 @@ describe("Agent structured output", () => {
     });
   });
 
+  it("retries a length-terminated structured stream without exposing or replaying it", async () => {
+    const partial = response('{"phase":"hypotheses","hypotheses":["stream-private');
+    partial.finishReason = "length";
+    partial.providerFinishReason = "length";
+    const model = new StreamingQueueModel([[{ type: "final", response: partial }], rawJson]);
+    const agent = new Agent({
+      id: "structured",
+      model,
+      outputSchema: structuredSchema,
+      retries: { maxAttempts: 2, initialDelayMs: 0, maxDelayMs: 0 },
+    });
+    const events = [];
+
+    for await (const event of agent.stream({ prompt: "Create hypotheses." })) {
+      events.push(event);
+    }
+
+    expect(JSON.stringify(events)).not.toContain("stream-private");
+    expect(JSON.stringify(model.requests[1])).not.toContain("stream-private");
+    expect(events.at(-1)).toMatchObject({
+      type: "final",
+      result: { output: { phase: "hypotheses", hypotheses: [] } },
+    });
+  });
+
   it("replays buffered reasoning and text on structured tool-call turns", async () => {
     const toolCall = AssistantContent.toolCall("call_1", "lookup", {});
     const model = new StreamingQueueModel([
@@ -349,12 +461,30 @@ describe("Agent structured output", () => {
   });
 
   it("leaves ordinary non-structured Agent output unchanged", async () => {
-    const model = new QueueModel([fencedJson]);
+    const partial = response(fencedJson);
+    partial.finishReason = "length";
+    partial.providerFinishReason = "length";
+    const model = new QueueModel([partial]);
     const agent = new Agent({ id: "ordinary", model });
 
     await expect(agent.generate({ prompt: "Answer normally." })).resolves.toMatchObject({
       output: fencedJson,
       text: fencedJson,
+      finishReason: "length",
+      providerFinishReason: "length",
+      messages: [
+        expect.anything(),
+        expect.objectContaining({
+          metadata: {
+            anvia: {
+              generation: expect.objectContaining({
+                finishReason: "length",
+                providerFinishReason: "length",
+              }),
+            },
+          },
+        }),
+      ],
     });
     expect(model.requests).toHaveLength(1);
   });

--- a/packages/embedding-fastembed/CHANGELOG.md
+++ b/packages/embedding-fastembed/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/fastembed
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/embedding-fastembed/package.json
+++ b/packages/embedding-fastembed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/fastembed",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "FastEmbed embedding model adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/embedding-transformers/CHANGELOG.md
+++ b/packages/embedding-transformers/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/transformers
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/embedding-transformers/package.json
+++ b/packages/embedding-transformers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/transformers",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Transformers.js embedding model adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/graph-neo4j/CHANGELOG.md
+++ b/packages/graph-neo4j/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/neo4j
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/graph-neo4j/package.json
+++ b/packages/graph-neo4j/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/neo4j",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Schema-first Neo4j GraphRAG integration for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @anvia/logger
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- 706b321: Preserve normalized and provider-native completion finish reasons across first-party adapters,
+  identify output-limit truncation before structured parsing, rebuild Agent repairs from the original
+  request with omitted or bounded text-only output, and log safe per-attempt retry diagnostics through
+  named observer events.
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -47,13 +47,19 @@ const result = await agent.generate({ prompt: "How do I reset my password?" });
 if (result.status === "completed") console.log(result.output);
 ```
 
-The logger observer omits final outputs, full model requests, model responses, and tool results by default. Pass `LoggerObserverOptions` to opt in when your data policy allows those payloads in logs.
+The logger observer omits final outputs, full model requests, model responses, and tool results by
+default. It records named Core observer events at their requested log level without copying their
+free-form attributes. In particular,
+`completion.retry` includes attempts, failure phase, finish reason, output lengths, per-attempt and
+cumulative usage, and whether rejected output was omitted or represented by a bounded preview; it
+never logs that output. Pass `LoggerObserverOptions` to opt in when your data policy allows the
+other payloads in logs.
 
 Agent errors are serialized before reaching the configured logger. Nested `Error.cause` chains keep
 their `name`, `message`, and `stack`, including when the destination is Pino. Cause traversal is
 bounded. Structured-output causes are reduced to safe type metadata because parser and schema error
 messages can contain rejected model content; the outer error still records its phase, attempts,
-lengths, and detected format.
+lengths, usage, finish reasons, and detected format.
 
 For local development without Pino output, use the console logger:
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/logger",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Structured logger adapters for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/logger/src/observer.ts
+++ b/packages/logger/src/observer.ts
@@ -6,6 +6,7 @@ import type {
   AgentObserver,
   AgentRunEndArgs,
   AgentRunErrorArgs,
+  AgentRunEventArgs,
   AgentRunObserver,
   AgentRunStartArgs,
   AgentToolEndArgs,
@@ -82,6 +83,24 @@ class LoggerRunObserver implements AgentRunObserver {
     return new LoggerToolObserver(toolLogger, this.options);
   }
 
+  event(args: AgentRunEventArgs): void {
+    const context: LogContext = {
+      eventName: args.name,
+      eventLevel: args.level ?? "DEFAULT",
+    };
+    if (args.timestamp !== undefined) context.eventTimestamp = args.timestamp;
+    if (args.name === "completion.retry" && args.attributes !== undefined) {
+      Object.assign(context, completionRetryContext(args.attributes));
+    }
+    if (args.level === "ERROR") {
+      this.logger.error("agent event", context);
+    } else if (args.level === "WARNING") {
+      this.logger.warn("agent event", context);
+    } else {
+      this.logger.info("agent event", context);
+    }
+  }
+
   end(args: AgentRunEndArgs): void {
     const context: LogContext = {
       runId: args.runId,
@@ -105,6 +124,40 @@ class LoggerRunObserver implements AgentRunObserver {
       messageCount: args.messages.length,
     });
   }
+}
+
+const COMPLETION_RETRY_SCALAR_ATTRIBUTES = [
+  "turn",
+  "attempt",
+  "nextAttempt",
+  "maxAttempts",
+  "delayMs",
+  "streaming",
+  "errorName",
+  "statusCode",
+  "errorCode",
+  "failurePhase",
+  "outputLength",
+  "normalizedLength",
+  "finishReason",
+  "providerFinishReason",
+  "previousResponse",
+  "includedOutputLength",
+] as const;
+
+function completionRetryContext(attributes: Readonly<Record<string, unknown>>): LogContext {
+  const context: LogContext = {};
+  for (const name of COMPLETION_RETRY_SCALAR_ATTRIBUTES) {
+    const value = attributes[name];
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      context[name] = value;
+    }
+  }
+  for (const name of ["attemptUsage", "cumulativeUsage"] as const) {
+    const value = attributes[name];
+    if (isUsageMetadata(value)) context[name] = { ...value };
+  }
+  return context;
 }
 
 class LoggerGenerationObserver implements AgentGenerationObserver {
@@ -203,11 +256,11 @@ function serializeError(error: unknown, seen = new Set<object>(), depth = 0): un
       message: error.message,
       stack: error.stack,
     };
-    if (error.name === "AgentStructuredOutputError") {
+    if (isStructuredOutputError(error)) {
       addStructuredOutputMetadata(serialized, error);
     }
     if (error.cause !== undefined) {
-      if (error.name === "AgentStructuredOutputError") {
+      if (isStructuredOutputError(error)) {
         serialized.cause = structuredOutputCauseMetadata(error.cause);
       } else {
         serialized.cause = serializeError(error.cause, seen, depth + 1);
@@ -221,7 +274,7 @@ function serializeError(error: unknown, seen = new Set<object>(), depth = 0): un
 
 function addStructuredOutputMetadata(serialized: Record<string, unknown>, error: Error): void {
   const details = error as unknown as Record<string, unknown>;
-  if (details.phase === "parse" || details.phase === "schema") {
+  if (details.phase === "truncated" || details.phase === "parse" || details.phase === "schema") {
     serialized.phase = details.phase;
   }
   for (const name of ["attempt", "maxAttempts", "outputLength", "normalizedLength"] as const) {
@@ -237,6 +290,37 @@ function addStructuredOutputMetadata(serialized: Record<string, unknown>, error:
   ) {
     serialized.outputFormat = details.outputFormat;
   }
+  if (
+    details.finishReason === "stop" ||
+    details.finishReason === "length" ||
+    details.finishReason === "content-filter" ||
+    details.finishReason === "tool-calls" ||
+    details.finishReason === "other"
+  ) {
+    serialized.finishReason = details.finishReason;
+  }
+  if (typeof details.providerFinishReason === "string") {
+    serialized.providerFinishReason = details.providerFinishReason;
+  }
+  for (const name of ["attemptUsage", "usage"] as const) {
+    if (isUsageMetadata(details[name])) serialized[name] = { ...details[name] };
+  }
+}
+
+function isStructuredOutputError(error: Error): boolean {
+  return (
+    error.name === "AgentStructuredOutputError" || error.name === "CompletionStructuredOutputError"
+  );
+}
+
+function isUsageMetadata(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const usage = value as Record<string, unknown>;
+  return (
+    typeof usage.inputTokens === "number" &&
+    typeof usage.outputTokens === "number" &&
+    typeof usage.totalTokens === "number"
+  );
 }
 
 function structuredOutputCauseMetadata(cause: unknown): Record<string, unknown> {

--- a/packages/logger/test/logger.test.ts
+++ b/packages/logger/test/logger.test.ts
@@ -194,6 +194,82 @@ describe("createLoggerObserver", () => {
     expect(logger.records[5]?.context).not.toHaveProperty("output");
   });
 
+  it("logs completion retry events with diagnostics and without model output", async () => {
+    const logger = new RecordingLogger();
+    const observer = createLoggerObserver({ logger });
+    const run = (await observer.startRun({
+      runId: "run_retry",
+      prompt: { role: "user", content: "hello" },
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+
+    await run.event?.({
+      name: "completion.retry",
+      level: "WARNING",
+      attributes: {
+        attempt: 1,
+        maxAttempts: 2,
+        failurePhase: "truncated",
+        finishReason: "length",
+        outputLength: 140_542,
+        attemptUsage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        cumulativeUsage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        previousResponse: "omitted",
+        includedOutputLength: 0,
+      },
+    });
+
+    expect(logger.records.at(-1)).toMatchObject({
+      level: "warn",
+      message: "agent event",
+      context: {
+        eventName: "completion.retry",
+        eventLevel: "WARNING",
+        attempt: 1,
+        maxAttempts: 2,
+        failurePhase: "truncated",
+        finishReason: "length",
+        outputLength: 140_542,
+        previousResponse: "omitted",
+        includedOutputLength: 0,
+      },
+    });
+    expect(JSON.stringify(logger.records.at(-1))).not.toContain("model output");
+  });
+
+  it("does not log arbitrary observer event attributes by default", async () => {
+    const logger = new RecordingLogger();
+    const observer = createLoggerObserver({ logger });
+    const run = (await observer.startRun({
+      runId: "run_event",
+      prompt: { role: "user", content: "hello" },
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+
+    await run.event?.({
+      name: "guardrail.decision",
+      level: "WARNING",
+      attributes: {
+        decision: "deny",
+        reason: "customer-secret-guardrail-reason",
+      },
+    });
+
+    expect(logger.records.at(-1)).toMatchObject({
+      level: "warn",
+      message: "agent event",
+      context: {
+        eventName: "guardrail.decision",
+        eventLevel: "WARNING",
+      },
+    });
+    expect(JSON.stringify(logger.records.at(-1))).not.toContain("customer-secret");
+    expect(logger.records.at(-1)?.context).not.toHaveProperty("decision");
+    expect(logger.records.at(-1)?.context).not.toHaveProperty("reason");
+  });
+
   it("serializes nested Error causes before handing them to Pino", async () => {
     const lines: Array<Record<string, unknown>> = [];
     const logger = createPinoLogger({
@@ -254,6 +330,7 @@ describe("createLoggerObserver", () => {
       outputLength: rejectedOutput.length,
       normalizedLength: rejectedOutput.length,
       outputFormat: "raw",
+      attemptUsage: Usage.empty(),
       usage: Usage.empty(),
       cause: new SyntaxError(`Unexpected token in ${rejectedOutput}`),
     });

--- a/packages/memory-drizzle/CHANGELOG.md
+++ b/packages/memory-drizzle/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/memory-drizzle
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/memory-drizzle/package.json
+++ b/packages/memory-drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/memory-drizzle",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Drizzle-backed durable session memory store for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/memory-postgres/CHANGELOG.md
+++ b/packages/memory-postgres/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/memory-postgres
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/memory-postgres/package.json
+++ b/packages/memory-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/memory-postgres",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Postgres-backed durable session memory store for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/memory-prisma/CHANGELOG.md
+++ b/packages/memory-prisma/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/memory-prisma
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/memory-prisma/package.json
+++ b/packages/memory-prisma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/memory-prisma",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Prisma-backed durable session memory store for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/memory-sqlite/CHANGELOG.md
+++ b/packages/memory-sqlite/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/memory-sqlite
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/memory-sqlite/package.json
+++ b/packages/memory-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/memory-sqlite",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "SQLite-backed durable session memory store for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/observability-langfuse/CHANGELOG.md
+++ b/packages/observability-langfuse/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/langfuse
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/observability-langfuse/package.json
+++ b/packages/observability-langfuse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/langfuse",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Langfuse tracing adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/observability-lens/CHANGELOG.md
+++ b/packages/observability-lens/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/lens
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+  - @anvia/otel@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/observability-lens/package.json
+++ b/packages/observability-lens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/lens",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Native Anvia Lens tracing and evaluation adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/observability-otel/CHANGELOG.md
+++ b/packages/observability-otel/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/otel
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/observability-otel/package.json
+++ b/packages/observability-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/otel",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "OpenTelemetry tracing and eval reporting adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/provider-anthropic/CHANGELOG.md
+++ b/packages/provider-anthropic/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @anvia/anthropic
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- 706b321: Preserve normalized and provider-native completion finish reasons across first-party adapters,
+  identify output-limit truncation before structured parsing, rebuild Agent repairs from the original
+  request with omitted or bounded text-only output, and log safe per-attempt retry diagnostics through
+  named observer events.
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/provider-anthropic/package.json
+++ b/packages/provider-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/anthropic",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Anthropic provider adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/provider-anthropic/src/anthropic/completion.ts
+++ b/packages/provider-anthropic/src/anthropic/completion.ts
@@ -4,6 +4,7 @@ import type { ModelContextLimits } from "@anvia/core/completion";
 import {
   type AssistantContentPart,
   assertCompletionRequestSupported,
+  type CompletionFinishReason,
   type CompletionModelCapabilities,
   type CompletionModelInfo,
   type CompletionModelStreamEvent,
@@ -105,6 +106,7 @@ export class AnthropicCompletionModel implements StreamingCompletionModel<unknow
     const streamUsageFields = emptyAnthropicStreamUsageFields();
     let hasStreamUsage = false;
     let streamMessageId: string | undefined;
+    let streamProviderFinishReason: string | undefined;
     for await (const event of stream as unknown as AsyncIterable<unknown>) {
       if (isPlainObject(event) && event.type === "content_block_start") {
         const index = numberFrom(event.index);
@@ -120,6 +122,12 @@ export class AnthropicCompletionModel implements StreamingCompletionModel<unknow
       if (isPlainObject(event)) {
         if (event.type === "message_start" && isPlainObject(event.message)) {
           streamMessageId = stringFrom(event.message.id) ?? streamMessageId;
+          streamProviderFinishReason =
+            stringFrom(event.message.stop_reason) ?? streamProviderFinishReason;
+        }
+        if (event.type === "message_delta" && isPlainObject(event.delta)) {
+          streamProviderFinishReason =
+            stringFrom(event.delta.stop_reason) ?? streamProviderFinishReason;
         }
         hasStreamUsage =
           applyAnthropicStreamUsage(event, streamUsage, streamUsageFields) || hasStreamUsage;
@@ -135,6 +143,9 @@ export class AnthropicCompletionModel implements StreamingCompletionModel<unknow
                 },
               }
             : mapped;
+        if (usageMapped.type === "final") {
+          applyAnthropicFinishReason(usageMapped.response, streamProviderFinishReason);
+        }
         const streamMapped =
           usageMapped.type === "final"
             ? {
@@ -167,6 +178,7 @@ export class AnthropicCompletionModel implements StreamingCompletionModel<unknow
         if (streamMessageId !== undefined) {
           response.messageId = streamMessageId;
         }
+        applyAnthropicFinishReason(response, streamProviderFinishReason);
         yield {
           type: "final",
           response: withContextUsage(response, this.modelInfo()),
@@ -437,12 +449,27 @@ export function fromAnthropicMessage(response: unknown): CompletionResponse {
     usage,
     rawResponse: response,
   };
+  applyAnthropicFinishReason(result, raw.stop_reason);
 
   if (typeof raw.id === "string") {
     result.messageId = raw.id;
   }
 
   return result;
+}
+
+function applyAnthropicFinishReason(response: CompletionResponse, value: unknown): void {
+  if (typeof value !== "string") return;
+  response.finishReason = anthropicFinishReason(value);
+  response.providerFinishReason = value;
+}
+
+function anthropicFinishReason(value: string): CompletionFinishReason {
+  if (value === "end_turn" || value === "stop_sequence") return "stop";
+  if (value === "max_tokens" || value === "model_context_window_exceeded") return "length";
+  if (value === "tool_use") return "tool-calls";
+  if (value === "refusal") return "content-filter";
+  return "other";
 }
 
 function anthropicUsage(

--- a/packages/provider-anthropic/test/anthropic-completion.test.ts
+++ b/packages/provider-anthropic/test/anthropic-completion.test.ts
@@ -345,6 +345,19 @@ describe("Anthropic Messages mapping", () => {
     expect(response.messageId).toBe("msg_1");
   });
 
+  it("maps Anthropic output limits to the normalized length reason", () => {
+    const response = fromAnthropicMessage({
+      stop_reason: "max_tokens",
+      content: [{ type: "text", text: '{"answer":"partial' }],
+      usage: {},
+    });
+
+    expect(response).toMatchObject({
+      finishReason: "length",
+      providerFinishReason: "max_tokens",
+    });
+  });
+
   it("maps Anthropic thinking and redacted thinking blocks", () => {
     const response = fromAnthropicMessage({
       content: [
@@ -525,7 +538,11 @@ describe("Anthropic Messages mapping", () => {
     });
     expect(events.find((event) => event.type === "turn_end")).toMatchObject({
       type: "turn_end",
-      response: { messageId: "msg_1" },
+      response: {
+        messageId: "msg_1",
+        finishReason: "stop",
+        providerFinishReason: "end_turn",
+      },
     });
   });
 

--- a/packages/provider-gemini/CHANGELOG.md
+++ b/packages/provider-gemini/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @anvia/gemini
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- 706b321: Preserve normalized and provider-native completion finish reasons across first-party adapters,
+  identify output-limit truncation before structured parsing, rebuild Agent repairs from the original
+  request with omitted or bounded text-only output, and log safe per-attempt retry diagnostics through
+  named observer events.
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/provider-gemini/package.json
+++ b/packages/provider-gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/gemini",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Gemini provider adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/provider-gemini/src/gemini/completion.ts
+++ b/packages/provider-gemini/src/gemini/completion.ts
@@ -2,6 +2,7 @@ import type { ModelContextLimits } from "@anvia/core/completion";
 import {
   type AssistantContentPart,
   assertCompletionRequestSupported,
+  type CompletionFinishReason,
   type CompletionModelCapabilities,
   type CompletionModelInfo,
   type CompletionModelStreamEvent,
@@ -478,11 +479,41 @@ export function fromGeminiGenerateContentResponse(response: unknown): Completion
     usage: usageFromGemini(raw.usageMetadata),
     rawResponse: response,
   };
+  applyGeminiFinishReason(result, raw);
   const id = stringFrom(raw.responseId) ?? stringFrom(raw.id);
   if (id !== undefined) {
     result.messageId = id;
   }
   return result;
+}
+
+function applyGeminiFinishReason(response: CompletionResponse, raw: Record<string, unknown>): void {
+  const value = stringFrom(primaryGeminiCandidate(raw)?.finishReason);
+  if (value === undefined) return;
+  response.finishReason = geminiFinishReason(value, response.choice);
+  response.providerFinishReason = value;
+}
+
+function geminiFinishReason(
+  value: string,
+  choice: readonly AssistantContentPart[],
+): CompletionFinishReason {
+  if (value === "MAX_TOKENS") return "length";
+  if (
+    value === "SAFETY" ||
+    value === "RECITATION" ||
+    value === "BLOCKLIST" ||
+    value === "PROHIBITED_CONTENT" ||
+    value === "SPII" ||
+    value === "IMAGE_SAFETY" ||
+    value === "IMAGE_PROHIBITED_CONTENT"
+  ) {
+    return "content-filter";
+  }
+  if (value === "STOP") {
+    return choice.some((part) => part.type === "tool-call") ? "tool-calls" : "stop";
+  }
+  return "other";
 }
 
 export function fromGeminiGenerateContentStreamChunk(chunk: unknown): CompletionModelStreamEvent[] {
@@ -656,6 +687,15 @@ function candidateParts(response: Record<string, unknown>): Array<Record<string,
       ? candidate.content.parts.filter(isPlainObject)
       : [];
   });
+}
+
+function primaryGeminiCandidate(
+  response: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const candidates = Array.isArray(response.candidates)
+    ? response.candidates.filter(isPlainObject)
+    : [];
+  return candidates.find((candidate) => candidate.index === 0) ?? candidates[0];
 }
 
 function usageFromGemini(usage: unknown): Usage {

--- a/packages/provider-gemini/test/completion.test.ts
+++ b/packages/provider-gemini/test/completion.test.ts
@@ -362,6 +362,77 @@ describe("Gemini completion mapping", () => {
     });
   });
 
+  it("maps Gemini token limits to the normalized length reason", () => {
+    const response = fromGeminiGenerateContentResponse({
+      candidates: [
+        {
+          index: 0,
+          finishReason: "MAX_TOKENS",
+          content: { parts: [{ text: '{"answer":"partial' }] },
+        },
+      ],
+      usageMetadata: {},
+    });
+
+    expect(response).toMatchObject({
+      finishReason: "length",
+      providerFinishReason: "MAX_TOKENS",
+    });
+  });
+
+  it("gives Gemini terminal failures precedence over inferred tool-call completion", () => {
+    const truncated = fromGeminiGenerateContentResponse({
+      candidates: [
+        {
+          finishReason: "MAX_TOKENS",
+          content: {
+            parts: [{ functionCall: { id: "call-1", name: "lookup", args: { id: "A1" } } }],
+          },
+        },
+      ],
+      usageMetadata: {},
+    });
+    const filtered = fromGeminiGenerateContentResponse({
+      candidates: [
+        {
+          finishReason: "IMAGE_PROHIBITED_CONTENT",
+          content: {
+            parts: [{ functionCall: { id: "call-2", name: "lookup", args: { id: "A2" } } }],
+          },
+        },
+      ],
+      usageMetadata: {},
+    });
+
+    expect(truncated).toMatchObject({
+      finishReason: "length",
+      providerFinishReason: "MAX_TOKENS",
+    });
+    expect(filtered).toMatchObject({
+      finishReason: "content-filter",
+      providerFinishReason: "IMAGE_PROHIBITED_CONTENT",
+    });
+  });
+
+  it("infers Gemini tool-call completion only from a normal stop", () => {
+    const response = fromGeminiGenerateContentResponse({
+      candidates: [
+        {
+          finishReason: "STOP",
+          content: {
+            parts: [{ functionCall: { id: "call-1", name: "lookup", args: { id: "A1" } } }],
+          },
+        },
+      ],
+      usageMetadata: {},
+    });
+
+    expect(response).toMatchObject({
+      finishReason: "tool-calls",
+      providerFinishReason: "STOP",
+    });
+  });
+
   it("maps Gemini streaming chunks", () => {
     expect(
       fromGeminiGenerateContentStreamChunk({

--- a/packages/provider-grok/CHANGELOG.md
+++ b/packages/provider-grok/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @anvia/grok
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- 706b321: Preserve normalized and provider-native completion finish reasons across first-party adapters,
+  identify output-limit truncation before structured parsing, rebuild Agent repairs from the original
+  request with omitted or bounded text-only output, and log safe per-attempt retry diagnostics through
+  named observer events.
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+  - @anvia/openai@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/provider-grok/package.json
+++ b/packages/provider-grok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/grok",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Grok provider adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/provider-mistral/CHANGELOG.md
+++ b/packages/provider-mistral/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @anvia/mistral
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- 706b321: Preserve normalized and provider-native completion finish reasons across first-party adapters,
+  identify output-limit truncation before structured parsing, rebuild Agent repairs from the original
+  request with omitted or bounded text-only output, and log safe per-attempt retry diagnostics through
+  named observer events.
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/provider-mistral/package.json
+++ b/packages/provider-mistral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/mistral",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Mistral provider adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/provider-mistral/src/mistral/completion.ts
+++ b/packages/provider-mistral/src/mistral/completion.ts
@@ -2,6 +2,7 @@ import type { ModelContextLimits } from "@anvia/core/completion";
 import {
   type AssistantContentPart,
   assertCompletionRequestSupported,
+  type CompletionFinishReason,
   type CompletionModelCapabilities,
   type CompletionModelInfo,
   type CompletionModelStreamEvent,
@@ -83,8 +84,13 @@ export class MistralCompletionModel implements StreamingCompletionModel<unknown>
       params as never,
       mistralRequestOptions(options) as never,
     );
+    let providerFinishReason: string | undefined;
     for await (const chunk of stream as unknown as AsyncIterable<unknown>) {
+      providerFinishReason = mistralProviderFinishReason(chunk) ?? providerFinishReason;
       for (const event of fromMistralChatStreamChunk(chunk)) {
+        if (event.type === "final") {
+          applyMistralFinishReason(event.response, providerFinishReason);
+        }
         yield event.type === "final"
           ? {
               ...event,
@@ -224,6 +230,7 @@ export function fromMistralChatResponse(response: unknown): CompletionResponse {
     usage: usageFromMistral(raw.usage),
     rawResponse: response,
   };
+  applyMistralFinishReason(result, mistralProviderFinishReason(response));
 
   if (typeof raw.id === "string") {
     result.messageId = raw.id;
@@ -279,10 +286,31 @@ export function fromMistralChatStreamChunk(chunk: unknown): CompletionModelStrea
     if (typeof chunk.id === "string") {
       response.messageId = chunk.id;
     }
+    applyMistralFinishReason(response, mistralProviderFinishReason(chunk));
     events.push({ type: "final", response });
   }
 
   return events;
+}
+
+function mistralProviderFinishReason(value: unknown): string | undefined {
+  if (!isPlainObject(value)) return undefined;
+  const choices = Array.isArray(value.choices) ? value.choices.filter(isPlainObject) : [];
+  const choice = choices.find((candidate) => candidate.index === 0) ?? choices[0];
+  return stringFrom(choice?.finishReason) ?? stringFrom(choice?.finish_reason);
+}
+
+function applyMistralFinishReason(response: CompletionResponse, value: string | undefined): void {
+  if (value === undefined) return;
+  response.finishReason = mistralFinishReason(value);
+  response.providerFinishReason = value;
+}
+
+function mistralFinishReason(value: string): CompletionFinishReason {
+  if (value === "stop") return "stop";
+  if (value === "length" || value === "model_length") return "length";
+  if (value === "tool_calls" || value === "function_call") return "tool-calls";
+  return "other";
 }
 
 function usageFromMistral(usage: unknown): Usage {

--- a/packages/provider-mistral/test/completion.test.ts
+++ b/packages/provider-mistral/test/completion.test.ts
@@ -347,12 +347,31 @@ describe("Mistral completion mapping", () => {
     });
   });
 
+  it("maps Mistral token limits to the normalized length reason", () => {
+    const response = fromMistralChatResponse({
+      choices: [
+        {
+          index: 0,
+          finishReason: "length",
+          message: { content: '{"answer":"partial' },
+        },
+      ],
+      usage: {},
+    });
+
+    expect(response).toMatchObject({
+      finishReason: "length",
+      providerFinishReason: "length",
+    });
+  });
+
   it("maps Mistral streaming chunks", () => {
     expect(
       fromMistralChatStreamChunk({
         id: "cmpl_1",
         choices: [
           {
+            finishReason: "length",
             delta: {
               content: "Hello",
               toolCalls: [
@@ -384,6 +403,8 @@ describe("Mistral completion mapping", () => {
         type: "final",
         response: expect.objectContaining({
           messageId: "cmpl_1",
+          finishReason: "length",
+          providerFinishReason: "length",
           usage: {
             ...Usage.empty(),
             inputTokens: 1,

--- a/packages/provider-openai/CHANGELOG.md
+++ b/packages/provider-openai/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @anvia/openai
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- 706b321: Preserve normalized and provider-native completion finish reasons across first-party adapters,
+  identify output-limit truncation before structured parsing, rebuild Agent repairs from the original
+  request with omitted or bounded text-only output, and log safe per-attempt retry diagnostics through
+  named observer events.
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/provider-openai/package.json
+++ b/packages/provider-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/openai",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "OpenAI provider adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/provider-openai/src/openai/chat-completion.ts
+++ b/packages/provider-openai/src/openai/chat-completion.ts
@@ -2,6 +2,7 @@ import type { ModelContextLimits } from "@anvia/core/completion";
 import {
   type AssistantContentPart,
   assertCompletionRequestSupported,
+  type CompletionFinishReason,
   type CompletionModelCapabilities,
   type CompletionModelInfo,
   type CompletionModelStreamEvent,
@@ -17,6 +18,7 @@ import {
   type ToolChoice,
   type ToolDefinition,
   type ToolResultPart,
+  Usage,
   type UserContentPart,
   withContextUsage,
 } from "@anvia/core/completion";
@@ -135,6 +137,13 @@ export class OpenAIChatCompletionModel implements StreamingCompletionModel<unkno
       }
     }
     streamState.assertComplete();
+    const finalEvent = streamState.finalEvent();
+    if (finalEvent !== undefined) {
+      yield {
+        ...finalEvent,
+        response: withContextUsage(finalEvent.response, this.modelInfo()),
+      };
+    }
   }
 }
 
@@ -302,6 +311,7 @@ export function fromOpenAIChatCompletionResponse(response: unknown): CompletionR
     usage: usageFromOpenAIChatCompletion(raw.usage),
     rawResponse: response,
   };
+  applyOpenAIChatFinishReason(result, firstChoice?.finish_reason);
 
   if (typeof raw.id === "string") {
     result.messageId = raw.id;
@@ -387,6 +397,11 @@ function mapOpenAIChatCompletionStreamChunk(
   };
   if (mapping.hasFinishReason) {
     mapping.finishReason = choice?.finish_reason;
+    for (const event of mapping.events) {
+      if (event.type === "final") {
+        applyOpenAIChatFinishReason(event.response, mapping.finishReason);
+      }
+    }
   }
   return mapping;
 }
@@ -395,16 +410,26 @@ class OpenAIChatCompletionStreamState {
   private readonly reasoningId = crypto.randomUUID();
   private hasToolCalls = false;
   private hasFinishReason = false;
+  private hasFinalResponse = false;
   private finishReason: unknown;
+  private terminalChunk: unknown;
 
   mapChunk(chunk: unknown): ChatCompletionStreamChunkMapping {
     const mapping = mapOpenAIChatCompletionStreamChunk(chunk, this.reasoningId);
-    this.accept(mapping);
+    this.accept(mapping, chunk);
+    if (this.hasFinishReason) {
+      for (const event of mapping.events) {
+        if (event.type === "final") {
+          applyOpenAIChatFinishReason(event.response, this.finishReason);
+        }
+      }
+    }
     return mapping;
   }
 
-  private accept(mapping: ChatCompletionStreamChunkMapping): void {
+  private accept(mapping: ChatCompletionStreamChunkMapping, chunk: unknown): void {
     this.hasToolCalls ||= mapping.hasToolCalls;
+    this.hasFinalResponse ||= mapping.events.some((event) => event.type === "final");
     if (!mapping.hasFinishReason) {
       return;
     }
@@ -413,9 +438,24 @@ class OpenAIChatCompletionStreamState {
     }
     this.hasFinishReason = true;
     this.finishReason = mapping.finishReason;
+    this.terminalChunk = chunk;
     if (this.hasToolCalls) {
       this.assertSupportedFinishReason();
     }
+  }
+
+  finalEvent(): Extract<CompletionModelStreamEvent, { type: "final" }> | undefined {
+    if (!this.hasFinishReason || this.hasFinalResponse) return undefined;
+    const response: CompletionResponse = {
+      choice: [],
+      usage: Usage.empty(),
+      rawResponse: this.terminalChunk,
+    };
+    applyOpenAIChatFinishReason(response, this.finishReason);
+    if (isPlainObject(this.terminalChunk) && typeof this.terminalChunk.id === "string") {
+      response.messageId = this.terminalChunk.id;
+    }
+    return { type: "final", response };
   }
 
   assertComplete(): void {
@@ -443,6 +483,20 @@ class OpenAIChatCompletionStreamState {
       throw new Error(UNSUPPORTED_TOOL_FINISH_ERROR);
     }
   }
+}
+
+function applyOpenAIChatFinishReason(response: CompletionResponse, value: unknown): void {
+  if (!isTerminalFinishReason(value)) return;
+  response.finishReason = openAIChatFinishReason(value);
+  if (typeof value === "string") response.providerFinishReason = value;
+}
+
+function openAIChatFinishReason(value: unknown): CompletionFinishReason {
+  if (value === "stop") return "stop";
+  if (value === "length") return "length";
+  if (value === "content_filter") return "content-filter";
+  if (value === "tool_calls" || value === "function_call") return "tool-calls";
+  return "other";
 }
 
 function primaryStreamChoice(value: unknown): Record<string, unknown> | undefined {

--- a/packages/provider-openai/src/openai/responses.ts
+++ b/packages/provider-openai/src/openai/responses.ts
@@ -2,6 +2,7 @@ import type { ModelContextLimits } from "@anvia/core/completion";
 import {
   type AssistantContentPart,
   assertCompletionRequestSupported,
+  type CompletionFinishReason,
   type CompletionModelCapabilities,
   type CompletionModelInfo,
   type CompletionModelStreamEvent,
@@ -293,6 +294,7 @@ export function fromOpenAIResponse(response: unknown): CompletionResponse {
     usage: usageFromOpenAIResponse(raw.usage),
     rawResponse: response,
   };
+  applyOpenAIResponseFinishReason(result, raw);
 
   if (typeof raw.id === "string") {
     result.messageId = raw.id;
@@ -305,6 +307,36 @@ export function fromOpenAIResponse(response: unknown): CompletionResponse {
   }
 
   return result;
+}
+
+function applyOpenAIResponseFinishReason(
+  response: CompletionResponse,
+  raw: Record<string, unknown>,
+): void {
+  const status = stringFrom(raw.status);
+  const incompleteDetails = isPlainObject(raw.incomplete_details) ? raw.incomplete_details : {};
+  const incompleteReason = stringFrom(incompleteDetails.reason);
+  const providerFinishReason = incompleteReason ?? status;
+  if (providerFinishReason === undefined) return;
+
+  let finishReason: CompletionFinishReason;
+  if (status === "incomplete") {
+    if (incompleteReason === "max_output_tokens") {
+      finishReason = "length";
+    } else if (incompleteReason === "content_filter") {
+      finishReason = "content-filter";
+    } else {
+      finishReason = "other";
+    }
+  } else if (response.choice.some((part) => part.type === "tool-call")) {
+    finishReason = "tool-calls";
+  } else if (status === "completed") {
+    finishReason = "stop";
+  } else {
+    finishReason = "other";
+  }
+  response.finishReason = finishReason;
+  response.providerFinishReason = providerFinishReason;
 }
 
 export function fromOpenAIStreamEvent(event: unknown): CompletionModelStreamEvent | undefined {

--- a/packages/provider-openai/test/openai-chat-completion.test.ts
+++ b/packages/provider-openai/test/openai-chat-completion.test.ts
@@ -80,6 +80,24 @@ describe("OpenAI chat-completions client path", () => {
     ]);
   });
 
+  it("preserves normalized and provider finish reasons for non-streaming responses", () => {
+    const response = fromOpenAIChatCompletionResponse({
+      choices: [
+        {
+          index: 0,
+          finish_reason: "length",
+          message: { role: "assistant", content: '{"answer":"partial' },
+        },
+      ],
+      usage: {},
+    });
+
+    expect(response).toMatchObject({
+      finishReason: "length",
+      providerFinishReason: "length",
+    });
+  });
+
   it("keeps protocol selection explicit for custom base URLs", () => {
     const openai = new OpenAIClient({
       apiKey: "test",
@@ -378,7 +396,76 @@ describe("OpenAI chat-completions client path", () => {
       done: false,
       value: { type: "text_delta", delta: " world" },
     });
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "final",
+        response: {
+          finishReason: "stop",
+          providerFinishReason: "stop",
+        },
+      },
+    });
     await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined });
+  });
+
+  it("preserves a length finish reason for text-only streams", async () => {
+    const model = openAIChatModelWithStreams([
+      [
+        {
+          choices: [
+            { index: 0, finish_reason: "length", delta: { content: '{"answer":"partial' } },
+          ],
+        },
+        { choices: [], usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 } },
+      ],
+    ]);
+
+    const events = await collectStreamEvents(model);
+    expect(events.at(-1)).toMatchObject({
+      type: "final",
+      response: {
+        finishReason: "length",
+        providerFinishReason: "length",
+      },
+    });
+  });
+
+  it("preserves a terminal finish reason when an OpenAI-compatible stream omits usage", async () => {
+    const model = openAIChatModelWithStreams([
+      [
+        {
+          id: "cmpl_without_usage",
+          choices: [
+            { index: 0, finish_reason: "length", delta: { content: '{"answer":"partial' } },
+          ],
+        },
+      ],
+    ]);
+
+    const events = await collectStreamEvents(model);
+    expect(events.at(-1)).toEqual({
+      type: "final",
+      response: {
+        choice: [],
+        usage: {
+          inputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+          cachedInputTokens: 0,
+          cacheCreationInputTokens: 0,
+        },
+        finishReason: "length",
+        providerFinishReason: "length",
+        rawResponse: {
+          id: "cmpl_without_usage",
+          choices: [
+            { index: 0, finish_reason: "length", delta: { content: '{"answer":"partial' } },
+          ],
+        },
+        messageId: "cmpl_without_usage",
+      },
+    });
   });
 
   it("rejects malformed non-streaming tool arguments", () => {

--- a/packages/provider-openai/test/openai-responses.test.ts
+++ b/packages/provider-openai/test/openai-responses.test.ts
@@ -55,6 +55,25 @@ describe("OpenAI Responses mapping", () => {
     expect(unknown.contextLimits).toBeUndefined();
   });
 
+  it("maps incomplete max-output responses to the normalized length reason", () => {
+    const response = fromOpenAIResponse({
+      status: "incomplete",
+      incomplete_details: { reason: "max_output_tokens" },
+      output: [
+        {
+          type: "message",
+          content: [{ type: "output_text", text: '{"answer":"partial' }],
+        },
+      ],
+      usage: {},
+    });
+
+    expect(response).toMatchObject({
+      finishReason: "length",
+      providerFinishReason: "max_output_tokens",
+    });
+  });
+
   it("attaches context usage to completed and streamed responses", async () => {
     const rawResponse = {
       output: [{ type: "message", content: [{ type: "output_text", text: "ok" }] }],

--- a/packages/react-ui/CHANGELOG.md
+++ b/packages/react-ui/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/react-ui
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- @anvia/client@1.0.0-rc.6
+- @anvia/react@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/react-ui",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Composable React UI primitives for Anvia chat and completion experiences.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/react
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+  - @anvia/client@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/react",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "React hooks for the explicit Anvia client stream protocol.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @anvia/server
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- @anvia/client@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/server",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Server-side client protocol and generic event stream responses for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/tool-browser/CHANGELOG.md
+++ b/packages/tool-browser/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/browser
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+  - @anvia/sandbox@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/tool-browser/package.json
+++ b/packages/tool-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/browser",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Visible Chromium runtime and semantic browser tools for Anvia agents.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/tool-sandbox/CHANGELOG.md
+++ b/packages/tool-sandbox/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/sandbox
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/tool-sandbox/package.json
+++ b/packages/tool-sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/sandbox",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Sandboxed workspace tools for Anvia agents.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/tool-studio/CHANGELOG.md
+++ b/packages/tool-studio/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @anvia/studio
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+  - @anvia/client@1.0.0-rc.6
+  - @anvia/react@1.0.0-rc.6
+  - @anvia/react-ui@1.0.0-rc.6
+  - @anvia/server@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/tool-studio/package.json
+++ b/packages/tool-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/studio",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Studio UI and HTTP runtime for Anvia agents.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/vector-chroma/CHANGELOG.md
+++ b/packages/vector-chroma/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/chroma
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/vector-chroma/package.json
+++ b/packages/vector-chroma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/chroma",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "ChromaDB vector store adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/vector-lancedb/CHANGELOG.md
+++ b/packages/vector-lancedb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/lancedb
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/vector-lancedb/package.json
+++ b/packages/vector-lancedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/lancedb",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "LanceDB vector store adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/vector-milvus/CHANGELOG.md
+++ b/packages/vector-milvus/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/milvus
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/vector-milvus/package.json
+++ b/packages/vector-milvus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/milvus",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Milvus vector store adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/vector-pgvector/CHANGELOG.md
+++ b/packages/vector-pgvector/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/pgvector
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/vector-pgvector/package.json
+++ b/packages/vector-pgvector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/pgvector",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Postgres pgvector store adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/vector-pinecone/CHANGELOG.md
+++ b/packages/vector-pinecone/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/pinecone
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/vector-pinecone/package.json
+++ b/packages/vector-pinecone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/pinecone",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Pinecone vector store adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/vector-qdrant/CHANGELOG.md
+++ b/packages/vector-qdrant/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/qdrant
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/vector-qdrant/package.json
+++ b/packages/vector-qdrant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/qdrant",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Qdrant vector store adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/vector-redis/CHANGELOG.md
+++ b/packages/vector-redis/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/redis
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/vector-redis/package.json
+++ b/packages/vector-redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/redis",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Redis vector store adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/vector-weaviate/CHANGELOG.md
+++ b/packages/vector-weaviate/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/weaviate
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- Updated dependencies [706b321]
+  - @anvia/core@1.0.0-rc.6
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/packages/vector-weaviate/package.json
+++ b/packages/vector-weaviate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/weaviate",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Weaviate vector store adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",


### PR DESCRIPTION
## Summary

Prepare Anvia 1.0.0-rc.6 with structured-output truncation hardening.

- preserve normalized and provider-native finish reasons across first-party completion adapters
- detect provider output-limit truncation before JSON parsing
- rebuild Agent repair attempts from the original request without replaying enormous truncated responses
- emit safe retry diagnostics without leaking arbitrary observer event attributes
- add regression coverage for provider mappings, retry behavior, streaming, and logging
- synchronize all 32 public packages at 1.0.0-rc.6

## Root cause

Providers could terminate structured output at their output limit, but finish reasons were discarded or incompletely propagated. The resulting partial JSON was reported as malformed and could be replayed into cumulative retries. Generic logger event attributes also bypassed safe logging defaults.

## Validation

- pnpm check
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm test:release-scripts
- pnpm release-train:validate
- pnpm release-train:verify-packs
- Bugbot review with all concrete findings fixed