### PR TITLE
fix(test): use fileURLToPath for cross-platform vitest path aliases

### DIFF
--- a/packages/client/vitest.config.ts
+++ b/packages/client/vitest.config.ts
@@ -1,18 +1,20 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@anvia/core/agent/interactions": new URL(
-        "../core/src/agent/interactions/index.ts",
-        import.meta.url,
-      ).pathname,
-      "@anvia/core/agent": new URL("../core/src/agent/index.ts", import.meta.url).pathname,
-      "@anvia/core/completion": new URL("../core/src/completion/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/guardrails": new URL("../core/src/guardrails/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
+      "@anvia/core/agent/interactions": fileURLToPath(
+        new URL("../core/src/agent/interactions/index.ts", import.meta.url),
+      ),
+      "@anvia/core/agent": fileURLToPath(new URL("../core/src/agent/index.ts", import.meta.url)),
+      "@anvia/core/completion": fileURLToPath(
+        new URL("../core/src/completion/index.ts", import.meta.url),
+      ),
+      "@anvia/core/guardrails": fileURLToPath(
+        new URL("../core/src/guardrails/index.ts", import.meta.url),
+      ),
+      "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/embedding-transformers/vitest.config.ts
+++ b/packages/embedding-transformers/vitest.config.ts
@@ -1,11 +1,13 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@anvia/core/embeddings": new URL("../core/src/embeddings/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
+      "@anvia/core/embeddings": fileURLToPath(
+        new URL("../core/src/embeddings/index.ts", import.meta.url),
+      ),
+      "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/logger/vitest.config.ts
+++ b/packages/logger/vitest.config.ts
@@ -1,11 +1,13 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
-      "@anvia/core/observability": new URL("../core/src/observability/index.ts", import.meta.url)
-        .pathname,
+      "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
+      "@anvia/core/observability": fileURLToPath(
+        new URL("../core/src/observability/index.ts", import.meta.url),
+      ),
     },
   },
   test: {

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -1,13 +1,15 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@anvia/core/completion": new URL("../core/src/completion/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/mcp": new URL("../core/src/mcp/index.ts", import.meta.url).pathname,
-      "@anvia/core/tool": new URL("../core/src/tool/index.ts", import.meta.url).pathname,
-      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
+      "@anvia/core/completion": fileURLToPath(
+        new URL("../core/src/completion/index.ts", import.meta.url),
+      ),
+      "@anvia/core/mcp": fileURLToPath(new URL("../core/src/mcp/index.ts", import.meta.url)),
+      "@anvia/core/tool": fileURLToPath(new URL("../core/src/tool/index.ts", import.meta.url)),
+      "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/memory-drizzle/vitest.config.ts
+++ b/packages/memory-drizzle/vitest.config.ts
@@ -1,10 +1,11 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@anvia/core/memory": new URL("../core/src/memory/index.ts", import.meta.url).pathname,
-      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
+      "@anvia/core/memory": fileURLToPath(new URL("../core/src/memory/index.ts", import.meta.url)),
+      "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/memory-postgres/vitest.config.ts
+++ b/packages/memory-postgres/vitest.config.ts
@@ -1,10 +1,11 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@anvia/core/memory": new URL("../core/src/memory/index.ts", import.meta.url).pathname,
-      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
+      "@anvia/core/memory": fileURLToPath(new URL("../core/src/memory/index.ts", import.meta.url)),
+      "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/memory-prisma/vitest.config.ts
+++ b/packages/memory-prisma/vitest.config.ts
@@ -1,10 +1,11 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@anvia/core/memory": new URL("../core/src/memory/index.ts", import.meta.url).pathname,
-      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
+      "@anvia/core/memory": fileURLToPath(new URL("../core/src/memory/index.ts", import.meta.url)),
+      "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/memory-sqlite/vitest.config.ts
+++ b/packages/memory-sqlite/vitest.config.ts
@@ -1,10 +1,11 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@anvia/core/memory": new URL("../core/src/memory/index.ts", import.meta.url).pathname,
-      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
+      "@anvia/core/memory": fileURLToPath(new URL("../core/src/memory/index.ts", import.meta.url)),
+      "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/observability-langfuse/vitest.config.ts
+++ b/packages/observability-langfuse/vitest.config.ts
@@ -1,14 +1,17 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@anvia/core/completion": new URL("../core/src/completion/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/evals": new URL("../core/src/evals/index.ts", import.meta.url).pathname,
-      "@anvia/core/observability": new URL("../core/src/observability/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
+      "@anvia/core/completion": fileURLToPath(
+        new URL("../core/src/completion/index.ts", import.meta.url),
+      ),
+      "@anvia/core/evals": fileURLToPath(new URL("../core/src/evals/index.ts", import.meta.url)),
+      "@anvia/core/observability": fileURLToPath(
+        new URL("../core/src/observability/index.ts", import.meta.url),
+      ),
+      "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/observability-lens/vitest.config.ts
+++ b/packages/observability-lens/vitest.config.ts
@@ -1,12 +1,14 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@anvia/core/evals": new URL("../core/src/evals/index.ts", import.meta.url).pathname,
-      "@anvia/core/observability": new URL("../core/src/observability/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/otel": new URL("../observability-otel/src/index.ts", import.meta.url).pathname,
+      "@anvia/core/evals": fileURLToPath(new URL("../core/src/evals/index.ts", import.meta.url)),
+      "@anvia/core/observability": fileURLToPath(
+        new URL("../core/src/observability/index.ts", import.meta.url),
+      ),
+      "@anvia/otel": fileURLToPath(new URL("../observability-otel/src/index.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/observability-otel/vitest.config.ts
+++ b/packages/observability-otel/vitest.config.ts
@@ -1,14 +1,17 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@anvia/core/completion": new URL("../core/src/completion/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/evals": new URL("../core/src/evals/index.ts", import.meta.url).pathname,
-      "@anvia/core/observability": new URL("../core/src/observability/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
+      "@anvia/core/completion": fileURLToPath(
+        new URL("../core/src/completion/index.ts", import.meta.url),
+      ),
+      "@anvia/core/evals": fileURLToPath(new URL("../core/src/evals/index.ts", import.meta.url)),
+      "@anvia/core/observability": fileURLToPath(
+        new URL("../core/src/observability/index.ts", import.meta.url),
+      ),
+      "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/provider-anthropic/vitest.config.ts
+++ b/packages/provider-anthropic/vitest.config.ts
@@ -1,19 +1,21 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@anvia/core/agent/interactions": new URL(
-        "../core/src/agent/interactions/index.ts",
-        import.meta.url,
-      ).pathname,
-      "@anvia/core/agent": new URL("../core/src/agent/index.ts", import.meta.url).pathname,
-      "@anvia/core/completion": new URL("../core/src/completion/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/model-listing": new URL("../core/src/model-listing/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/tool": new URL("../core/src/tool/index.ts", import.meta.url).pathname,
-      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
+      "@anvia/core/agent/interactions": fileURLToPath(
+        new URL("../core/src/agent/interactions/index.ts", import.meta.url),
+      ),
+      "@anvia/core/agent": fileURLToPath(new URL("../core/src/agent/index.ts", import.meta.url)),
+      "@anvia/core/completion": fileURLToPath(
+        new URL("../core/src/completion/index.ts", import.meta.url),
+      ),
+      "@anvia/core/model-listing": fileURLToPath(
+        new URL("../core/src/model-listing/index.ts", import.meta.url),
+      ),
+      "@anvia/core/tool": fileURLToPath(new URL("../core/src/tool/index.ts", import.meta.url)),
+      "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/provider-gemini/vitest.config.ts
+++ b/packages/provider-gemini/vitest.config.ts
@@ -1,25 +1,28 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@anvia/core/speech-generation": new URL(
-        "../core/src/speech-generation/index.ts",
-        import.meta.url,
-      ).pathname,
-      "@anvia/core/completion": new URL("../core/src/completion/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/embeddings": new URL("../core/src/embeddings/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/image-generation": new URL(
-        "../core/src/image-generation/index.ts",
-        import.meta.url,
-      ).pathname,
-      "@anvia/core/model-listing": new URL("../core/src/model-listing/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/transcription": new URL("../core/src/transcription/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
+      "@anvia/core/speech-generation": fileURLToPath(
+        new URL("../core/src/speech-generation/index.ts", import.meta.url),
+      ),
+      "@anvia/core/completion": fileURLToPath(
+        new URL("../core/src/completion/index.ts", import.meta.url),
+      ),
+      "@anvia/core/embeddings": fileURLToPath(
+        new URL("../core/src/embeddings/index.ts", import.meta.url),
+      ),
+      "@anvia/core/image-generation": fileURLToPath(
+        new URL("../core/src/image-generation/index.ts", import.meta.url),
+      ),
+      "@anvia/core/model-listing": fileURLToPath(
+        new URL("../core/src/model-listing/index.ts", import.meta.url),
+      ),
+      "@anvia/core/transcription": fileURLToPath(
+        new URL("../core/src/transcription/index.ts", import.meta.url),
+      ),
+      "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/provider-grok/vitest.config.ts
+++ b/packages/provider-grok/vitest.config.ts
@@ -1,18 +1,20 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@anvia/core/completion": new URL("../core/src/completion/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/image-generation": new URL(
-        "../core/src/image-generation/index.ts",
-        import.meta.url,
-      ).pathname,
-      "@anvia/core/model-listing": new URL("../core/src/model-listing/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
-      "@anvia/openai": new URL("../provider-openai/src/index.ts", import.meta.url).pathname,
+      "@anvia/core/completion": fileURLToPath(
+        new URL("../core/src/completion/index.ts", import.meta.url),
+      ),
+      "@anvia/core/image-generation": fileURLToPath(
+        new URL("../core/src/image-generation/index.ts", import.meta.url),
+      ),
+      "@anvia/core/model-listing": fileURLToPath(
+        new URL("../core/src/model-listing/index.ts", import.meta.url),
+      ),
+      "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
+      "@anvia/openai": fileURLToPath(new URL("../provider-openai/src/index.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/provider-mistral/vitest.config.ts
+++ b/packages/provider-mistral/vitest.config.ts
@@ -1,15 +1,19 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@anvia/core/completion": new URL("../core/src/completion/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/embeddings": new URL("../core/src/embeddings/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/model-listing": new URL("../core/src/model-listing/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
+      "@anvia/core/completion": fileURLToPath(
+        new URL("../core/src/completion/index.ts", import.meta.url),
+      ),
+      "@anvia/core/embeddings": fileURLToPath(
+        new URL("../core/src/embeddings/index.ts", import.meta.url),
+      ),
+      "@anvia/core/model-listing": fileURLToPath(
+        new URL("../core/src/model-listing/index.ts", import.meta.url),
+      ),
+      "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/provider-openai/vitest.config.ts
+++ b/packages/provider-openai/vitest.config.ts
@@ -1,25 +1,28 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@anvia/core/speech-generation": new URL(
-        "../core/src/speech-generation/index.ts",
-        import.meta.url,
-      ).pathname,
-      "@anvia/core/completion": new URL("../core/src/completion/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/embeddings": new URL("../core/src/embeddings/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/image-generation": new URL(
-        "../core/src/image-generation/index.ts",
-        import.meta.url,
-      ).pathname,
-      "@anvia/core/model-listing": new URL("../core/src/model-listing/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/transcription": new URL("../core/src/transcription/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
+      "@anvia/core/speech-generation": fileURLToPath(
+        new URL("../core/src/speech-generation/index.ts", import.meta.url),
+      ),
+      "@anvia/core/completion": fileURLToPath(
+        new URL("../core/src/completion/index.ts", import.meta.url),
+      ),
+      "@anvia/core/embeddings": fileURLToPath(
+        new URL("../core/src/embeddings/index.ts", import.meta.url),
+      ),
+      "@anvia/core/image-generation": fileURLToPath(
+        new URL("../core/src/image-generation/index.ts", import.meta.url),
+      ),
+      "@anvia/core/model-listing": fileURLToPath(
+        new URL("../core/src/model-listing/index.ts", import.meta.url),
+      ),
+      "@anvia/core/transcription": fileURLToPath(
+        new URL("../core/src/transcription/index.ts", import.meta.url),
+      ),
+      "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/react-ui/vitest.config.ts
+++ b/packages/react-ui/vitest.config.ts
@@ -1,21 +1,23 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@anvia/client": new URL("../client/src/index.ts", import.meta.url).pathname,
-      "@anvia/core/agent/interactions": new URL(
-        "../core/src/agent/interactions/index.ts",
-        import.meta.url,
-      ).pathname,
-      "@anvia/core/agent": new URL("../core/src/agent/index.ts", import.meta.url).pathname,
-      "@anvia/core/completion": new URL("../core/src/completion/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/guardrails": new URL("../core/src/guardrails/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/memory": new URL("../core/src/memory/index.ts", import.meta.url).pathname,
-      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
-      "@anvia/react": new URL("../react/src/index.ts", import.meta.url).pathname,
+      "@anvia/client": fileURLToPath(new URL("../client/src/index.ts", import.meta.url)),
+      "@anvia/core/agent/interactions": fileURLToPath(
+        new URL("../core/src/agent/interactions/index.ts", import.meta.url),
+      ),
+      "@anvia/core/agent": fileURLToPath(new URL("../core/src/agent/index.ts", import.meta.url)),
+      "@anvia/core/completion": fileURLToPath(
+        new URL("../core/src/completion/index.ts", import.meta.url),
+      ),
+      "@anvia/core/guardrails": fileURLToPath(
+        new URL("../core/src/guardrails/index.ts", import.meta.url),
+      ),
+      "@anvia/core/memory": fileURLToPath(new URL("../core/src/memory/index.ts", import.meta.url)),
+      "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
+      "@anvia/react": fileURLToPath(new URL("../react/src/index.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -1,20 +1,22 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@anvia/client": new URL("../client/src/index.ts", import.meta.url).pathname,
-      "@anvia/core/agent/interactions": new URL(
-        "../core/src/agent/interactions/index.ts",
-        import.meta.url,
-      ).pathname,
-      "@anvia/core/agent": new URL("../core/src/agent/index.ts", import.meta.url).pathname,
-      "@anvia/core/completion": new URL("../core/src/completion/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/guardrails": new URL("../core/src/guardrails/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/memory": new URL("../core/src/memory/index.ts", import.meta.url).pathname,
-      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
+      "@anvia/client": fileURLToPath(new URL("../client/src/index.ts", import.meta.url)),
+      "@anvia/core/agent/interactions": fileURLToPath(
+        new URL("../core/src/agent/interactions/index.ts", import.meta.url),
+      ),
+      "@anvia/core/agent": fileURLToPath(new URL("../core/src/agent/index.ts", import.meta.url)),
+      "@anvia/core/completion": fileURLToPath(
+        new URL("../core/src/completion/index.ts", import.meta.url),
+      ),
+      "@anvia/core/guardrails": fileURLToPath(
+        new URL("../core/src/guardrails/index.ts", import.meta.url),
+      ),
+      "@anvia/core/memory": fileURLToPath(new URL("../core/src/memory/index.ts", import.meta.url)),
+      "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -1,19 +1,21 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@anvia/client": new URL("../client/src/index.ts", import.meta.url).pathname,
-      "@anvia/core/agent/interactions": new URL(
-        "../core/src/agent/interactions/index.ts",
-        import.meta.url,
-      ).pathname,
-      "@anvia/core/agent": new URL("../core/src/agent/index.ts", import.meta.url).pathname,
-      "@anvia/core/completion": new URL("../core/src/completion/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/guardrails": new URL("../core/src/guardrails/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
+      "@anvia/client": fileURLToPath(new URL("../client/src/index.ts", import.meta.url)),
+      "@anvia/core/agent/interactions": fileURLToPath(
+        new URL("../core/src/agent/interactions/index.ts", import.meta.url),
+      ),
+      "@anvia/core/agent": fileURLToPath(new URL("../core/src/agent/index.ts", import.meta.url)),
+      "@anvia/core/completion": fileURLToPath(
+        new URL("../core/src/completion/index.ts", import.meta.url),
+      ),
+      "@anvia/core/guardrails": fileURLToPath(
+        new URL("../core/src/guardrails/index.ts", import.meta.url),
+      ),
+      "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/tool-browser/vitest.config.ts
+++ b/packages/tool-browser/vitest.config.ts
@@ -1,11 +1,12 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@anvia/core/tool": new URL("../core/src/tool/index.ts", import.meta.url).pathname,
-      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
-      "@anvia/sandbox": new URL("../tool-sandbox/src/index.ts", import.meta.url).pathname,
+      "@anvia/core/tool": fileURLToPath(new URL("../core/src/tool/index.ts", import.meta.url)),
+      "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
+      "@anvia/sandbox": fileURLToPath(new URL("../tool-sandbox/src/index.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/tool-sandbox/vitest.config.ts
+++ b/packages/tool-sandbox/vitest.config.ts
@@ -1,10 +1,11 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@anvia/core/tool": new URL("../core/src/tool/index.ts", import.meta.url).pathname,
-      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
+      "@anvia/core/tool": fileURLToPath(new URL("../core/src/tool/index.ts", import.meta.url)),
+      "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/tool-studio/vitest.config.ts
+++ b/packages/tool-studio/vitest.config.ts
@@ -1,37 +1,46 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     dedupe: ["react", "react-dom"],
     alias: {
-      "@anvia/client/transport": new URL("../client/src/transport/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/client": new URL("../client/src/index.ts", import.meta.url).pathname,
-      "@anvia/react-ui/stream": new URL("../react-ui/src/stream/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/react": new URL("../react/src/index.ts", import.meta.url).pathname,
-      "@anvia/core/agent/interactions": new URL(
-        "../core/src/agent/interactions/index.ts",
-        import.meta.url,
-      ).pathname,
-      "@anvia/core/agent": new URL("../core/src/agent/index.ts", import.meta.url).pathname,
-      "@anvia/core/completion": new URL("../core/src/completion/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/embeddings": new URL("../core/src/embeddings/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/evals": new URL("../core/src/evals/index.ts", import.meta.url).pathname,
-      "@anvia/core/internal/agent": new URL("../core/src/internal/agent.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/mcp": new URL("../core/src/mcp/index.ts", import.meta.url).pathname,
-      "@anvia/core/memory": new URL("../core/src/memory/index.ts", import.meta.url).pathname,
-      "@anvia/core/observability": new URL("../core/src/observability/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/pipeline": new URL("../core/src/pipeline/index.ts", import.meta.url).pathname,
-      "@anvia/core/tool": new URL("../core/src/tool/index.ts", import.meta.url).pathname,
-      "@anvia/core/vector-store": new URL("../core/src/vector-store/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
-      "@": new URL("./src/ui/app", import.meta.url).pathname,
+      "@anvia/client/transport": fileURLToPath(
+        new URL("../client/src/transport/index.ts", import.meta.url),
+      ),
+      "@anvia/client": fileURLToPath(new URL("../client/src/index.ts", import.meta.url)),
+      "@anvia/react-ui/stream": fileURLToPath(
+        new URL("../react-ui/src/stream/index.ts", import.meta.url),
+      ),
+      "@anvia/react": fileURLToPath(new URL("../react/src/index.ts", import.meta.url)),
+      "@anvia/core/agent/interactions": fileURLToPath(
+        new URL("../core/src/agent/interactions/index.ts", import.meta.url),
+      ),
+      "@anvia/core/agent": fileURLToPath(new URL("../core/src/agent/index.ts", import.meta.url)),
+      "@anvia/core/completion": fileURLToPath(
+        new URL("../core/src/completion/index.ts", import.meta.url),
+      ),
+      "@anvia/core/embeddings": fileURLToPath(
+        new URL("../core/src/embeddings/index.ts", import.meta.url),
+      ),
+      "@anvia/core/evals": fileURLToPath(new URL("../core/src/evals/index.ts", import.meta.url)),
+      "@anvia/core/internal/agent": fileURLToPath(
+        new URL("../core/src/internal/agent.ts", import.meta.url),
+      ),
+      "@anvia/core/mcp": fileURLToPath(new URL("../core/src/mcp/index.ts", import.meta.url)),
+      "@anvia/core/memory": fileURLToPath(new URL("../core/src/memory/index.ts", import.meta.url)),
+      "@anvia/core/observability": fileURLToPath(
+        new URL("../core/src/observability/index.ts", import.meta.url),
+      ),
+      "@anvia/core/pipeline": fileURLToPath(
+        new URL("../core/src/pipeline/index.ts", import.meta.url),
+      ),
+      "@anvia/core/tool": fileURLToPath(new URL("../core/src/tool/index.ts", import.meta.url)),
+      "@anvia/core/vector-store": fileURLToPath(
+        new URL("../core/src/vector-store/index.ts", import.meta.url),
+      ),
+      "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
+      "@": fileURLToPath(new URL("./src/ui/app", import.meta.url)),
     },
   },
   test: {

--- a/packages/vector-chroma/vitest.config.ts
+++ b/packages/vector-chroma/vitest.config.ts
@@ -1,14 +1,17 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@anvia/core/embeddings": new URL("../core/src/embeddings/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/tool": new URL("../core/src/tool/index.ts", import.meta.url).pathname,
-      "@anvia/core/vector-store": new URL("../core/src/vector-store/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
+      "@anvia/core/embeddings": fileURLToPath(
+        new URL("../core/src/embeddings/index.ts", import.meta.url),
+      ),
+      "@anvia/core/tool": fileURLToPath(new URL("../core/src/tool/index.ts", import.meta.url)),
+      "@anvia/core/vector-store": fileURLToPath(
+        new URL("../core/src/vector-store/index.ts", import.meta.url),
+      ),
+      "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/vector-pgvector/vitest.config.ts
+++ b/packages/vector-pgvector/vitest.config.ts
@@ -1,14 +1,17 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@anvia/core/embeddings": new URL("../core/src/embeddings/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/tool": new URL("../core/src/tool/index.ts", import.meta.url).pathname,
-      "@anvia/core/vector-store": new URL("../core/src/vector-store/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
+      "@anvia/core/embeddings": fileURLToPath(
+        new URL("../core/src/embeddings/index.ts", import.meta.url),
+      ),
+      "@anvia/core/tool": fileURLToPath(new URL("../core/src/tool/index.ts", import.meta.url)),
+      "@anvia/core/vector-store": fileURLToPath(
+        new URL("../core/src/vector-store/index.ts", import.meta.url),
+      ),
+      "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/vector-qdrant/vitest.config.ts
+++ b/packages/vector-qdrant/vitest.config.ts
@@ -1,14 +1,17 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@anvia/core/embeddings": new URL("../core/src/embeddings/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/tool": new URL("../core/src/tool/index.ts", import.meta.url).pathname,
-      "@anvia/core/vector-store": new URL("../core/src/vector-store/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
+      "@anvia/core/embeddings": fileURLToPath(
+        new URL("../core/src/embeddings/index.ts", import.meta.url),
+      ),
+      "@anvia/core/tool": fileURLToPath(new URL("../core/src/tool/index.ts", import.meta.url)),
+      "@anvia/core/vector-store": fileURLToPath(
+        new URL("../core/src/vector-store/index.ts", import.meta.url),
+      ),
+      "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/vector-redis/vitest.config.ts
+++ b/packages/vector-redis/vitest.config.ts
@@ -1,14 +1,17 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@anvia/core/embeddings": new URL("../core/src/embeddings/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/tool": new URL("../core/src/tool/index.ts", import.meta.url).pathname,
-      "@anvia/core/vector-store": new URL("../core/src/vector-store/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
+      "@anvia/core/embeddings": fileURLToPath(
+        new URL("../core/src/embeddings/index.ts", import.meta.url),
+      ),
+      "@anvia/core/tool": fileURLToPath(new URL("../core/src/tool/index.ts", import.meta.url)),
+      "@anvia/core/vector-store": fileURLToPath(
+        new URL("../core/src/vector-store/index.ts", import.meta.url),
+      ),
+      "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/vector-weaviate/vitest.config.ts
+++ b/packages/vector-weaviate/vitest.config.ts
@@ -1,14 +1,17 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@anvia/core/embeddings": new URL("../core/src/embeddings/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core/tool": new URL("../core/src/tool/index.ts", import.meta.url).pathname,
-      "@anvia/core/vector-store": new URL("../core/src/vector-store/index.ts", import.meta.url)
-        .pathname,
-      "@anvia/core": new URL("../core/src/index.ts", import.meta.url).pathname,
+      "@anvia/core/embeddings": fileURLToPath(
+        new URL("../core/src/embeddings/index.ts", import.meta.url),
+      ),
+      "@anvia/core/tool": fileURLToPath(new URL("../core/src/tool/index.ts", import.meta.url)),
+      "@anvia/core/vector-store": fileURLToPath(
+        new URL("../core/src/vector-store/index.ts", import.meta.url),
+      ),
+      "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
     },
   },
   test: {


### PR DESCRIPTION
### Summary

When running test suites on Windows environments, Vitest configurations that use `new URL(..., import.meta.url).pathname` fail during module resolution. This PR updates all 27 package-level `vitest.config.ts` files across the workspace to use `fileURLToPath(new URL(..., import.meta.url))` from `node:url`.

### Problem & Root Cause

In ESM, resolving relative paths with `new URL(relativePath, import.meta.url).pathname` works as expected on POSIX platforms where paths start with `/` (e.g. `/home/user/project/...`).

On Windows, however, the `pathname` property of a `file:` URL retains the leading forward slash before the drive letter, yielding strings formatted like `/D:/Portfolio/anvia/packages/core/src/index.ts`. When Vitest attempts to resolve these alias entries via Vite's internal module loader or `esbuild`, the malformed path with the leading slash fails to match real filesystem locations.

`packages/vector-lancedb/vitest.config.ts` already uses the standard `fileURLToPath` pattern correctly, but the remaining 27 package test configs still had the `.pathname` pattern.

### Changes Made

- Added `import { fileURLToPath } from "node:url"` to 27 `vitest.config.ts` files.
- Replaced all instances of `new URL(...).pathname` in `resolve.alias` definitions with `fileURLToPath(new URL(...))`.
- Preserved existing formatting and alias order across each configuration file.

### Affected Packages

- `packages/client`
- `packages/embedding-transformers`
- `packages/logger`
- `packages/mcp`
- `packages/memory-drizzle`
- `packages/memory-postgres`
- `packages/memory-prisma`
- `packages/memory-sqlite`
- `packages/observability-langfuse`
- `packages/observability-lens`
- `packages/observability-otel`
- `packages/provider-anthropic`
- `packages/provider-gemini`
- `packages/provider-grok`
- `packages/provider-mistral`
- `packages/provider-openai`
- `packages/react-ui`
- `packages/react`
- `packages/server`
- `packages/tool-browser`
- `packages/tool-sandbox`
- `packages/tool-studio`
- `packages/vector-chroma`
- `packages/vector-pgvector`
- `packages/vector-qdrant`
- `packages/vector-redis`
- `packages/vector-weaviate`

### Validation Performed

1. **Formatting & Linting**:
   - `npx oxfmt --check packages/*/vitest.config.ts` (All 32 config files match project formatting rules).
   - `npx oxlint packages/*/vitest.config.ts` (Passed with 0 errors and 0 warnings).

2. **TypeScript Typecheck**:
   - `pnpm --filter @anvia/provider-openai typecheck` (Passed)
   - `pnpm --filter @anvia/provider-anthropic typecheck` (Passed)
   - `pnpm --filter @anvia/provider-gemini typecheck` (Passed)
   - `pnpm --filter @anvia/provider-mistral typecheck` (Passed)
   - `pnpm --filter @anvia/provider-grok typecheck` (Passed)

3. **Test Suites on Windows**:
   - `pnpm --filter @anvia/provider-openai test` (84 tests passed)
   - `pnpm --filter @anvia/provider-anthropic test` (83 tests passed)
   - `pnpm --filter @anvia/provider-gemini test` (79 tests passed)
   - `pnpm --filter @anvia/provider-mistral test` (55 tests passed)
   - `pnpm --filter @anvia/provider-grok test` (53 tests passed)
   - `pnpm --filter @anvia/memory-sqlite test` (25 tests passed)
   - `pnpm --filter @anvia/server test` (8 tests passed)
   - Total: 387 unit tests passed with aliases properly resolved.

4. **Changeset**:
   - No runtime packages or public library APIs were modified; this is a developer experience and test harness fix only, so no changeset is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved test module path resolution across packages.
  - Fixed compatibility with Windows and paths containing encoded characters.
  - Ensured aliases resolve to decoded, platform-correct filesystem paths during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->