### PR TITLE
fix(observability): gracefully finalize cancelled runs

### DIFF
--- a/.changeset/graceful-observability-shutdown.md
+++ b/.changeset/graceful-observability-shutdown.md
@@ -1,0 +1,11 @@
+---
+"@anvia/core": patch
+"@anvia/langfuse": patch
+"@anvia/lens": patch
+"@anvia/logger": patch
+"@anvia/otel": patch
+"@anvia/studio": patch
+---
+
+Report cancelled Agent runs explicitly and gracefully drain active Studio runs before observability
+providers shut down on SIGINT or SIGTERM.

--- a/cookbook/10_integrations/03-langfuse-tracing.ts
+++ b/cookbook/10_integrations/03-langfuse-tracing.ts
@@ -3,12 +3,13 @@ import { createTool } from "@anvia/core/tool";
 import { LangfuseClient } from "@anvia/langfuse";
 import { OpenAIClient } from "@anvia/openai";
 import { z } from "zod";
+import { createProcessShutdownSignal } from "./_support/process-shutdown";
 
 const client = new OpenAIClient({
   baseUrl: process.env.OPENAI_BASEURL,
   apiKey: process.env.OPENAI_API_KEY ?? "",
 });
-await using tracing = new LangfuseClient({
+const tracing = new LangfuseClient({
   publicKey: process.env.LANGFUSE_PUBLIC_KEY,
   secretKey: process.env.LANGFUSE_SECRET_KEY,
   baseUrl: process.env.LANGFUSE_BASE_URL,
@@ -50,17 +51,24 @@ const agent = new Agent({
   },
 });
 
-const response = await agent.generate({
-  prompt: "Summarize ticket TICKET-1001 for the product engineering team.",
-  trace: {
-    name: "support-ticket-summary",
-    userId: "cookbook-user",
-    sessionId: "cookbook-session",
-    metadata: { ticketId: "TICKET-1001", example: "integrations:03" },
-    tags: ["cookbook", "anvia"],
-  },
-});
+const shutdown = createProcessShutdownSignal();
+try {
+  const response = await agent.generate({
+    prompt: "Summarize ticket TICKET-1001 for the product engineering team.",
+    abortSignal: shutdown.signal,
+    trace: {
+      name: "support-ticket-summary",
+      userId: "cookbook-user",
+      sessionId: "cookbook-session",
+      metadata: { ticketId: "TICKET-1001", example: "integrations:03" },
+      tags: ["cookbook", "anvia"],
+    },
+  });
 
-if (response.type !== "response") throw new Error("Unexpected tool approval request.");
-console.log(response.output);
-console.log("trace:", response.trace);
+  if (response.type !== "response") throw new Error("Unexpected tool approval request.");
+  console.log(response.output);
+  console.log("trace:", response.trace);
+} finally {
+  shutdown.dispose();
+  await tracing.close();
+}

--- a/cookbook/10_integrations/04-langfuse-eval-reporting.ts
+++ b/cookbook/10_integrations/04-langfuse-eval-reporting.ts
@@ -7,6 +7,7 @@ import {
 } from "@anvia/core";
 import { agentEvalTarget, contains, runEvalSuite } from "@anvia/core/evals";
 import { LangfuseClient } from "@anvia/langfuse";
+import { createProcessShutdownSignal } from "./_support/process-shutdown";
 
 class StaticCompletionModel implements CompletionModel {
   readonly provider = "cookbook";
@@ -30,7 +31,7 @@ class StaticCompletionModel implements CompletionModel {
   }
 }
 
-await using langfuse = new LangfuseClient({
+const langfuse = new LangfuseClient({
   publicKey: process.env.LANGFUSE_PUBLIC_KEY,
   secretKey: process.env.LANGFUSE_SECRET_KEY,
   baseUrl: process.env.LANGFUSE_BASE_URL,
@@ -43,25 +44,31 @@ const agent = new Agent({
   instructions: "Answer support questions from policy.",
 });
 
-const result = await runEvalSuite({
-  name: "support-agent-regression",
-  cases: [
-    {
-      id: "refund-window",
-      input: "How long do refunds stay available?",
-      expected: "30 days",
-      metadata: {
-        traceId: "trace-from-existing-run",
-        observationId: "observation-from-existing-run",
+const shutdown = createProcessShutdownSignal();
+try {
+  const result = await runEvalSuite({
+    name: "support-agent-regression",
+    cases: [
+      {
+        id: "refund-window",
+        input: "How long do refunds stay available?",
+        expected: "30 days",
+        metadata: {
+          traceId: "trace-from-existing-run",
+          observationId: "observation-from-existing-run",
+        },
       },
-    },
-  ],
-  target: agentEvalTarget<string>({
-    agent,
-    request: ({ input }) => ({ prompt: input }),
-  }),
-  metrics: [contains()],
-  reporters: [reporter],
-});
+    ],
+    target: agentEvalTarget<string>({
+      agent,
+      request: ({ input }) => ({ prompt: input, abortSignal: shutdown.signal }),
+    }),
+    metrics: [contains()],
+    reporters: [reporter],
+  });
 
-console.log(result.results[0]?.metrics[0]);
+  console.log(result.results[0]?.metrics[0]);
+} finally {
+  shutdown.dispose();
+  await langfuse.close();
+}

--- a/cookbook/10_integrations/05-otel-tracing.ts
+++ b/cookbook/10_integrations/05-otel-tracing.ts
@@ -8,6 +8,7 @@ import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { BatchLogRecordProcessor } from "@opentelemetry/sdk-logs";
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { z } from "zod";
+import { createProcessShutdownSignal } from "./_support/process-shutdown";
 
 const exporterOptions =
   process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT === undefined
@@ -69,9 +70,11 @@ const agent = new Agent({
   },
 });
 
+const shutdown = createProcessShutdownSignal();
 try {
   const response = await agent.generate({
     prompt: "Summarize ticket TICKET-1001 for the product engineering team.",
+    abortSignal: shutdown.signal,
     trace: {
       name: "support-ticket-summary",
       userId: "cookbook-user",
@@ -96,7 +99,7 @@ try {
     ],
     target: agentEvalTarget<string>({
       agent,
-      request: ({ input }) => ({ prompt: input }),
+      request: ({ input }) => ({ prompt: input, abortSignal: shutdown.signal }),
     }),
     metrics: [contains()],
     reporters: [createOtelEvalReporter({ onMissingTrace: "warn" })],
@@ -104,5 +107,6 @@ try {
 
   console.log("eval:", evalResult.results[0]?.metrics[0]?.outcome);
 } finally {
+  shutdown.dispose();
   await sdk.shutdown();
 }

--- a/cookbook/10_integrations/08-lens-native.ts
+++ b/cookbook/10_integrations/08-lens-native.ts
@@ -7,6 +7,7 @@ import {
 } from "@anvia/core";
 import { agentEvalTarget, contains, runEvalSuite } from "@anvia/core/evals";
 import { LensClient } from "@anvia/lens";
+import { createProcessShutdownSignal } from "./_support/process-shutdown";
 
 class StaticSupportModel implements CompletionModel {
   readonly provider = "smoke";
@@ -30,7 +31,7 @@ class StaticSupportModel implements CompletionModel {
   }
 }
 
-await using lens = new LensClient({ serviceName: "lens-native-smoke" });
+const lens = new LensClient({ serviceName: "lens-native-smoke" });
 const agent = new Agent({
   id: "lens-native-smoke",
   model: new StaticSupportModel(),
@@ -42,35 +43,41 @@ const agent = new Agent({
   },
 });
 
-const suite = await runEvalSuite({
-  name: "lens-native-smoke",
-  run: { datasetName: "lens-smoke", datasetVersion: "v3" },
-  cases: [
-    {
-      id: "refund-window",
-      input: "How long are refunds available?",
-      expected: "30 days",
-    },
-  ],
-  target: agentEvalTarget<string>({
-    agent,
-    request: ({ input }) => ({ prompt: input }),
-  }),
-  metrics: [contains({ name: "refund-policy-correctness" })],
-  reporters: [lens.evalReporter({ includePayloads: true })],
-  reporterErrorPolicy: "throw",
-});
-const result = suite.results[0];
-console.log(
-  JSON.stringify(
-    {
-      suite: suite.name,
-      runId: suite.run.id,
-      caseId: result?.case.id,
-      outcome: result?.metrics[0]?.outcome.outcome,
-      trace: result?.output?.trace,
-    },
-    null,
-    2,
-  ),
-);
+const shutdown = createProcessShutdownSignal();
+try {
+  const suite = await runEvalSuite({
+    name: "lens-native-smoke",
+    run: { datasetName: "lens-smoke", datasetVersion: "v3" },
+    cases: [
+      {
+        id: "refund-window",
+        input: "How long are refunds available?",
+        expected: "30 days",
+      },
+    ],
+    target: agentEvalTarget<string>({
+      agent,
+      request: ({ input }) => ({ prompt: input, abortSignal: shutdown.signal }),
+    }),
+    metrics: [contains({ name: "refund-policy-correctness" })],
+    reporters: [lens.evalReporter({ includePayloads: true })],
+    reporterErrorPolicy: "throw",
+  });
+  const result = suite.results[0];
+  console.log(
+    JSON.stringify(
+      {
+        suite: suite.name,
+        runId: suite.run.id,
+        caseId: result?.case.id,
+        outcome: result?.metrics[0]?.outcome.outcome,
+        trace: result?.output?.trace,
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  shutdown.dispose();
+  await lens.close();
+}

--- a/cookbook/10_integrations/_support/process-shutdown.ts
+++ b/cookbook/10_integrations/_support/process-shutdown.ts
@@ -1,0 +1,21 @@
+export function createProcessShutdownSignal(): {
+  readonly signal: AbortSignal;
+  dispose(): void;
+} {
+  const controller = new AbortController();
+  const abortFor = (signal: "SIGINT" | "SIGTERM") => {
+    process.exitCode = signal === "SIGINT" ? 130 : 143;
+    controller.abort(new Error(`Process received ${signal}.`));
+  };
+  const sigint = () => abortFor("SIGINT");
+  const sigterm = () => abortFor("SIGTERM");
+  process.once("SIGINT", sigint);
+  process.once("SIGTERM", sigterm);
+  return {
+    signal: controller.signal,
+    dispose() {
+      process.off("SIGINT", sigint);
+      process.off("SIGTERM", sigterm);
+    },
+  };
+}

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -327,6 +327,8 @@ Use `stream.textStream` instead of `stream.events` when only text deltas are nee
 iteration share one underlying stream and therefore cannot be consumed independently.
 
 Pass `abortSignal` on a run to cancel the active provider call, tools, and nested Agent tools.
+Run observers receive terminal errors with `status: "cancelled"` for cancellation and
+`status: "failed"` for other failures.
 
 ## Memory
 

--- a/packages/core/src/internal/agent-runtime/agent-run.ts
+++ b/packages/core/src/internal/agent-runtime/agent-run.ts
@@ -1715,6 +1715,7 @@ export class AgentRun<Output = string, M extends CompletionModel = CompletionMod
         }),
       () =>
         runObservers?.error({
+          status: reportedError instanceof AgentRunCancelledError ? "cancelled" : "failed",
           error: reportedError,
           usage,
           messages: [...messages],

--- a/packages/core/src/internal/agent-runtime/agent-run.ts
+++ b/packages/core/src/internal/agent-runtime/agent-run.ts
@@ -1734,10 +1734,11 @@ export class AgentRun<Output = string, M extends CompletionModel = CompletionMod
     try {
       await this.runRunErrorHook(error, usage, messages);
     } catch {
-      // Error hooks are diagnostic cleanup and must not replace the run failure.
+      // Thrown hook errors are diagnostic cleanup and must not replace the run failure.
     }
-    await this.runLifecycleError(error, runId, usage, messages);
-    return error;
+    const reportedError = this.cancellationError ?? error;
+    await this.runLifecycleError(reportedError, runId, usage, messages);
+    return reportedError;
   }
 
   private async runOutputGuardrailsForResponse(

--- a/packages/core/src/observability/group.ts
+++ b/packages/core/src/observability/group.ts
@@ -76,6 +76,7 @@ export async function startAgentRunObservers(
     const cleanupFailures = await terminateObservers(runObservers, (observer) =>
       observer.error?.(
         observerSnapshot({
+          status: "failed",
           error: startupError,
           usage: Usage.empty(),
           messages: [...args.history, args.prompt],

--- a/packages/core/src/observability/types.ts
+++ b/packages/core/src/observability/types.ts
@@ -77,6 +77,7 @@ export type AgentRunEndArgs =
     });
 
 export type AgentRunErrorArgs = {
+  readonly status: "failed" | "cancelled";
   readonly error: unknown;
   readonly usage: DeepReadonly<Usage>;
   readonly messages: readonly DeepReadonly<Message>[];

--- a/packages/core/test/observability.test.ts
+++ b/packages/core/test/observability.test.ts
@@ -8,6 +8,7 @@ import {
 import * as anvia from "./helpers/imports";
 import {
   Agent,
+  AgentRunCancelledError,
   type AgentGenerationEndArgs,
   type AgentGenerationErrorArgs,
   type AgentGenerationStartArgs,
@@ -940,6 +941,40 @@ describe("agent observability", () => {
       "lifecycle",
       "run observer",
     ]);
+  });
+
+  it("reports failures terminated by the run-error hook as cancelled", async () => {
+    const observer = new RecordingObserver();
+    const hook = createHook({
+      onRunError({ run }) {
+        return run.cancel("stop after model failure");
+      },
+    });
+    const agent = new Agent({
+      id: "test-agent",
+      model: new QueueModel([]),
+      observability: { observers: { test: observer }, primaryTrace: "test" },
+    });
+
+    let reportedError: unknown;
+    try {
+      await agent.generate({ prompt: "fail", ...withInternalAgentRunOptions({}, { hook }) });
+    } catch (error) {
+      reportedError = error;
+    }
+
+    expect(reportedError).toMatchObject({
+      name: "AgentRunCancelledError",
+      reason: "stop after model failure",
+    });
+    expect(reportedError).toBeInstanceOf(AgentRunCancelledError);
+    const runErrorEvent = observer.events.find(
+      (event) => (event as { type?: unknown }).type === "run_error",
+    ) as { args: AgentRunErrorArgs } | undefined;
+    expect(runErrorEvent?.args.status).toBe("cancelled");
+    expect(runErrorEvent?.args.error).toMatchObject({
+      reason: "stop after model failure",
+    });
   });
 });
 

--- a/packages/core/test/observability.test.ts
+++ b/packages/core/test/observability.test.ts
@@ -1622,6 +1622,7 @@ function runEndArgs(): AgentRunEndArgs {
 
 function runErrorArgs(): AgentRunErrorArgs {
   return {
+    status: "failed",
     error: new Error("run failed"),
     usage: Usage.empty(),
     messages: [],

--- a/packages/core/test/streaming.test.ts
+++ b/packages/core/test/streaming.test.ts
@@ -148,6 +148,7 @@ describe("Agent streaming", () => {
     let providerClosed = false;
     let runEnded = false;
     let runError: unknown;
+    let runErrorStatus: AgentRunErrorArgs["status"] | undefined;
     let generationError: unknown;
     const providerEvents = (async function* (): AsyncIterable<CompletionModelStreamEvent> {
       try {
@@ -171,8 +172,9 @@ describe("Agent streaming", () => {
           end() {
             runEnded = true;
           },
-          error({ error }) {
+          error({ error, status }) {
             runError = error;
+            runErrorStatus = status;
           },
         };
       },
@@ -191,6 +193,7 @@ describe("Agent streaming", () => {
     expect(providerClosed).toBe(true);
     expect(runEnded).toBe(false);
     expect(runError).toBeInstanceOf(AgentRunCancelledError);
+    expect(runErrorStatus).toBe("cancelled");
     expect(generationError).toBeInstanceOf(AgentRunCancelledError);
     expect(generationError).not.toBe(runError);
     expect(generationError).toMatchObject({
@@ -616,6 +619,7 @@ describe("Agent streaming", () => {
     const errorEvent = await nextAgentError(iterator);
 
     expect(errorEvent.usage).toEqual(turnUsage);
+    expect(observedError?.status).toBe("cancelled");
     expect(observedError?.usage).toEqual(errorEvent.usage);
     await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined });
   });

--- a/packages/logger/src/observer.ts
+++ b/packages/logger/src/observer.ts
@@ -118,11 +118,17 @@ class LoggerRunObserver implements AgentRunObserver {
   }
 
   error(args: AgentRunErrorArgs): void {
-    this.logger.error("agent run failed", {
+    const context = {
+      status: args.status,
       error: serializeError(args.error),
       usage: args.usage,
       messageCount: args.messages.length,
-    });
+    };
+    if (args.status === "cancelled") {
+      this.logger.warn("agent run cancelled", context);
+    } else {
+      this.logger.error("agent run failed", context);
+    }
   }
 }
 

--- a/packages/logger/test/logger.test.ts
+++ b/packages/logger/test/logger.test.ts
@@ -272,7 +272,7 @@ describe("createLoggerObserver", () => {
               toolCallId: "private-provider-tool-id",
             });
 
-      await run.error?.({ error, usage: Usage.empty(), messages: [] });
+      await run.error?.({ status: "failed", error, usage: Usage.empty(), messages: [] });
 
       expect(logger.records.at(-1)).toMatchObject({
         level: "error",
@@ -291,6 +291,30 @@ describe("createLoggerObserver", () => {
       expect(JSON.stringify(logger.records.at(-1))).not.toContain("private-provider-tool-id");
     },
   );
+
+  it("logs cancelled runs as warnings", async () => {
+    const logger = new RecordingLogger();
+    const observer = createLoggerObserver({ logger });
+    const run = (await observer.startRun({
+      runId: "run_cancelled",
+      prompt: { role: "user", content: "hello" },
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+
+    await run.error?.({
+      status: "cancelled",
+      error: new Error("CLI stopped"),
+      usage: Usage.empty(),
+      messages: [],
+    });
+
+    expect(logger.records.at(-1)).toMatchObject({
+      level: "warn",
+      message: "agent run cancelled",
+      context: { status: "cancelled" },
+    });
+  });
 
   it("does not log arbitrary observer event attributes by default", async () => {
     const logger = new RecordingLogger();
@@ -346,6 +370,7 @@ describe("createLoggerObserver", () => {
     const error = new Error("Structured output failed", { cause: nestedCause });
 
     run.error?.({
+      status: "failed",
       error,
       usage: {
         inputTokens: 0,
@@ -437,7 +462,7 @@ async function recordPinoRunError(error: Error): Promise<Record<string, unknown>
     history: [],
     maxTurns: 1,
   })) as AgentRunObserver;
-  run.error?.({ error, usage: Usage.empty(), messages: [] });
+  run.error?.({ status: "failed", error, usage: Usage.empty(), messages: [] });
   const record = lines[0];
   if (record === undefined) throw new Error("Expected Pino error record.");
   return record;

--- a/packages/observability-langfuse/README.md
+++ b/packages/observability-langfuse/README.md
@@ -63,6 +63,10 @@ process needs an explicit mid-lifecycle delivery checkpoint. `close()` is idempo
 Each client owns an isolated, unregistered tracer provider, so multiple Langfuse clients and an
 application-wide OpenTelemetry provider can coexist without replacing one another.
 
+Process signals do not unwind an `await using` scope. A CLI should handle `SIGINT` and `SIGTERM`,
+abort and await its active Agent run, and only then await `langfuse.close()`. This order lets Core
+finish the root observation as `cancelled` before Langfuse flushes it.
+
 Observer capture policy is registration-specific:
 
 ```ts

--- a/packages/observability-langfuse/src/tracing.ts
+++ b/packages/observability-langfuse/src/tracing.ts
@@ -846,6 +846,7 @@ class LangfuseRunObserver implements AgentRunObserver {
     this.closeAllTurns();
     const redactedError = this.redactOutputValue(errorMessage(args.error));
     const metadata: Record<string, unknown> = {
+      status: args.status,
       usage: args.usage,
       messageCount: args.messages.length,
     };
@@ -854,8 +855,13 @@ class LangfuseRunObserver implements AgentRunObserver {
     }
     this.root
       .update({
-        level: "ERROR",
-        statusMessage: typeof redactedError === "string" ? redactedError : "Agent run failed",
+        level: args.status === "cancelled" ? "WARNING" : "ERROR",
+        statusMessage:
+          typeof redactedError === "string"
+            ? redactedError
+            : args.status === "cancelled"
+              ? "Agent run cancelled"
+              : "Agent run failed",
         output: {
           error: redactedError,
         },

--- a/packages/observability-langfuse/test/langfuse.test.ts
+++ b/packages/observability-langfuse/test/langfuse.test.ts
@@ -1045,6 +1045,34 @@ describe("langfuse", () => {
     );
   });
 
+  it("records cancelled runs as warnings with terminal cancellation metadata", async () => {
+    const root = fakeObservation("root", "trace-cancelled", "obs-cancelled");
+    mocks.startObservation.mockReturnValueOnce(root);
+    const tracing = new LangfuseClient({ publicKey: "pk", secretKey: "sk" });
+    const run = (await tracing.observer().startRun({
+      runId: "run_cancelled",
+      prompt: userMessage("stop"),
+      history: [],
+      maxTurns: 1,
+    })) as AgentRunObserver;
+
+    await run.error?.({
+      status: "cancelled",
+      error: new Error("CLI stopped"),
+      usage: usage(1, 0),
+      messages: [],
+    });
+
+    expect(root.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: "WARNING",
+        statusMessage: "CLI stopped",
+        metadata: expect.objectContaining({ status: "cancelled" }),
+      }),
+    );
+    expect(root.end).toHaveBeenCalledOnce();
+  });
+
   it("nests streamed child agent observations under the parent tool observation", async () => {
     const root = fakeObservation("root", "trace-1", "obs-root");
     const turn = fakeObservation("turn", "trace-1", "obs-turn");

--- a/packages/observability-lens/README.md
+++ b/packages/observability-lens/README.md
@@ -52,6 +52,10 @@ const suite = await runEvalSuite({
 `await using` disposes the client at scope exit, flushing and shutting down both owned providers.
 Use `flush()` only for an explicit delivery checkpoint. `close()` is idempotent and terminal.
 
+Process signals do not unwind an `await using` scope. A CLI should handle `SIGINT` and `SIGTERM`,
+abort and await its active Agent run, and only then await `lens.close()`. This order lets Core finish
+the root observation as `cancelled` before Lens flushes it.
+
 Set `optional: true` to obtain a disabled client when all Lens connection environment variables
 are absent. `lens.enabled` reports the state. The disabled observer and reporter are safe no-ops;
 dataset access still rejects because it requires a configured connection. Partial configuration is

--- a/packages/observability-otel/README.md
+++ b/packages/observability-otel/README.md
@@ -50,6 +50,10 @@ console.log(result.trace?.traceId);
 
 Initialize OpenTelemetry in your application before creating spans. For OTLP HTTP, configure `@opentelemetry/sdk-node` and `@opentelemetry/exporter-trace-otlp-http` in your app process.
 
+The application also owns graceful process shutdown. On `SIGINT` or `SIGTERM`, abort and await the
+active Agent run before awaiting the OpenTelemetry SDK's `shutdown()`. Core marks aborted runs as
+`cancelled`; shutting down the SDK first cannot export a root span that is still open.
+
 Set `captureMode: "safe"` to record operational attributes without prompt or response bodies.
 Existing `@anvia/otel` integrations retain full capture when the option is omitted. Use
 `captureMaxBytes` to set a per-value limit and `transformInput` / `transformOutput` to redact or

--- a/packages/observability-otel/src/helpers.ts
+++ b/packages/observability-otel/src/helpers.ts
@@ -81,6 +81,7 @@ export function runErrorAttributes(
   options: OtelObserverOptions = {},
 ): Attributes {
   return compactAttributes({
+    "anvia.run.status": args.status,
     "anvia.run.error": errorMessage(args.error),
     "anvia.run.messages": capturedJson(args.messages, "output", options),
     ...usageAttributes(args.usage),

--- a/packages/observability-otel/test/otel.test.ts
+++ b/packages/observability-otel/test/otel.test.ts
@@ -761,6 +761,7 @@ describe("otel", () => {
       error: "tool failed",
     });
     await run?.error?.({
+      status: "failed",
       error: new Error("run failed"),
       usage: usage(0, 0),
       messages: [],
@@ -781,7 +782,30 @@ describe("otel", () => {
       code: SpanStatusCode.ERROR,
       message: "run failed",
     });
+    expect(tracer.spans[0]?.attributes["anvia.run.status"]).toBe("failed");
     expect(tracer.spans.every((span) => span.ended)).toBe(true);
+  });
+
+  it("ends cancelled runs with an explicit cancellation attribute", async () => {
+    const tracer = new FakeTracer();
+    const tracing = createOtelObserver({ tracer: tracer.tracer });
+    const run = await tracing.startRun({
+      runId: "run_cancelled",
+      agentName: "support",
+      prompt: userMessage("hello"),
+      history: [],
+      maxTurns: 1,
+    });
+
+    await run?.error?.({
+      status: "cancelled",
+      error: new Error("CLI stopped"),
+      usage: usage(0, 0),
+      messages: [],
+    });
+
+    expect(tracer.spans[0]?.attributes["anvia.run.status"]).toBe("cancelled");
+    expect(tracer.spans[0]?.ended).toBe(true);
   });
 
   it("nests streamed child agent spans under the parent tool span", async () => {

--- a/packages/tool-studio/README.md
+++ b/packages/tool-studio/README.md
@@ -35,7 +35,7 @@ const agent = new Agent({
   instructions: "Answer support questions clearly.",
 });
 
-new Studio([agent]).start({
+await new Studio([agent]).serve({
   port: 4021,
 });
 ```
@@ -45,6 +45,25 @@ Then open:
 ```txt
 http://localhost:4021/ui/playground
 ```
+
+## Graceful shutdown
+
+`serve()` handles both `SIGINT` and `SIGTERM`. Studio stops accepting work, aborts active Agent and
+Pipeline runs, waits for their cancellation observers, and then runs `onShutdown`. Use that callback
+to close observability clients or other caller-owned resources:
+
+```ts
+await new Studio([agent]).serve({
+  port: 4021,
+  shutdownTimeoutMs: 30_000,
+  onShutdown: async () => {
+    await Promise.all([lens.close(), langfuse.close(), otelSdk.shutdown()]);
+  },
+});
+```
+
+`shutdown()` provides the same draining behavior for application-managed lifecycles. `close()`
+remains synchronous for compatibility: it aborts active work but does not wait for cleanup.
 
 ## Multi-Provider Models
 

--- a/packages/tool-studio/package.json
+++ b/packages/tool-studio/package.json
@@ -77,5 +77,8 @@
   },
   "peerDependencies": {
     "@anvia/core": "workspace:*"
+  },
+  "engines": {
+    "node": ">=20.12.0"
   }
 }

--- a/packages/tool-studio/src/runtime/agent-runs.ts
+++ b/packages/tool-studio/src/runtime/agent-runs.ts
@@ -27,6 +27,7 @@ import {
 } from "./models";
 import { rawObservedStore } from "./observability";
 import type { ResolvedStores } from "./options";
+import type { StudioRunLease, StudioRunLifecycle } from "./run-lifecycle";
 import {
   assignTranscriptRunDuration,
   createPersistedStreamingSessionTranscript,
@@ -54,6 +55,7 @@ type AgentRunRouteProps = {
   stores: ResolvedStores;
   modelRegistry: ReturnType<typeof createStudioModelRegistry>;
   continuationRegistry: StudioContinuationRegistry<PreparedAgentRun>;
+  runLifecycle: StudioRunLifecycle;
 };
 
 type SelectedModel = ReturnType<typeof resolveStudioModel>;
@@ -86,20 +88,36 @@ export function registerAgentRunRoute(app: Hono, props: AgentRunRouteProps): voi
 }
 
 async function handleAgentRun(c: Context, props: AgentRunRouteProps): Promise<Response> {
-  const prepared = await prepareAgentRun(c, props);
-  if (prepared instanceof Response) {
-    return prepared;
+  const lease = props.runLifecycle.start(c.req.raw.signal);
+  if (lease === undefined) {
+    return errorResponse(c, 503, "service_unavailable", "Anvia Studio is shutting down");
   }
 
-  if (prepared.body.stream === true) {
-    return handleStreamingAgentRun(c, prepared, props);
+  try {
+    const prepared = await prepareAgentRun(c, props, lease.abortSignal);
+    if (prepared instanceof Response) {
+      lease.finish();
+      return prepared;
+    }
+
+    if (prepared.body.stream === true) {
+      return handleStreamingAgentRun(c, prepared, props, lease);
+    }
+    try {
+      return await handleBufferedAgentRun(c, prepared, props);
+    } finally {
+      lease.finish();
+    }
+  } catch (error) {
+    lease.finish();
+    throw error;
   }
-  return handleBufferedAgentRun(c, prepared, props);
 }
 
 async function prepareAgentRun(
   c: Context,
   props: AgentRunRouteProps,
+  abortSignal: AbortSignal,
 ): Promise<PreparedAgentRun | Response> {
   const agentId = c.req.param("agentId") as string;
   const agent = props.agentMap.get(agentId);
@@ -136,7 +154,7 @@ async function prepareAgentRun(
     if (body.stream !== undefined) resumedBody = { ...resumedBody, stream: body.stream };
     if (body.metadata !== undefined) resumedBody = { ...resumedBody, metadata: body.metadata };
     if (body.trace !== undefined) resumedBody = { ...resumedBody, trace: body.trace };
-    const runOptions = createRunOptions(resumedBody, agentId, source.session, c.req.raw.signal);
+    const runOptions = createRunOptions(resumedBody, agentId, source.session, abortSignal);
     const execution: RunExecution = {
       generate: (options) =>
         source.runAgent.generate({
@@ -229,7 +247,7 @@ async function prepareAgentRun(
     execution,
     failureMessages: undefined,
     memoryCompactionLogged: false,
-    options: createRunOptions(body, agentId, session, c.req.raw.signal),
+    options: createRunOptions(body, agentId, session, abortSignal),
     runAgent,
     runId,
     runStartedAt,
@@ -417,6 +435,7 @@ function handleStreamingAgentRun(
   c: Context,
   run: PreparedAgentRun,
   props: AgentRunRouteProps,
+  lease: StudioRunLease,
 ): Response {
   const streamOptions = withInternalAgentRunOptions({ ...run.options }, { runId: run.runId });
   const runStream = registerStreamingContinuation(
@@ -446,7 +465,7 @@ function handleStreamingAgentRun(
     stream = persistedRun.events;
   }
 
-  return streamAgentRunEvents(c, stream, {
+  return streamAgentRunEvents(c, finishRunLease(stream, lease), {
     runId: run.runId,
     onCancel: async () => {
       const persistence: Promise<unknown>[] = [];
@@ -464,6 +483,17 @@ function handleStreamingAgentRun(
       await Promise.all(persistence);
     },
   });
+}
+
+async function* finishRunLease(
+  events: AsyncIterable<AgentRunStreamEvent>,
+  lease: StudioRunLease,
+): AsyncIterable<AgentRunStreamEvent> {
+  try {
+    yield* events;
+  } finally {
+    lease.finish();
+  }
 }
 
 async function handleBufferedAgentRun(

--- a/packages/tool-studio/src/runtime/pipelines.ts
+++ b/packages/tool-studio/src/runtime/pipelines.ts
@@ -26,6 +26,7 @@ import {
   pipelineStageLog,
 } from "./pipeline-logs";
 import { AsyncEventQueue } from "./runs";
+import type { StudioRunLease, StudioRunLifecycle } from "./run-lifecycle";
 import { streamStudioJsonl } from "./streams";
 import { isJsonObject, isJsonValue, isObject } from "./type-guards";
 
@@ -36,6 +37,7 @@ export function registerPipelineRoutes(
     pipelineMap: Map<string, StudioPipeline>;
     logStore?: StudioPipelineLogStore;
     runStore?: StudioPipelineRunStore;
+    runLifecycle: StudioRunLifecycle;
   },
 ): void {
   app.get("/pipelines", (c) =>
@@ -123,7 +125,7 @@ export function registerPipelineRoutes(
       return body.error;
     }
 
-    return executePipelineRun(c, props, pipeline, body);
+    return executeTrackedPipelineRun(c, props, pipeline, body);
   });
 
   app.post("/pipelines/:pipelineId/runs/:runId/replay", async (c) => {
@@ -163,8 +165,30 @@ export function registerPipelineRoutes(
       metadata: replayMetadata(sourceRun.metadata, body.metadata, sourceRun.runId),
     };
     if (body.stream !== undefined) replayRequest.stream = body.stream;
-    return executePipelineRun(c, props, pipeline, replayRequest);
+    return executeTrackedPipelineRun(c, props, pipeline, replayRequest);
   });
+}
+
+async function executeTrackedPipelineRun(
+  c: Context,
+  props: {
+    logStore?: StudioPipelineLogStore;
+    runStore?: StudioPipelineRunStore;
+    runLifecycle: StudioRunLifecycle;
+  },
+  pipeline: StudioPipeline,
+  body: StudioPipelineRunRequest,
+): Promise<Response> {
+  const lease = props.runLifecycle.start(c.req.raw.signal);
+  if (lease === undefined) {
+    return errorResponse(c, 503, "service_unavailable", "Anvia Studio is shutting down");
+  }
+  try {
+    return await executePipelineRun(c, props, pipeline, body, lease);
+  } catch (error) {
+    lease.finish();
+    throw error;
+  }
 }
 
 async function executePipelineRun(
@@ -175,6 +199,7 @@ async function executePipelineRun(
   },
   pipeline: StudioPipeline,
   body: StudioPipelineRunRequest,
+  lease: StudioRunLease,
 ): Promise<Response> {
   const runId = globalThis.crypto.randomUUID();
   const startedAt = Date.now();
@@ -204,11 +229,12 @@ async function executePipelineRun(
       input: body.input,
       startedAt,
       startedAtIso,
+      onFinish: lease.finish,
     };
     if (body.metadata !== undefined) streamOptions.metadata = body.metadata;
     if (props.logStore !== undefined) streamOptions.logStore = props.logStore;
     if (props.runStore !== undefined) streamOptions.runStore = props.runStore;
-    streamOptions.abortSignal = c.req.raw.signal;
+    streamOptions.abortSignal = lease.abortSignal;
     return streamPipelineRun(c, streamOptions);
   }
 
@@ -218,7 +244,7 @@ async function executePipelineRun(
       input: body.input,
       runId,
       metadata: body.metadata,
-      abortSignal: c.req.raw.signal,
+      abortSignal: lease.abortSignal,
       observer: {
         async onEvent(event) {
           await appendPipelineLog(props.logStore, pipelineStageLog(event, pipeline.id));
@@ -275,6 +301,8 @@ async function executePipelineRun(
       pipelineRunFailedLog(pipeline.id, runId, error, startedAt),
     );
     return errorResponse(c, 500, "internal_error", "Pipeline run failed", serializeError(error));
+  } finally {
+    lease.finish();
   }
 }
 
@@ -299,6 +327,7 @@ function streamPipelineRun(
     logStore?: StudioPipelineLogStore;
     runStore?: StudioPipelineRunStore;
     abortSignal?: AbortSignal;
+    onFinish: () => void;
   },
 ): Response {
   return streamStudioJsonl(pipelineRunEvents(props));
@@ -314,6 +343,7 @@ async function* pipelineRunEvents(props: {
   logStore?: StudioPipelineLogStore;
   runStore?: StudioPipelineRunStore;
   abortSignal?: AbortSignal;
+  onFinish: () => void;
 }): AsyncIterable<AgentRunStreamEvent> {
   yield* emitPipelineLog(props.logStore, pipelineRunStartedLog(props.pipeline, props.runId));
 
@@ -405,7 +435,11 @@ async function* pipelineRunEvents(props: {
       yield next.value;
     }
   } finally {
-    await run;
+    try {
+      await run;
+    } finally {
+      props.onFinish();
+    }
   }
 }
 

--- a/packages/tool-studio/src/runtime/query.ts
+++ b/packages/tool-studio/src/runtime/query.ts
@@ -35,7 +35,8 @@ export function parseTraceStatus(value: string | undefined): StudioTraceStatus |
   return status === "running" ||
     status === "success" ||
     status === "suspended" ||
-    status === "error"
+    status === "error" ||
+    status === "cancelled"
     ? status
     : false;
 }

--- a/packages/tool-studio/src/runtime/run-lifecycle.ts
+++ b/packages/tool-studio/src/runtime/run-lifecycle.ts
@@ -1,0 +1,64 @@
+export type StudioRunLease = {
+  readonly abortSignal: AbortSignal;
+  finish(): void;
+};
+
+export class StudioRunLifecycle {
+  private readonly shutdownController = new AbortController();
+  private readonly active = new Set<symbol>();
+  private drainPromise: Promise<void> | undefined;
+  private resolveDrain: (() => void) | undefined;
+  private closed = false;
+
+  start(requestSignal: AbortSignal): StudioRunLease | undefined {
+    if (this.closed) return undefined;
+
+    const token = Symbol("studio-run");
+    this.active.add(token);
+    let finished = false;
+    return {
+      abortSignal: AbortSignal.any([requestSignal, this.shutdownController.signal]),
+      finish: () => {
+        if (finished) return;
+        finished = true;
+        this.active.delete(token);
+        if (this.active.size === 0) {
+          this.resolveDrain?.();
+          this.resolveDrain = undefined;
+          this.drainPromise = undefined;
+        }
+      },
+    };
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.shutdownController.abort(new Error("Anvia Studio is shutting down."));
+  }
+
+  async drain(timeoutMs: number): Promise<void> {
+    this.close();
+    if (this.active.size === 0) return;
+
+    this.drainPromise ??= new Promise<void>((resolve) => {
+      this.resolveDrain = resolve;
+    });
+    await withTimeout(this.drainPromise, timeoutMs);
+  }
+}
+
+async function withTimeout(promise: Promise<void>, timeoutMs: number): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`Anvia Studio shutdown timed out after ${timeoutMs}ms.`)),
+      timeoutMs,
+    );
+  });
+  try {
+    await Promise.race([promise, timeout]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}

--- a/packages/tool-studio/src/runtime/studio.ts
+++ b/packages/tool-studio/src/runtime/studio.ts
@@ -49,6 +49,7 @@ import {
 } from "./observability";
 import type { StudioRuntimeOptions } from "./options";
 import { registerPipelineRoutes } from "./pipelines";
+import { StudioRunLifecycle } from "./run-lifecycle";
 import { registerSandboxViewRoutes } from "./sandbox-views";
 import { createStudioSandboxRegistry, registerSandboxRoutes } from "./sandboxes";
 import { registerSessionRoutes } from "./sessions";
@@ -68,7 +69,8 @@ export class Studio implements AnviaStudio {
   private studio: StudioApp;
   private server: ReturnType<typeof serve> | undefined;
   private websocketServer: WebSocketServer | undefined;
-  private sigintHandler: (() => void) | undefined;
+  private signalHandlers: { readonly sigint: () => void; readonly sigterm: () => void } | undefined;
+  private shutdownPromise: Promise<void> | undefined;
 
   constructor(targets: StudioTarget[] = [], options: StudioOptions = {}) {
     this.options = studioOptionsFromTargets(targets, options);
@@ -96,6 +98,7 @@ export class Studio implements AnviaStudio {
   start(serveOptions: StudioServeOptions = {}): this {
     this.close();
     this.studio = createStudioApp(this.options);
+    this.shutdownPromise = undefined;
 
     const port = serveOptions.port ?? Number(process.env.RUNNER_PORT ?? 4021);
     const serverOptions: Parameters<typeof serve>[0] = {
@@ -118,18 +121,29 @@ export class Studio implements AnviaStudio {
     }
 
     if (serveOptions.handleSignals ?? true) {
-      this.sigintHandler = () => {
-        this.close();
-        process.exit(0);
+      const shutdownFor = (signal: "SIGINT" | "SIGTERM") => {
+        process.exitCode = signal === "SIGINT" ? 130 : 143;
+        void this.shutdown(shutdownOptions(serveOptions.shutdownTimeoutMs)).catch(
+          (error: unknown) => {
+            console.error(error);
+            process.exitCode = 1;
+          },
+        );
       };
-      process.once("SIGINT", this.sigintHandler);
+      this.signalHandlers = {
+        sigint: () => shutdownFor("SIGINT"),
+        sigterm: () => shutdownFor("SIGTERM"),
+      };
+      process.once("SIGINT", this.signalHandlers.sigint);
+      process.once("SIGTERM", this.signalHandlers.sigterm);
     }
 
     return this;
   }
 
   async serve(serveOptions: StudioServeLifecycleOptions = {}): Promise<void> {
-    const { onShutdown, signal, ...startOptions } = serveOptions;
+    const { onShutdown, shutdownTimeoutMs, signal, ...startOptions } = serveOptions;
+    const failures: unknown[] = [];
 
     try {
       this.start({ ...startOptions, log: false, handleSignals: false });
@@ -148,22 +162,62 @@ export class Studio implements AnviaStudio {
       }
 
       await waitForShutdown(signal);
-    } finally {
-      this.close();
+    } catch (error) {
+      failures.push(error);
+    }
+
+    try {
+      await this.shutdown(shutdownOptions(shutdownTimeoutMs));
+    } catch (error) {
+      failures.push(error);
+    }
+    try {
       await onShutdown?.();
+    } catch (error) {
+      failures.push(error);
+    }
+
+    if (failures.length === 1) throw failures[0];
+    if (failures.length > 1) {
+      throw new AggregateError(failures, "Failed to run and shut down Anvia Studio.");
     }
   }
 
   close(): void {
-    if (this.sigintHandler !== undefined) {
-      process.off("SIGINT", this.sigintHandler);
-      this.sigintHandler = undefined;
+    this.removeSignalHandlers();
+    this.closeNetwork();
+    this.studio.close();
+  }
+
+  shutdown(options: { timeoutMs?: number } = {}): Promise<void> {
+    const timeoutMs = options.timeoutMs ?? 30_000;
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+      return Promise.reject(
+        new TypeError("Anvia Studio shutdown timeoutMs must be a positive number."),
+      );
     }
+    this.shutdownPromise ??= this.shutdownResources(timeoutMs);
+    return this.shutdownPromise;
+  }
+
+  private async shutdownResources(timeoutMs: number): Promise<void> {
+    this.removeSignalHandlers();
+    this.closeNetwork();
+    await this.studio.shutdown({ timeoutMs });
+  }
+
+  private removeSignalHandlers(): void {
+    if (this.signalHandlers === undefined) return;
+    process.off("SIGINT", this.signalHandlers.sigint);
+    process.off("SIGTERM", this.signalHandlers.sigterm);
+    this.signalHandlers = undefined;
+  }
+
+  private closeNetwork(): void {
     this.server?.close();
     this.server = undefined;
     this.websocketServer?.close();
     this.websocketServer = undefined;
-    this.studio.close();
   }
 
   private logAddress(host: string, port: number): void {
@@ -174,6 +228,10 @@ export class Studio implements AnviaStudio {
       console.log(`Studio API: http://${host}:${port}`);
     }
   }
+}
+
+function shutdownOptions(timeoutMs: number | undefined): { timeoutMs?: number } {
+  return timeoutMs === undefined ? {} : { timeoutMs };
 }
 
 type StudioServer = ReturnType<typeof serve>;
@@ -339,6 +397,7 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
   const pipelineMap = new Map(pipelines.map((pipeline) => [pipeline.id, pipeline]));
   const evalMap = new Map(options.evals.map((suite) => [suite.id ?? suite.name, suite]));
   const continuationRegistry = createStudioContinuationRegistry<PreparedAgentRun>();
+  const runLifecycle = new StudioRunLifecycle();
   const sandboxRegistry = createStudioSandboxRegistry(agents, options.sandboxes ?? []);
   const memorySources = createStudioMemorySourceRegistry(agents, stores.sessions);
   const app = new HonoApp();
@@ -410,6 +469,7 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
   const pipelineOptions: Parameters<typeof registerPipelineRoutes>[1] = {
     pipelines,
     pipelineMap,
+    runLifecycle,
   };
   if (stores.pipelineLogs !== undefined) pipelineOptions.logStore = stores.pipelineLogs;
   if (stores.pipelineRuns !== undefined) pipelineOptions.runStore = stores.pipelineRuns;
@@ -420,6 +480,7 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
     stores,
     modelRegistry,
     continuationRegistry,
+    runLifecycle,
   });
 
   if (memorySources.size > 0 || stores.sessions !== undefined) {
@@ -447,6 +508,14 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
     app.all(`/${capability}/*`, (c) => unsupportedCapability(c, capability));
   }
 
+  let closing = false;
+  const beginClose = () => {
+    if (closing) return;
+    closing = true;
+    continuationRegistry.clear();
+    closeSandboxViews();
+    runLifecycle.close();
+  };
   const studio: StudioApp = {
     app,
     fetch(request: Request): Response | Promise<Response> {
@@ -456,8 +525,11 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
       return buildConfig(options, agents, pipelines, stores, sandboxRegistry.size);
     },
     close() {
-      continuationRegistry.clear();
-      closeSandboxViews();
+      beginClose();
+    },
+    async shutdown(shutdownOptions = {}) {
+      beginClose();
+      await runLifecycle.drain(shutdownOptions.timeoutMs ?? 30_000);
     },
   };
   if (stores.sessions !== undefined) Object.assign(studio, { sessionStore: stores.sessions });

--- a/packages/tool-studio/src/traces/trace-observer.ts
+++ b/packages/tool-studio/src/traces/trace-observer.ts
@@ -177,7 +177,7 @@ class StudioRunTraceObserver implements AgentRunObserver {
   }
 
   async error(args: AgentRunErrorArgs): Promise<void> {
-    await this.save("error", {
+    await this.save(args.status === "cancelled" ? "cancelled" : "error", {
       endedAt: new Date(),
       error: serializeError(args.error),
       usage: args.usage,
@@ -406,7 +406,9 @@ class ChildAgentToolTraceAccumulator {
         name: `${agentLabel(agentStart.agentId, agentStart.agentName)}.run`,
         status: agentChildren.some((observation) => observation.status === "error")
           ? "error"
-          : "success",
+          : agentChildren.some((observation) => observation.status === "cancelled")
+            ? "cancelled"
+            : "success",
         turn: this.parent.turn,
         startedAt,
         endedAt,

--- a/packages/tool-studio/src/traces/trace-observer.ts
+++ b/packages/tool-studio/src/traces/trace-observer.ts
@@ -1,3 +1,4 @@
+import { AgentRunCancelledError } from "@anvia/core/agent";
 import type { JsonObject, JsonValue } from "@anvia/core/completion";
 import type {
   AgentGenerationEndArgs,
@@ -366,11 +367,12 @@ class ChildAgentToolTraceAccumulator {
     if (child.type === "error") {
       const metadata = this.childMetadata(agentId, agentName, childTurn);
       if (isRecord(child.usage)) metadata.usage = toJsonValue(child.usage);
+      const status = child.error instanceof AgentRunCancelledError ? "cancelled" : "error";
       this.completedObservations.push(
         traceObservation({
           kind: "tool",
           name: `${agentLabel(agentId, agentName)}.error`,
-          status: "error",
+          status,
           turn: this.parent.turn,
           startedAt: new Date(),
           error: serializeError(child.error),

--- a/packages/tool-studio/src/types.ts
+++ b/packages/tool-studio/src/types.ts
@@ -723,7 +723,7 @@ export type StudioSessionStore = StudioMemoryStore & {
   deleteSession?(id: string): boolean | Promise<boolean>;
 };
 
-export type StudioTraceStatus = "running" | "success" | "suspended" | "error";
+export type StudioTraceStatus = "running" | "success" | "suspended" | "error" | "cancelled";
 
 export type StudioTraceObservationKind = "agent" | "generation" | "tool";
 
@@ -1037,6 +1037,7 @@ export type StudioServeOptions = {
   hostname?: string;
   log?: boolean;
   handleSignals?: boolean;
+  shutdownTimeoutMs?: number;
 };
 
 export type StudioServeLifecycleOptions = Omit<StudioServeOptions, "handleSignals"> & {
@@ -1267,6 +1268,7 @@ export type StudioErrorCode =
   | "forbidden"
   | "not_found"
   | "payload_too_large"
+  | "service_unavailable"
   | "unsupported_capability"
   | "internal_error";
 
@@ -1285,4 +1287,5 @@ export type AnviaStudio = {
   fetch(request: Request): Response | Promise<Response>;
   config(): StudioConfig;
   close(): void;
+  shutdown(options?: { timeoutMs?: number }): Promise<void>;
 };

--- a/packages/tool-studio/src/ui/app/modules/tracing/trace-browser-detail.tsx
+++ b/packages/tool-studio/src/ui/app/modules/tracing/trace-browser-detail.tsx
@@ -753,6 +753,9 @@ export function observationStatusSummary(observations: TraceObservationItem[]): 
   if (observations.some((observation) => observation.status === "error")) {
     return "error";
   }
+  if (observations.some((observation) => observation.status === "cancelled")) {
+    return "cancelled";
+  }
   if (observations.some((observation) => observation.status === "running")) {
     return "running";
   }

--- a/packages/tool-studio/src/ui/app/modules/tracing/trace-browser.tsx
+++ b/packages/tool-studio/src/ui/app/modules/tracing/trace-browser.tsx
@@ -311,12 +311,13 @@ function TraceStatusBadge({ status }: { status: string }) {
         status === "success" &&
           "bg-emerald-200 text-emerald-950 dark:bg-emerald-300 dark:text-emerald-950",
         status === "error" && "bg-rose-200 text-rose-950 dark:bg-rose-300 dark:text-rose-950",
-        (status === "running" || status === "suspended") &&
+        (status === "running" || status === "suspended" || status === "cancelled") &&
           "bg-amber-200 text-amber-950 dark:bg-amber-300 dark:text-amber-950",
         status !== "success" &&
           status !== "error" &&
           status !== "running" &&
           status !== "suspended" &&
+          status !== "cancelled" &&
           "bg-slate-200 text-slate-900 dark:bg-slate-300 dark:text-slate-950",
       )}
     >

--- a/packages/tool-studio/test/runner.test.ts
+++ b/packages/tool-studio/test/runner.test.ts
@@ -117,6 +117,49 @@ class AbortableModel extends QueueModel {
   }
 }
 
+class AbortableStreamingModel implements StreamingCompletionModel {
+  readonly provider = "test";
+  readonly modelId = "test";
+  readonly capabilities = {
+    streaming: true,
+    tools: true,
+    toolChoice: true,
+    imageInput: true,
+    documentInput: true,
+    outputSchema: true,
+    reasoning: true,
+  };
+  readonly started: Promise<void>;
+  private markStarted: () => void = () => {};
+
+  constructor() {
+    this.started = new Promise<void>((resolve) => {
+      this.markStarted = resolve;
+    });
+  }
+
+  completion(): Promise<CompletionResponse> {
+    throw new Error("completion should not be called");
+  }
+
+  async *streamCompletion(
+    _request: CompletionRequest,
+    options?: ModelCallOptions,
+  ): AsyncIterable<CompletionModelStreamEvent> {
+    this.markStarted();
+    yield { type: "text_delta", delta: "partial" };
+    const signal = options?.abortSignal;
+    if (signal === undefined) throw new Error("Expected an abort signal");
+    await new Promise<void>((_resolve, reject) => {
+      if (signal.aborted) {
+        reject(signal.reason);
+        return;
+      }
+      signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+    });
+  }
+}
+
 type CompletionOutcome = { response: CompletionResponse } | { error: unknown };
 
 class FlakyQueueModel {
@@ -1280,6 +1323,38 @@ describe("Anvia studio", () => {
     await shutdown;
     expect(shutdownSettled).toBe(true);
 
+    const rejected = await studio.fetch(
+      new Request("http://runner.test/agents/support/runs", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ type: "messages", messages: [Message.user("late")] }),
+      }),
+    );
+    expect(rejected.status).toBe(503);
+  });
+
+  it("drains an active streaming run before shutdown completes", async () => {
+    const model = new AbortableStreamingModel();
+    const agent = new Agent({ id: "support", model });
+    const studio = new Studio([agent]);
+    const response = await studio.fetch(
+      new Request("http://runner.test/agents/support/runs", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          type: "messages",
+          messages: [Message.user("wait")],
+          stream: true,
+        }),
+      }),
+    );
+    const events = readJsonl(response);
+    await model.started;
+
+    const shutdown = studio.shutdown({ timeoutMs: 1_000 });
+    const [streamEvents] = await Promise.all([events, shutdown]);
+
+    expect(streamEvents).toContainEqual(expect.objectContaining({ type: "error" }));
     const rejected = await studio.fetch(
       new Request("http://runner.test/agents/support/runs", {
         method: "POST",

--- a/packages/tool-studio/test/runner.test.ts
+++ b/packages/tool-studio/test/runner.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { Agent, createVectorContext } from "@anvia/core/agent";
 import {
   type CompletionModelStreamEvent,
+  type ModelCallOptions,
   type CompletionRequest,
   type CompletionResponse,
   type Message as CoreMessage,
@@ -86,6 +87,33 @@ class QueueModel {
       throw new Error("No queued response");
     }
     return response;
+  }
+}
+
+class AbortableModel extends QueueModel {
+  readonly started: Promise<void>;
+  private markStarted: () => void = () => {};
+
+  constructor() {
+    super([]);
+    this.started = new Promise<void>((resolve) => {
+      this.markStarted = resolve;
+    });
+  }
+
+  override completion(
+    _request: CompletionRequest,
+    options?: ModelCallOptions,
+  ): Promise<CompletionResponse> {
+    this.markStarted();
+    return new Promise((_resolve, reject) => {
+      const signal = options?.abortSignal;
+      if (signal?.aborted === true) {
+        reject(signal.reason);
+        return;
+      }
+      signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+    });
   }
 }
 
@@ -1153,14 +1181,113 @@ describe("Anvia studio", () => {
 
   it("can leave process signal handling to the application", () => {
     const listenersBeforeStart = process.listeners("SIGINT");
+    const termListenersBeforeStart = process.listeners("SIGTERM");
     const agent = new Agent({ id: "support", model: new QueueModel([]) });
     const runner = new Studio([agent]).start({ port: 0, log: false, handleSignals: false });
 
     try {
       expect(process.listeners("SIGINT")).toEqual(listenersBeforeStart);
+      expect(process.listeners("SIGTERM")).toEqual(termListenersBeforeStart);
     } finally {
       runner.close();
     }
+  });
+
+  it("handles SIGTERM through graceful shutdown and removes both signal listeners", async () => {
+    const interruptListenersBeforeStart = new Set(process.listeners("SIGINT"));
+    const terminateListenersBeforeStart = new Set(process.listeners("SIGTERM"));
+    const exitCodeBeforeStart = process.exitCode;
+    const agent = new Agent({ id: "support", model: new QueueModel([]) });
+    const runner = new Studio([agent]).start({ port: 0, log: false });
+
+    try {
+      const interruptListeners = process.listeners("SIGINT");
+      const terminateListeners = process.listeners("SIGTERM");
+      expect(interruptListeners).toHaveLength(interruptListenersBeforeStart.size + 1);
+      expect(terminateListeners).toHaveLength(terminateListenersBeforeStart.size + 1);
+
+      const handler = terminateListeners.find(
+        (listener) => !terminateListenersBeforeStart.has(listener),
+      );
+      expect(handler).toBeDefined();
+      handler?.("SIGTERM");
+      await runner.shutdown();
+
+      expect(process.exitCode).toBe(143);
+      expect(process.listeners("SIGINT")).toEqual([...interruptListenersBeforeStart]);
+      expect(process.listeners("SIGTERM")).toEqual([...terminateListenersBeforeStart]);
+    } finally {
+      runner.close();
+      process.exitCode = exitCodeBeforeStart;
+    }
+  });
+
+  it("allows shutdown to be retried after rejecting an invalid timeout", async () => {
+    const studio = new Studio();
+
+    await expect(studio.shutdown({ timeoutMs: 0 })).rejects.toThrow(/positive number/);
+    await expect(studio.shutdown({ timeoutMs: 100 })).resolves.toBeUndefined();
+  });
+
+  it("aborts active runs and waits for observer cancellation before shutdown completes", async () => {
+    const model = new AbortableModel();
+    let observedStatus: "failed" | "cancelled" | undefined;
+    let releaseObserver: () => void = () => {};
+    let markObserverStarted: () => void = () => {};
+    const observerGate = new Promise<void>((resolve) => {
+      releaseObserver = resolve;
+    });
+    const observerStarted = new Promise<void>((resolve) => {
+      markObserverStarted = resolve;
+    });
+    const observer: AgentObserver = {
+      startRun(): AgentRunObserver {
+        return {
+          end() {},
+          async error(args) {
+            observedStatus = args.status;
+            markObserverStarted();
+            await observerGate;
+          },
+        };
+      },
+    };
+    const agent = new Agent({
+      id: "support",
+      model,
+      observability: { observers: { test: observer } },
+    });
+    const studio = new Studio([agent]);
+    const request = studio.fetch(
+      new Request("http://runner.test/agents/support/runs", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ type: "messages", messages: [Message.user("wait")] }),
+      }),
+    );
+    await model.started;
+
+    let shutdownSettled = false;
+    const shutdown = studio.shutdown({ timeoutMs: 1_000 }).then(() => {
+      shutdownSettled = true;
+    });
+    await observerStarted;
+    expect(observedStatus).toBe("cancelled");
+    expect(shutdownSettled).toBe(false);
+
+    releaseObserver();
+    await expect(request).resolves.toMatchObject({ status: 500 });
+    await shutdown;
+    expect(shutdownSettled).toBe(true);
+
+    const rejected = await studio.fetch(
+      new Request("http://runner.test/agents/support/runs", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ type: "messages", messages: [Message.user("late")] }),
+      }),
+    );
+    expect(rejected.status).toBe(503);
   });
 
   it("preserves loopback connection metadata for local sandbox views", async () => {

--- a/packages/tool-studio/test/trace-browser-helpers.test.ts
+++ b/packages/tool-studio/test/trace-browser-helpers.test.ts
@@ -159,6 +159,7 @@ describe("trace browser helper behavior", () => {
     expect(observationStatusSummary([])).toBe("empty");
     expect(observationStatusSummary([observation({ status: "running" })])).toBe("running");
     expect(observationStatusSummary([observation({ status: "error" })])).toBe("error");
+    expect(observationStatusSummary([observation({ status: "cancelled" })])).toBe("cancelled");
     expect(observationStatusSummary([observation({ status: "success" })])).toBe("success");
     expect(traceObservationLabel(observation({ kind: "agent", name: "agent.run" }))).toBe(
       "agent.run",

--- a/packages/tool-studio/test/trace-observer.test.ts
+++ b/packages/tool-studio/test/trace-observer.test.ts
@@ -1,0 +1,69 @@
+import type { AgentToolStartArgs } from "@anvia/core/observability";
+import { describe, expect, it } from "vitest";
+import {
+  AgentRunCancelledError,
+  AssistantContent,
+  Message,
+  Usage,
+} from "../../core/test/helpers/imports";
+import { StudioTraceObserver } from "../src/traces/trace-observer";
+import type { StudioTrace, StudioTraceStore } from "../src/types";
+
+describe("StudioTraceObserver", () => {
+  it("preserves cancellation status for nested Agent observations", async () => {
+    let savedTrace: StudioTrace | undefined;
+    const store: StudioTraceStore = {
+      listSessionTraces: () => [],
+      getTrace: () => undefined,
+      saveTrace(trace) {
+        savedTrace = trace;
+        return trace;
+      },
+    };
+    const observer = new StudioTraceObserver({ store });
+    const run = observer.startRun({
+      runId: "run_parent",
+      prompt: Message.user("delegate"),
+      history: [],
+      maxTurns: 1,
+      trace: { sessionId: "session_1" },
+    });
+    const toolArgs: AgentToolStartArgs = {
+      turn: 1,
+      toolCall: AssistantContent.toolCall("call_child", "ask_child", { prompt: "wait" }),
+      toolName: "ask_child",
+      args: '{"prompt":"wait"}',
+      internalCallId: "internal_child",
+      toolCallId: "call_child",
+    };
+    const tool = await run.startTool?.(toolArgs);
+    const cancellation = new AgentRunCancelledError([], "parent stopped");
+
+    await tool?.streamEvent?.({
+      ...toolArgs,
+      event: {
+        agentId: "child",
+        agentName: "Child Agent",
+        event: { type: "error", error: cancellation, usage: Usage.empty() },
+      },
+    });
+    await tool?.end({ ...toolArgs, result: "", skipped: false });
+    await run.error?.({
+      status: "cancelled",
+      error: cancellation,
+      usage: Usage.empty(),
+      messages: [Message.user("delegate")],
+    });
+
+    expect(savedTrace?.observations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "agent", name: "Child_Agent.run", status: "cancelled" }),
+        expect.objectContaining({
+          kind: "tool",
+          name: "Child_Agent.error",
+          status: "cancelled",
+        }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- distinguish cancelled Agent runs from failed runs across Core, Logger, OTel/Lens, Langfuse, and Studio
- make Studio handle SIGINT and SIGTERM by aborting and draining active Agent and Pipeline runs before caller-owned observability clients shut down
- preserve cancellation through run-error hooks and nested Agent trace observations
- declare the Studio Node runtime requirement and cover buffered plus streaming shutdown paths
- document graceful CLI shutdown, update cookbook integrations, and add patch changesets for all affected public packages

## Validation

- pnpm check
- Core: 579 tests passed
- Studio: 199 tests passed
- OTel: 25 tests passed
- Langfuse: 153 tests passed
- Lens: 15 tests passed
- Logger: 12 tests passed
- relevant package typechecks passed
- relevant package builds passed, including the Studio UI production build
- git diff --check

## Review feedback

- addressed hook-triggered cancellation classification
- addressed nested Agent cancellation classification
- added Studio engines.node >=20.12.0
- added streaming-run drain coverage

## Visual verification

- No manual Studio UI screenshot verification was run; the cancelled status badge and helpers are covered by tests and the production UI build.