### PR TITLE
feat: add consistent text ingestion helpers

### DIFF
--- a/.changeset/gentle-graphs-ingest.md
+++ b/.changeset/gentle-graphs-ingest.md
@@ -1,0 +1,7 @@
+---
+"@anvia/core": patch
+"@anvia/graph": patch
+---
+
+Add matching raw-text ingestion helpers for vector stores and managed knowledge graphs, including
+shared deterministic chunking and reusable graph/vector embeddings.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -538,6 +538,32 @@ slice. PDF pages are one-based, and the parser task is disposed before extractio
 If parsing or abort handling fails together with parser cleanup, extraction rejects with an
 `AggregateError` containing the operation failure first and the cleanup failure second.
 
+For the common vector ingestion path, embed and upsert raw text with one call:
+
+```ts
+import { ingestVectorText } from "@anvia/core/vector-store";
+
+await ingestVectorText({
+  store,
+  document: {
+    id: "incident-42",
+    text,
+    metadata: { tenant: "acme" },
+  },
+  embeddingModel,
+  chunking: {
+    strategy: "recursive",
+    maxSize: 1_000,
+    overlap: 100,
+    separators: ["\n\n", "\n", " "],
+  },
+});
+```
+
+`ingestVectorDocuments()` accepts the same document shape for batches. Without `chunking`, each
+source document is embedded as one chunk. Chunk embeddings remain grouped under the source document
+ID so re-ingestion replaces its complete vector representation instead of leaving stale chunks.
+
 ## Media
 
 Media helpers follow the same one-object API and share `providerOptions`, `retries`, and

--- a/packages/core/src/documents/index.ts
+++ b/packages/core/src/documents/index.ts
@@ -1,2 +1,3 @@
 export * from "./chunk-text";
 export * from "./pdf";
+export * from "./text-document";

--- a/packages/core/src/documents/text-document.ts
+++ b/packages/core/src/documents/text-document.ts
@@ -1,0 +1,123 @@
+import { chunkText } from "./chunk-text";
+
+export type TextDocumentMetadata = Record<string, string | number | boolean>;
+
+export type TextDocument<Metadata = TextDocumentMetadata> = Readonly<{
+  id: string;
+  text: string;
+  metadata?: Metadata | undefined;
+}>;
+
+export type TextDocumentChunk<Metadata = TextDocumentMetadata> = Readonly<{
+  id: string;
+  documentId: string;
+  index: number;
+  text: string;
+  metadata?: Metadata | undefined;
+}>;
+
+export type TextDocumentChunkingOptions =
+  | Readonly<{ strategy: "none" }>
+  | Readonly<{
+      strategy: "fixed";
+      maxSize: number;
+      overlap?: number | undefined;
+    }>
+  | Readonly<{
+      strategy: "recursive";
+      maxSize: number;
+      overlap?: number | undefined;
+      separators: readonly string[];
+    }>;
+
+export type ChunkTextDocumentsOptions<Metadata = TextDocumentMetadata> = Readonly<{
+  documents: readonly TextDocument<Metadata>[];
+  chunking?: TextDocumentChunkingOptions | undefined;
+}>;
+
+export function chunkTextDocuments<Metadata>(
+  options: ChunkTextDocumentsOptions<Metadata>,
+): readonly TextDocumentChunk<Metadata>[] {
+  if (typeof options !== "object" || options === null) {
+    throw new TypeError("chunkTextDocuments options must contain a documents array");
+  }
+  const documents = options.documents;
+  if (!Array.isArray(documents)) {
+    throw new TypeError("chunkTextDocuments options must contain a documents array");
+  }
+
+  const ids = new Set<string>();
+  const chunks: TextDocumentChunk<Metadata>[] = [];
+  for (const document of documents as readonly TextDocument<Metadata>[]) {
+    validateDocument(document, ids);
+    chunks.push(...chunkDocument(document, options.chunking));
+  }
+  return chunks;
+}
+
+function validateDocument<Metadata>(document: TextDocument<Metadata>, ids: Set<string>): void {
+  if (typeof document !== "object" || document === null) {
+    throw new TypeError("Text documents must be objects");
+  }
+  if (typeof document.id !== "string" || document.id.length === 0) {
+    throw new TypeError("Text document ids must be non-empty strings");
+  }
+  if (ids.has(document.id)) {
+    throw new TypeError(`Duplicate text document id: ${document.id}`);
+  }
+  if (typeof document.text !== "string" || document.text.length === 0) {
+    throw new TypeError(`Text document ${document.id} must contain non-empty text`);
+  }
+  ids.add(document.id);
+}
+
+function chunkDocument<Metadata>(
+  document: TextDocument<Metadata>,
+  chunking: TextDocumentChunkingOptions | undefined,
+): readonly TextDocumentChunk<Metadata>[] {
+  if (chunking === undefined || chunking.strategy === "none") {
+    return [createDocumentChunk(document, 0, document.text)];
+  }
+
+  const textChunks = chunkDocumentText(document.text, chunking);
+  return textChunks.map((chunk) => createDocumentChunk(document, chunk.index, chunk.text));
+}
+
+function chunkDocumentText(
+  text: string,
+  chunking: Exclude<TextDocumentChunkingOptions, Readonly<{ strategy: "none" }>>,
+) {
+  const overlap = chunking.overlap ?? 0;
+  if (chunking.strategy === "fixed") {
+    return chunkText({
+      text,
+      strategy: "fixed",
+      maxSize: chunking.maxSize,
+      overlap,
+    });
+  }
+  return chunkText({
+    text,
+    strategy: "recursive",
+    maxSize: chunking.maxSize,
+    overlap,
+    separators: chunking.separators,
+  });
+}
+
+function createDocumentChunk<Metadata>(
+  document: TextDocument<Metadata>,
+  index: number,
+  text: string,
+): TextDocumentChunk<Metadata> {
+  const chunk = {
+    id: `${document.id}:chunk:${index}`,
+    documentId: document.id,
+    index,
+    text,
+  };
+  if (document.metadata === undefined) {
+    return chunk;
+  }
+  return { ...chunk, metadata: document.metadata };
+}

--- a/packages/core/src/vector-store/index.ts
+++ b/packages/core/src/vector-store/index.ts
@@ -24,6 +24,7 @@ import type {
 } from "./types";
 
 export { matchesVectorFilter, vectorFilter } from "./filter";
+export * from "./ingest";
 export { retrieveDocuments } from "./retrieve";
 export type * from "./types";
 

--- a/packages/core/src/vector-store/ingest.ts
+++ b/packages/core/src/vector-store/ingest.ts
@@ -1,0 +1,127 @@
+import type { JsonObject } from "../completion";
+import {
+  chunkTextDocuments,
+  type TextDocument,
+  type TextDocumentChunk,
+  type TextDocumentChunkingOptions,
+} from "../documents";
+import {
+  embedDocuments,
+  type EmbeddedDocument,
+  type EmbeddingModel,
+  type VectorMetadata,
+  type VectorMetadataValue,
+} from "../embeddings";
+import type { RetrySetting } from "../retry";
+import type { VectorStore } from "./types";
+
+export type IngestVectorDocumentsOptions<Metadata extends VectorMetadata = VectorMetadata> =
+  Readonly<{
+    store: VectorStore<TextDocument<Metadata>, Metadata>;
+    documents: readonly TextDocument<Metadata>[];
+    embeddingModel: EmbeddingModel;
+    chunking?: TextDocumentChunkingOptions | undefined;
+    retries?: RetrySetting | undefined;
+    concurrency?: number | undefined;
+    providerOptions?: JsonObject | undefined;
+    abortSignal?: AbortSignal | undefined;
+  }>;
+
+export type IngestVectorTextOptions<Metadata extends VectorMetadata = VectorMetadata> = Omit<
+  IngestVectorDocumentsOptions<Metadata>,
+  "documents"
+> &
+  Readonly<{ document: TextDocument<Metadata> }>;
+
+export type IngestVectorDocumentsResult<Metadata extends VectorMetadata = VectorMetadata> =
+  Readonly<{
+    documents: readonly EmbeddedDocument<TextDocument<Metadata>, Metadata>[];
+  }>;
+
+export async function ingestVectorText<Metadata extends VectorMetadata = VectorMetadata>(
+  options: IngestVectorTextOptions<Metadata>,
+): Promise<IngestVectorDocumentsResult<Metadata>> {
+  return ingestVectorDocuments({
+    store: options.store,
+    documents: [options.document],
+    embeddingModel: options.embeddingModel,
+    chunking: options.chunking,
+    retries: options.retries,
+    concurrency: options.concurrency,
+    providerOptions: options.providerOptions,
+    abortSignal: options.abortSignal,
+  });
+}
+
+export async function ingestVectorDocuments<Metadata extends VectorMetadata = VectorMetadata>(
+  options: IngestVectorDocumentsOptions<Metadata>,
+): Promise<IngestVectorDocumentsResult<Metadata>> {
+  for (const document of options.documents) {
+    validateVectorMetadata(document.metadata, document.id);
+  }
+  const chunks = chunkTextDocuments({
+    documents: options.documents,
+    chunking: options.chunking,
+  });
+  const chunksByDocument = groupChunksByDocument(chunks);
+  const embedded = await embedDocuments({
+    model: options.embeddingModel,
+    documents: [...options.documents],
+    id: (document) => document.id,
+    content: (document) => {
+      const documentChunks = chunksByDocument.get(document.id);
+      if (documentChunks === undefined) {
+        throw new TypeError(`Text document ${document.id} has no chunks`);
+      }
+      return documentChunks.map((chunk) => chunk.text);
+    },
+    metadata: (document) => document.metadata,
+    retries: options.retries,
+    concurrency: options.concurrency,
+    abortSignal: options.abortSignal,
+  });
+  await options.store.upsert({
+    documents: embedded.documents,
+    providerOptions: options.providerOptions,
+  });
+  return { documents: embedded.documents };
+}
+
+function validateVectorMetadata(metadata: VectorMetadata | undefined, documentId: string): void {
+  if (metadata === undefined) {
+    return;
+  }
+  if (typeof metadata !== "object" || metadata === null || Array.isArray(metadata)) {
+    throw new TypeError(`Text document ${documentId} metadata must be an object`);
+  }
+  for (const [key, value] of Object.entries(metadata)) {
+    validateVectorMetadataValue(value, `Text document ${documentId} metadata.${key}`);
+  }
+}
+
+function validateVectorMetadataValue(value: VectorMetadataValue, label: string): void {
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
+    return;
+  }
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new TypeError(`${label} must be a finite vector metadata value`);
+  }
+  if (Number.isInteger(value) && !Number.isSafeInteger(value)) {
+    throw new TypeError(`${label} must be a safe integer`);
+  }
+}
+
+function groupChunksByDocument<Metadata>(
+  chunks: readonly TextDocumentChunk<Metadata>[],
+): ReadonlyMap<string, readonly TextDocumentChunk<Metadata>[]> {
+  const grouped = new Map<string, TextDocumentChunk<Metadata>[]>();
+  for (const chunk of chunks) {
+    const documentChunks = grouped.get(chunk.documentId);
+    if (documentChunks === undefined) {
+      grouped.set(chunk.documentId, [chunk]);
+    } else {
+      documentChunks.push(chunk);
+    }
+  }
+  return grouped;
+}

--- a/packages/core/test/documents.test.ts
+++ b/packages/core/test/documents.test.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { chunkText, extractPdfText } from "../src/documents";
+import { chunkText, chunkTextDocuments, extractPdfText } from "../src/documents";
 
 const fixtureDir = join(dirname(fileURLToPath(import.meta.url)), "fixtures", "loaders");
 
@@ -186,6 +186,54 @@ describe("chunkText", () => {
       // @ts-expect-error Recursive chunking requires explicit separators.
       chunkText({ text: "text", strategy: "recursive", maxSize: 4 });
     }
+  });
+});
+
+describe("chunkTextDocuments", () => {
+  it("creates stable source-aware chunks and preserves metadata", () => {
+    expect(
+      chunkTextDocuments({
+        documents: [{ id: "incident", text: "abcdefgh", metadata: { tenant: "one" } }],
+        chunking: { strategy: "fixed", maxSize: 4 },
+      }),
+    ).toEqual([
+      {
+        id: "incident:chunk:0",
+        documentId: "incident",
+        index: 0,
+        text: "abcd",
+        metadata: { tenant: "one" },
+      },
+      {
+        id: "incident:chunk:1",
+        documentId: "incident",
+        index: 1,
+        text: "efgh",
+        metadata: { tenant: "one" },
+      },
+    ]);
+  });
+
+  it("uses one chunk by default and rejects unsafe source documents", () => {
+    expect(chunkTextDocuments({ documents: [{ id: "one", text: "whole document" }] })).toEqual([
+      {
+        id: "one:chunk:0",
+        documentId: "one",
+        index: 0,
+        text: "whole document",
+      },
+    ]);
+    expect(() =>
+      chunkTextDocuments({
+        documents: [
+          { id: "same", text: "one" },
+          { id: "same", text: "two" },
+        ],
+      }),
+    ).toThrow("Duplicate text document id");
+    expect(() => chunkTextDocuments({ documents: [{ id: "empty", text: "" }] })).toThrow(
+      "non-empty text",
+    );
   });
 });
 

--- a/packages/core/test/embeddings-vector-store.test.ts
+++ b/packages/core/test/embeddings-vector-store.test.ts
@@ -11,6 +11,8 @@ import {
   type HybridVectorSearchRequest,
   type HybridVectorStore,
   InMemoryVectorStore,
+  ingestVectorDocuments,
+  ingestVectorText,
   isVectorContext,
   retrieveDocuments,
   type SparseEmbeddingModel,
@@ -208,6 +210,40 @@ describe("embedding helpers", () => {
 });
 
 describe("vector stores and retrieval", () => {
+  it("ingests chunked text while preserving document-scoped replacement", async () => {
+    const store = new InMemoryVectorStore<{
+      id: string;
+      text: string;
+      metadata?: { tenant: string } | undefined;
+    }>();
+    const first = await ingestVectorDocuments({
+      store,
+      documents: [{ id: "incident", text: "cat abcdef", metadata: { tenant: "one" } }],
+      embeddingModel: new KeywordModel(),
+      chunking: { strategy: "fixed", maxSize: 4 },
+    });
+
+    expect(first.documents).toHaveLength(1);
+    expect(first.documents[0]).toMatchObject({ id: "incident", metadata: { tenant: "one" } });
+    expect(first.documents[0]?.embeddings).toHaveLength(3);
+
+    await ingestVectorText({
+      store,
+      document: { id: "incident", text: "cat", metadata: { tenant: "one" } },
+      embeddingModel: new KeywordModel(),
+      chunking: { strategy: "fixed", maxSize: 4 },
+    });
+    expect(store.get({ id: "incident" })?.embeddings).toHaveLength(1);
+
+    await expect(
+      ingestVectorText({
+        store,
+        document: { id: "invalid", text: "cat", metadata: { score: Number.NaN } } as never,
+        embeddingModel: new KeywordModel(),
+      }),
+    ).rejects.toThrow("finite vector metadata value");
+  });
+
   it("searches an in-memory store with raw vectors and replaces documents", async () => {
     const model = new KeywordModel();
     const { documents } = await embedDocuments({

--- a/packages/core/test/public-exports.test.ts
+++ b/packages/core/test/public-exports.test.ts
@@ -183,7 +183,15 @@ describe("public exports", () => {
 
   it("exposes provider-neutral vector filter matching from the vector-store subpath", () => {
     expect("matchesVectorFilter" in vectorStore).toBe(true);
+    expect("ingestVectorDocuments" in vectorStore).toBe(true);
+    expect("ingestVectorText" in vectorStore).toBe(true);
     expect("matchesVectorFilter" in publicCore).toBe(false);
+    expect("ingestVectorText" in publicCore).toBe(false);
+  });
+
+  it("exposes portable text document chunking from the documents subpath", () => {
+    expect("chunkTextDocuments" in documents).toBe(true);
+    expect("chunkTextDocuments" in publicCore).toBe(false);
   });
 
   it("exposes middleware helpers from public entrypoints", () => {

--- a/packages/graph-memgraph/README.md
+++ b/packages/graph-memgraph/README.md
@@ -11,7 +11,7 @@ pnpm add @anvia/graph @anvia/memgraph @anvia/core
 ## Managed knowledge graph
 
 ```ts
-import { createGraphSearchTool, defineGraphSchema, extractGraphFacts } from "@anvia/graph";
+import { createGraphSearchTool, defineGraphSchema, ingestGraphText } from "@anvia/graph";
 import { MemgraphClient } from "@anvia/memgraph";
 import { z } from "zod";
 
@@ -86,14 +86,17 @@ const graph = client.managedKnowledgeGraph({
 
 await graph.ensure();
 
-const facts = await extractGraphFacts({ model: extractionModel, schema, chunks });
-
-await graph.replaceDocuments({
-  documents,
-  chunks: embeddedChunks,
-  entities: embeddedEntities,
-  relationships: facts.output.relationships,
-  mentions: facts.output.mentions,
+const ingestion = await ingestGraphText({
+  graph,
+  document: { id: "incident-42", text },
+  extractionModel,
+  embeddingModel,
+  chunking: {
+    strategy: "recursive",
+    maxSize: 1_000,
+    overlap: 100,
+    separators: ["\n\n", "\n", " "],
+  },
   conflict: "error",
   orphanEntities: "delete",
 });

--- a/packages/graph-memgraph/test/public-types.ts
+++ b/packages/graph-memgraph/test/public-types.ts
@@ -1,0 +1,26 @@
+import type { EmbeddingModel } from "@anvia/core/embeddings";
+import { ingestGraphText } from "@anvia/graph";
+import type {
+  ManagedMemgraphKnowledgeGraph,
+  MemgraphGraphSchema,
+  MemgraphKnowledgeGraph,
+} from "../src/index.js";
+
+declare const model: EmbeddingModel;
+declare const managed: ManagedMemgraphKnowledgeGraph<MemgraphGraphSchema>;
+declare const existing: MemgraphKnowledgeGraph<MemgraphGraphSchema>;
+
+ingestGraphText({
+  graph: managed,
+  document: { id: "one", text: "Product One" },
+  extractionModel: {} as never,
+  embeddingModel: model,
+});
+
+ingestGraphText({
+  // @ts-expect-error Existing Memgraph registrations are read-only ingestion targets.
+  graph: existing,
+  document: { id: "one", text: "Product One" },
+  extractionModel: {} as never,
+  embeddingModel: model,
+});

--- a/packages/graph-memgraph/test/public-types.ts
+++ b/packages/graph-memgraph/test/public-types.ts
@@ -15,6 +15,8 @@ ingestGraphText({
   document: { id: "one", text: "Product One" },
   extractionModel: {} as never,
   embeddingModel: model,
+  conflict: "error",
+  orphanEntities: "delete",
 });
 
 ingestGraphText({
@@ -23,4 +25,6 @@ ingestGraphText({
   document: { id: "one", text: "Product One" },
   extractionModel: {} as never,
   embeddingModel: model,
+  conflict: "error",
+  orphanEntities: "delete",
 });

--- a/packages/graph-neo4j/README.md
+++ b/packages/graph-neo4j/README.md
@@ -16,9 +16,8 @@ pnpm add @anvia/graph @anvia/neo4j @anvia/core
 
 ```ts
 import { Agent } from "@anvia/core/agent";
-import { embedDocuments } from "@anvia/core/embeddings";
-import { createGraphSearchTool } from "@anvia/graph";
-import { Neo4jClient, defineNeo4jGraphSchema, extractGraphFacts } from "@anvia/neo4j";
+import { createGraphSearchTool, ingestGraphText } from "@anvia/graph";
+import { Neo4jClient, defineNeo4jGraphSchema } from "@anvia/neo4j";
 import { z } from "zod";
 
 const schema = defineNeo4jGraphSchema({
@@ -71,32 +70,21 @@ const graph = client.managedKnowledgeGraph({
 
 await graph.ensure({ indexTimeoutMs: 60_000 });
 
-const facts = await extractGraphFacts({ model: extractionModel, schema, chunks });
-const [embeddedChunks, embeddedEntities] = await Promise.all([
-  embedDocuments({
-    model: embeddingModel,
-    documents: chunks,
-    id: (chunk) => chunk.id,
-    content: (chunk) => chunk.text,
-  }),
-  embedDocuments({
-    model: embeddingModel,
-    documents: [...facts.output.entities],
-    id: (entity) => entity.key,
-    content: (entity) => formatEntity(entity),
-  }),
-]);
-
-const write = await graph.replaceDocuments({
-  documents,
-  chunks: embeddedChunks.documents,
-  entities: embeddedEntities.documents,
-  relationships: facts.output.relationships,
-  mentions: facts.output.mentions,
+const ingestion = await ingestGraphText({
+  graph,
+  document: { id: "incident-42", text },
+  extractionModel,
+  embeddingModel,
+  chunking: {
+    strategy: "recursive",
+    maxSize: 1_000,
+    overlap: 100,
+    separators: ["\n\n", "\n", " "],
+  },
   conflict: "error",
   orphanEntities: "delete",
 });
-console.log(write);
+console.log(ingestion.write);
 
 const searchGraph = createGraphSearchTool({
   name: "search_support_graph",
@@ -123,9 +111,10 @@ const searchGraph = createGraphSearchTool({
 const agent = new Agent({ id: "support", model: chatModel, tools: [searchGraph] });
 ```
 
-The application owns file discovery, reading, chunking, entity embedding text, model loading,
-retry policy, and Agent lifecycle. `extractGraphFacts()` performs model extraction but no writes.
-`replaceDocuments()` performs one deterministic transaction but no model calls.
+The application owns file discovery, reading, model loading, retry policy, and Agent lifecycle.
+`ingestGraphText()` and `ingestGraphDocuments()` provide the convenient end-to-end path. Advanced
+callers can compose `prepareGraphDocuments()`, `extractGraphFacts()`, `embedDocuments()`, and
+`replaceDocuments()` directly when they need custom orchestration.
 
 Graph property schemas must use `z.strictObject()` and must not coerce, default, transform,
 preprocess, catch, trim, or otherwise overwrite values. This keeps extraction, comparison, and

--- a/packages/graph-neo4j/test/public-types.ts
+++ b/packages/graph-neo4j/test/public-types.ts
@@ -93,6 +93,8 @@ ingestGraphText({
   document: { id: "one", text: "Product One" },
   extractionModel: {} as never,
   embeddingModel: model,
+  conflict: "error",
+  orphanEntities: "delete",
 });
 
 ingestGraphText({
@@ -101,6 +103,8 @@ ingestGraphText({
   document: { id: "one", text: "Product One" },
   extractionModel: {} as never,
   embeddingModel: model,
+  conflict: "error",
+  orphanEntities: "delete",
 });
 
 void [

--- a/packages/graph-neo4j/test/public-types.ts
+++ b/packages/graph-neo4j/test/public-types.ts
@@ -1,5 +1,5 @@
 import type { EmbeddingModel } from "@anvia/core/embeddings";
-import type { CreateGraphSearchToolOptions } from "@anvia/graph";
+import { ingestGraphText, type CreateGraphSearchToolOptions } from "@anvia/graph";
 import type {
   ManagedNeo4jKnowledgeGraph,
   Neo4jGraphSchema,
@@ -87,6 +87,21 @@ const existingToolEvidence: CreateGraphSearchToolOptions<
   // @ts-expect-error Existing graph tools cannot hydrate managed chunk evidence.
   evidence: { type: "chunks", maxChunks: 2 },
 };
+
+ingestGraphText({
+  graph: managed,
+  document: { id: "one", text: "Product One" },
+  extractionModel: {} as never,
+  embeddingModel: model,
+});
+
+ingestGraphText({
+  // @ts-expect-error Existing Neo4j registrations are read-only ingestion targets.
+  graph: existing,
+  document: { id: "one", text: "Product One" },
+  extractionModel: {} as never,
+  embeddingModel: model,
+});
 
 void [
   managedEvidence,

--- a/packages/graph/README.md
+++ b/packages/graph/README.md
@@ -23,6 +23,49 @@ const facts = await extractGraphFacts({ model, schema, chunks });
 Database provisioning, persistence, and query execution belong to graph adapter packages such as
 `@anvia/neo4j` and `@anvia/memgraph`.
 
+## Ingestion
+
+Managed graphs accept the same raw text document shape as vector ingestion:
+
+```ts
+import { ingestGraphText } from "@anvia/graph";
+
+const ingestion = await ingestGraphText({
+  graph,
+  document: {
+    id: "incident-42",
+    text,
+    metadata: { tenant: "acme" },
+  },
+  extractionModel,
+  embeddingModel,
+  chunking: {
+    strategy: "recursive",
+    maxSize: 1_000,
+    overlap: 100,
+    separators: ["\n\n", "\n", " "],
+  },
+  conflict: "error",
+  orphanEntities: "delete",
+});
+```
+
+Use `ingestGraphDocuments()` for a batch. Both functions extract facts, embed chunks and entities,
+and atomically replace each source document in the managed graph. Existing graph registrations are
+read-only and are rejected as ingestion targets by TypeScript.
+
+The result also exposes `vectorDocuments`, grouped by source document ID, so a vector store can
+reuse the chunk embeddings without another model call:
+
+```ts
+await vectorStore.upsert({ documents: ingestion.vectorDocuments });
+```
+
+The graph and vector writes are separate transactions. Applications that require cross-store
+reconciliation should persist their own ingestion status and retry the incomplete write. Advanced
+callers can use `prepareGraphDocuments()` to run chunking, extraction, and embedding without writing,
+then pass its graph fields to `graph.replaceDocuments()` and its `vectorDocuments` to a vector store.
+
 ## Search tool
 
 Create the same Agent tool for any graph adapter implementing `GraphContextRetriever`:

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -1,5 +1,15 @@
 export { extractGraphFacts, GraphFactConflictError } from "./extract.js";
 export {
+  ingestGraphDocuments,
+  ingestGraphText,
+  prepareGraphDocuments,
+  type IngestGraphDocumentsOptions,
+  type IngestGraphDocumentsResult,
+  type IngestGraphTextOptions,
+  type PreparedGraphDocuments,
+  type PrepareGraphDocumentsOptions,
+} from "./ingest.js";
+export {
   resolveGraphExploreOptions,
   type ResolvedGraphExploreExpandOptions,
   type ResolvedGraphExploreOptions,

--- a/packages/graph/src/ingest.ts
+++ b/packages/graph/src/ingest.ts
@@ -1,0 +1,270 @@
+import type { CompletionModel, RetrySetting, Usage } from "@anvia/core";
+import {
+  chunkTextDocuments,
+  type TextDocument,
+  type TextDocumentChunk,
+  type TextDocumentChunkingOptions,
+  type TextDocumentMetadata,
+} from "@anvia/core/documents";
+import { embedDocuments, type EmbeddedDocument, type EmbeddingModel } from "@anvia/core/embeddings";
+import { extractGraphFacts } from "./extract.js";
+import { parseGraphProperties } from "./schema.js";
+import type {
+  GraphChunk,
+  GraphDocument,
+  GraphDocumentWriter,
+  GraphEntity,
+  GraphMention,
+  GraphOrphanEntityPolicy,
+  GraphProperties,
+  GraphRelationship,
+  GraphSchemaLike,
+  GraphWriteConflict,
+  GraphWriteResult,
+} from "./types.js";
+
+type GraphPreparationOptions<
+  Schema extends GraphSchemaLike,
+  ExtractionModel extends CompletionModel,
+> = Readonly<{
+  graph: Readonly<{ schema: Schema }>;
+  documents: readonly TextDocument<TextDocumentMetadata>[];
+  extractionModel: ExtractionModel;
+  embeddingModel: EmbeddingModel;
+  chunking?: TextDocumentChunkingOptions | undefined;
+  entityText?: ((entity: GraphEntity<Schema>) => string) | undefined;
+  instructions?: string | undefined;
+  retries?: RetrySetting | undefined;
+  concurrency?: number | undefined;
+  abortSignal?: AbortSignal | undefined;
+}>;
+
+export type PrepareGraphDocumentsOptions<
+  Schema extends GraphSchemaLike,
+  ExtractionModel extends CompletionModel = CompletionModel,
+> = GraphPreparationOptions<Schema, ExtractionModel>;
+
+export type IngestGraphDocumentsOptions<
+  Schema extends GraphSchemaLike,
+  ExtractionModel extends CompletionModel = CompletionModel,
+> = Omit<GraphPreparationOptions<Schema, ExtractionModel>, "graph"> &
+  Readonly<{
+    graph: GraphDocumentWriter<Schema>;
+    conflict?: GraphWriteConflict | undefined;
+    orphanEntities?: GraphOrphanEntityPolicy | undefined;
+  }>;
+
+export type IngestGraphTextOptions<
+  Schema extends GraphSchemaLike,
+  ExtractionModel extends CompletionModel = CompletionModel,
+> = Omit<IngestGraphDocumentsOptions<Schema, ExtractionModel>, "documents"> &
+  Readonly<{ document: TextDocument<TextDocumentMetadata> }>;
+
+export type PreparedGraphDocuments<Schema extends GraphSchemaLike> = Readonly<{
+  documents: readonly GraphDocument[];
+  chunks: readonly EmbeddedDocument<GraphChunk<TextDocumentMetadata>, TextDocumentMetadata>[];
+  vectorDocuments: readonly EmbeddedDocument<
+    TextDocument<TextDocumentMetadata>,
+    TextDocumentMetadata
+  >[];
+  entities: readonly EmbeddedDocument<GraphEntity<Schema>>[];
+  relationships: readonly GraphRelationship<Schema>[];
+  mentions: readonly GraphMention[];
+  usage: Usage;
+}>;
+
+export type IngestGraphDocumentsResult<Schema extends GraphSchemaLike> =
+  PreparedGraphDocuments<Schema> & Readonly<{ write: GraphWriteResult }>;
+
+export async function ingestGraphText<
+  Schema extends GraphSchemaLike,
+  ExtractionModel extends CompletionModel,
+>(
+  options: IngestGraphTextOptions<Schema, ExtractionModel>,
+): Promise<IngestGraphDocumentsResult<Schema>> {
+  return ingestGraphDocuments({
+    graph: options.graph,
+    documents: [options.document],
+    extractionModel: options.extractionModel,
+    embeddingModel: options.embeddingModel,
+    chunking: options.chunking,
+    entityText: options.entityText,
+    instructions: options.instructions,
+    retries: options.retries,
+    concurrency: options.concurrency,
+    abortSignal: options.abortSignal,
+    conflict: options.conflict,
+    orphanEntities: options.orphanEntities,
+  });
+}
+
+export async function ingestGraphDocuments<
+  Schema extends GraphSchemaLike,
+  ExtractionModel extends CompletionModel,
+>(
+  options: IngestGraphDocumentsOptions<Schema, ExtractionModel>,
+): Promise<IngestGraphDocumentsResult<Schema>> {
+  const prepared = await prepareGraphDocuments(options);
+  const write = await options.graph.replaceDocuments({
+    documents: prepared.documents,
+    chunks: prepared.chunks,
+    entities: prepared.entities,
+    relationships: prepared.relationships,
+    mentions: prepared.mentions,
+    conflict: options.conflict ?? "overwrite",
+    orphanEntities: options.orphanEntities ?? "delete",
+    abortSignal: options.abortSignal,
+  });
+  return { ...prepared, write };
+}
+
+export async function prepareGraphDocuments<
+  Schema extends GraphSchemaLike,
+  ExtractionModel extends CompletionModel,
+>(
+  options: PrepareGraphDocumentsOptions<Schema, ExtractionModel>,
+): Promise<PreparedGraphDocuments<Schema>> {
+  validatePortableMetadata(options.documents);
+  const chunks = chunkTextDocuments({
+    documents: options.documents,
+    chunking: options.chunking,
+  });
+  const graphChunks: GraphChunk<TextDocumentMetadata>[] = chunks.map((chunk) => graphChunk(chunk));
+  const [facts, embeddedChunks] = await Promise.all([
+    extractGraphFacts({
+      model: options.extractionModel,
+      schema: options.graph.schema,
+      chunks: graphChunks,
+      instructions: options.instructions,
+      retries: options.retries,
+      concurrency: options.concurrency,
+      abortSignal: options.abortSignal,
+    }),
+    embedDocuments({
+      model: options.embeddingModel,
+      documents: graphChunks,
+      id: (chunk) => chunk.id,
+      content: (chunk) => chunk.text,
+      metadata: (chunk) => chunk.metadata,
+      retries: options.retries,
+      concurrency: options.concurrency,
+      abortSignal: options.abortSignal,
+    }),
+  ]);
+  const embeddedEntities = await embedDocuments({
+    model: options.embeddingModel,
+    documents: [...facts.output.entities],
+    id: (entity) => entity.key,
+    content: options.entityText ?? defaultGraphEntityText,
+    retries: options.retries,
+    concurrency: options.concurrency,
+    abortSignal: options.abortSignal,
+  });
+  const vectorDocuments = groupVectorDocuments(options.documents, embeddedChunks.documents);
+  return {
+    documents: options.documents.map((document) => graphDocument(document)),
+    chunks: embeddedChunks.documents,
+    vectorDocuments,
+    entities: embeddedEntities.documents,
+    relationships: facts.output.relationships,
+    mentions: facts.output.mentions,
+    usage: facts.usage,
+  };
+}
+
+function validatePortableMetadata(documents: readonly TextDocument<TextDocumentMetadata>[]): void {
+  for (const document of documents) {
+    if (document.metadata === undefined) {
+      continue;
+    }
+    const metadata = parseGraphProperties(
+      document.metadata,
+      `Text document ${document.id} metadata`,
+    );
+    for (const [key, value] of Object.entries(metadata)) {
+      if (Array.isArray(value)) {
+        throw new TypeError(
+          `Text document ${document.id} metadata.${key} must be a portable primitive value`,
+        );
+      }
+    }
+  }
+}
+
+function groupVectorDocuments(
+  documents: readonly TextDocument<TextDocumentMetadata>[],
+  chunks: readonly EmbeddedDocument<GraphChunk<TextDocumentMetadata>, TextDocumentMetadata>[],
+): readonly EmbeddedDocument<TextDocument<TextDocumentMetadata>, TextDocumentMetadata>[] {
+  const chunksByDocument = new Map<
+    string,
+    EmbeddedDocument<GraphChunk<TextDocumentMetadata>, TextDocumentMetadata>[]
+  >();
+  for (const chunk of chunks) {
+    const documentChunks = chunksByDocument.get(chunk.document.documentId);
+    if (documentChunks === undefined) {
+      chunksByDocument.set(chunk.document.documentId, [chunk]);
+    } else {
+      documentChunks.push(chunk);
+    }
+  }
+  return documents.map((document) => {
+    const documentChunks = chunksByDocument.get(document.id);
+    if (documentChunks === undefined) {
+      throw new TypeError(`Text document ${document.id} has no embedded graph chunks`);
+    }
+    const embeddedDocument: EmbeddedDocument<
+      TextDocument<TextDocumentMetadata>,
+      TextDocumentMetadata
+    > = {
+      id: document.id,
+      document,
+      embeddings: documentChunks.flatMap((chunk) => chunk.embeddings),
+    };
+    if (document.metadata !== undefined) {
+      embeddedDocument.metadata = document.metadata;
+    }
+    return embeddedDocument;
+  });
+}
+
+function graphDocument(document: TextDocument<TextDocumentMetadata>): GraphDocument {
+  if (document.metadata === undefined) {
+    return { id: document.id };
+  }
+  return { id: document.id, properties: document.metadata };
+}
+
+function graphChunk(
+  chunk: TextDocumentChunk<TextDocumentMetadata>,
+): GraphChunk<TextDocumentMetadata> {
+  if (chunk.metadata === undefined) {
+    return {
+      id: chunk.id,
+      documentId: chunk.documentId,
+      index: chunk.index,
+      text: chunk.text,
+    };
+  }
+  return {
+    id: chunk.id,
+    documentId: chunk.documentId,
+    index: chunk.index,
+    text: chunk.text,
+    metadata: chunk.metadata,
+  };
+}
+
+function defaultGraphEntityText(entity: GraphEntity<GraphSchemaLike>): string {
+  const properties = Object.entries(entity.properties)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}: ${formatGraphProperty(value)}`)
+    .join("\n");
+  return properties.length === 0 ? entity.type : `${entity.type}\n${properties}`;
+}
+
+function formatGraphProperty(value: GraphProperties[string]): string {
+  if (Array.isArray(value)) {
+    return value.join(", ");
+  }
+  return String(value);
+}

--- a/packages/graph/src/ingest.ts
+++ b/packages/graph/src/ingest.ts
@@ -50,8 +50,8 @@ export type IngestGraphDocumentsOptions<
 > = Omit<GraphPreparationOptions<Schema, ExtractionModel>, "graph"> &
   Readonly<{
     graph: GraphDocumentWriter<Schema>;
-    conflict?: GraphWriteConflict | undefined;
-    orphanEntities?: GraphOrphanEntityPolicy | undefined;
+    conflict: GraphWriteConflict;
+    orphanEntities: GraphOrphanEntityPolicy;
   }>;
 
 export type IngestGraphTextOptions<
@@ -111,8 +111,8 @@ export async function ingestGraphDocuments<
     entities: prepared.entities,
     relationships: prepared.relationships,
     mentions: prepared.mentions,
-    conflict: options.conflict ?? "overwrite",
-    orphanEntities: options.orphanEntities ?? "delete",
+    conflict: options.conflict,
+    orphanEntities: options.orphanEntities,
     abortSignal: options.abortSignal,
   });
   return { ...prepared, write };

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -1,5 +1,5 @@
 import type { CompletionModel, RetrySetting, Usage } from "@anvia/core";
-import type { EmbeddingModel } from "@anvia/core/embeddings";
+import type { EmbeddedDocument, EmbeddingModel } from "@anvia/core/embeddings";
 import type { Tool } from "@anvia/core/tool";
 import type { z } from "zod";
 
@@ -282,3 +282,22 @@ export type GraphWriteResult = Readonly<{
   relationships: GraphChangeCounts;
   mentions: GraphChangeCounts;
 }>;
+
+export type GraphWriteConflict = "error" | "overwrite" | "keep-existing";
+export type GraphOrphanEntityPolicy = "delete" | "keep";
+
+export type ReplaceGraphDocumentsOptions<Schema extends GraphSchemaLike> = Readonly<{
+  documents: readonly GraphDocument[];
+  chunks: readonly EmbeddedDocument<GraphChunk>[];
+  entities: readonly EmbeddedDocument<GraphEntity<Schema>>[];
+  relationships: readonly GraphRelationship<Schema>[];
+  mentions: readonly GraphMention[];
+  conflict: GraphWriteConflict;
+  orphanEntities: GraphOrphanEntityPolicy;
+  abortSignal?: AbortSignal | undefined;
+}>;
+
+export interface GraphDocumentWriter<Schema extends GraphSchemaLike = GraphSchemaLike> {
+  readonly schema: Schema;
+  replaceDocuments(options: ReplaceGraphDocumentsOptions<Schema>): Promise<GraphWriteResult>;
+}

--- a/packages/graph/test/graph.test.ts
+++ b/packages/graph/test/graph.test.ts
@@ -9,6 +9,8 @@ import {
   defineGraphSchema,
   extractGraphFacts,
   GraphFactConflictError,
+  ingestGraphText,
+  prepareGraphDocuments,
   resolveGraphExploreOptions,
 } from "../src/index.js";
 
@@ -91,6 +93,86 @@ describe("provider-neutral graph primitives", () => {
         ],
       }),
     ).rejects.toBeInstanceOf(GraphFactConflictError);
+  });
+
+  it("prepares and writes text with reusable vector documents", async () => {
+    extractMock.mockResolvedValue({
+      output: {
+        entities: [{ ref: "p", type: "Product", properties: { id: "one", name: "One" } }],
+        relationships: [],
+      },
+      usage: Usage.empty(),
+    });
+    const embeddedTexts: string[] = [];
+    const embeddingModel = {
+      provider: "test",
+      modelId: "test",
+      async embedTexts(texts: string[]) {
+        embeddedTexts.push(...texts);
+        return texts.map((document) => ({ document, vector: [document.length] }));
+      },
+    };
+    const replaceDocuments = vi.fn(async () => ({
+      documents: { created: 1, updated: 0, deleted: 0, unchanged: 0 },
+      chunks: { created: 2, updated: 0, deleted: 0, unchanged: 0 },
+      entities: { created: 1, updated: 0, deleted: 0, unchanged: 0 },
+      relationships: { created: 0, updated: 0, deleted: 0, unchanged: 0 },
+      mentions: { created: 1, updated: 0, deleted: 0, unchanged: 0 },
+    }));
+    const graph = { schema, replaceDocuments };
+
+    const result = await ingestGraphText({
+      graph,
+      document: { id: "incident", text: "Product One", metadata: { tenant: "acme" } },
+      extractionModel: {} as never,
+      embeddingModel,
+      chunking: { strategy: "fixed", maxSize: 8 },
+    });
+
+    expect(result.chunks).toHaveLength(2);
+    expect(result.vectorDocuments).toMatchObject([
+      {
+        id: "incident",
+        metadata: { tenant: "acme" },
+        embeddings: [{ vector: [8] }, { vector: [3] }],
+      },
+    ]);
+    expect(embeddedTexts).toContain("Product\nid: one\nname: One");
+    expect(replaceDocuments).toHaveBeenCalledWith(
+      expect.objectContaining({ conflict: "overwrite", orphanEntities: "delete" }),
+    );
+  });
+
+  it("lets advanced callers prepare graph data without writing", async () => {
+    extractMock.mockResolvedValue({
+      output: { entities: [], relationships: [] },
+      usage: Usage.empty(),
+    });
+    const embeddingModel = {
+      provider: "test",
+      modelId: "test",
+      async embedTexts(texts: string[]) {
+        return texts.map((document) => ({ document, vector: [1] }));
+      },
+    };
+    const prepared = await prepareGraphDocuments({
+      graph: { schema },
+      documents: [{ id: "one", text: "Product One" }],
+      extractionModel: {} as never,
+      embeddingModel,
+    });
+
+    expect(prepared.documents).toEqual([{ id: "one" }]);
+    expect(prepared.vectorDocuments[0]?.id).toBe("one");
+
+    await expect(
+      prepareGraphDocuments({
+        graph: { schema },
+        documents: [{ id: "invalid", text: "Product One", metadata: { tags: ["one"] } } as never],
+        extractionModel: {} as never,
+        embeddingModel,
+      }),
+    ).rejects.toThrow("portable primitive value");
   });
 
   it("resolves bounded graph exploration options", () => {

--- a/packages/graph/test/graph.test.ts
+++ b/packages/graph/test/graph.test.ts
@@ -127,6 +127,8 @@ describe("provider-neutral graph primitives", () => {
       extractionModel: {} as never,
       embeddingModel,
       chunking: { strategy: "fixed", maxSize: 8 },
+      conflict: "keep-existing",
+      orphanEntities: "keep",
     });
 
     expect(result.chunks).toHaveLength(2);
@@ -139,7 +141,7 @@ describe("provider-neutral graph primitives", () => {
     ]);
     expect(embeddedTexts).toContain("Product\nid: one\nname: One");
     expect(replaceDocuments).toHaveBeenCalledWith(
-      expect.objectContaining({ conflict: "overwrite", orphanEntities: "delete" }),
+      expect.objectContaining({ conflict: "keep-existing", orphanEntities: "keep" }),
     );
   });
 

--- a/packages/graph/test/public-types.ts
+++ b/packages/graph/test/public-types.ts
@@ -37,11 +37,23 @@ ingestGraphText({
   document: { id: "one", text: "Product One" },
   extractionModel: {} as never,
   embeddingModel: model,
+  conflict: "error",
+  orphanEntities: "delete",
 });
 
 ingestGraphText({
   // @ts-expect-error Read-only graph registrations do not implement document writes.
   graph: existing,
+  document: { id: "one", text: "Product One" },
+  extractionModel: {} as never,
+  embeddingModel: model,
+  conflict: "error",
+  orphanEntities: "delete",
+});
+
+// @ts-expect-error Graph ingestion requires explicit conflict and orphan policies.
+ingestGraphText({
+  graph: writer,
   document: { id: "one", text: "Product One" },
   extractionModel: {} as never,
   embeddingModel: model,

--- a/packages/graph/test/public-types.ts
+++ b/packages/graph/test/public-types.ts
@@ -1,13 +1,16 @@
 import type { EmbeddingModel } from "@anvia/core/embeddings";
 import {
   createGraphSearchTool,
+  ingestGraphText,
   type GraphContextRetriever,
+  type GraphDocumentWriter,
   type GraphSchemaLike,
 } from "../src/index.js";
 
 declare const model: EmbeddingModel;
 declare const existing: GraphContextRetriever<GraphSchemaLike, "none">;
 declare const managed: GraphContextRetriever<GraphSchemaLike, "chunks">;
+declare const writer: GraphDocumentWriter<GraphSchemaLike>;
 
 const retrieval = {
   name: "search_graph",
@@ -27,6 +30,21 @@ createGraphSearchTool({
   ...retrieval,
   graph: existing,
   evidence: { type: "none" },
+});
+
+ingestGraphText({
+  graph: writer,
+  document: { id: "one", text: "Product One" },
+  extractionModel: {} as never,
+  embeddingModel: model,
+});
+
+ingestGraphText({
+  // @ts-expect-error Read-only graph registrations do not implement document writes.
+  graph: existing,
+  document: { id: "one", text: "Product One" },
+  extractionModel: {} as never,
+  embeddingModel: model,
 });
 
 createGraphSearchTool({


### PR DESCRIPTION
## Summary

- add shared raw-text document chunking and vector ingestion helpers
- add managed graph ingestion and preparation helpers for Neo4j and Memgraph
- reuse graph chunk embeddings for document-scoped vector replacement
- require explicit graph conflict and orphan-entity policies
- document the convenience and advanced composition paths

## Validation

- `pnpm check`
- `pnpm --filter @anvia/core typecheck`
- `pnpm --filter @anvia/core test`
- `pnpm --filter @anvia/core build`
- `pnpm --filter @anvia/graph typecheck`
- `pnpm --filter @anvia/graph test`
- `pnpm --filter @anvia/graph build`
- `pnpm --filter @anvia/neo4j typecheck`
- `pnpm --filter @anvia/neo4j test`
- `pnpm --filter @anvia/neo4j build`
- `pnpm --filter @anvia/memgraph typecheck`
- `pnpm --filter @anvia/memgraph test`
- `pnpm --filter @anvia/memgraph build`

Neo4j and Memgraph integration tests remain skipped without their opt-in environment flags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added text document chunking with fixed-size, recursive, and single-chunk options.
  - Added vector ingestion for single documents and batches, including embedding, retries, metadata validation, and replacement of existing document vectors.
  - Added end-to-end graph ingestion and preparation APIs for chunking, extraction, embedding, conflict handling, and orphan-entity policies.
  - Added configurable graph document writing with atomic replacement support.

- **Documentation**
  - Expanded ingestion guidance and updated graph database examples to use the new workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->