### PR TITLE
test: verify Bun runtime compatibility

### DIFF
--- a/.changeset/calm-buns-run.md
+++ b/.changeset/calm-buns-run.md
@@ -1,7 +1,9 @@
 ---
 "@anvia/core": patch
+"@anvia/mcp": patch
 "@anvia/openai": patch
 ---
 
 Declare and verify Bun 1.3.14 runtime compatibility for the built packages, public Core exports,
-and OpenAI SDK transport and media paths.
+OpenAI SDK transport and media paths, and MCP HTTP/SSE and stdio transports. Make structured tool
+output branding stable across multiple Core module instances.

--- a/.changeset/calm-buns-run.md
+++ b/.changeset/calm-buns-run.md
@@ -1,0 +1,7 @@
+---
+"@anvia/core": patch
+"@anvia/openai": patch
+---
+
+Declare and verify Bun 1.3.14 runtime compatibility for the built packages, public Core exports,
+and OpenAI SDK transport and media paths.

--- a/.changeset/calm-buns-run.md
+++ b/.changeset/calm-buns-run.md
@@ -1,9 +1,11 @@
 ---
+"@anvia/client": patch
 "@anvia/core": patch
 "@anvia/mcp": patch
 "@anvia/openai": patch
+"@anvia/server": patch
 ---
 
 Declare and verify Bun 1.3.14 runtime compatibility for the built packages, public Core exports,
-OpenAI SDK transport and media paths, and MCP HTTP/SSE and stdio transports. Make structured tool
-output branding stable across multiple Core module instances.
+Client and Server streaming, OpenAI SDK transport and media paths, and MCP HTTP/SSE and stdio
+transports. Make structured tool output branding stable across multiple Core module instances.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,35 @@ jobs:
 
       - name: Test packages
         run: pnpm --filter './packages/**' test
+
+  bun-compatibility:
+    name: Bun compatibility
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.0.4
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Test built packages with Bun
+        run: pnpm --filter bun-runtime-compat test:bun

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -22,6 +22,17 @@ keeping the matching `AgentContinuation` exclusively on the server.
 Agent interaction wire contracts come from the browser-safe `@anvia/core/agent/interactions`
 subpath; importing Client does not load the Agent runtime or its infrastructure dependencies.
 
+## Bun
+
+Bun 1.3.14 is the currently tested and supported runtime baseline:
+
+```sh
+bun add @anvia/client @anvia/core
+```
+
+Compatibility tests cover framed JSONL and SSE consumption, resumable client streams, fetch
+cancellation, and installation from packed package artifacts.
+
 ## Public API
 
 - `completionToClientStream({ events, ...options })` adapts native completion events.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -20,6 +20,18 @@ adapter on the same release channel.
 pnpm add @anvia/core@rc
 ```
 
+### Bun
+
+Bun 1.3.14 is the currently tested and supported runtime baseline. Install Core on the same
+release channel as the rest of your Anvia packages:
+
+```sh
+bun add @anvia/core@rc
+```
+
+The repository itself remains a pnpm workspace; Bun support applies to applications consuming the
+published package.
+
 See the repository's [1.0 release policy](../../docs/releases/v1.md) for channel and support
 details.
 

--- a/packages/core/src/tool/tool.ts
+++ b/packages/core/src/tool/tool.ts
@@ -121,11 +121,8 @@ export function toolResultContentToText(content: readonly ToolResultContentPart[
 }
 
 function isRichToolOutput(value: unknown): value is RichToolOutput {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    (value as { [richToolOutput]?: unknown })[richToolOutput] === true
-  );
+  if (typeof value !== "object" || value === null) return false;
+  return Object.getOwnPropertyDescriptor(value, richToolOutput)?.value === true;
 }
 
 export function parseToolArgs(args: string): JsonValue {

--- a/packages/core/src/tool/tool.ts
+++ b/packages/core/src/tool/tool.ts
@@ -60,7 +60,7 @@ export type AnyTool = Omit<Tool<unknown, unknown>, "requiresApproval"> & {
   readonly requiresApproval?: unknown;
 };
 
-const richToolOutput = Symbol("anvia.tool-output.content");
+const richToolOutput: unique symbol = Symbol.for("anvia.tool-output.content");
 
 export type RichToolOutput = Readonly<{
   [richToolOutput]: true;
@@ -121,7 +121,11 @@ export function toolResultContentToText(content: readonly ToolResultContentPart[
 }
 
 function isRichToolOutput(value: unknown): value is RichToolOutput {
-  return typeof value === "object" && value !== null && richToolOutput in value;
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { [richToolOutput]?: unknown })[richToolOutput] === true
+  );
 }
 
 export function parseToolArgs(args: string): JsonValue {

--- a/packages/core/test/tool-execution.test.ts
+++ b/packages/core/test/tool-execution.test.ts
@@ -10,6 +10,8 @@ import {
   ToolJsonError,
   ToolNotFoundError,
   ToolOutput,
+  ToolResultSerializationError,
+  normalizeToolResultOutput,
 } from "./helpers/imports";
 
 const model: CompletionModel = {
@@ -249,6 +251,19 @@ describe("Agent tool execution", () => {
       type: "content",
       value: content,
     });
+  });
+
+  it("does not invoke accessors while classifying structured tool output", () => {
+    let getterCalls = 0;
+    const output = Object.defineProperty({ content: [] }, Symbol.for("anvia.tool-output.content"), {
+      get() {
+        getterCalls += 1;
+        throw new Error("marker getter should not run");
+      },
+    });
+
+    expect(() => normalizeToolResultOutput(output)).toThrow(ToolResultSerializationError);
+    expect(getterCalls).toBe(0);
   });
 
   it("rejects malformed rich tool result content", async () => {

--- a/packages/core/test/tool-execution.test.ts
+++ b/packages/core/test/tool-execution.test.ts
@@ -230,6 +230,27 @@ describe("Agent tool execution", () => {
     });
   });
 
+  it("recognizes structured output branded by another Core module instance", async () => {
+    const content = [{ type: "text" as const, text: "cross-instance output" }];
+    const externalOutput = {
+      [Symbol.for("anvia.tool-output.content")]: true,
+      content,
+    };
+    const agent = agentWithTools([
+      createTool({
+        name: "external_output",
+        description: "Return output from another Core instance",
+        inputSchema: z.object({}),
+        execute: () => externalOutput,
+      }),
+    ]);
+
+    await expect(agent.callTool("external_output", "{}")).resolves.toEqual({
+      type: "content",
+      value: content,
+    });
+  });
+
   it("rejects malformed rich tool result content", async () => {
     const agent = agentWithTools([
       createTool({

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -10,7 +10,7 @@ Requires Node.js 20 or newer, or Bun 1.3.14, and uses the official MCP TypeScrip
 ## Installation
 
 ```sh
-pnpm add @anvia/mcp @anvia/core
+pnpm add @anvia/mcp@rc @anvia/core@rc
 ```
 
 ### Bun
@@ -18,7 +18,7 @@ pnpm add @anvia/mcp @anvia/core
 Bun 1.3.14 is the currently tested and supported runtime baseline:
 
 ```sh
-bun add @anvia/mcp @anvia/core
+bun add @anvia/mcp@rc @anvia/core@rc
 ```
 
 Compatibility tests cover modern protocol negotiation, Streamable HTTP with chunked SSE responses,

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -5,13 +5,24 @@ Model Context Protocol client integration for Anvia agents.
 This package owns MCP connections, transports, tool discovery, and cleanup. `@anvia/core` keeps only
 the lightweight MCP registration contracts consumed by `Agent`.
 
-Requires Node.js 20 or newer and uses the official MCP TypeScript SDK v2 client.
+Requires Node.js 20 or newer, or Bun 1.3.14, and uses the official MCP TypeScript SDK v2 client.
 
 ## Installation
 
 ```sh
 pnpm add @anvia/mcp @anvia/core
 ```
+
+### Bun
+
+Bun 1.3.14 is the currently tested and supported runtime baseline:
+
+```sh
+bun add @anvia/mcp @anvia/core
+```
+
+Compatibility tests cover modern protocol negotiation, Streamable HTTP with chunked SSE responses,
+stdio subprocesses, URL-safety enforcement, and installation from packed package artifacts.
 
 ## Usage
 

--- a/packages/provider-openai/README.md
+++ b/packages/provider-openai/README.md
@@ -11,6 +11,17 @@ speech generation, or transcription to run on OpenAI models or OpenAI-compatible
 pnpm add @anvia/openai @anvia/core
 ```
 
+### Bun
+
+Bun 1.3.14 is the currently tested and supported runtime baseline:
+
+```sh
+bun add @anvia/openai @anvia/core
+```
+
+Compatibility tests exercise the OpenAI SDK's JSON, streaming, abort, multipart, and binary media
+paths without contacting a model provider.
+
 In this monorepo, the package is available through the workspace:
 
 ```sh

--- a/packages/provider-openai/README.md
+++ b/packages/provider-openai/README.md
@@ -16,7 +16,7 @@ pnpm add @anvia/openai @anvia/core
 Bun 1.3.14 is the currently tested and supported runtime baseline:
 
 ```sh
-bun add @anvia/openai @anvia/core
+bun add @anvia/openai@rc @anvia/core@rc
 ```
 
 Compatibility tests exercise the OpenAI SDK's JSON, streaming, abort, multipart, and binary media

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -2,6 +2,17 @@
 
 Server response helpers for the Anvia client protocol and explicitly generic event streams.
 
+## Bun
+
+Bun 1.3.14 is the currently tested and supported runtime baseline:
+
+```sh
+bun add @anvia/server @anvia/client
+```
+
+Compatibility tests run these helpers through `Bun.serve`, covering framed JSONL and SSE,
+resumable replay, cancellation cleanup, and installation from packed package artifacts.
+
 ## Client protocol responses
 
 Adapt native runtime events at the server boundary, then frame them for the client:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -395,7 +395,7 @@ importers:
         version: 24.12.2
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(typescript@5.9.3))(@types/pg@8.20.0)(pg@8.23.0)
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(typescript@5.9.3))(@types/pg@8.20.0)(bun-types@1.3.14)(pg@8.23.0)
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.26)(tsx@4.23.12)(typescript@5.9.3)(yaml@2.9.0)
@@ -1201,6 +1201,22 @@ importers:
       vitest:
         specifier: ^4.0.8
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@8.2.2(@types/node@24.12.2)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.12)(yaml@2.9.0))
+
+  tests/compat/bun-runtime:
+    dependencies:
+      '@anvia/core':
+        specifier: workspace:*
+        version: link:../../../packages/core
+      '@anvia/openai':
+        specifier: workspace:*
+        version: link:../../../packages/provider-openai
+    devDependencies:
+      '@types/bun':
+        specifier: 1.3.14
+        version: 1.3.14
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
 
   tests/compat/peer-core:
     dependencies:
@@ -3680,6 +3696,9 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
+  '@types/bun@1.3.14':
+    resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -4104,6 +4123,9 @@ packages:
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -9658,6 +9680,10 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
+  '@types/bun@1.3.14':
+    dependencies:
+      bun-types: 1.3.14
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -10114,6 +10140,10 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bun-types@1.3.14:
+    dependencies:
+      '@types/node': 24.12.2
+
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
@@ -10451,11 +10481,12 @@ snapshots:
 
   dotenv@17.4.2: {}
 
-  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(typescript@5.9.3))(@types/pg@8.20.0)(pg@8.23.0):
+  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(typescript@5.9.3))(@types/pg@8.20.0)(bun-types@1.3.14)(pg@8.23.0):
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@prisma/client': 7.9.1(typescript@5.9.3)
       '@types/pg': 8.20.0
+      bun-types: 1.3.14
       pg: 8.23.0
 
   dunder-proto@1.0.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1204,6 +1204,9 @@ importers:
 
   tests/compat/bun-runtime:
     dependencies:
+      '@anvia/client':
+        specifier: workspace:*
+        version: link:../../../packages/client
       '@anvia/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -1213,6 +1216,9 @@ importers:
       '@anvia/openai':
         specifier: workspace:*
         version: link:../../../packages/provider-openai
+      '@anvia/server':
+        specifier: workspace:*
+        version: link:../../../packages/server
     devDependencies:
       '@types/bun':
         specifier: 1.3.14

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1207,6 +1207,9 @@ importers:
       '@anvia/core':
         specifier: workspace:*
         version: link:../../../packages/core
+      '@anvia/mcp':
+        specifier: workspace:*
+        version: link:../../../packages/mcp
       '@anvia/openai':
         specifier: workspace:*
         version: link:../../../packages/provider-openai

--- a/tests/compat/bun-runtime/package.json
+++ b/tests/compat/bun-runtime/package.json
@@ -4,12 +4,13 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "pretest:bun": "pnpm --filter @anvia/core build && pnpm --filter @anvia/openai build",
+    "pretest:bun": "pnpm --filter @anvia/core build && pnpm --filter @anvia/openai build && pnpm --filter @anvia/mcp build",
     "test:bun": "bun test ./test && node ./scripts/test-packed-artifacts.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@anvia/core": "workspace:*",
+    "@anvia/mcp": "workspace:*",
     "@anvia/openai": "workspace:*"
   },
   "devDependencies": {

--- a/tests/compat/bun-runtime/package.json
+++ b/tests/compat/bun-runtime/package.json
@@ -4,14 +4,16 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "pretest:bun": "pnpm --filter @anvia/core build && pnpm --filter @anvia/openai build && pnpm --filter @anvia/mcp build",
+    "pretest:bun": "pnpm --filter @anvia/core build && pnpm --filter @anvia/client build && pnpm --filter @anvia/server build && pnpm --filter @anvia/openai build && pnpm --filter @anvia/mcp build",
     "test:bun": "bun test ./test && node ./scripts/test-packed-artifacts.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@anvia/client": "workspace:*",
     "@anvia/core": "workspace:*",
     "@anvia/mcp": "workspace:*",
-    "@anvia/openai": "workspace:*"
+    "@anvia/openai": "workspace:*",
+    "@anvia/server": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",

--- a/tests/compat/bun-runtime/package.json
+++ b/tests/compat/bun-runtime/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "bun-runtime-compat",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "pretest:bun": "pnpm --filter @anvia/core build && pnpm --filter @anvia/openai build",
+    "test:bun": "bun test ./test && node ./scripts/test-packed-artifacts.mjs",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@anvia/core": "workspace:*",
+    "@anvia/openai": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "1.3.14",
+    "typescript": "^5.9.3"
+  }
+}

--- a/tests/compat/bun-runtime/scripts/test-packed-artifacts.mjs
+++ b/tests/compat/bun-runtime/scripts/test-packed-artifacts.mjs
@@ -17,6 +17,12 @@ try {
     cwd: join(repositoryRoot, "packages/core"),
   });
   await run("pnpm", ["pack", "--pack-destination", packsDirectory], {
+    cwd: join(repositoryRoot, "packages/client"),
+  });
+  await run("pnpm", ["pack", "--pack-destination", packsDirectory], {
+    cwd: join(repositoryRoot, "packages/server"),
+  });
+  await run("pnpm", ["pack", "--pack-destination", packsDirectory], {
     cwd: join(repositoryRoot, "packages/provider-openai"),
   });
   await run("pnpm", ["pack", "--pack-destination", packsDirectory], {
@@ -25,6 +31,8 @@ try {
 
   const archives = await readdir(packsDirectory);
   const coreArchive = requireArchive(archives, "anvia-core-");
+  const clientArchive = requireArchive(archives, "anvia-client-");
+  const serverArchive = requireArchive(archives, "anvia-server-");
   const openaiArchive = requireArchive(archives, "anvia-openai-");
   const mcpArchive = requireArchive(archives, "anvia-mcp-");
   await writeFile(
@@ -35,9 +43,11 @@ try {
         private: true,
         type: "module",
         dependencies: {
+          "@anvia/client": `file:${join(packsDirectory, clientArchive)}`,
           "@anvia/core": `file:${join(packsDirectory, coreArchive)}`,
           "@anvia/mcp": `file:${join(packsDirectory, mcpArchive)}`,
           "@anvia/openai": `file:${join(packsDirectory, openaiArchive)}`,
+          "@anvia/server": `file:${join(packsDirectory, serverArchive)}`,
         },
       },
       undefined,
@@ -88,16 +98,20 @@ function run(command, args, options) {
 function smokeTestSource() {
   return `
 import assert from "node:assert/strict";
+import { createHttpClientTransport } from "@anvia/client";
 import { Agent } from "@anvia/core";
 import { extractPdfText } from "@anvia/core/documents";
 import { toReadableStream } from "@anvia/core/streaming";
 import { McpClient } from "@anvia/mcp";
 import { OpenAIClient } from "@anvia/openai";
+import { createClientStreamResponse } from "@anvia/server";
 
 assert.equal(typeof Agent, "function");
+assert.equal(typeof createHttpClientTransport, "function");
 assert.equal(typeof extractPdfText, "function");
 assert.equal(typeof toReadableStream, "function");
 assert.equal(typeof McpClient, "function");
+assert.equal(typeof createClientStreamResponse, "function");
 
 const mcpClient = new McpClient({
   name: "packed-mcp",
@@ -109,6 +123,28 @@ const mcpClient = new McpClient({
   },
 });
 assert.equal(mcpClient.name, "packed-mcp");
+
+const packedTransport = createHttpClientTransport({
+  endpoint: "https://packed.invalid/stream",
+  fetch: async () =>
+    createClientStreamResponse({
+      events: (async function* () {
+        yield { type: "run_start", runId: "packed-run", source: "completion" };
+        yield { type: "run_end", runId: "packed-run", status: "completed" };
+      })(),
+      streamId: "packed-stream",
+    }),
+});
+const packedFrames = [];
+for await (const frame of packedTransport.send({
+  request: { type: "messages", messages: [] },
+})) {
+  packedFrames.push(frame);
+}
+assert.deepEqual(
+  packedFrames.map((frame) => frame.type),
+  ["stream_start", "stream_event", "stream_event", "stream_end"],
+);
 
 const model = new OpenAIClient({
   client: {
@@ -135,6 +171,6 @@ const result = await agent.generate({ prompt: "hello" });
 assert.equal(result.output, "packed packages work");
 assert.equal(result.usage.totalTokens, 4);
 
-console.log("Packed @anvia/core, @anvia/openai, and @anvia/mcp artifacts work under Bun.");
+console.log("Packed Core, Client, Server, OpenAI, and MCP artifacts work under Bun.");
 `;
 }

--- a/tests/compat/bun-runtime/scripts/test-packed-artifacts.mjs
+++ b/tests/compat/bun-runtime/scripts/test-packed-artifacts.mjs
@@ -19,10 +19,14 @@ try {
   await run("pnpm", ["pack", "--pack-destination", packsDirectory], {
     cwd: join(repositoryRoot, "packages/provider-openai"),
   });
+  await run("pnpm", ["pack", "--pack-destination", packsDirectory], {
+    cwd: join(repositoryRoot, "packages/mcp"),
+  });
 
   const archives = await readdir(packsDirectory);
   const coreArchive = requireArchive(archives, "anvia-core-");
   const openaiArchive = requireArchive(archives, "anvia-openai-");
+  const mcpArchive = requireArchive(archives, "anvia-mcp-");
   await writeFile(
     join(consumerDirectory, "package.json"),
     JSON.stringify(
@@ -32,6 +36,7 @@ try {
         type: "module",
         dependencies: {
           "@anvia/core": `file:${join(packsDirectory, coreArchive)}`,
+          "@anvia/mcp": `file:${join(packsDirectory, mcpArchive)}`,
           "@anvia/openai": `file:${join(packsDirectory, openaiArchive)}`,
         },
       },
@@ -86,11 +91,24 @@ import assert from "node:assert/strict";
 import { Agent } from "@anvia/core";
 import { extractPdfText } from "@anvia/core/documents";
 import { toReadableStream } from "@anvia/core/streaming";
+import { McpClient } from "@anvia/mcp";
 import { OpenAIClient } from "@anvia/openai";
 
 assert.equal(typeof Agent, "function");
 assert.equal(typeof extractPdfText, "function");
 assert.equal(typeof toReadableStream, "function");
+assert.equal(typeof McpClient, "function");
+
+const mcpClient = new McpClient({
+  name: "packed-mcp",
+  transport: {
+    type: "custom",
+    create() {
+      throw new Error("Packed MCP transport should not connect during this smoke test");
+    },
+  },
+});
+assert.equal(mcpClient.name, "packed-mcp");
 
 const model = new OpenAIClient({
   client: {
@@ -117,6 +135,6 @@ const result = await agent.generate({ prompt: "hello" });
 assert.equal(result.output, "packed packages work");
 assert.equal(result.usage.totalTokens, 4);
 
-console.log("Packed @anvia/core and @anvia/openai artifacts work under Bun.");
+console.log("Packed @anvia/core, @anvia/openai, and @anvia/mcp artifacts work under Bun.");
 `;
 }

--- a/tests/compat/bun-runtime/scripts/test-packed-artifacts.mjs
+++ b/tests/compat/bun-runtime/scripts/test-packed-artifacts.mjs
@@ -1,0 +1,122 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, mkdir, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = resolve(scriptDirectory, "../../../..");
+const temporaryRoot = await mkdtemp(join(tmpdir(), "anvia-bun-packed-"));
+const packsDirectory = join(temporaryRoot, "packs");
+const consumerDirectory = join(temporaryRoot, "consumer");
+
+try {
+  await mkdir(packsDirectory);
+  await mkdir(consumerDirectory);
+  await run("pnpm", ["pack", "--pack-destination", packsDirectory], {
+    cwd: join(repositoryRoot, "packages/core"),
+  });
+  await run("pnpm", ["pack", "--pack-destination", packsDirectory], {
+    cwd: join(repositoryRoot, "packages/provider-openai"),
+  });
+
+  const archives = await readdir(packsDirectory);
+  const coreArchive = requireArchive(archives, "anvia-core-");
+  const openaiArchive = requireArchive(archives, "anvia-openai-");
+  await writeFile(
+    join(consumerDirectory, "package.json"),
+    JSON.stringify(
+      {
+        name: "anvia-bun-packed-consumer",
+        private: true,
+        type: "module",
+        dependencies: {
+          "@anvia/core": `file:${join(packsDirectory, coreArchive)}`,
+          "@anvia/openai": `file:${join(packsDirectory, openaiArchive)}`,
+        },
+      },
+      undefined,
+      2,
+    ),
+  );
+  await writeFile(join(consumerDirectory, "smoke.mjs"), smokeTestSource());
+
+  await run("bun", ["install", "--ignore-scripts"], { cwd: consumerDirectory });
+  await run("bun", ["run", "./smoke.mjs"], { cwd: consumerDirectory });
+} finally {
+  await rm(temporaryRoot, { force: true, recursive: true });
+}
+
+function requireArchive(archives, prefix) {
+  const archive = archives.find((entry) => entry.startsWith(prefix) && entry.endsWith(".tgz"));
+  if (archive === undefined) {
+    throw new Error(`Packed archive not found for ${prefix}`);
+  }
+  return archive;
+}
+
+function run(command, args, options) {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: process.env,
+      shell: false,
+      stdio: "inherit",
+    });
+    child.once("error", reject);
+    child.once("close", (code, signal) => {
+      if (code === 0) {
+        resolvePromise();
+        return;
+      }
+      reject(
+        new Error(
+          `${command} ${args.join(" ")} failed with ${
+            signal === null ? `exit code ${code ?? "unknown"}` : `signal ${signal}`
+          }`,
+        ),
+      );
+    });
+  });
+}
+
+function smokeTestSource() {
+  return `
+import assert from "node:assert/strict";
+import { Agent } from "@anvia/core";
+import { extractPdfText } from "@anvia/core/documents";
+import { toReadableStream } from "@anvia/core/streaming";
+import { OpenAIClient } from "@anvia/openai";
+
+assert.equal(typeof Agent, "function");
+assert.equal(typeof extractPdfText, "function");
+assert.equal(typeof toReadableStream, "function");
+
+const model = new OpenAIClient({
+  client: {
+    chat: {
+      completions: {
+        async create() {
+          return {
+            choices: [
+              {
+                message: { role: "assistant", content: "packed packages work" },
+                finish_reason: "stop",
+              },
+            ],
+            usage: { prompt_tokens: 1, completion_tokens: 3, total_tokens: 4 },
+          };
+        },
+      },
+    },
+  },
+}).completionModel({ modelId: "gpt-4o-mini", api: "chat" });
+
+const agent = new Agent({ id: "packed-bun-consumer", model });
+const result = await agent.generate({ prompt: "hello" });
+assert.equal(result.output, "packed packages work");
+assert.equal(result.usage.totalTokens, 4);
+
+console.log("Packed @anvia/core and @anvia/openai artifacts work under Bun.");
+`;
+}

--- a/tests/compat/bun-runtime/test/core.test.ts
+++ b/tests/compat/bun-runtime/test/core.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Agent, generateCompletion, loadSkills, skill, streamCompletion, Usage } from "@anvia/core";
+import { toReadableStream } from "@anvia/core/streaming";
+
+const tempDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirectories.splice(0).map((directory) => rm(directory, { force: true, recursive: true })),
+  );
+});
+
+describe("@anvia/core under Bun", () => {
+  it("runs direct and streaming completions through built package exports", async () => {
+    const model = createCompletionModel();
+
+    const completion = await generateCompletion({ model, prompt: "hello" });
+    const events = await collect(streamCompletion({ model, prompt: "hello" }));
+
+    expect(completion.text).toBe("Hello from Bun");
+    expect(events).toEqual([
+      { type: "text_delta", delta: "Hello from " },
+      { type: "text_delta", delta: "Bun" },
+      expect.objectContaining({
+        type: "final",
+        result: expect.objectContaining({ text: "Hello from Bun" }),
+      }),
+    ]);
+  });
+
+  it("converts async events to a Web ReadableStream", async () => {
+    const events = (async function* () {
+      yield { type: "text_delta", delta: "one" };
+      yield { type: "text_delta", delta: "two" };
+    })();
+
+    const body = await new Response(toReadableStream(events)).text();
+
+    expect(body).toBe('{"type":"text_delta","delta":"one"}\n{"type":"text_delta","delta":"two"}\n');
+  });
+
+  it("loads a local skill and executes its script with Node-compatible APIs", async () => {
+    const root = await mkdtemp(join(tmpdir(), "anvia-bun-core-"));
+    tempDirectories.push(root);
+    const directory = join(root, "bun-check");
+    const scriptsDirectory = join(directory, "scripts");
+    await mkdir(scriptsDirectory, { recursive: true });
+    await writeFile(
+      join(directory, "SKILL.md"),
+      "---\nname: bun-check\ndescription: Check Bun runtime compatibility.\n---\nRun the check.\n",
+    );
+    const scriptPath = join(scriptsDirectory, "check.sh");
+    await writeFile(scriptPath, "#!/bin/sh\nprintf 'runtime:%s\\n' \"$1\"\n");
+    await chmod(scriptPath, 0o755);
+
+    const skillSet = await loadSkills(skill.local(directory));
+    const agent = new Agent({
+      id: "bun-compat",
+      model: createCompletionModel(),
+      tools: skillSet.tools,
+    });
+
+    await expect(
+      agent.callTool(
+        "run_skill_script",
+        JSON.stringify({
+          skillName: "bun-check",
+          scriptPath: "check.sh",
+          args: ["bun"],
+        }),
+      ),
+    ).resolves.toEqual({ type: "text", value: "stdout:\nruntime:bun\n" });
+  });
+});
+
+function createCompletionModel() {
+  return {
+    provider: "bun-compat",
+    modelId: "bun-compat",
+    capabilities: {
+      streaming: true,
+      tools: true,
+      toolChoice: true,
+      imageInput: true,
+      documentInput: true,
+      outputSchema: true,
+      reasoning: true,
+    },
+    async completion() {
+      return completionResponse("Hello from Bun");
+    },
+    async *streamCompletion() {
+      yield { type: "text_delta" as const, delta: "Hello from " };
+      yield { type: "text_delta" as const, delta: "Bun" };
+      yield {
+        type: "final" as const,
+        response: { ...completionResponse("Hello from Bun"), finishReason: "stop" as const },
+      };
+    },
+  };
+}
+
+function completionResponse(text: string) {
+  return {
+    choice: [{ type: "text" as const, text }],
+    usage: Usage.empty(),
+    rawResponse: {},
+  };
+}
+
+async function collect<T>(events: AsyncIterable<T>): Promise<T[]> {
+  const values: T[] = [];
+  for await (const event of events) values.push(event);
+  return values;
+}

--- a/tests/compat/bun-runtime/test/fixtures/mcp-stdio-server.mjs
+++ b/tests/compat/bun-runtime/test/fixtures/mcp-stdio-server.mjs
@@ -1,0 +1,61 @@
+let buffer = "";
+
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  while (true) {
+    const newline = buffer.indexOf("\n");
+    if (newline === -1) return;
+    const line = buffer.slice(0, newline);
+    buffer = buffer.slice(newline + 1);
+    if (line.trim() === "") continue;
+    respond(JSON.parse(line));
+  }
+});
+
+function respond(message) {
+  process.stdout.write(
+    `${JSON.stringify({ jsonrpc: "2.0", id: message.id, result: resultFor(message) })}\n`,
+  );
+}
+
+function resultFor(message) {
+  if (message.method === "server/discover") {
+    return {
+      supportedVersions: ["2026-07-28"],
+      capabilities: { tools: {} },
+      _meta: {
+        "io.modelcontextprotocol/serverInfo": {
+          name: "bun-stdio-fixture",
+          version: "1.0.0",
+        },
+      },
+    };
+  }
+  if (message.method === "tools/list") {
+    return {
+      resultType: "complete",
+      ttlMs: 0,
+      cacheScope: "public",
+      tools: [
+        {
+          name: "echo",
+          inputSchema: {
+            type: "object",
+            properties: { text: { type: "string" } },
+            required: ["text"],
+          },
+        },
+      ],
+    };
+  }
+  if (message.method === "tools/call") {
+    return {
+      resultType: "complete",
+      ttlMs: 0,
+      cacheScope: "private",
+      content: [{ type: "text", text: `echo:${String(message.params?.arguments?.text ?? "")}` }],
+    };
+  }
+  return {};
+}

--- a/tests/compat/bun-runtime/test/mcp.test.ts
+++ b/tests/compat/bun-runtime/test/mcp.test.ts
@@ -1,0 +1,209 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import { fileURLToPath } from "node:url";
+import { normalizeToolResultOutput } from "@anvia/core/tool";
+import { McpClient } from "@anvia/mcp";
+
+type RpcRequest = {
+  jsonrpc: "2.0";
+  id: string | number;
+  method: string;
+  params?: Record<string, unknown> | undefined;
+};
+
+type RecordedRequest = {
+  method: string;
+  headers: Headers;
+  params?: Record<string, unknown> | undefined;
+};
+
+const requests: RecordedRequest[] = [];
+const server = Bun.serve({
+  hostname: "127.0.0.1",
+  port: 0,
+  async fetch(request) {
+    const message = (await request.json()) as RpcRequest;
+    requests.push({
+      method: message.method,
+      headers: new Headers(request.headers),
+      params: message.params,
+    });
+    const response = {
+      jsonrpc: "2.0" as const,
+      id: message.id,
+      result: resultFor(message),
+    };
+
+    return message.method === "tools/call" ? eventStream(response) : Response.json(response);
+  },
+});
+
+afterAll(() => {
+  server.stop(true);
+});
+
+describe("@anvia/mcp under Bun", () => {
+  it("negotiates and calls a Streamable HTTP tool through a chunked SSE response", async () => {
+    requests.length = 0;
+    const client = new McpClient({
+      name: "bun-http",
+      transport: {
+        type: "streamableHttp",
+        url: new URL("/mcp", server.url),
+        ssrfProtection: "disabled",
+        headers: { "x-api-key": "bun-test-secret" },
+      },
+      tools: { prefix: "bun_" },
+    });
+
+    try {
+      const registration = await client.connect();
+      expect(registration).toMatchObject({
+        name: "bun-http",
+        serverInfo: { name: "bun-http-fixture", version: "1.0.0" },
+        instructions: "Served by Bun.",
+      });
+      expect(registration.tools).toHaveLength(1);
+      const tool = registration.tools[0];
+      if (tool === undefined) throw new Error("Expected the Bun MCP fixture tool");
+      expect(tool.name).toBe("bun_echo");
+
+      const output = normalizeToolResultOutput(await tool.call({ text: "hello from Bun" }));
+      expect(output).toEqual({
+        type: "content",
+        value: [{ type: "text", text: "echo:hello from Bun" }],
+      });
+
+      expect(requests.map((request) => request.method)).toEqual([
+        "server/discover",
+        "tools/list",
+        "tools/call",
+      ]);
+      expect(
+        requests.every((request) => request.headers.get("x-api-key") === "bun-test-secret"),
+      ).toBe(true);
+      expect(requests.map((request) => request.headers.get("mcp-method"))).toEqual([
+        "server/discover",
+        "tools/list",
+        "tools/call",
+      ]);
+      expect(requests[2]?.headers.get("mcp-name")).toBe("echo");
+      expect(requests[2]?.params).toMatchObject({
+        name: "echo",
+        arguments: { text: "hello from Bun" },
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("spawns and communicates with an MCP stdio subprocess", async () => {
+    const fixturePath = fileURLToPath(new URL("./fixtures/mcp-stdio-server.mjs", import.meta.url));
+    const client = new McpClient({
+      name: "bun-stdio",
+      transport: {
+        type: "stdio",
+        command: process.execPath,
+        args: [fixturePath],
+      },
+    });
+
+    try {
+      const registration = await client.connect();
+      expect(registration).toMatchObject({
+        name: "bun-stdio",
+        serverInfo: { name: "bun-stdio-fixture", version: "1.0.0" },
+      });
+      const tool = registration.tools[0];
+      if (tool === undefined) throw new Error("Expected the Bun stdio fixture tool");
+
+      await expect(
+        Promise.resolve(tool.call({ text: "subprocess" })).then(normalizeToolResultOutput),
+      ).resolves.toEqual({
+        type: "content",
+        value: [{ type: "text", text: "echo:subprocess" }],
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("blocks a loopback Streamable HTTP endpoint before Bun fetch runs", async () => {
+    requests.length = 0;
+    const client = new McpClient({
+      name: "blocked-local",
+      transport: {
+        type: "streamableHttp",
+        url: new URL("/mcp", server.url),
+      },
+    });
+
+    await expect(client.connect()).rejects.toThrow("localhost not allowed");
+    expect(requests).toHaveLength(0);
+    await client.close();
+  });
+});
+
+function resultFor(message: RpcRequest): Record<string, unknown> {
+  if (message.method === "server/discover") {
+    return {
+      supportedVersions: ["2026-07-28"],
+      capabilities: { tools: {} },
+      instructions: "Served by Bun.",
+      _meta: {
+        "io.modelcontextprotocol/serverInfo": {
+          name: "bun-http-fixture",
+          version: "1.0.0",
+        },
+      },
+    };
+  }
+  if (message.method === "tools/list") {
+    return {
+      resultType: "complete",
+      ttlMs: 0,
+      cacheScope: "public",
+      tools: [
+        {
+          name: "echo",
+          description: "Echo text from the Bun fixture.",
+          inputSchema: {
+            type: "object",
+            properties: { text: { type: "string" } },
+            required: ["text"],
+          },
+        },
+      ],
+    };
+  }
+  if (message.method === "tools/call") {
+    const text = message.params?.arguments;
+    const value =
+      typeof text === "object" && text !== null && "text" in text
+        ? String((text as { text: unknown }).text)
+        : "";
+    return {
+      resultType: "complete",
+      ttlMs: 0,
+      cacheScope: "private",
+      content: [{ type: "text", text: `echo:${value}` }],
+    };
+  }
+  return {};
+}
+
+function eventStream(message: unknown): Response {
+  const encoded = new TextEncoder().encode(`event: message\ndata: ${JSON.stringify(message)}\n\n`);
+  const splitAt = Math.floor(encoded.byteLength / 2);
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoded.slice(0, splitAt));
+        queueMicrotask(() => {
+          controller.enqueue(encoded.slice(splitAt));
+          controller.close();
+        });
+      },
+    }),
+    { headers: { "content-type": "text/event-stream" } },
+  );
+}

--- a/tests/compat/bun-runtime/test/openai.test.ts
+++ b/tests/compat/bun-runtime/test/openai.test.ts
@@ -1,0 +1,344 @@
+import { afterAll, beforeEach, describe, expect, it } from "bun:test";
+import { generateCompletion, streamCompletion } from "@anvia/core/completion";
+import { generateImage } from "@anvia/core/image-generation";
+import { generateSpeech } from "@anvia/core/speech-generation";
+import { transcribe } from "@anvia/core/transcription";
+import { OpenAIClient } from "@anvia/openai";
+
+type RecordedRequest = {
+  method: string;
+  pathname: string;
+  body?: unknown;
+  contentType?: string | undefined;
+};
+
+const requests: RecordedRequest[] = [];
+let resolveSlowRequest: (() => void) | undefined;
+let slowRequestStarted = Promise.resolve();
+
+resetSlowRequest();
+
+const server = Bun.serve({
+  hostname: "127.0.0.1",
+  port: 0,
+  async fetch(request) {
+    const url = new URL(request.url);
+    const contentType = request.headers.get("content-type") ?? undefined;
+    const recorded: RecordedRequest = {
+      method: request.method,
+      pathname: url.pathname,
+      contentType,
+    };
+
+    if (contentType?.startsWith("application/json")) {
+      recorded.body = await request.json();
+    } else if (contentType?.startsWith("multipart/form-data")) {
+      const form = await request.formData();
+      const file = form.get("file");
+      recorded.body = {
+        fileName: file instanceof File ? file.name : undefined,
+        language: form.get("language"),
+        model: form.get("model"),
+      };
+    }
+    requests.push(recorded);
+    const body = isRecord(recorded.body) ? recorded.body : {};
+
+    if (url.pathname === "/v1/chat/completions") {
+      return json({
+        id: "chatcmpl_bun",
+        object: "chat.completion",
+        created: 1_700_000_000,
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "Hello from OpenAI on Bun" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 2, completion_tokens: 5, total_tokens: 7 },
+      });
+    }
+
+    if (url.pathname === "/v1/responses") {
+      if (body.model === "slow-model") {
+        resolveSlowRequest?.();
+        return new Response(new ReadableStream(), {
+          headers: { "content-type": "application/json" },
+        });
+      }
+      const response = responsesPayload();
+      return body.stream === true
+        ? eventStream([
+            { type: "response.output_text.delta", delta: "Hello from " },
+            { type: "response.output_text.delta", delta: "Responses on Bun" },
+            { type: "response.completed", response },
+          ])
+        : json(response);
+    }
+
+    if (url.pathname === "/v1/embeddings") {
+      return json({
+        object: "list",
+        model: "text-embedding-3-small",
+        data: [
+          { object: "embedding", index: 0, embedding: "AACAPwAAAAA=" },
+          { object: "embedding", index: 1, embedding: "AAAAAAAAgD8=" },
+        ],
+        usage: { prompt_tokens: 2, total_tokens: 2 },
+      });
+    }
+
+    if (url.pathname === "/v1/images/generations") {
+      return json({ output_format: "png", data: [{ b64_json: "AQID" }] });
+    }
+
+    if (url.pathname === "/v1/audio/speech") {
+      return new Response(new Uint8Array([4, 5, 6]), {
+        headers: { "content-type": "audio/wav" },
+      });
+    }
+
+    if (url.pathname === "/v1/audio/transcriptions") {
+      return json({ text: "Bun heard this" });
+    }
+
+    if (url.pathname === "/v1/models") {
+      return json({
+        object: "list",
+        data: [
+          {
+            id: "gpt-4o-mini",
+            object: "model",
+            created: 1_700_000_000,
+            owned_by: "openai",
+          },
+        ],
+        has_more: false,
+      });
+    }
+
+    return new Response("Not found", { status: 404 });
+  },
+});
+
+const client = new OpenAIClient({
+  apiKey: "bun-compat-test-key",
+  baseUrl: new URL("/v1", server.url).toString().replace(/\/$/, ""),
+});
+
+beforeEach(() => {
+  requests.length = 0;
+  resetSlowRequest();
+});
+
+afterAll(() => {
+  server.stop(true);
+});
+
+describe("@anvia/openai under Bun", () => {
+  it("uses Bun fetch for chat completions", async () => {
+    const model = client.completionModel({ modelId: "gpt-4o-mini", api: "chat" });
+
+    const completion = await generateCompletion({ model, prompt: "hello" });
+
+    expect(completion.text).toBe("Hello from OpenAI on Bun");
+    expect(completion.usage).toMatchObject({ inputTokens: 2, outputTokens: 5, totalTokens: 7 });
+    expect(requests).toEqual([
+      expect.objectContaining({
+        method: "POST",
+        pathname: "/v1/chat/completions",
+        body: expect.objectContaining({ model: "gpt-4o-mini" }),
+      }),
+    ]);
+  });
+
+  it("uses Bun fetch for Responses completions", async () => {
+    const model = client.completionModel({ modelId: "gpt-4o-mini", api: "responses" });
+
+    const completion = await generateCompletion({ model, prompt: "hello" });
+
+    expect(completion.text).toBe("Hello from Responses on Bun");
+    expect(completion.usage).toMatchObject({ inputTokens: 3, outputTokens: 4, totalTokens: 7 });
+    expect(requests[0]).toMatchObject({
+      method: "POST",
+      pathname: "/v1/responses",
+      body: expect.objectContaining({ model: "gpt-4o-mini" }),
+    });
+  });
+
+  it("parses chunked Responses SSE streams", async () => {
+    const model = client.completionModel({ modelId: "gpt-4o-mini", api: "responses" });
+
+    const events = await collect(streamCompletion({ model, prompt: "hello" }));
+
+    expect(events).toEqual([
+      { type: "text_delta", delta: "Hello from " },
+      { type: "text_delta", delta: "Responses on Bun" },
+      expect.objectContaining({
+        type: "final",
+        result: expect.objectContaining({ text: "Hello from Responses on Bun" }),
+      }),
+    ]);
+    expect(requests[0]).toMatchObject({
+      pathname: "/v1/responses",
+      body: expect.objectContaining({ stream: true }),
+    });
+  });
+
+  it("propagates AbortSignal cancellation through Bun fetch", async () => {
+    const model = client.completionModel({ modelId: "slow-model", api: "responses" });
+    const controller = new AbortController();
+    const completion = generateCompletion({
+      model,
+      prompt: "wait",
+      abortSignal: controller.signal,
+    });
+    await slowRequestStarted;
+
+    controller.abort("caller stopped");
+
+    await expect(completion).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("maps embeddings returned through Bun fetch", async () => {
+    const model = client.embeddingModel({ modelId: "text-embedding-3-small" });
+
+    await expect(model.embedTexts(["one", "two"])).resolves.toEqual([
+      { document: "one", vector: [1, 0] },
+      { document: "two", vector: [0, 1] },
+    ]);
+    expect(requests[0]).toMatchObject({
+      method: "POST",
+      pathname: "/v1/embeddings",
+      body: expect.objectContaining({ input: ["one", "two"], encoding_format: "base64" }),
+    });
+  });
+
+  it("decodes base64 image responses", async () => {
+    const model = client.imageGenerationModel({ modelId: "gpt-image-1" });
+
+    const result = await generateImage({ model, prompt: "draw a bun" });
+
+    expect(result.images).toEqual([{ data: new Uint8Array([1, 2, 3]), mediaType: "image/png" }]);
+    expect(requests[0]).toMatchObject({ method: "POST", pathname: "/v1/images/generations" });
+  });
+
+  it("uploads transcription audio as multipart form data", async () => {
+    const model = client.transcriptionModel({ modelId: "whisper-1" });
+
+    const result = await transcribe({
+      model,
+      audio: {
+        data: new Uint8Array([1, 2, 3]),
+        filename: "sample.wav",
+        mediaType: "audio/wav",
+      },
+      language: "en",
+    });
+
+    expect(result.text).toBe("Bun heard this");
+    expect(requests[0]).toMatchObject({
+      method: "POST",
+      pathname: "/v1/audio/transcriptions",
+      contentType: expect.stringContaining("multipart/form-data; boundary="),
+      body: { fileName: "sample.wav", language: "en", model: "whisper-1" },
+    });
+  });
+
+  it("reads binary speech responses", async () => {
+    const model = client.speechGenerationModel({ modelId: "tts-1" });
+
+    const result = await generateSpeech({
+      model,
+      text: "hello",
+      voice: "alloy",
+      providerOptions: { response_format: "wav" },
+    });
+
+    expect(result.audio).toEqual({ data: new Uint8Array([4, 5, 6]), mediaType: "audio/wav" });
+    expect(requests[0]).toMatchObject({
+      method: "POST",
+      pathname: "/v1/audio/speech",
+      body: expect.objectContaining({ response_format: "wav" }),
+    });
+  });
+
+  it("iterates models returned by the OpenAI SDK", async () => {
+    await expect(client.listModels()).resolves.toEqual({
+      data: [
+        {
+          id: "gpt-4o-mini",
+          type: "model",
+          createdAt: 1_700_000_000,
+          ownedBy: "openai",
+        },
+      ],
+    });
+    expect(requests[0]).toMatchObject({ method: "GET", pathname: "/v1/models" });
+  });
+});
+
+function json(value: unknown): Response {
+  return Response.json(value);
+}
+
+function responsesPayload() {
+  return {
+    id: "resp_bun",
+    object: "response",
+    created_at: 1_700_000_000,
+    status: "completed",
+    model: "gpt-4o-mini",
+    output: [
+      {
+        id: "msg_bun",
+        type: "message",
+        status: "completed",
+        role: "assistant",
+        content: [{ type: "output_text", text: "Hello from Responses on Bun", annotations: [] }],
+      },
+    ],
+    usage: { input_tokens: 3, output_tokens: 4, total_tokens: 7 },
+  };
+}
+
+function eventStream(events: readonly unknown[]): Response {
+  const chunks = [
+    ...events.map((event) => `data: ${JSON.stringify(event)}\n\n`),
+    "data: [DONE]\n\n",
+  ];
+  const encoder = new TextEncoder();
+  let index = 0;
+  return new Response(
+    new ReadableStream({
+      pull(controller) {
+        const chunk = chunks[index];
+        if (chunk === undefined) {
+          controller.close();
+          return;
+        }
+        index += 1;
+        controller.enqueue(encoder.encode(chunk));
+      },
+    }),
+    { headers: { "content-type": "text/event-stream" } },
+  );
+}
+
+function resetSlowRequest(): void {
+  slowRequestStarted = new Promise((resolve) => {
+    resolveSlowRequest = resolve;
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+async function collect<T>(events: AsyncIterable<T>): Promise<T[]> {
+  const values: T[] = [];
+  for await (const event of events) values.push(event);
+  return values;
+}

--- a/tests/compat/bun-runtime/test/server.test.ts
+++ b/tests/compat/bun-runtime/test/server.test.ts
@@ -1,0 +1,243 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import type { ClientStream, ClientStreamEvent, ClientStreamRequest } from "@anvia/client";
+import { createHttpClientTransport, parseClientStreamRequest } from "@anvia/client";
+import { fetchEventStream } from "@anvia/client/transport";
+import {
+  type ClientResumableEvent,
+  createClientStreamResponse,
+  createEventStreamResponse,
+  createMemoryResumableStreamStore,
+  resumeClientStreamResponse,
+} from "@anvia/server";
+
+type GenericEvent = { kind: string };
+
+const requests: Array<{
+  pathname: string;
+  request: ClientStreamRequest;
+  clientHeader: string | null;
+}> = [];
+const resumableStore = createMemoryResumableStreamStore<ClientResumableEvent>();
+let observeCancellation: (() => void) | undefined;
+
+const server = Bun.serve({
+  hostname: "127.0.0.1",
+  port: 0,
+  async fetch(request) {
+    const url = new URL(request.url);
+    if (url.pathname === "/cancel") {
+      return createEventStreamResponse({
+        events: cancellableEvents(() => observeCancellation?.()),
+      });
+    }
+
+    const body = parseClientStreamRequest(await request.json());
+    requests.push({
+      pathname: url.pathname,
+      request: body,
+      clientHeader: request.headers.get("x-bun-client"),
+    });
+
+    if (url.pathname === "/resumable") {
+      if (body.resume !== undefined) {
+        return resumeClientStreamResponse({
+          streamId: body.resume.streamId,
+          after: body.resume.after,
+          store: resumableStore,
+        });
+      }
+      return createClientStreamResponse({
+        events: clientEvents([
+          { type: "run_start", runId: "resume-run", source: "completion" },
+          { type: "run_end", runId: "resume-run", status: "completed" },
+        ]),
+        resumable: { streamId: "bun-resumable", store: resumableStore },
+      });
+    }
+
+    const format = url.pathname === "/sse" ? "sse" : "jsonl";
+    return createClientStreamResponse({
+      events: clientEvents([
+        { type: "run_start", runId: `${format}-run`, source: "completion" },
+        { type: "run_end", runId: `${format}-run`, status: "completed" },
+      ]),
+      format,
+      streamId: `bun-${format}`,
+    });
+  },
+});
+
+afterAll(() => {
+  server.stop(true);
+});
+
+describe("@anvia/client and @anvia/server under Bun", () => {
+  it("round-trips framed JSONL and SSE responses through Bun fetch", async () => {
+    requests.length = 0;
+
+    for (const format of ["jsonl", "sse"] as const) {
+      const transport = createHttpClientTransport({
+        endpoint: new URL(`/${format}`, server.url),
+      });
+      const frames = await collect(
+        transport.send({
+          request: { type: "messages", messages: [] },
+          headers: { "x-bun-client": format },
+        }),
+      );
+
+      expect(frames.map((frame) => frame.type)).toEqual([
+        "stream_start",
+        "stream_event",
+        "stream_event",
+        "stream_end",
+      ]);
+      expect(frames[0]).toMatchObject({
+        protocol: "anvia.client.v3",
+        streamId: `bun-${format}`,
+        resumable: false,
+      });
+      expect(frames[2]).toMatchObject({
+        event: { type: "run_end", runId: `${format}-run`, status: "completed" },
+      });
+    }
+
+    expect(requests.map((request) => request.pathname)).toEqual(["/jsonl", "/sse"]);
+    expect(requests.map((request) => request.clientHeader)).toEqual(["jsonl", "sse"]);
+    expect(requests.every((request) => request.request.type === "messages")).toBe(true);
+  });
+
+  it("replays a resumable client stream from the requested event ID", async () => {
+    const transport = createHttpClientTransport({
+      endpoint: new URL("/resumable", server.url),
+    });
+    const initial = await collect(transport.send({ request: { type: "messages", messages: [] } }));
+    expect(initial.at(-1)).toMatchObject({ type: "stream_end", eventId: 2 });
+
+    const resume = { streamId: "bun-resumable", after: 1 };
+    const resumed = await collect(
+      transport.send({
+        request: { type: "messages", messages: [], resume },
+      }),
+    );
+
+    expect(resumed).toEqual([
+      expect.objectContaining({
+        type: "stream_start",
+        streamId: "bun-resumable",
+        resumable: true,
+      }),
+      expect.objectContaining({
+        type: "stream_event",
+        streamId: "bun-resumable",
+        eventId: 2,
+        event: { type: "run_end", runId: "resume-run", status: "completed" },
+      }),
+      { type: "stream_end", streamId: "bun-resumable", eventId: 2, status: "completed" },
+    ]);
+  });
+
+  it("cancels the server iterator when a Bun fetch consumer disconnects", async () => {
+    const cancelled = deferred<void>();
+    observeCancellation = cancelled.resolve;
+    const controller = new AbortController();
+    const iterator = fetchEventStream<GenericEvent>({
+      input: new URL("/cancel", server.url),
+      signal: controller.signal,
+    })[Symbol.asyncIterator]();
+
+    try {
+      await expect(iterator.next()).resolves.toEqual({
+        done: false,
+        value: { kind: "first" },
+      });
+      const pending = iterator.next();
+      controller.abort();
+
+      await within(
+        pending.then(
+          () => undefined,
+          () => undefined,
+        ),
+      );
+      await within(cancelled.promise);
+    } finally {
+      controller.abort();
+      await iterator.return?.();
+      observeCancellation = undefined;
+    }
+  });
+});
+
+function clientEvents(events: readonly ClientStreamEvent[]): ClientStream {
+  return values(events);
+}
+
+function values<T>(items: readonly T[]): AsyncIterable<T> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield* items;
+    },
+  };
+}
+
+function cancellableEvents(onCancel: () => void): AsyncIterable<GenericEvent> {
+  return {
+    [Symbol.asyncIterator]() {
+      let emitted = false;
+      let finish: ((result: IteratorResult<GenericEvent>) => void) | undefined;
+      return {
+        next() {
+          if (!emitted) {
+            emitted = true;
+            return Promise.resolve({ done: false as const, value: { kind: "first" } });
+          }
+          return new Promise<IteratorResult<GenericEvent>>((resolve) => {
+            finish = resolve;
+          });
+        },
+        return() {
+          onCancel();
+          finish?.({ done: true, value: undefined });
+          return Promise.resolve({ done: true as const, value: undefined });
+        },
+      };
+    },
+  };
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    resolve(value) {
+      resolvePromise?.(value);
+    },
+  };
+}
+
+async function within<T>(promise: Promise<T>, timeoutMs = 2_000): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error("Timed out waiting for stream cleanup")),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}
+
+async function collect<T>(events: AsyncIterable<T>): Promise<T[]> {
+  const values: T[] = [];
+  for await (const event of events) values.push(event);
+  return values;
+}

--- a/tests/compat/bun-runtime/tsconfig.json
+++ b/tests/compat/bun-runtime/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["bun"]
+  },
+  "include": ["test/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- add Bun 1.3.14 CI coverage for Core, OpenAI, MCP, Client, and Server
- exercise direct imports, streaming, cancellation, MCP transports, SSRF protection, and packed package artifacts under Bun
- make rich tool output branding stable across Bun module instances
- document the tested Bun compatibility surface

## Validation

- Bun 1.3.14 compatibility suite: 18 passed
- packed Core, Client, Server, OpenAI, and MCP artifacts installed and exercised under Bun
- affected package tests: 839 passed
- affected package typechecks passed
- repository formatting and lint checks passed
- changeset status passed

## Changeset

Includes patch changesets for the five directly affected public packages. Required dependent package bumps are determined by the repository Changesets configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Bun 1.3.14 across client, core, server, OpenAI, and MCP packages.
  * Improved recognition of structured tool output across package instances.
* **Documentation**
  * Added Bun installation requirements, commands, and supported compatibility details to package documentation.
* **Tests**
  * Added comprehensive Bun compatibility coverage for streaming, cancellation, resumable responses, MCP transports, OpenAI features, and packed package installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->