### PR TITLE
feat(observability): add trace-correlated scoring

### DIFF
--- a/.changeset/bright-lenses-score.md
+++ b/.changeset/bright-lenses-score.md
@@ -1,0 +1,7 @@
+---
+"@anvia/otel": minor
+"@anvia/lens": minor
+---
+
+Add trace-correlated runtime scoring with explicit end-user feedback provenance, and expose it
+through both the OpenTelemetry scorer and `LensClient.score()`.

--- a/.changeset/bright-lenses-score.md
+++ b/.changeset/bright-lenses-score.md
@@ -1,6 +1,6 @@
 ---
-"@anvia/otel": minor
-"@anvia/lens": minor
+"@anvia/otel": patch
+"@anvia/lens": patch
 ---
 
 Add trace-correlated runtime scoring with explicit end-user feedback provenance, and expose it

--- a/packages/observability-lens/README.md
+++ b/packages/observability-lens/README.md
@@ -111,6 +111,30 @@ const reporter = lens.evalReporter({
 Lens eval reporters accept traces from the `"lens"` Agent observer registration by default. Set
 `traceObserver` to the Agent registration name when it differs.
 
+## Runtime scores and end-user feedback
+
+`score()` records a trace-correlated evaluation result through Lens's existing OTLP logs exporter:
+
+```ts
+await lens.score({
+  id: feedbackId,
+  traceId,
+  observationId,
+  responseId,
+  name: "user-feedback",
+  value: liked ? 1 : 0,
+  dataType: "BOOLEAN",
+  source: "end_user",
+  comment,
+  metadata: { channel: "thumbs", userIdHash },
+});
+```
+
+Use a stable `id` when a later vote should replace an earlier one. Omit it when each score should be
+stored as a separate event. `score()` queues the log in the owned provider; `flush()` or client
+disposal completes delivery. Comments are limited to 2,000 characters; validate metadata before
+recording it and avoid raw personal identifiers.
+
 ## Managed datasets
 
 ```ts

--- a/packages/observability-lens/src/index.ts
+++ b/packages/observability-lens/src/index.ts
@@ -16,4 +16,5 @@ export type {
   LensPipelineObserverOptions,
   LensRedactionOptions,
   LensRedactorPattern,
+  LensScoreArgs,
 } from "./types.js";

--- a/packages/observability-lens/src/tracing.ts
+++ b/packages/observability-lens/src/tracing.ts
@@ -5,6 +5,8 @@ import {
   createOtelEvalReporter,
   createOtelObserver,
   createOtelPipelineObserver,
+  createOtelScorer,
+  type OtelScorer,
 } from "@anvia/otel";
 import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
@@ -24,6 +26,7 @@ import type {
   LensEvalReporterOptions,
   LensObserverOptions,
   LensPipelineObserverOptions,
+  LensScoreArgs,
 } from "./types.js";
 
 type LensResources = {
@@ -31,6 +34,7 @@ type LensResources = {
   readonly loggerProvider: LoggerProvider;
   readonly tracer: ReturnType<NodeTracerProvider["getTracer"]>;
   readonly logger: ReturnType<LoggerProvider["getLogger"]>;
+  readonly scorer: OtelScorer;
 };
 
 export class LensClient {
@@ -124,6 +128,12 @@ export class LensClient {
         await (await resolve()).onRunEnd?.(args);
       },
     };
+  }
+
+  async score(args: LensScoreArgs): Promise<void> {
+    this.assertOpen();
+    if (!this.enabled) return;
+    (await this.resources()).scorer.score(args);
   }
 
   datasetClient(options: LensDatasetClientOptions = {}): LensDatasetClient {
@@ -255,11 +265,13 @@ async function createLensResources(config: ResolvedLensConfig): Promise<LensReso
         }),
       ],
     });
+    const logger = loggerProvider.getLogger("@anvia/lens", "1.0.0");
     return {
       tracerProvider,
       loggerProvider,
       tracer: tracerProvider.getTracer("@anvia/lens", "1.0.0"),
-      logger: loggerProvider.getLogger("@anvia/lens", "1.0.0"),
+      logger,
+      scorer: createOtelScorer({ logger }),
     };
   } catch (error) {
     await Promise.allSettled([

--- a/packages/observability-lens/src/types.ts
+++ b/packages/observability-lens/src/types.ts
@@ -1,5 +1,6 @@
 import type { JsonValue } from "@anvia/core/completion";
 import type { EvalReporter } from "@anvia/core/evals";
+import type { OtelScoreArgs } from "@anvia/otel";
 
 export type LensCaptureMode = "safe" | "full";
 
@@ -35,6 +36,8 @@ export type LensObserverOptions = Pick<
 >;
 
 export type LensPipelineObserverOptions = LensObserverOptions;
+
+export type LensScoreArgs = OtelScoreArgs;
 
 export type LensEvalReporterOptions = {
   traceObserver?: string | undefined;

--- a/packages/observability-lens/test/lens.test.ts
+++ b/packages/observability-lens/test/lens.test.ts
@@ -1,3 +1,5 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import { defineEvalSuite, exactMatch, selectPromptOutput } from "@anvia/core/evals";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveLensConfig } from "../src/config";
@@ -112,8 +114,80 @@ describe("Lens eval ergonomics", () => {
       }),
     ).toBeUndefined();
     await expect(client.flush()).resolves.toBeUndefined();
+    await expect(
+      client.score({
+        traceId: "1234567890abcdef1234567890abcdef",
+        name: "user-feedback",
+        value: 1,
+        dataType: "BOOLEAN",
+        source: "end_user",
+      }),
+    ).resolves.toBeUndefined();
     await expect(client.close()).resolves.toBeUndefined();
     await expect(client.close()).resolves.toBeUndefined();
+  });
+
+  it("exports runtime scores through the owned OTLP logs provider", async () => {
+    let resolveRequest!: (request: {
+      url: string | undefined;
+      authorization: string | undefined;
+      body: string;
+    }) => void;
+    const request = new Promise<{
+      url: string | undefined;
+      authorization: string | undefined;
+      body: string;
+    }>((resolve) => {
+      resolveRequest = resolve;
+    });
+    const server = createServer((incoming, response) => {
+      const chunks: Buffer[] = [];
+      incoming.on("data", (chunk: Buffer) => chunks.push(chunk));
+      incoming.on("end", () => {
+        resolveRequest({
+          url: incoming.url,
+          authorization: incoming.headers.authorization,
+          body: Buffer.concat(chunks).toString("utf8"),
+        });
+        response.writeHead(200, { "Content-Type": "application/json" });
+        response.end("{}");
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address() as AddressInfo;
+    const client = new LensClient({
+      baseUrl: `http://127.0.0.1:${address.port}`,
+      publicKey: "public",
+      secretKey: "secret",
+      serviceName: "score-test",
+    });
+
+    try {
+      await client.score({
+        id: "feedback-1",
+        traceId: "1234567890abcdef1234567890abcdef",
+        observationId: "1234567890abcdef",
+        name: "user-feedback",
+        value: 1,
+        dataType: "BOOLEAN",
+        source: "end_user",
+      });
+      await client.flush();
+      const exported = await request;
+
+      expect(exported.url).toBe("/api/public/otel/v1/logs");
+      expect(exported.authorization).toBe(
+        `Basic ${Buffer.from("public:secret").toString("base64")}`,
+      );
+      expect(exported.body).toContain('"eventName":"gen_ai.evaluation.result"');
+      expect(exported.body).toContain('"stringValue":"user-feedback"');
+      expect(exported.body).toContain('"stringValue":"end_user"');
+    } finally {
+      await client.close();
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
   });
 
   it("still rejects partially configured optional environments", () => {
@@ -143,6 +217,13 @@ describe("Lens eval ergonomics", () => {
     await client[Symbol.asyncDispose]();
     expect(() => client.observer()).toThrow("LensClient is closed");
     expect(() => client.pipelineObserver()).toThrow("LensClient is closed");
+    await expect(
+      client.score({
+        traceId: "1234567890abcdef1234567890abcdef",
+        name: "user-feedback",
+        value: 1,
+      }),
+    ).rejects.toThrow("LensClient is closed");
     await expect(
       observer.startRun({
         runId: "closed",

--- a/packages/observability-otel/README.md
+++ b/packages/observability-otel/README.md
@@ -122,14 +122,44 @@ Metric events include required status, score direction, threshold, and evaluator
 available. Run-finished events publish separate metric and case totals plus aggregate usage and
 optional caller-calculated cost.
 
+## Runtime scores
+
+Record trace-correlated runtime scores, including end-user feedback, without creating an eval suite:
+
+```ts
+import { createOtelScorer } from "@anvia/otel";
+
+const scorer = createOtelScorer();
+scorer.score({
+  id: feedbackId,
+  traceId,
+  observationId,
+  responseId,
+  name: "user-feedback",
+  value: liked ? 1 : 0,
+  dataType: "BOOLEAN",
+  source: "end_user",
+  comment,
+  metadata: { channel: "thumbs", userIdHash },
+});
+```
+
+The scorer emits `gen_ai.evaluation.result` through the OpenTelemetry logs API. Configure a logs
+provider/exporter or inject a `Logger`. A valid 32-character OpenTelemetry trace ID is required;
+the 16-character observation ID is optional. Comments are limited to 2,000 characters. Validate
+end-user metadata at the application boundary, and avoid sending raw personal identifiers.
+
 ## Exports
 
 - `createOtelObserver`
 - `createOtelPipelineObserver`
 - `createOtelEvalReporter`
+- `createOtelScorer`
 - `OtelObserverOptions`
 - `OtelPipelineObserverOptions`
 - `OtelEvalReporterOptions`
+- `OtelScoreArgs`
+- `OtelScorerOptions`
 
 ## Development
 

--- a/packages/observability-otel/src/eval-reporter.ts
+++ b/packages/observability-otel/src/eval-reporter.ts
@@ -6,18 +6,10 @@ import {
   projectEvalOutcome,
   resolveEvalTraceRef,
 } from "@anvia/core/evals";
-import { type Context, ROOT_CONTEXT, TraceFlags, trace } from "@opentelemetry/api";
-import {
-  type AnyValue,
-  type AnyValueMap,
-  type LogAttributes,
-  type Logger,
-  logs,
-  SeverityNumber,
-} from "@opentelemetry/api-logs";
+import type { Context } from "@opentelemetry/api";
+import { type LogAttributes, type Logger, logs, SeverityNumber } from "@opentelemetry/api-logs";
+import { addMetadata, contextFromTraceRef, EVALUATION_EVENT_NAME } from "./evaluation-logging.js";
 import type { OtelEvalReporterOptions } from "./types.js";
-
-const EVALUATION_EVENT_NAME = "gen_ai.evaluation.result";
 
 export function createOtelEvalReporter<Input = unknown, Output = unknown, Expected = unknown>(
   options: OtelEvalReporterOptions = {},
@@ -280,54 +272,7 @@ function addRunAttributes(
   if (includeMetadata) addMetadata(attributes, "anvia.eval.run.metadata", run.metadata);
 }
 
-function contextFromTraceRef(ref: EvalReportArgs<unknown, unknown>["trace"]): Context | undefined {
-  if (ref === undefined || !isValidTraceId(ref.traceId) || !isValidSpanId(ref.observationId)) {
-    return undefined;
-  }
-  return trace.setSpanContext(ROOT_CONTEXT, {
-    traceId: ref.traceId,
-    spanId: ref.observationId,
-    traceFlags: TraceFlags.SAMPLED,
-    isRemote: true,
-  });
-}
-
-function addMetadata(
-  attributes: LogAttributes,
-  key: string,
-  metadata: Record<string, unknown> | undefined,
-): void {
-  if (metadata === undefined) return;
-  attributes[key] = toAnyValue(metadata);
-}
-
-function toAnyValue(value: unknown): AnyValue {
-  if (value === null || value === undefined) return value;
-  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
-    return value;
-  }
-  if (Array.isArray(value)) return value.map(toAnyValue);
-  if (typeof value === "object") {
-    const result: AnyValueMap = {};
-    for (const [key, entry] of Object.entries(value)) result[key] = toAnyValue(entry);
-    return result;
-  }
-  return String(value);
-}
-
 function errorType(error: unknown): string {
   if (error instanceof Error && error.name.length > 0) return error.name;
   return "evaluation_invalid";
-}
-
-function isValidTraceId(value: string | undefined): value is string {
-  return (
-    value !== undefined &&
-    /^[0-9a-f]{32}$/i.test(value) &&
-    value !== "00000000000000000000000000000000"
-  );
-}
-
-function isValidSpanId(value: string | undefined): value is string {
-  return value !== undefined && /^[0-9a-f]{16}$/i.test(value) && value !== "0000000000000000";
 }

--- a/packages/observability-otel/src/evaluation-logging.ts
+++ b/packages/observability-otel/src/evaluation-logging.ts
@@ -1,0 +1,45 @@
+import { type Context, ROOT_CONTEXT, TraceFlags, trace } from "@opentelemetry/api";
+import type { AnyValue, AnyValueMap, LogAttributes } from "@opentelemetry/api-logs";
+import { isValidSpanId, isValidTraceId } from "./helpers.js";
+
+export const EVALUATION_EVENT_NAME = "gen_ai.evaluation.result";
+
+export type EvaluationTraceRef = {
+  traceId: string;
+  observationId?: string | undefined;
+};
+
+export function contextFromTraceRef(ref: EvaluationTraceRef | undefined): Context | undefined {
+  if (ref === undefined || !isValidTraceId(ref.traceId) || !isValidSpanId(ref.observationId)) {
+    return undefined;
+  }
+  return trace.setSpanContext(ROOT_CONTEXT, {
+    traceId: ref.traceId,
+    spanId: ref.observationId,
+    traceFlags: TraceFlags.SAMPLED,
+    isRemote: true,
+  });
+}
+
+export function addMetadata(
+  attributes: LogAttributes,
+  key: string,
+  metadata: Record<string, unknown> | undefined,
+): void {
+  if (metadata === undefined) return;
+  attributes[key] = toAnyValue(metadata);
+}
+
+function toAnyValue(value: unknown): AnyValue {
+  if (value === null || value === undefined) return value;
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  if (Array.isArray(value)) return value.map(toAnyValue);
+  if (typeof value === "object") {
+    const result: AnyValueMap = {};
+    for (const [key, entry] of Object.entries(value)) result[key] = toAnyValue(entry);
+    return result;
+  }
+  return String(value);
+}

--- a/packages/observability-otel/src/helpers.ts
+++ b/packages/observability-otel/src/helpers.ts
@@ -287,7 +287,7 @@ export function agentLabel(agentId: string, agentName: string | undefined): stri
   return (agentName ?? agentId).replaceAll(/\s+/g, "_");
 }
 
-function isValidTraceId(traceId: string | undefined): traceId is string {
+export function isValidTraceId(traceId: string | undefined): traceId is string {
   return (
     traceId !== undefined &&
     /^[0-9a-f]{32}$/i.test(traceId) &&
@@ -295,7 +295,7 @@ function isValidTraceId(traceId: string | undefined): traceId is string {
   );
 }
 
-function isValidSpanId(spanId: string | undefined): spanId is string {
+export function isValidSpanId(spanId: string | undefined): spanId is string {
   return spanId !== undefined && /^[0-9a-f]{16}$/i.test(spanId) && spanId !== "0000000000000000";
 }
 

--- a/packages/observability-otel/src/index.ts
+++ b/packages/observability-otel/src/index.ts
@@ -1,8 +1,15 @@
 export { createOtelEvalReporter } from "./eval-reporter.js";
 export { createOtelPipelineObserver } from "./pipeline-tracing.js";
+export { createOtelScorer } from "./scoring.js";
 export { createOtelObserver } from "./tracing.js";
 export type {
   OtelEvalReporterOptions,
   OtelObserverOptions,
   OtelPipelineObserverOptions,
+  OtelScoreArgs,
+  OtelScoreDataType,
+  OtelScoreOutcome,
+  OtelScorer,
+  OtelScorerOptions,
+  OtelScoreSource,
 } from "./types.js";

--- a/packages/observability-otel/src/scoring.ts
+++ b/packages/observability-otel/src/scoring.ts
@@ -1,0 +1,102 @@
+import { logs, SeverityNumber, type LogAttributes, type Logger } from "@opentelemetry/api-logs";
+import { addMetadata, contextFromTraceRef, EVALUATION_EVENT_NAME } from "./evaluation-logging.js";
+import { isValidSpanId, isValidTraceId } from "./helpers.js";
+import type { OtelScoreArgs, OtelScorer, OtelScorerOptions } from "./types.js";
+
+const MAX_SCORE_COMMENT_LENGTH = 2_000;
+
+export function createOtelScorer(options: OtelScorerOptions = {}): OtelScorer {
+  const logger =
+    options.logger ?? logs.getLogger(options.loggerName ?? "@anvia/otel", options.loggerVersion);
+  return {
+    score(args) {
+      validateScore(args);
+      emitScore(logger, args);
+    },
+  };
+}
+
+function emitScore(logger: Logger, args: OtelScoreArgs): void {
+  const outcome = args.outcome ?? inferOutcome(args);
+  const attributes: LogAttributes = {
+    "anvia.eval.id": args.id ?? globalThis.crypto.randomUUID(),
+    "anvia.eval.suite.name": args.suiteName ?? defaultSuiteName(args),
+    "anvia.eval.outcome": outcome,
+    "anvia.eval.target.trace_id": args.traceId,
+    "gen_ai.evaluation.name": args.name,
+    "gen_ai.evaluation.score.label": args.label ?? scoreLabel(args, outcome),
+  };
+  if (typeof args.value === "number") {
+    attributes["gen_ai.evaluation.score.value"] = args.value;
+  }
+  if (args.observationId !== undefined) {
+    attributes["anvia.eval.target.observation_id"] = args.observationId;
+  }
+  if (args.responseId !== undefined) attributes["gen_ai.response.id"] = args.responseId;
+  if (args.dataType !== undefined) attributes["anvia.eval.data_type"] = args.dataType;
+  if (args.comment !== undefined) attributes["gen_ai.evaluation.explanation"] = args.comment;
+  if (args.configId !== undefined) attributes["anvia.eval.config_id"] = args.configId;
+  if (args.source !== undefined) attributes["anvia.eval.source"] = args.source;
+  addMetadata(attributes, "anvia.eval.score.metadata", args.metadata);
+
+  const record: Parameters<Logger["emit"]>[0] = {
+    eventName: EVALUATION_EVENT_NAME,
+    severityNumber: SeverityNumber.INFO,
+    severityText: "INFO",
+    attributes,
+  };
+  const context = contextFromTraceRef(args);
+  if (context !== undefined) record.context = context;
+  logger.emit(record);
+}
+
+function validateScore(args: OtelScoreArgs): void {
+  if (!isValidTraceId(args.traceId)) {
+    throw new TypeError("OpenTelemetry score requires a valid 32-character traceId");
+  }
+  if (args.observationId !== undefined && !isValidSpanId(args.observationId)) {
+    throw new TypeError("OpenTelemetry score observationId must be a valid 16-character span ID");
+  }
+  if (args.name.trim().length === 0) {
+    throw new TypeError("OpenTelemetry score requires a non-empty name");
+  }
+  if (args.id !== undefined && args.id.trim().length === 0) {
+    throw new TypeError("OpenTelemetry score id must not be empty");
+  }
+  if (args.comment !== undefined && args.comment.length > MAX_SCORE_COMMENT_LENGTH) {
+    throw new TypeError(
+      `OpenTelemetry score comment must be at most ${MAX_SCORE_COMMENT_LENGTH} characters`,
+    );
+  }
+  if (typeof args.value === "number" && !Number.isFinite(args.value)) {
+    throw new TypeError("OpenTelemetry score value must be finite");
+  }
+  if (args.dataType === "NUMERIC" && typeof args.value !== "number") {
+    throw new TypeError("OpenTelemetry score dataType=NUMERIC requires a number value");
+  }
+  if (args.dataType === "CATEGORICAL" && typeof args.value !== "string") {
+    throw new TypeError("OpenTelemetry score dataType=CATEGORICAL requires a string value");
+  }
+  if (args.dataType === "BOOLEAN" && args.value !== 0 && args.value !== 1) {
+    throw new TypeError("OpenTelemetry score dataType=BOOLEAN requires value 0 or 1");
+  }
+}
+
+function inferOutcome(args: OtelScoreArgs): NonNullable<OtelScoreArgs["outcome"]> {
+  if (args.dataType === "BOOLEAN") return args.value === 1 ? "pass" : "fail";
+  if (typeof args.value === "string") {
+    const normalized = args.value.toLowerCase();
+    if (normalized === "pass" || normalized === "fail" || normalized === "invalid") {
+      return normalized;
+    }
+  }
+  return "unknown";
+}
+
+function scoreLabel(args: OtelScoreArgs, outcome: NonNullable<OtelScoreArgs["outcome"]>): string {
+  return typeof args.value === "string" ? args.value : outcome;
+}
+
+function defaultSuiteName(args: OtelScoreArgs): string {
+  return args.source === "end_user" ? "production-feedback" : "production-score";
+}

--- a/packages/observability-otel/src/types.ts
+++ b/packages/observability-otel/src/types.ts
@@ -1,5 +1,6 @@
 import type { Tracer } from "@opentelemetry/api";
 import type { Logger } from "@opentelemetry/api-logs";
+import type { JsonValue } from "@anvia/core/completion";
 
 export type OtelObserverOptions = {
   tracer?: Tracer | undefined;
@@ -26,4 +27,35 @@ export type OtelEvalReporterOptions = {
   transformInput?: ((value: unknown) => unknown) | undefined;
   transformOutput?: ((value: unknown) => unknown) | undefined;
   onMissingTrace?: "emit" | "ignore" | "warn" | "throw" | undefined;
+};
+
+export type OtelScoreDataType = "NUMERIC" | "CATEGORICAL" | "BOOLEAN";
+export type OtelScoreOutcome = "pass" | "fail" | "invalid" | "unknown";
+export type OtelScoreSource = "telemetry" | "end_user";
+
+export type OtelScoreArgs = {
+  id?: string | undefined;
+  traceId: string;
+  observationId?: string | undefined;
+  responseId?: string | undefined;
+  name: string;
+  value: number | string;
+  dataType?: OtelScoreDataType | undefined;
+  outcome?: OtelScoreOutcome | undefined;
+  label?: string | undefined;
+  source?: OtelScoreSource | undefined;
+  suiteName?: string | undefined;
+  comment?: string | undefined;
+  metadata?: Record<string, JsonValue | undefined> | undefined;
+  configId?: string | undefined;
+};
+
+export type OtelScorerOptions = {
+  logger?: Logger | undefined;
+  loggerName?: string | undefined;
+  loggerVersion?: string | undefined;
+};
+
+export type OtelScorer = {
+  score(args: OtelScoreArgs): void;
 };

--- a/packages/observability-otel/test/scoring.test.ts
+++ b/packages/observability-otel/test/scoring.test.ts
@@ -1,0 +1,96 @@
+import { trace } from "@opentelemetry/api";
+import { type Logger, SeverityNumber } from "@opentelemetry/api-logs";
+import { describe, expect, it, vi } from "vitest";
+import { createOtelScorer } from "../src/index";
+
+describe("OpenTelemetry scorer", () => {
+  it("emits correlated end-user feedback with stable identity and metadata", () => {
+    const emit = vi.fn<Logger["emit"]>();
+    const scorer = createOtelScorer({ logger: fakeLogger(emit) });
+    const traceId = "1234567890abcdef1234567890abcdef";
+    const observationId = "1234567890abcdef";
+
+    scorer.score({
+      id: "feedback-1",
+      traceId,
+      observationId,
+      responseId: "response-1",
+      name: "user-feedback",
+      value: 0,
+      dataType: "BOOLEAN",
+      source: "end_user",
+      comment: "The answer missed the requested detail.",
+      metadata: { channel: "thumbs", userIdHash: "sha256:abc" },
+    });
+
+    expect(emit).toHaveBeenCalledOnce();
+    const record = emit.mock.calls[0]?.[0] as Parameters<Logger["emit"]>[0];
+    expect(record).toMatchObject({
+      eventName: "gen_ai.evaluation.result",
+      severityNumber: SeverityNumber.INFO,
+      severityText: "INFO",
+      attributes: {
+        "anvia.eval.id": "feedback-1",
+        "anvia.eval.suite.name": "production-feedback",
+        "anvia.eval.outcome": "fail",
+        "anvia.eval.source": "end_user",
+        "anvia.eval.target.trace_id": traceId,
+        "anvia.eval.target.observation_id": observationId,
+        "anvia.eval.data_type": "BOOLEAN",
+        "anvia.eval.score.metadata": { channel: "thumbs", userIdHash: "sha256:abc" },
+        "gen_ai.evaluation.name": "user-feedback",
+        "gen_ai.evaluation.score.label": "fail",
+        "gen_ai.evaluation.score.value": 0,
+        "gen_ai.evaluation.explanation": "The answer missed the requested detail.",
+        "gen_ai.response.id": "response-1",
+      },
+    });
+    expect(trace.getSpanContext(record.context!)).toMatchObject({ traceId, spanId: observationId });
+  });
+
+  it("emits a trace-correlated categorical score without requiring an observation", () => {
+    const emit = vi.fn<Logger["emit"]>();
+    const scorer = createOtelScorer({ logger: fakeLogger(emit) });
+
+    scorer.score({
+      traceId: "1234567890abcdef1234567890abcdef",
+      name: "sentiment",
+      value: "positive",
+      dataType: "CATEGORICAL",
+    });
+
+    expect(emit.mock.calls[0]?.[0]).toMatchObject({
+      attributes: {
+        "anvia.eval.outcome": "unknown",
+        "gen_ai.evaluation.score.label": "positive",
+      },
+    });
+    expect(emit.mock.calls[0]?.[0].context).toBeUndefined();
+  });
+
+  it("validates correlation identifiers and typed score values", () => {
+    const scorer = createOtelScorer({ logger: fakeLogger(vi.fn()) });
+    const valid = {
+      traceId: "1234567890abcdef1234567890abcdef",
+      name: "user-feedback",
+    } as const;
+
+    expect(() => scorer.score({ ...valid, value: 2, dataType: "BOOLEAN" })).toThrow(/BOOLEAN/);
+    expect(() => scorer.score({ ...valid, value: "high", dataType: "NUMERIC" })).toThrow(/NUMERIC/);
+    expect(() => scorer.score({ ...valid, value: 1, observationId: "invalid" })).toThrow(
+      /observationId/,
+    );
+    expect(() => scorer.score({ ...valid, value: 1, traceId: "invalid" })).toThrow(/traceId/);
+    expect(() => scorer.score({ ...valid, value: Number.NaN })).toThrow(/finite/);
+    expect(() => scorer.score({ ...valid, value: 1, comment: "x".repeat(2_001) })).toThrow(
+      /at most 2000 characters/,
+    );
+  });
+});
+
+function fakeLogger(emit: Logger["emit"]): Logger {
+  return {
+    emit: (record) => emit(record),
+    enabled: () => true,
+  };
+}


### PR DESCRIPTION
## Summary

- add createOtelScorer for trace-correlated runtime evaluations with explicit end-user feedback provenance
- expose LensClient.score so applications can submit scores through the configured Lens OTLP endpoint
- share evaluation log encoding and identifier validation across scoring and eval reporting
- document both APIs and add unit plus local OTLP receiver integration coverage
- add patch changesets for @anvia/otel and @anvia/lens

## Validation

- pnpm check
- pnpm --filter @anvia/otel typecheck
- pnpm --filter @anvia/otel test
- pnpm --filter @anvia/otel build
- pnpm --filter @anvia/lens typecheck
- pnpm --filter @anvia/lens test
- pnpm --filter @anvia/lens build

All checks passed after rebasing onto origin/main.