### PR TITLE
chore: prepare 1.0.0-rc.9

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -47,6 +47,7 @@
     "explicit-client-stream-boundary",
     "fix-browser-interaction-boundary",
     "fix-lancedb-metadata-filters",
+    "fix-oidc-publish-workspace-install",
     "fix-provider-tool-output-integrity",
     "fix-structured-output-truncation",
     "migrate-npm-trusted-publishing",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/client
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/client",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Framework-neutral client protocol, transports, and UI message state for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @anvia/core
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- c0c6cb8: Install workspace dependencies in the OIDC publish job before packing the synchronized release train.
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/core",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Core runtime primitives for context-aware Anvia agents.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/embedding-fastembed/CHANGELOG.md
+++ b/packages/embedding-fastembed/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/fastembed
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/embedding-fastembed/package.json
+++ b/packages/embedding-fastembed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/fastembed",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "FastEmbed embedding model adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/embedding-transformers/CHANGELOG.md
+++ b/packages/embedding-transformers/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/transformers
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/embedding-transformers/package.json
+++ b/packages/embedding-transformers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/transformers",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Transformers.js embedding model adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/graph-neo4j/CHANGELOG.md
+++ b/packages/graph-neo4j/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/neo4j
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/graph-neo4j/package.json
+++ b/packages/graph-neo4j/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/neo4j",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Schema-first Neo4j GraphRAG integration for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/logger
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/logger",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Structured logger adapters for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/memory-drizzle/CHANGELOG.md
+++ b/packages/memory-drizzle/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/memory-drizzle
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/memory-drizzle/package.json
+++ b/packages/memory-drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/memory-drizzle",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Drizzle-backed durable session memory store for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/memory-postgres/CHANGELOG.md
+++ b/packages/memory-postgres/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/memory-postgres
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/memory-postgres/package.json
+++ b/packages/memory-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/memory-postgres",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Postgres-backed durable session memory store for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/memory-prisma/CHANGELOG.md
+++ b/packages/memory-prisma/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/memory-prisma
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/memory-prisma/package.json
+++ b/packages/memory-prisma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/memory-prisma",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Prisma-backed durable session memory store for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/memory-sqlite/CHANGELOG.md
+++ b/packages/memory-sqlite/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/memory-sqlite
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/memory-sqlite/package.json
+++ b/packages/memory-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/memory-sqlite",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "SQLite-backed durable session memory store for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/observability-langfuse/CHANGELOG.md
+++ b/packages/observability-langfuse/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/langfuse
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/observability-langfuse/package.json
+++ b/packages/observability-langfuse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/langfuse",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Langfuse tracing adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/observability-lens/CHANGELOG.md
+++ b/packages/observability-lens/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/lens
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+  - @anvia/otel@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/observability-lens/package.json
+++ b/packages/observability-lens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/lens",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Native Anvia Lens tracing and evaluation adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/observability-otel/CHANGELOG.md
+++ b/packages/observability-otel/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/otel
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/observability-otel/package.json
+++ b/packages/observability-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/otel",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "OpenTelemetry tracing and eval reporting adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/provider-anthropic/CHANGELOG.md
+++ b/packages/provider-anthropic/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/anthropic
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/provider-anthropic/package.json
+++ b/packages/provider-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/anthropic",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Anthropic provider adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/provider-gemini/CHANGELOG.md
+++ b/packages/provider-gemini/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/gemini
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/provider-gemini/package.json
+++ b/packages/provider-gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/gemini",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Gemini provider adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/provider-grok/CHANGELOG.md
+++ b/packages/provider-grok/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/grok
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+  - @anvia/openai@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/provider-grok/package.json
+++ b/packages/provider-grok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/grok",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Grok provider adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/provider-mistral/CHANGELOG.md
+++ b/packages/provider-mistral/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/mistral
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/provider-mistral/package.json
+++ b/packages/provider-mistral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/mistral",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Mistral provider adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/provider-openai/CHANGELOG.md
+++ b/packages/provider-openai/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/openai
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/provider-openai/package.json
+++ b/packages/provider-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/openai",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "OpenAI provider adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/react-ui/CHANGELOG.md
+++ b/packages/react-ui/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/react-ui
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- @anvia/client@1.0.0-rc.9
+- @anvia/react@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/react-ui",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Composable React UI primitives for Anvia chat and completion experiences.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/react
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+  - @anvia/client@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/react",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "React hooks for the explicit Anvia client stream protocol.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @anvia/server
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- @anvia/client@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/server",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Server-side client protocol and generic event stream responses for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/tool-browser/CHANGELOG.md
+++ b/packages/tool-browser/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @anvia/browser
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+  - @anvia/sandbox@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/tool-browser/package.json
+++ b/packages/tool-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/browser",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Visible Chromium runtime and semantic browser tools for Anvia agents.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/tool-sandbox/CHANGELOG.md
+++ b/packages/tool-sandbox/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/sandbox
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/tool-sandbox/package.json
+++ b/packages/tool-sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/sandbox",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Sandboxed workspace tools for Anvia agents.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/tool-studio/CHANGELOG.md
+++ b/packages/tool-studio/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @anvia/studio
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+  - @anvia/client@1.0.0-rc.9
+  - @anvia/react@1.0.0-rc.9
+  - @anvia/react-ui@1.0.0-rc.9
+  - @anvia/server@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/tool-studio/package.json
+++ b/packages/tool-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/studio",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Studio UI and HTTP runtime for Anvia agents.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/vector-chroma/CHANGELOG.md
+++ b/packages/vector-chroma/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/chroma
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/vector-chroma/package.json
+++ b/packages/vector-chroma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/chroma",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "ChromaDB vector store adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/vector-lancedb/CHANGELOG.md
+++ b/packages/vector-lancedb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/lancedb
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/vector-lancedb/package.json
+++ b/packages/vector-lancedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/lancedb",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "LanceDB vector store adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/vector-milvus/CHANGELOG.md
+++ b/packages/vector-milvus/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/milvus
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/vector-milvus/package.json
+++ b/packages/vector-milvus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/milvus",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Milvus vector store adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/vector-pgvector/CHANGELOG.md
+++ b/packages/vector-pgvector/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/pgvector
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/vector-pgvector/package.json
+++ b/packages/vector-pgvector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/pgvector",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Postgres pgvector store adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/vector-pinecone/CHANGELOG.md
+++ b/packages/vector-pinecone/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/pinecone
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/vector-pinecone/package.json
+++ b/packages/vector-pinecone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/pinecone",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Pinecone vector store adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/vector-qdrant/CHANGELOG.md
+++ b/packages/vector-qdrant/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/qdrant
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/vector-qdrant/package.json
+++ b/packages/vector-qdrant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/qdrant",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Qdrant vector store adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/vector-redis/CHANGELOG.md
+++ b/packages/vector-redis/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/redis
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/vector-redis/package.json
+++ b/packages/vector-redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/redis",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Redis vector store adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",

--- a/packages/vector-weaviate/CHANGELOG.md
+++ b/packages/vector-weaviate/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @anvia/weaviate
 
+## 1.0.0-rc.9
+
+### Patch Changes
+
+- Updated dependencies [c0c6cb8]
+  - @anvia/core@1.0.0-rc.9
+
 ## 1.0.0-rc.8
 
 ### Patch Changes

--- a/packages/vector-weaviate/package.json
+++ b/packages/vector-weaviate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/weaviate",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Weaviate vector store adapter for Anvia.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",


### PR DESCRIPTION
## Summary

- prepare all 32 public packages as `1.0.0-rc.9`
- include the OIDC publish workspace-install fix
- supersede the partial Core-only `rc.8`

## Validation

- `pnpm rc:version`
- `node scripts/validate-release-train.mjs --tag v1.0.0-rc.9`
- `pnpm test:release-scripts`
- `pnpm check`

No `rc.9` package has been published by this PR.