### PR TITLE
fix(ci): install workspace dependencies before publish

### DIFF
--- a/.changeset/fix-oidc-publish-workspace-install.md
+++ b/.changeset/fix-oidc-publish-workspace-install.md
@@ -1,0 +1,5 @@
+---
+"@anvia/core": patch
+---
+
+Install workspace dependencies in the OIDC publish job before packing the synchronized release train.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,6 +233,9 @@ jobs:
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Install OIDC-capable npm
         run: npm install --global npm@12.0.2
 

--- a/scripts/release-train.test.mjs
+++ b/scripts/release-train.test.mjs
@@ -145,6 +145,21 @@ test("RC notifications use the dedicated npm channel and presentation", () => {
   });
 });
 
+test("OIDC publishing installs workspace dependencies before packing", () => {
+  const workflow = readFileSync(
+    path.join(repositoryRoot, ".github", "workflows", "release.yml"),
+    "utf8",
+  );
+  const publishJob = workflow.slice(workflow.indexOf("\n  publish:"));
+  const installDependencies = publishJob.indexOf("- name: Install dependencies");
+  const publishPackages = publishJob.indexOf("- name: Publish packages");
+
+  assert.notEqual(installDependencies, -1);
+  assert.notEqual(publishPackages, -1);
+  assert.ok(installDependencies < publishPackages);
+  assert.match(publishJob, /- name: Install dependencies\n\s+run: pnpm install --frozen-lockfile/);
+});
+
 test("Changesets drives rc.0 through rc.2 and exits to stable 1.0.0", () => {
   const fixture = createReleaseFixture();
   try {


### PR DESCRIPTION
## Summary

- install the workspace in the OIDC publish job before packing packages
- prevent `ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL` for packages with `workspace:*` dependencies
- add release-workflow regression coverage

## Incident

The `v1.0.0-rc.8` OIDC run successfully published `@anvia/core@1.0.0-rc.8` with provenance, then failed to pack the other 31 packages because the publish job had not installed workspace dependencies.

## Validation

- `pnpm test:release-scripts`
- `pnpm check`
- local `pnpm --filter @anvia/client pack` after install

A follow-up `rc.9` release will supersede the partial `rc.8`.