### PR TITLE
Preserve canonical memory during compaction

### DIFF
--- a/.changeset/clean-memory-replay.md
+++ b/.changeset/clean-memory-replay.md
@@ -1,0 +1,12 @@
+---
+"@anvia/core": patch
+"@anvia/memory-sqlite": patch
+"@anvia/memory-postgres": patch
+"@anvia/memory-drizzle": patch
+"@anvia/memory-prisma": patch
+"@anvia/studio": patch
+---
+
+Preserve canonical memory messages during compaction and store the latest summary as a separate
+model-context checkpoint. Memory loads and inspection now remain fully replayable, while compacted
+model requests receive the summary plus only the unsummarized tail.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -392,9 +392,11 @@ new Agent({
 Without `session`, the same Agent is stateless. Pass `{ messages }` when the caller already owns a
 complete transcript; transcripts cannot be combined with persisted sessions.
 
-Compaction is an explicit Agent policy over a store capability. The adapter persists the summary as
-an ordinary system message with `metadata.anvia.memoryCompaction`, so `load()` and inspectors expose
-exactly what future runs receive:
+Compaction is an explicit Agent policy over a store capability. The store preserves the canonical
+message history for `load()` and inspectors, and persists one latest compaction checkpoint
+separately. Future model calls receive the checkpoint summary (a system message tagged with
+`metadata.anvia.memoryCompaction`) plus the unsummarized tail, not the individual messages already
+covered by that summary:
 
 ```ts
 import { createSummaryMemoryCompactor } from "@anvia/core/memory";
@@ -463,9 +465,10 @@ if (result.type === "compacted") {
 }
 ```
 
-The automatic trigger is a threshold, not a hard storage limit. Summary-provider retries belong to
-the compactor; full snapshot-to-replacement conflict retries are separately opt-in. A streamed
-`memory_compaction` event is emitted only after the store atomically commits the replacement.
+The automatic trigger is a threshold, not a hard storage limit. Omitting `compaction` keeps the
+full canonical history model-facing. Summary-provider retries belong to the compactor; full
+snapshot-to-checkpoint conflict retries are separately opt-in. A streamed `memory_compaction`
+event is emitted only after the store atomically commits the checkpoint.
 
 ## Structured Extraction
 

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -91,6 +91,7 @@ export interface MemoryInspector {
 export interface MemoryStore {
   readonly inspector?: MemoryInspector | undefined;
   readonly compaction?: MemoryCompactionCapability | undefined;
+  /** Loads the canonical, replayable conversation history. */
   load(options: MemoryLoadOptions): Promise<Message[]>;
   append(options: MemoryAppendOptions): Promise<void>;
   clear(options: MemoryClearOptions): Promise<void>;
@@ -113,6 +114,7 @@ export type MemoryCompactionMessage = Omit<SystemMessage, "metadata"> & {
 export type MemoryCompactionSnapshot = {
   /** Opaque store revision used to reject stale compaction replacements. */
   revision: string;
+  /** Current model-context projection: the latest summary checkpoint plus unsummarized messages. */
   messages: Message[];
 };
 
@@ -123,6 +125,7 @@ export type MemoryCompactionSnapshotOptions = {
 export type MemoryCompactionReplacePrefixOptions = {
   scope: MemoryScope;
   revision: string;
+  /** Number of projected messages covered by `replacement`, including any prior summary message. */
   messageCount: number;
   replacement: MemoryCompactionMessage;
   runId: string;
@@ -132,7 +135,12 @@ export type MemoryCompactionReplacePrefixResult = {
   status: "committed" | "conflict";
 };
 
-/** Optional atomic prefix-replacement capability used by automatic memory compaction. */
+/**
+ * Optional atomic context-projection capability used by memory compaction.
+ *
+ * Implementations must preserve canonical messages. `snapshot()` returns the current model-context
+ * projection, while `replacePrefix()` replaces only that projection's prefix with a summary.
+ */
 export interface MemoryCompactionCapability {
   snapshot(options: MemoryCompactionSnapshotOptions): Promise<MemoryCompactionSnapshot>;
   replacePrefix(

--- a/packages/core/test/memory-compaction.test.ts
+++ b/packages/core/test/memory-compaction.test.ts
@@ -12,6 +12,7 @@ import {
   isMemoryCompactionMessage,
   type MemoryAppendOptions,
   type MemoryCompactionCapability,
+  type MemoryCompactionMessage,
   MemoryCompactionConflictError,
   MemoryCompactionError,
   type MemoryCompactionReplacePrefixOptions,
@@ -86,7 +87,7 @@ class CompactingMemoryStore implements MemoryStore {
   readonly compaction: MemoryCompactionCapability = {
     snapshot: async () => ({
       revision: String(this.revision),
-      messages: [...this.messages],
+      messages: this.projectedMessages(),
     }),
     replacePrefix: async (input) => {
       this.replaceCalls.push(input);
@@ -97,18 +98,28 @@ class CompactingMemoryStore implements MemoryStore {
       if (input.revision !== String(this.revision)) {
         return { status: "conflict" };
       }
-      this.messages = [input.replacement, ...this.messages.slice(input.messageCount)];
+      const previousBoundary = this.checkpoint?.throughIndex ?? -1;
+      const physicalPrefixCount = input.messageCount - (this.checkpoint === undefined ? 0 : 1);
+      this.checkpoint = {
+        summary: input.replacement,
+        throughIndex: previousBoundary + physicalPrefixCount,
+      };
       this.revision += 1;
       this.afterCommit?.();
       return { status: "committed" };
     },
   };
   private revision = 1;
+  private checkpoint: { summary: MemoryCompactionMessage; throughIndex: number } | undefined;
+
+  private messages: MessageType[];
 
   constructor(
-    private messages: MessageType[],
+    messages: MessageType[],
     private conflictsRemaining = 0,
-  ) {}
+  ) {
+    this.messages = [...messages];
+  }
 
   async load(): Promise<MessageType[]> {
     return [...this.messages];
@@ -126,7 +137,21 @@ class CompactingMemoryStore implements MemoryStore {
   }
 
   snapshot(): MessageType[] {
+    return this.projectedMessages();
+  }
+
+  canonicalMessages(): MessageType[] {
     return [...this.messages];
+  }
+
+  private projectedMessages(): MessageType[] {
+    if (this.checkpoint === undefined) {
+      return [...this.messages];
+    }
+    return [
+      structuredClone(this.checkpoint.summary),
+      ...this.messages.slice(this.checkpoint.throughIndex + 1),
+    ];
   }
 }
 
@@ -232,6 +257,11 @@ describe("memory compaction", () => {
     expect(events).toContain("memory.compaction");
     expect(store.replaceCalls[0]).toMatchObject({ messageCount: 4 });
     expect(store.snapshot().filter(isMemoryCompactionMessage)).toHaveLength(1);
+    expect(store.canonicalMessages()).toEqual([
+      ...history,
+      Message.user("next"),
+      expect.objectContaining({ role: "assistant" }),
+    ]);
   });
 
   it("does not compact below the configured threshold", async () => {
@@ -295,9 +325,10 @@ describe("memory compaction", () => {
       Message.user("recent"),
       Message.assistant("recent answer"),
     ]);
+    const model = new QueueModel([response("done")]);
     const agent = new Agent({
       id: "test",
-      model: new QueueModel([]),
+      model,
       memory: {
         store,
         compaction: {
@@ -324,6 +355,25 @@ describe("memory compaction", () => {
       usage: Usage.empty(),
     });
     expect(store.snapshot()[0]).toSatisfy(isMemoryCompactionMessage);
+    expect(store.canonicalMessages()).toEqual([
+      Message.user("first"),
+      Message.assistant("first answer"),
+      Message.user("second"),
+      Message.assistant("second answer"),
+      Message.user("recent"),
+      Message.assistant("recent answer"),
+    ]);
+
+    await agent.generate({ prompt: "next", session: scope });
+
+    expect(model.requests[0]?.chatHistory).toEqual([
+      expect.objectContaining({ role: "system", content: "Earlier discussion." }),
+      Message.user("second"),
+      Message.assistant("second answer"),
+      Message.user("recent"),
+      Message.assistant("recent answer"),
+      Message.user("next"),
+    ]);
   });
 
   it("returns an explicit skipped result when manual compaction cannot preserve a newer turn", async () => {
@@ -785,24 +835,17 @@ describe("memory compaction", () => {
   });
 
   it("stores a cumulative compacted-message count across repeated compactions", async () => {
-    const priorCompaction = Message.system("Earlier summary.", {
-      metadata: {
-        anvia: {
-          memoryCompaction: {
-            version: 1,
-            compactedMessageCount: 4,
-          },
-        },
-      },
-    });
-    const store = new CompactingMemoryStore([
-      priorCompaction,
+    const canonical = [
+      Message.user("first"),
+      Message.assistant("first answer"),
       Message.user("middle"),
       Message.assistant("middle answer"),
       Message.user("recent"),
       Message.assistant("recent answer"),
-    ]);
-    const mainModel = new QueueModel([response("done")]);
+    ];
+    const store = new CompactingMemoryStore(canonical);
+    const mainModel = new QueueModel([response("first done"), response("second done")]);
+    let summaryNumber = 0;
     const agent = new Agent({
       id: "test",
       model: mainModel,
@@ -811,14 +854,20 @@ describe("memory compaction", () => {
         compaction: {
           trigger: { afterTokens: 5 },
           retention: { recentTokens: 1 },
-          compactor: async () => ({ summary: "Updated summary." }),
+          compactor: async () => ({ summary: `Updated summary ${++summaryNumber}.` }),
         },
       },
     });
 
-    const result = await agent.generate({ prompt: "next", session: scope });
+    const first = await agent.generate({ prompt: "next one", session: scope });
+    const second = await agent.generate({ prompt: "next two", session: scope });
 
-    expect(result.memoryCompaction).toMatchObject({
+    expect(first.memoryCompaction).toMatchObject({
+      originalMessageCount: 6,
+      compactedMessageCount: 4,
+      retainedMessageCount: 2,
+    });
+    expect(second.memoryCompaction).toMatchObject({
       originalMessageCount: 5,
       compactedMessageCount: 3,
       retainedMessageCount: 2,
@@ -834,6 +883,13 @@ describe("memory compaction", () => {
         },
       },
     });
+    expect(store.canonicalMessages()).toEqual([
+      ...canonical,
+      Message.user("next one"),
+      expect.objectContaining({ role: "assistant" }),
+      Message.user("next two"),
+      expect.objectContaining({ role: "assistant" }),
+    ]);
   });
 
   it("retries summary provider calls independently from the main agent model", async () => {

--- a/packages/memory-drizzle/README.md
+++ b/packages/memory-drizzle/README.md
@@ -76,8 +76,11 @@ Its optional read-only memory inspector lets `@anvia/studio` discover existing c
 ordered message records directly from these tables.
 
 The store exposes `compaction.snapshot({ scope })` and atomic
-`compaction.replacePrefix({ ... })`. Compaction messages remain visible as ordinary ordered system
-messages; this adapter never chooses retention, calls a model, or retries mutations.
+`compaction.replacePrefix({ ... })`. `load()` and inspection return the full canonical history;
+the snapshot projects the session's latest checkpoint summary plus its unsummarized tail for model
+context. The exported session table includes nullable `compactionState`; add the generated column
+through the application's normal migration workflow. This adapter never chooses retention, calls a
+model, or retries mutations.
 
 ## Development
 

--- a/packages/memory-drizzle/src/schema.ts
+++ b/packages/memory-drizzle/src/schema.ts
@@ -1,6 +1,13 @@
-import type { JsonObject, JsonValue, Message } from "@anvia/core";
+import type { JsonObject, JsonValue, MemoryCompactionMessage, Message } from "@anvia/core";
 import { sql } from "drizzle-orm";
 import { integer, jsonb, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+
+type MemoryCompactionStateValue = {
+  version: 1;
+  generation: number;
+  summary: MemoryCompactionMessage;
+  summarizedThroughPosition: number;
+};
 
 export const agentMemorySessions = pgTable(
   "agent_memory_sessions",
@@ -13,6 +20,7 @@ export const agentMemorySessions = pgTable(
       .$type<JsonObject>()
       .notNull()
       .default(sql`'{}'::jsonb`),
+    compactionState: jsonb("compaction_state").$type<MemoryCompactionStateValue>(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/memory-drizzle/src/store.ts
+++ b/packages/memory-drizzle/src/store.ts
@@ -1,4 +1,4 @@
-import type { JsonObject, MemoryStore, Message } from "@anvia/core";
+import type { JsonObject, MemoryCompactionMessage, MemoryStore, Message } from "@anvia/core";
 import type {
   MemoryAppendOptions,
   MemoryCompactionCapability,
@@ -12,8 +12,8 @@ import type {
   MemoryInspector,
   MemoryScope,
 } from "@anvia/core/memory";
-import { createMemoryScopeKey } from "@anvia/core/memory";
-import { asc, desc, eq, inArray, sql } from "drizzle-orm";
+import { createMemoryScopeKey, isMemoryCompactionMessage } from "@anvia/core/memory";
+import { and, asc, desc, eq, gte, sql } from "drizzle-orm";
 import { parseMemoryMessage, serializeUnknownError } from "./message.js";
 import { drizzleMemorySchema } from "./schema.js";
 import type {
@@ -57,6 +57,17 @@ type DrizzleDeleteBuilder = {
 
 type SessionRow = {
   id: string;
+};
+
+type CompactionSessionRow = SessionRow & {
+  compactionState: unknown;
+};
+
+type StoredCompactionState = {
+  version: 1;
+  generation: number;
+  summary: MemoryCompactionMessage;
+  summarizedThroughPosition: number;
 };
 
 type PositionRow = {
@@ -133,6 +144,7 @@ export class DrizzleMemoryStore implements MemoryStore {
       .select({
         sessionId: sessions.id,
         scopeKey: sessions.scopeKey,
+        compactionState: sessions.compactionState,
         messageId: messages.id,
         position: messages.position,
         message: messages.message,
@@ -225,6 +237,16 @@ export class DrizzleMemoryStore implements MemoryStore {
   private async loadCompactionSnapshot(context: MemoryScope): Promise<MemoryCompactionSnapshot> {
     const db = runtimeDatabase(this.db);
     const { agentMemorySessions: sessions, agentMemoryMessages: messages } = this.schema;
+    const sessionRows = (await db
+      .select({ id: sessions.id, compactionState: sessions.compactionState })
+      .from(sessions)
+      .where(eq(sessions.scopeKey, this.scopeKey(context)))
+      .limit(1)) as CompactionSessionRow[];
+    const session = sessionRows[0];
+    if (session === undefined) {
+      return { revision: compactionRevision([], undefined), messages: [] };
+    }
+    const state = this.compactionStateFromValue(session.compactionState);
     const rows = (await db
       .select({
         id: messages.id,
@@ -232,12 +254,18 @@ export class DrizzleMemoryStore implements MemoryStore {
         message: messages.message,
       })
       .from(messages)
-      .innerJoin(sessions, eq(messages.memorySessionId, sessions.id))
-      .where(eq(sessions.scopeKey, this.scopeKey(context)))
+      .where(
+        state === undefined
+          ? eq(messages.memorySessionId, session.id)
+          : and(
+              eq(messages.memorySessionId, session.id),
+              gte(messages.position, state.summarizedThroughPosition),
+            ),
+      )
       .orderBy(asc(messages.position))) as CompactionMessageRow[];
     return {
-      revision: compactionRevision(rows),
-      messages: rows.map((row) =>
+      revision: compactionRevision(rows, state),
+      messages: projectedMessages(rows, state, (row) =>
         this.options.validateMessages ? parseMemoryMessage(row.message) : (row.message as Message),
       ),
     };
@@ -253,6 +281,14 @@ export class DrizzleMemoryStore implements MemoryStore {
     return this.transaction(async (tx) => {
       await this.lock(tx, scopeKey);
       const { agentMemorySessions: sessions, agentMemoryMessages: messages } = this.schema;
+      const sessionRows = (await tx
+        .select({ id: sessions.id, compactionState: sessions.compactionState })
+        .from(sessions)
+        .where(eq(sessions.scopeKey, scopeKey))
+        .limit(1)) as CompactionSessionRow[];
+      const session = sessionRows[0];
+      if (session === undefined) return { status: "conflict" };
+      const state = this.compactionStateFromValue(session.compactionState);
       const rows = (await tx
         .select({
           id: messages.id,
@@ -260,30 +296,36 @@ export class DrizzleMemoryStore implements MemoryStore {
           message: messages.message,
         })
         .from(messages)
-        .innerJoin(sessions, eq(messages.memorySessionId, sessions.id))
-        .where(eq(sessions.scopeKey, scopeKey))
+        .where(
+          state === undefined
+            ? eq(messages.memorySessionId, session.id)
+            : and(
+                eq(messages.memorySessionId, session.id),
+                gte(messages.position, state.summarizedThroughPosition),
+              ),
+        )
         .orderBy(asc(messages.position))) as CompactionMessageRow[];
-      if (compactionRevision(rows) !== input.revision || input.messageCount > rows.length) {
+      const activeRows = activeCompactionRows(rows, state);
+      const physicalPrefixCount = input.messageCount - (state === undefined ? 0 : 1);
+      if (
+        compactionRevision(rows, state) !== input.revision ||
+        physicalPrefixCount < 0 ||
+        physicalPrefixCount > activeRows.length
+      ) {
         return { status: "conflict" };
       }
-      const boundary = rows[input.messageCount - 1];
-      if (boundary === undefined) {
+      const summarizedThroughPosition =
+        physicalPrefixCount === 0
+          ? state?.summarizedThroughPosition
+          : activeRows[physicalPrefixCount - 1]?.position;
+      if (summarizedThroughPosition === undefined) {
         return { status: "conflict" };
       }
-      const session = await this.upsertSession(tx, input.scope, scopeKey);
-      await tx.delete(messages).where(
-        inArray(
-          messages.id,
-          rows.slice(0, input.messageCount).map((row) => row.id),
-        ),
-      );
-      await tx.insert(messages).values({
-        memorySessionId: session.id,
-        runId: input.runId,
-        turn: 0,
-        position: boundary.position,
-        role: input.replacement.role,
-        message: input.replacement,
+      await this.upsertSession(tx, input.scope, scopeKey, {
+        version: 1,
+        generation: (state?.generation ?? 0) + 1,
+        summary: input.replacement,
+        summarizedThroughPosition,
       });
       return { status: "committed" };
     });
@@ -385,6 +427,7 @@ export class DrizzleMemoryStore implements MemoryStore {
     db: DrizzleRuntimeDatabase,
     context: MemoryScope,
     scopeKey: string,
+    compactionState?: StoredCompactionState,
   ): Promise<SessionRow> {
     const { agentMemorySessions: sessions } = this.schema;
     const rows = (await db
@@ -394,6 +437,7 @@ export class DrizzleMemoryStore implements MemoryStore {
         sessionId: context.sessionId,
         userId: context.userId ?? null,
         metadata: metadata(context),
+        ...(compactionState === undefined ? {} : { compactionState }),
       })
       .onConflictDoUpdate({
         target: sessions.scopeKey,
@@ -401,6 +445,7 @@ export class DrizzleMemoryStore implements MemoryStore {
           sessionId: context.sessionId,
           userId: context.userId ?? null,
           metadata: metadata(context),
+          ...(compactionState === undefined ? {} : { compactionState }),
           updatedAt: sql`now()`,
         },
       })
@@ -426,6 +471,13 @@ export class DrizzleMemoryStore implements MemoryStore {
         parseMemoryMessage(message);
       }
     }
+  }
+
+  private compactionStateFromValue(value: unknown): StoredCompactionState | undefined {
+    if (value === null || value === undefined) return undefined;
+    return parseCompactionState(value, (message) =>
+      this.options.validateMessages ? parseMemoryMessage(message) : (message as Message),
+    );
   }
 }
 
@@ -454,8 +506,61 @@ function metadata(context: MemoryScope): JsonObject {
   return context.metadata ?? {};
 }
 
-function compactionRevision(rows: CompactionMessageRow[]): string {
-  return JSON.stringify(rows.map((row) => row.id));
+function compactionRevision(
+  rows: CompactionMessageRow[],
+  state: StoredCompactionState | undefined,
+): string {
+  return JSON.stringify([state?.generation ?? 0, rows.map((row) => row.id)]);
+}
+
+function projectedMessages(
+  rows: CompactionMessageRow[],
+  state: StoredCompactionState | undefined,
+  message: (row: CompactionMessageRow) => Message,
+): Message[] {
+  if (state === undefined) return rows.map(message);
+  return [state.summary, ...activeCompactionRows(rows, state).map(message)];
+}
+
+function activeCompactionRows(
+  rows: CompactionMessageRow[],
+  state: StoredCompactionState | undefined,
+): CompactionMessageRow[] {
+  if (state === undefined) return rows;
+  const boundaryIndex = rows.findIndex((row) => row.position === state.summarizedThroughPosition);
+  if (boundaryIndex === -1) {
+    throw new Error("Drizzle memory compaction state boundary is invalid.");
+  }
+  return rows.slice(boundaryIndex + 1);
+}
+
+function parseCompactionState(
+  value: unknown,
+  parseMessage: (message: unknown) => Message,
+): StoredCompactionState {
+  if (typeof value !== "object" || value === null) {
+    throw new Error("Drizzle memory compaction state must be an object.");
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    record.version !== 1 ||
+    !Number.isSafeInteger(record.generation) ||
+    (record.generation as number) < 1 ||
+    !Number.isSafeInteger(record.summarizedThroughPosition) ||
+    (record.summarizedThroughPosition as number) < 0
+  ) {
+    throw new Error("Drizzle memory compaction state is invalid.");
+  }
+  const summary = parseMessage(record.summary);
+  if (!isMemoryCompactionMessage(summary)) {
+    throw new Error("Drizzle memory compaction state summary is invalid.");
+  }
+  return {
+    version: 1,
+    generation: record.generation as number,
+    summarizedThroughPosition: record.summarizedThroughPosition as number,
+    summary,
+  };
 }
 
 function assertCompactionMessageCount(value: number): void {

--- a/packages/memory-drizzle/test/store.test.ts
+++ b/packages/memory-drizzle/test/store.test.ts
@@ -194,10 +194,14 @@ describe("Drizzle memory public API", () => {
       }),
     ).resolves.toEqual({ status: "committed" });
     await expect(store.load({ scope: context })).resolves.toEqual([
-      replacement,
+      userMessage,
+      assistantMessage,
       userMessage,
       assistantMessage,
     ]);
+    await expect(store.compaction.snapshot({ scope: context })).resolves.toMatchObject({
+      messages: [replacement, userMessage, assistantMessage],
+    });
 
     const [conversation] = await store.inspector.listConversations({ limit: 1 });
     const inspected =
@@ -205,9 +209,10 @@ describe("Drizzle memory public API", () => {
         ? undefined
         : await store.inspector.getConversation({ ref: conversation.ref });
     expect(inspected).toMatchObject({
-      messageCount: 3,
+      messageCount: 4,
       messages: [
-        { position: 1, runId: "memory-compaction:2", turn: 0, message: replacement },
+        { position: 0, runId: "run-1", turn: 1, message: userMessage },
+        { position: 1, runId: "run-1", turn: 1, message: assistantMessage },
         { position: 2, runId: "run-2", turn: 1, message: userMessage },
         { position: 3, runId: "run-2", turn: 2, message: assistantMessage },
       ],
@@ -461,6 +466,7 @@ type SessionRow = {
   sessionId: string;
   userId: string | null;
   metadata: unknown;
+  compactionState: unknown;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -524,6 +530,14 @@ class FakeDrizzleDb {
   }
 
   selectRows(selection: unknown, fromTable: unknown, condition: unknown): unknown[] {
+    if (fromTable === agentMemorySessions && hasSelection(selection, "compactionState")) {
+      const scopeKey = String(extractParam(condition));
+      const session = this.sessions.get(scopeKey);
+      return session === undefined
+        ? []
+        : [{ id: session.id, compactionState: session.compactionState }];
+    }
+
     if (fromTable === agentMemorySessions && hasSelection(selection, "ref")) {
       const filter = extractParam(condition);
       const sessions = [...this.sessions.values()];
@@ -548,12 +562,11 @@ class FakeDrizzleDb {
     }
 
     if (hasSelection(selection, "id")) {
-      const scopeKey = String(extractParam(condition));
-      const session = this.sessions.get(scopeKey);
-      if (session === undefined) {
-        return [];
-      }
-      return [...(this.messages.get(session.id) ?? [])]
+      const [keyParam, boundary] = extractParams(condition);
+      const key = String(keyParam);
+      const sessionId = this.sessions.get(key)?.id ?? key;
+      return [...(this.messages.get(sessionId) ?? [])]
+        .filter((row) => boundary === undefined || row.position >= Number(boundary))
         .sort((left, right) => left.position - right.position)
         .map((row) => ({
           id: row.id,
@@ -602,6 +615,9 @@ class FakeDrizzleDb {
     const scopeKey = String(row.scopeKey);
     const existing = this.sessions.get(scopeKey);
     if (existing !== undefined) {
+      if ("compactionState" in row) {
+        existing.compactionState = row.compactionState;
+      }
       return existing;
     }
 
@@ -611,6 +627,7 @@ class FakeDrizzleDb {
       sessionId: String(row.sessionId),
       userId: row.userId === null ? null : String(row.userId),
       metadata: row.metadata,
+      compactionState: row.compactionState ?? null,
       createdAt: new Date("2026-07-17T01:00:00.000Z"),
       updatedAt: new Date("2026-07-17T01:05:00.000Z"),
     };

--- a/packages/memory-postgres/README.md
+++ b/packages/memory-postgres/README.md
@@ -31,8 +31,13 @@ compaction operations never provision resources.
 `PostgresMemoryClient` closes pools it creates. A pool or client supplied with `{ client }` remains
 caller-owned. The client also exposes `close()` and supports `await using`.
 
-The store exposes Studio inspection and atomic compaction. Compaction messages remain ordinary
-ordered system messages; the adapter never chooses retention, calls a model, or retries mutations.
+The store exposes Studio inspection and atomic compaction. `load()` and Studio inspection always
+return the full canonical message history. Compaction stores one latest checkpoint in the session
+row; `compaction.snapshot()` projects its tagged system summary plus the unsummarized tail for model
+context. The adapter never chooses retention, calls a model, or retries mutations.
+
+The session schema includes nullable `compaction_state`. `ensure()` adds the column to an existing
+managed schema; `validate()` requires it without mutating application-owned schema.
 
 Use `createPostgresMemorySchemaSql({ ... })` to include the default or customized schema in an
 application migration.

--- a/packages/memory-postgres/src/store.ts
+++ b/packages/memory-postgres/src/store.ts
@@ -1,4 +1,4 @@
-import type { JsonObject, MemoryStore, Message } from "@anvia/core";
+import type { JsonObject, MemoryCompactionMessage, MemoryStore, Message } from "@anvia/core";
 import type {
   MemoryAppendOptions,
   MemoryCompactionCapability,
@@ -12,7 +12,7 @@ import type {
   MemoryInspector,
   MemoryScope,
 } from "@anvia/core/memory";
-import { createMemoryScopeKey } from "@anvia/core/memory";
+import { createMemoryScopeKey, isMemoryCompactionMessage } from "@anvia/core/memory";
 import type { PostgresMemoryClient } from "./client.js";
 import { parseMemoryMessage, serializeUnknownError } from "./message.js";
 import type {
@@ -37,6 +37,17 @@ type ResolvedPostgresMemoryTables = {
 
 type SessionRow = {
   id: string;
+};
+
+type CompactionSessionRow = SessionRow & {
+  compaction_state: unknown;
+};
+
+type StoredCompactionState = {
+  version: 1;
+  generation: number;
+  summary: MemoryCompactionMessage;
+  summarizedThroughPosition: number;
 };
 
 type PositionRow = {
@@ -81,9 +92,13 @@ CREATE TABLE IF NOT EXISTS ${tables.sessions} (
   session_id text NOT NULL,
   user_id text,
   metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  compaction_state jsonb,
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now()
 );
+
+ALTER TABLE ${tables.sessions}
+  ADD COLUMN IF NOT EXISTS compaction_state jsonb;
 
 CREATE TABLE IF NOT EXISTS ${tables.messages} (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -231,20 +246,31 @@ export class PostgresMemoryStore implements MemoryStore {
   }
 
   private async loadCompactionSnapshot(context: MemoryScope): Promise<MemoryCompactionSnapshot> {
-    const result = await (
-      await this.client()
-    ).query(
-      `SELECT m.id, m.position, m.message
-       FROM ${this.tables.messages} m
-       INNER JOIN ${this.tables.sessions} s ON s.id = m.memory_session_id
-       WHERE s.scope_key = $1
-       ORDER BY m.position ASC`,
-      [this.scopeKey(context)],
+    const client = await this.client();
+    const scopeKey = this.scopeKey(context);
+    const sessionResult = await client.query(
+      `SELECT id, compaction_state
+       FROM ${this.tables.sessions}
+       WHERE scope_key = $1`,
+      [scopeKey],
+    );
+    const session = sessionResult.rows[0] as CompactionSessionRow | undefined;
+    if (session === undefined) {
+      return { revision: compactionRevision([], undefined), messages: [] };
+    }
+    const state = this.compactionStateFromValue(session.compaction_state);
+    const result = await client.query(
+      `SELECT id, position, message
+       FROM ${this.tables.messages}
+       WHERE memory_session_id = $1
+         ${state === undefined ? "" : "AND position >= $2"}
+       ORDER BY position ASC`,
+      state === undefined ? [session.id] : [session.id, state.summarizedThroughPosition],
     );
     const rows = result.rows as CompactionMessageRow[];
     return {
-      revision: compactionRevision(rows),
-      messages: rows.map((row) => this.messageFromValue(row.message)),
+      revision: compactionRevision(rows, state),
+      messages: projectedMessages(rows, state, (row) => this.messageFromValue(row.message)),
     };
   }
 
@@ -259,37 +285,52 @@ export class PostgresMemoryStore implements MemoryStore {
       if (this.options.lock === "advisory") {
         await tx.query("SELECT pg_advisory_xact_lock(hashtext($1))", [scopeKey]);
       }
-      const result = await tx.query(
-        `SELECT m.id, m.position, m.message
-         FROM ${this.tables.messages} m
-         INNER JOIN ${this.tables.sessions} s ON s.id = m.memory_session_id
-         WHERE s.scope_key = $1
-         ORDER BY m.position ASC`,
+      const sessionResult = await tx.query(
+        `SELECT id, compaction_state
+         FROM ${this.tables.sessions}
+         WHERE scope_key = $1`,
         [scopeKey],
       );
+      const session = sessionResult.rows[0] as CompactionSessionRow | undefined;
+      if (session === undefined) return { status: "conflict" };
+      const state = this.compactionStateFromValue(session.compaction_state);
+      const result = await tx.query(
+        `SELECT id, position, message
+         FROM ${this.tables.messages}
+         WHERE memory_session_id = $1
+           ${state === undefined ? "" : "AND position >= $2"}
+         ORDER BY position ASC`,
+        state === undefined ? [session.id] : [session.id, state.summarizedThroughPosition],
+      );
       const rows = result.rows as CompactionMessageRow[];
-      if (compactionRevision(rows) !== input.revision || input.messageCount > rows.length) {
+      const activeRows = activeCompactionRows(rows, state);
+      const physicalPrefixCount = input.messageCount - (state === undefined ? 0 : 1);
+      if (
+        compactionRevision(rows, state) !== input.revision ||
+        physicalPrefixCount < 0 ||
+        physicalPrefixCount > activeRows.length
+      ) {
         return { status: "conflict" };
       }
-      const boundary = rows[input.messageCount - 1];
-      if (boundary === undefined) {
+      const summarizedThroughPosition =
+        physicalPrefixCount === 0
+          ? state?.summarizedThroughPosition
+          : Number(activeRows[physicalPrefixCount - 1]?.position);
+      if (summarizedThroughPosition === undefined || Number.isNaN(summarizedThroughPosition)) {
         return { status: "conflict" };
       }
-      const session = await this.upsertSession(tx, input.scope, scopeKey);
-      const compactedRows = rows.slice(0, input.messageCount);
-      await tx.query(`DELETE FROM ${this.tables.messages} WHERE id = ANY($1::uuid[])`, [
-        compactedRows.map((row) => row.id),
-      ]);
-      await this.insertMessages(
-        tx,
-        session.id,
-        {
-          scope: input.scope,
-          runId: input.runId,
-          turn: 0,
-          messages: [input.replacement],
-        },
-        Number(boundary.position),
+      const nextState: StoredCompactionState = {
+        version: 1,
+        generation: (state?.generation ?? 0) + 1,
+        summary: input.replacement,
+        summarizedThroughPosition,
+      };
+      await tx.query(
+        `UPDATE ${this.tables.sessions}
+         SET compaction_state = $2::jsonb,
+             updated_at = now()
+         WHERE id = $1`,
+        [session.id, JSON.stringify(nextState)],
       );
       return { status: "committed" };
     });
@@ -473,6 +514,14 @@ export class PostgresMemoryStore implements MemoryStore {
     return this.options.validateMessages ? parseMemoryMessage(parsed) : (parsed as Message);
   }
 
+  private compactionStateFromValue(value: unknown): StoredCompactionState | undefined {
+    if (value === null || value === undefined) return undefined;
+    const parsed = typeof value === "string" ? (JSON.parse(value) as unknown) : value;
+    return parseCompactionState(parsed, (message) =>
+      this.options.validateMessages ? parseMemoryMessage(message) : (message as Message),
+    );
+  }
+
   private validateInputMessages(messages: Message[]): void {
     if (this.options.validateMessages) {
       for (const message of messages) {
@@ -495,7 +544,8 @@ export class PostgresMemoryStore implements MemoryStore {
   private async validateClient(client: PostgresMemoryClientLike): Promise<void> {
     await client.query(
       `SELECT
-         s.id, s.scope_key, s.session_id, s.user_id, s.metadata, s.created_at, s.updated_at,
+         s.id, s.scope_key, s.session_id, s.user_id, s.metadata, s.compaction_state,
+         s.created_at, s.updated_at,
          m.id, m.memory_session_id, m.run_id, m.turn, m.position, m.role, m.message, m.created_at
        FROM ${this.tables.sessions} s
        LEFT JOIN ${this.tables.messages} m ON m.memory_session_id = s.id
@@ -518,8 +568,63 @@ function resolveOptions(options: PostgresMemoryStoreOptions): ResolvedPostgresMe
   };
 }
 
-function compactionRevision(rows: CompactionMessageRow[]): string {
-  return JSON.stringify(rows.map((row) => row.id));
+function compactionRevision(
+  rows: CompactionMessageRow[],
+  state: StoredCompactionState | undefined,
+): string {
+  return JSON.stringify([state?.generation ?? 0, rows.map((row) => row.id)]);
+}
+
+function projectedMessages(
+  rows: CompactionMessageRow[],
+  state: StoredCompactionState | undefined,
+  message: (row: CompactionMessageRow) => Message,
+): Message[] {
+  if (state === undefined) return rows.map(message);
+  return [state.summary, ...activeCompactionRows(rows, state).map(message)];
+}
+
+function activeCompactionRows(
+  rows: CompactionMessageRow[],
+  state: StoredCompactionState | undefined,
+): CompactionMessageRow[] {
+  if (state === undefined) return rows;
+  const boundaryIndex = rows.findIndex(
+    (row) => Number(row.position) === state.summarizedThroughPosition,
+  );
+  if (boundaryIndex === -1) {
+    throw new Error("Postgres memory compaction state boundary is invalid.");
+  }
+  return rows.slice(boundaryIndex + 1);
+}
+
+function parseCompactionState(
+  value: unknown,
+  parseMessage: (message: unknown) => Message,
+): StoredCompactionState {
+  if (typeof value !== "object" || value === null) {
+    throw new Error("Postgres memory compaction state must be an object.");
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    record.version !== 1 ||
+    !Number.isSafeInteger(record.generation) ||
+    (record.generation as number) < 1 ||
+    !Number.isSafeInteger(record.summarizedThroughPosition) ||
+    (record.summarizedThroughPosition as number) < 0
+  ) {
+    throw new Error("Postgres memory compaction state is invalid.");
+  }
+  const summary = parseMessage(record.summary);
+  if (!isMemoryCompactionMessage(summary)) {
+    throw new Error("Postgres memory compaction state summary is invalid.");
+  }
+  return {
+    version: 1,
+    generation: record.generation as number,
+    summarizedThroughPosition: record.summarizedThroughPosition as number,
+    summary,
+  };
 }
 
 function assertCompactionMessageCount(value: number): void {

--- a/packages/memory-postgres/test/store.test.ts
+++ b/packages/memory-postgres/test/store.test.ts
@@ -48,6 +48,7 @@ type FakePgState = {
       sessionId: string;
       userId: string | null;
       metadata: unknown;
+      compactionState: unknown;
       createdAt: string;
       updatedAt: string;
     }
@@ -118,6 +119,7 @@ class FakePgClient implements PostgresMemoryClientLike {
         sessionId: values[1] as string,
         userId: values[2] as string | null,
         metadata: JSON.parse(values[3] as string) as unknown,
+        compactionState: null,
         createdAt: "2026-07-17T01:00:00.000Z",
         updatedAt: "2026-07-17T01:05:00.000Z",
       };
@@ -127,6 +129,24 @@ class FakePgClient implements PostgresMemoryClientLike {
       this.state.nextSessionId += this.state.sessions.has(scopeKey) ? 0 : 1;
       this.state.sessions.set(scopeKey, current);
       return { rows: [current] };
+    }
+
+    if (text.includes("SELECT id, compaction_state") && text.includes("memory_sessions")) {
+      const session = this.state.sessions.get(values[0] as string);
+      return {
+        rows:
+          session === undefined
+            ? []
+            : [{ id: session.id, compaction_state: session.compactionState }],
+      };
+    }
+
+    if (text.startsWith("UPDATE") && text.includes("memory_sessions")) {
+      const session = [...this.state.sessions.values()].find((item) => item.id === values[0]);
+      if (session !== undefined) {
+        session.compactionState = JSON.parse(values[1] as string) as unknown;
+      }
+      return { rows: [] };
     }
 
     if (
@@ -164,19 +184,17 @@ class FakePgClient implements PostgresMemoryClientLike {
       return { rows: [] };
     }
 
-    if (text.includes("SELECT m.id, m.position, m.message")) {
-      const session = this.state.sessions.get(values[0] as string);
+    if (text.includes("SELECT id, position, message") && text.includes("memory_messages")) {
+      const boundary = values[1];
       return {
-        rows:
-          session === undefined
-            ? []
-            : [...(this.state.messages.get(session.id) ?? [])]
-                .sort((left, right) => left.position - right.position)
-                .map((row) => ({
-                  id: row.id,
-                  position: row.position,
-                  message: row.message,
-                })),
+        rows: [...(this.state.messages.get(values[0] as string) ?? [])]
+          .filter((row) => boundary === undefined || row.position >= Number(boundary))
+          .sort((left, right) => left.position - right.position)
+          .map((row) => ({
+            id: row.id,
+            position: row.position,
+            message: row.message,
+          })),
       };
     }
 
@@ -418,10 +436,14 @@ describe("PostgresMemoryStore", () => {
       }),
     ).resolves.toEqual({ status: "committed" });
     await expect(store.load({ scope: context })).resolves.toEqual([
-      replacement,
+      userMessage,
+      assistantMessage,
       userMessage,
       assistantMessage,
     ]);
+    await expect(store.compaction.snapshot({ scope: context })).resolves.toMatchObject({
+      messages: [replacement, userMessage, assistantMessage],
+    });
 
     const [conversation] = await store.inspector.listConversations({ limit: 1 });
     const inspected =
@@ -429,9 +451,10 @@ describe("PostgresMemoryStore", () => {
         ? undefined
         : await store.inspector.getConversation({ ref: conversation.ref });
     expect(inspected).toMatchObject({
-      messageCount: 3,
+      messageCount: 4,
       messages: [
-        { position: 1, runId: "memory-compaction:2", turn: 0, message: replacement },
+        { position: 0, runId: "run-1", turn: 1, message: userMessage },
+        { position: 1, runId: "run-1", turn: 1, message: assistantMessage },
         { position: 2, runId: "run-2", turn: 1, message: userMessage },
         { position: 3, runId: "run-2", turn: 2, message: assistantMessage },
       ],
@@ -506,6 +529,7 @@ describe("PostgresMemoryStore", () => {
 
     expect(client.queries[0]).toContain("CREATE EXTENSION IF NOT EXISTS pgcrypto");
     expect(client.queries[0]).toContain('"anvia_memory_sessions"');
+    expect(client.queries[0]).toContain("ADD COLUMN IF NOT EXISTS compaction_state jsonb");
   });
 
   it("rolls back failed transactional appends", async () => {

--- a/packages/memory-prisma/README.md
+++ b/packages/memory-prisma/README.md
@@ -88,10 +88,13 @@ The store also exposes core's optional read-only memory inspector. When this age
 with `@anvia/studio`, existing Prisma conversations appear automatically on the Memory page. Studio
 does not copy the messages or require another schema migration.
 
-When the messages delegate supports `deleteMany`, the store also exposes
-`compaction.snapshot({ scope })` and atomic `compaction.replacePrefix({ ... })`. Compaction messages
-remain visible as ordinary ordered system messages. With narrower custom delegates the capability
-is absent, rather than pretending replacement is atomic.
+When the sessions delegate (including the delegate supplied inside transactions) supports
+`findUnique`, the store also exposes
+`compaction.snapshot({ scope })` and atomic `compaction.replacePrefix({ ... })`. `load()` and
+inspection return the full canonical history; the snapshot projects the session's latest checkpoint
+summary plus its unsummarized tail for model context. The generated session model includes nullable
+`compactionState`; add it through the application's normal Prisma migration workflow. With narrower
+custom delegates the capability is absent, rather than pretending checkpoint updates are atomic.
 
 ## Custom delegates
 

--- a/packages/memory-prisma/src/schema.ts
+++ b/packages/memory-prisma/src/schema.ts
@@ -10,6 +10,7 @@ export const prismaMemorySchema = `model AgentMemorySession {
   sessionId String
   userId    String?
   metadata  Json
+  compactionState Json?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 

--- a/packages/memory-prisma/src/store.ts
+++ b/packages/memory-prisma/src/store.ts
@@ -1,4 +1,4 @@
-import type { JsonObject, MemoryStore, Message } from "@anvia/core";
+import type { JsonObject, MemoryCompactionMessage, MemoryStore, Message } from "@anvia/core";
 import type {
   MemoryAppendOptions,
   MemoryCompactionCapability,
@@ -12,7 +12,7 @@ import type {
   MemoryInspector,
   MemoryScope,
 } from "@anvia/core/memory";
-import { createMemoryScopeKey } from "@anvia/core/memory";
+import { createMemoryScopeKey, isMemoryCompactionMessage } from "@anvia/core/memory";
 import { parseMemoryMessage, serializeUnknownError } from "./message.js";
 import type {
   PrismaMemoryClientLike,
@@ -52,6 +52,18 @@ type PrismaCompactionMessageRow = {
   message: unknown;
 };
 
+type PrismaCompactionSessionRow = {
+  id: string;
+  compactionState: unknown;
+};
+
+type StoredCompactionState = {
+  version: 1;
+  generation: number;
+  summary: MemoryCompactionMessage;
+  summarizedThroughPosition: number;
+};
+
 export class PrismaMemoryStore implements MemoryStore {
   readonly kind = "prisma";
   readonly inspector: MemoryInspector | undefined;
@@ -72,7 +84,7 @@ export class PrismaMemoryStore implements MemoryStore {
         }
       : undefined;
     this.compaction =
-      typeof delegates.messages.deleteMany === "function"
+      typeof delegates.sessions.findUnique === "function"
         ? {
             snapshot: ({ scope }) => this.loadCompactionSnapshot(scope),
             replacePrefix: (options) => this.replaceCompactionPrefix(options),
@@ -81,6 +93,10 @@ export class PrismaMemoryStore implements MemoryStore {
   }
 
   async validate(): Promise<void> {
+    await this.delegates.sessions.findUnique?.({
+      where: { scopeKey: "__anvia_memory_validation__" },
+      select: { id: true, compactionState: true },
+    });
     await this.delegates.messages.findMany({
       where: { memorySession: { scopeKey: "__anvia_memory_validation__" } },
       orderBy: { position: "asc" },
@@ -178,14 +194,29 @@ export class PrismaMemoryStore implements MemoryStore {
   }
 
   private async loadCompactionSnapshot(context: MemoryScope): Promise<MemoryCompactionSnapshot> {
+    const sessions = this.delegates.sessions;
+    if (sessions.findUnique === undefined) {
+      throw new Error("Prisma memory compaction requires a sessions findUnique delegate.");
+    }
+    const session = (await sessions.findUnique({
+      where: { scopeKey: this.scopeKey(context) },
+      select: { id: true, compactionState: true },
+    })) as PrismaCompactionSessionRow | null;
+    if (session === null) {
+      return { revision: compactionRevision([], undefined), messages: [] };
+    }
+    const state = this.compactionStateFromValue(session.compactionState);
     const rows = (await this.delegates.messages.findMany({
-      where: { memorySession: { scopeKey: this.scopeKey(context) } },
+      where: {
+        memorySessionId: session.id,
+        ...(state === undefined ? {} : { position: { gte: state.summarizedThroughPosition } }),
+      },
       orderBy: { position: "asc" },
       select: { id: true, memorySessionId: true, position: true, message: true },
     })) as PrismaCompactionMessageRow[];
     return {
-      revision: compactionRevision(rows),
-      messages: rows.map((row) =>
+      revision: compactionRevision(rows, state),
+      messages: projectedMessages(rows, state, (row) =>
         this.options.validateMessages ? parseMemoryMessage(row.message) : (row.message as Message),
       ),
     };
@@ -197,57 +228,51 @@ export class PrismaMemoryStore implements MemoryStore {
     this.validateInputMessages([input.replacement]);
     assertCompactionMessageCount(input.messageCount);
 
-    try {
-      return await this.delegates.transaction(async (tx) => {
-        const rows = (await tx.messages.findMany({
-          where: { memorySession: { scopeKey: this.scopeKey(input.scope) } },
-          orderBy: { position: "asc" },
-          select: { id: true, memorySessionId: true, position: true, message: true },
-        })) as PrismaCompactionMessageRow[];
-        if (compactionRevision(rows) !== input.revision || input.messageCount > rows.length) {
-          return { status: "conflict" };
-        }
-        const boundary = rows[input.messageCount - 1];
-        if (boundary === undefined) {
-          return { status: "conflict" };
-        }
-        if (tx.messages.deleteMany === undefined) {
-          throw new Error(
-            "PrismaMemoryStore transaction did not provide a messages deleteMany delegate.",
-          );
-        }
-        const deleted = await tx.messages.deleteMany({
-          where: {
-            id: {
-              in: rows.slice(0, input.messageCount).map((row) => row.id),
-            },
-          },
-        });
-        if (deleted.count !== input.messageCount) {
-          // Throw so Prisma rolls back the deleteMany before mapping to "conflict".
-          throw new MemoryCompactionConflictAbort();
-        }
-        const session = await upsertSession(tx, input.scope, this.scopeKey(input.scope));
-        await tx.messages.createMany({
-          data: [
-            {
-              memorySessionId: session.id,
-              runId: input.runId,
-              turn: 0,
-              position: boundary.position,
-              role: input.replacement.role,
-              message: input.replacement,
-            },
-          ],
-        });
-        return { status: "committed" };
-      }, compactionTransactionOptions(this.options.transaction));
-    } catch (error) {
-      if (error instanceof MemoryCompactionConflictAbort) {
+    return this.delegates.transaction(async (tx) => {
+      if (tx.sessions.findUnique === undefined) {
+        throw new Error(
+          "Prisma memory compaction requires a transactional sessions findUnique delegate.",
+        );
+      }
+      const scopeKey = this.scopeKey(input.scope);
+      const session = (await tx.sessions.findUnique({
+        where: { scopeKey },
+        select: { id: true, compactionState: true },
+      })) as PrismaCompactionSessionRow | null;
+      if (session === null) return { status: "conflict" };
+      const state = this.compactionStateFromValue(session.compactionState);
+      const rows = (await tx.messages.findMany({
+        where: {
+          memorySessionId: session.id,
+          ...(state === undefined ? {} : { position: { gte: state.summarizedThroughPosition } }),
+        },
+        orderBy: { position: "asc" },
+        select: { id: true, memorySessionId: true, position: true, message: true },
+      })) as PrismaCompactionMessageRow[];
+      const activeRows = activeCompactionRows(rows, state);
+      const physicalPrefixCount = input.messageCount - (state === undefined ? 0 : 1);
+      if (
+        compactionRevision(rows, state) !== input.revision ||
+        physicalPrefixCount < 0 ||
+        physicalPrefixCount > activeRows.length
+      ) {
         return { status: "conflict" };
       }
-      throw error;
-    }
+      const summarizedThroughPosition =
+        physicalPrefixCount === 0
+          ? state?.summarizedThroughPosition
+          : activeRows[physicalPrefixCount - 1]?.position;
+      if (summarizedThroughPosition === undefined) {
+        return { status: "conflict" };
+      }
+      await upsertSession(tx, input.scope, scopeKey, {
+        version: 1,
+        generation: (state?.generation ?? 0) + 1,
+        summary: input.replacement,
+        summarizedThroughPosition,
+      });
+      return { status: "committed" };
+    }, compactionTransactionOptions(this.options.transaction));
   }
 
   private async listConversations(
@@ -314,6 +339,13 @@ export class PrismaMemoryStore implements MemoryStore {
       }
     }
   }
+
+  private compactionStateFromValue(value: unknown): StoredCompactionState | undefined {
+    if (value === null || value === undefined) return undefined;
+    return parseCompactionState(value, (message) =>
+      this.options.validateMessages ? parseMemoryMessage(message) : (message as Message),
+    );
+  }
 }
 
 function resolveOptions(options: PrismaMemoryStoreOptions): ResolvedPrismaMemoryStoreOptions {
@@ -329,6 +361,7 @@ async function upsertSession(
   delegates: PrismaMemoryDelegates,
   context: MemoryScope,
   scopeKey: string,
+  compactionState?: StoredCompactionState,
 ): Promise<{ id: string }> {
   return delegates.sessions.upsert({
     where: { scopeKey },
@@ -336,8 +369,12 @@ async function upsertSession(
       sessionId: context.sessionId,
       userId: context.userId ?? null,
       metadata: metadata(context),
+      ...(compactionState === undefined ? {} : { compactionState }),
     },
-    create: sessionCreateData(context, scopeKey),
+    create: {
+      ...sessionCreateData(context, scopeKey),
+      ...(compactionState === undefined ? {} : { compactionState }),
+    },
     select: { id: true },
   });
 }
@@ -451,8 +488,61 @@ function hasInspectionDelegates(delegates: PrismaMemoryDelegates): boolean {
   );
 }
 
-function compactionRevision(rows: PrismaCompactionMessageRow[]): string {
-  return JSON.stringify(rows.map((row) => row.id));
+function compactionRevision(
+  rows: PrismaCompactionMessageRow[],
+  state: StoredCompactionState | undefined,
+): string {
+  return JSON.stringify([state?.generation ?? 0, rows.map((row) => row.id)]);
+}
+
+function projectedMessages(
+  rows: PrismaCompactionMessageRow[],
+  state: StoredCompactionState | undefined,
+  message: (row: PrismaCompactionMessageRow) => Message,
+): Message[] {
+  if (state === undefined) return rows.map(message);
+  return [state.summary, ...activeCompactionRows(rows, state).map(message)];
+}
+
+function activeCompactionRows(
+  rows: PrismaCompactionMessageRow[],
+  state: StoredCompactionState | undefined,
+): PrismaCompactionMessageRow[] {
+  if (state === undefined) return rows;
+  const boundaryIndex = rows.findIndex((row) => row.position === state.summarizedThroughPosition);
+  if (boundaryIndex === -1) {
+    throw new Error("Prisma memory compaction state boundary is invalid.");
+  }
+  return rows.slice(boundaryIndex + 1);
+}
+
+function parseCompactionState(
+  value: unknown,
+  parseMessage: (message: unknown) => Message,
+): StoredCompactionState {
+  if (typeof value !== "object" || value === null) {
+    throw new Error("Prisma memory compaction state must be an object.");
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    record.version !== 1 ||
+    !Number.isSafeInteger(record.generation) ||
+    (record.generation as number) < 1 ||
+    !Number.isSafeInteger(record.summarizedThroughPosition) ||
+    (record.summarizedThroughPosition as number) < 0
+  ) {
+    throw new Error("Prisma memory compaction state is invalid.");
+  }
+  const summary = parseMessage(record.summary);
+  if (!isMemoryCompactionMessage(summary)) {
+    throw new Error("Prisma memory compaction state summary is invalid.");
+  }
+  return {
+    version: 1,
+    generation: record.generation as number,
+    summarizedThroughPosition: record.summarizedThroughPosition as number,
+    summary,
+  };
 }
 
 function compactionTransactionOptions(
@@ -460,17 +550,10 @@ function compactionTransactionOptions(
 ): PrismaMemoryTransactionOptions {
   return {
     ...options,
-    // Compaction is a read/check/delete/insert sequence without advisory locks.
+    // Compaction reads messages and updates a checkpoint without advisory locks.
     // Serializable prevents concurrent commits from both passing the revision check.
     isolationLevel: "Serializable",
   };
-}
-
-class MemoryCompactionConflictAbort extends Error {
-  constructor() {
-    super("Memory compaction conflict");
-    this.name = "MemoryCompactionConflictAbort";
-  }
 }
 
 function assertCompactionMessageCount(value: number): void {

--- a/packages/memory-prisma/test/store.test.ts
+++ b/packages/memory-prisma/test/store.test.ts
@@ -26,6 +26,7 @@ type SessionRow = {
   sessionId: string;
   userId?: string | undefined;
   metadata: JsonObject;
+  compactionState?: unknown;
 };
 
 type MessageRow = {
@@ -64,12 +65,14 @@ type UpsertArgs = {
     sessionId: string;
     userId: string | null;
     metadata: JsonObject;
+    compactionState?: unknown;
   };
   create: {
     scopeKey: string;
     sessionId: string;
     userId?: string | undefined;
     metadata: JsonObject;
+    compactionState?: unknown;
   };
 };
 
@@ -78,7 +81,9 @@ type DeleteManyArgs = {
 };
 
 type FindManyArgs = {
-  where: { memorySession: { scopeKey: string } } | { memorySessionId: string };
+  where:
+    | { memorySession: { scopeKey: string } }
+    | { memorySessionId: string; position?: { gte: number } };
 };
 
 type FindFirstArgs = {
@@ -109,6 +114,9 @@ class FakePrisma {
         existing.sessionId = args.update.sessionId;
         existing.userId = args.update.userId ?? undefined;
         existing.metadata = args.update.metadata;
+        if ("compactionState" in args.update) {
+          existing.compactionState = args.update.compactionState;
+        }
         return { id: existing.id };
       }
 
@@ -120,6 +128,9 @@ class FakePrisma {
       };
       if (args.create.userId !== undefined) {
         session.userId = args.create.userId;
+      }
+      if (args.create.compactionState !== undefined) {
+        session.compactionState = args.create.compactionState;
       }
       this.nextSessionId += 1;
       this.sessions.set(args.where.scopeKey, session);
@@ -160,14 +171,18 @@ class FakePrisma {
         }));
     },
     findUnique: async (rawArgs: unknown) => {
-      const args = rawArgs as { where: { id: string } };
-      const session = [...this.sessions.values()].find((item) => item.id === args.where.id);
+      const args = rawArgs as { where: { id?: string; scopeKey?: string } };
+      const session =
+        args.where.scopeKey === undefined
+          ? [...this.sessions.values()].find((item) => item.id === args.where.id)
+          : this.sessions.get(args.where.scopeKey);
       if (session === undefined) return null;
       return {
         id: session.id,
         sessionId: session.sessionId,
         userId: session.userId ?? null,
         metadata: session.metadata,
+        compactionState: session.compactionState ?? null,
         createdAt: new Date("2026-07-17T01:00:00.000Z"),
         updatedAt: new Date("2026-07-17T01:05:00.000Z"),
         _count: {
@@ -182,9 +197,10 @@ class FakePrisma {
     findMany: async (rawArgs: unknown) => {
       const args = rawArgs as FindManyArgs;
       if ("memorySessionId" in args.where) {
-        const { memorySessionId } = args.where;
+        const { memorySessionId, position } = args.where;
         return this.messages
           .filter((message) => message.memorySessionId === memorySessionId)
+          .filter((message) => position === undefined || message.position >= position.gte)
           .sort((left, right) => left.position - right.position)
           .map((message) => ({
             id: message.id,
@@ -444,10 +460,14 @@ describe("PrismaMemoryStore", () => {
     ).resolves.toEqual({ status: "committed" });
     expect(prisma.transactionOptions.at(-1)).toEqual({ isolationLevel: "Serializable" });
     await expect(store.load({ scope: context })).resolves.toEqual([
-      replacement,
+      Message.user("old"),
+      Message.assistant("old answer"),
       Message.user("recent"),
       Message.assistant("recent answer"),
     ]);
+    await expect(compaction.snapshot({ scope: context })).resolves.toMatchObject({
+      messages: [replacement, Message.user("recent"), Message.assistant("recent answer")],
+    });
 
     const conversations = await store.inspector?.listConversations({ limit: 1 });
     const conversation = conversations?.[0];
@@ -456,9 +476,15 @@ describe("PrismaMemoryStore", () => {
         ? undefined
         : await store.inspector?.getConversation({ ref: conversation.ref });
     expect(inspected).toMatchObject({
-      messageCount: 3,
+      messageCount: 4,
       messages: [
-        { position: 1, runId: "memory-compaction:2", turn: 0, message: replacement },
+        { position: 0, runId: "run-1", turn: 1, message: Message.user("old") },
+        {
+          position: 1,
+          runId: "run-1",
+          turn: 1,
+          message: Message.assistant("old answer"),
+        },
         { position: 2, runId: "run-2", turn: 1, message: Message.user("recent") },
         {
           position: 3,
@@ -470,7 +496,7 @@ describe("PrismaMemoryStore", () => {
     });
   });
 
-  it("throws when the transaction client omits messages.deleteMany", async () => {
+  it("compacts without a messages deleteMany delegate", async () => {
     const prisma = new FakePrisma();
     const context = { sessionId: "thread-missing-delete", userId: "user-1" };
     const seed = createTestMemoryStore(prisma.client);
@@ -485,34 +511,21 @@ describe("PrismaMemoryStore", () => {
       throw new Error("Expected Prisma compaction capability");
     }
 
-    const store = createTestMemoryStoreFromDelegates({
+    let delegates: PrismaMemoryDelegates;
+    delegates = {
       sessions: prisma.agentMemorySession,
-      messages: prisma.agentMemoryMessage,
+      messages: {
+        findMany: prisma.agentMemoryMessage.findMany,
+        findFirst: prisma.agentMemoryMessage.findFirst,
+        createMany: prisma.agentMemoryMessage.createMany,
+      },
       errors: prisma.agentMemoryError,
       transaction: async (operation, options) => {
         prisma.transactionOptions.push(options);
-        return operation({
-          sessions: prisma.agentMemorySession,
-          messages: {
-            findMany: prisma.agentMemoryMessage.findMany,
-            findFirst: prisma.agentMemoryMessage.findFirst,
-            createMany: prisma.agentMemoryMessage.createMany,
-          },
-          transaction: async (nested) =>
-            nested({
-              sessions: prisma.agentMemorySession,
-              messages: {
-                findMany: prisma.agentMemoryMessage.findMany,
-                findFirst: prisma.agentMemoryMessage.findFirst,
-                createMany: prisma.agentMemoryMessage.createMany,
-              },
-              transaction: async () => {
-                throw new Error("Nested transactions are not supported.");
-              },
-            }),
-        });
+        return operation(delegates);
       },
-    });
+    };
+    const store = createTestMemoryStoreFromDelegates(delegates);
     const compaction = store.compaction;
     if (compaction === undefined) {
       throw new Error("Expected Prisma compaction capability");
@@ -526,88 +539,28 @@ describe("PrismaMemoryStore", () => {
         replacement: memoryCompactionMessage("summary", 2),
         runId: "memory-compaction:missing-delete",
       }),
-    ).rejects.toThrow("messages deleteMany delegate");
+    ).resolves.toEqual({ status: "committed" });
+    await expect(store.load({ scope: context })).resolves.toEqual([
+      Message.user("old"),
+      Message.assistant("old answer"),
+      Message.user("recent"),
+    ]);
   });
 
-  it("rolls back prefix deletes when deleteMany reports a count mismatch", async () => {
+  it("omits compaction when custom sessions cannot read checkpoint state", () => {
     const prisma = new FakePrisma();
-    const context = { sessionId: "thread-delete-mismatch", userId: "user-1" };
-    const seed = createTestMemoryStore(prisma.client);
-    await seed.append({
-      scope: context,
-      runId: "run-1",
-      turn: 1,
-      messages: [Message.user("old"), Message.assistant("old answer"), Message.user("recent")],
-    });
-    const before = await seed.load({ scope: context });
-    const snapshot = await seed.compaction?.snapshot({ scope: context });
-    if (snapshot === undefined) {
-      throw new Error("Expected Prisma compaction capability");
-    }
-
-    const store = createTestMemoryStoreFromDelegates({
-      sessions: prisma.agentMemorySession,
-      messages: {
-        ...prisma.agentMemoryMessage,
-        deleteMany: async () => ({ count: 0 }),
+    let delegates: PrismaMemoryDelegates;
+    delegates = {
+      sessions: {
+        upsert: prisma.agentMemorySession.upsert,
+        deleteMany: prisma.agentMemorySession.deleteMany,
       },
+      messages: prisma.agentMemoryMessage,
       errors: prisma.agentMemoryError,
-      transaction: async (operation, options) => {
-        prisma.transactionOptions.push(options);
-        const sessions = new Map(
-          [...prisma.sessions.entries()].map(([key, session]) => [key, { ...session }]),
-        );
-        const messages = prisma.messages.map((message) => ({ ...message }));
-        try {
-          return await operation({
-            sessions: prisma.agentMemorySession,
-            messages: {
-              findMany: prisma.agentMemoryMessage.findMany,
-              findFirst: prisma.agentMemoryMessage.findFirst,
-              createMany: prisma.agentMemoryMessage.createMany,
-              deleteMany: async () => {
-                prisma.messages.length = 0;
-                return { count: 0 };
-              },
-            },
-            errors: prisma.agentMemoryError,
-            transaction: async (nested) =>
-              nested({
-                sessions: prisma.agentMemorySession,
-                messages: prisma.agentMemoryMessage,
-                errors: prisma.agentMemoryError,
-                transaction: async () => {
-                  throw new Error("Nested transactions are not supported.");
-                },
-              }),
-          });
-        } catch (error) {
-          prisma.sessions.clear();
-          for (const [key, session] of sessions) {
-            prisma.sessions.set(key, session);
-          }
-          prisma.messages.length = 0;
-          prisma.messages.push(...messages);
-          throw error;
-        }
-      },
-    });
-    const compaction = store.compaction;
-    if (compaction === undefined) {
-      throw new Error("Expected Prisma compaction capability");
-    }
+      transaction: async (operation) => operation(delegates),
+    };
 
-    await expect(
-      compaction.replacePrefix({
-        scope: context,
-        revision: snapshot.revision,
-        messageCount: 2,
-        replacement: memoryCompactionMessage("summary", 2),
-        runId: "memory-compaction:delete-mismatch",
-      }),
-    ).resolves.toEqual({ status: "conflict" });
-    await expect(seed.load({ scope: context })).resolves.toEqual(before);
-    expect(prisma.transactionOptions.at(-1)).toEqual({ isolationLevel: "Serializable" });
+    expect(createTestMemoryStoreFromDelegates(delegates).compaction).toBeUndefined();
   });
 
   it("inspects conventional Prisma sessions when read delegates are available", async () => {

--- a/packages/memory-sqlite/README.md
+++ b/packages/memory-sqlite/README.md
@@ -38,7 +38,12 @@ caller-owned and must have SQLite foreign-key enforcement enabled; `ensure()` an
 reject incompatible injected connections. The client also supports `await using` through
 `Symbol.asyncDispose`.
 
-The store exposes Studio inspection and atomic compaction. Compaction messages remain ordinary
-ordered system messages; the adapter never chooses retention, calls a model, or retries mutations.
+The store exposes Studio inspection and atomic compaction. `load()` and Studio inspection always
+return the full canonical message history. Compaction stores one latest checkpoint in the session
+row; `compaction.snapshot()` projects its tagged system summary plus the unsummarized tail for model
+context. The adapter never chooses retention, calls a model, or retries mutations.
+
+The session schema includes nullable `compaction_state_json`. `ensure()` adds the column to an
+existing managed schema; `validate()` requires it without mutating application-owned schema.
 
 Use `createSqliteMemorySchemaSql({ ... })` when schema SQL belongs in an application migration.

--- a/packages/memory-sqlite/src/store.ts
+++ b/packages/memory-sqlite/src/store.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type { JsonObject, MemoryStore, Message } from "@anvia/core";
+import type { JsonObject, MemoryCompactionMessage, MemoryStore, Message } from "@anvia/core";
 import type {
   MemoryAppendOptions,
   MemoryCompactionCapability,
@@ -13,7 +13,7 @@ import type {
   MemoryInspector,
   MemoryScope,
 } from "@anvia/core/memory";
-import { createMemoryScopeKey } from "@anvia/core/memory";
+import { createMemoryScopeKey, isMemoryCompactionMessage } from "@anvia/core/memory";
 import { type SqliteMemoryClient, sqliteMemoryExistingClient } from "./client.js";
 import { parseMemoryMessage, serializeUnknownError } from "./message.js";
 import type {
@@ -51,6 +51,17 @@ type SqliteForeignKeysRow = {
 
 type SessionIdRow = {
   id: string;
+};
+
+type CompactionSessionRow = SessionIdRow & {
+  compaction_state_json: string | null;
+};
+
+type StoredCompactionState = {
+  version: 1;
+  generation: number;
+  summary: MemoryCompactionMessage;
+  summarizedThroughPosition: number;
 };
 
 type PositionRow = {
@@ -118,6 +129,7 @@ export class SqliteMemoryStore implements MemoryStore {
   async ensure(): Promise<void> {
     const database = await this.owner.nativeClient();
     database.exec(sqliteMemorySchemaSql(this.tables));
+    ensureCompactionStateColumn(database, this.tables.sessions);
     await this.validateDatabase(database);
   }
 
@@ -256,18 +268,22 @@ export class SqliteMemoryStore implements MemoryStore {
   }
 
   private async loadCompactionSnapshot(context: MemoryScope): Promise<MemoryCompactionSnapshot> {
-    const rows = (await this.database())
+    const database = await this.database();
+    const session = database
       .prepare(
-        `SELECT m.id, m.position, m.message_json
-         FROM ${this.tables.messages} m
-         INNER JOIN ${this.tables.sessions} s ON s.id = m.memory_session_id
-         WHERE s.scope_key = $scopeKey
-         ORDER BY m.position ASC`,
+        `SELECT id, compaction_state_json
+         FROM ${this.tables.sessions}
+         WHERE scope_key = $scopeKey`,
       )
-      .all({ $scopeKey: this.scopeKey(context) }) as CompactionMessageRow[];
+      .get({ $scopeKey: this.scopeKey(context) }) as CompactionSessionRow | undefined;
+    if (session === undefined) {
+      return { revision: compactionRevision([], undefined), messages: [] };
+    }
+    const state = this.compactionStateFromJson(session.compaction_state_json);
+    const rows = this.compactionRows(database, session.id, state);
     return {
-      revision: compactionRevision(rows),
-      messages: rows.map((row) => this.messageFromJson(row.message_json)),
+      revision: compactionRevision(rows, state),
+      messages: projectedMessages(rows, state, (row) => this.messageFromJson(row.message_json)),
     };
   }
 
@@ -281,56 +297,51 @@ export class SqliteMemoryStore implements MemoryStore {
 
     try {
       db.exec("BEGIN IMMEDIATE");
-      const rows = db
+      const session = db
         .prepare(
-          `SELECT m.id, m.position, m.message_json
-           FROM ${this.tables.messages} m
-           INNER JOIN ${this.tables.sessions} s ON s.id = m.memory_session_id
-           WHERE s.scope_key = $scopeKey
-           ORDER BY m.position ASC`,
+          `SELECT id, compaction_state_json
+           FROM ${this.tables.sessions}
+           WHERE scope_key = $scopeKey`,
         )
-        .all({ $scopeKey: scopeKey }) as CompactionMessageRow[];
-      if (compactionRevision(rows) !== input.revision || input.messageCount > rows.length) {
+        .get({ $scopeKey: scopeKey }) as CompactionSessionRow | undefined;
+      if (session === undefined) {
         db.exec("ROLLBACK");
         return { status: "conflict" };
       }
-      const boundary = rows[input.messageCount - 1];
-      if (boundary === undefined) {
+      const state = this.compactionStateFromJson(session.compaction_state_json);
+      const rows = this.compactionRows(db, session.id, state);
+      const activeRows = activeCompactionRows(rows, state);
+      const physicalPrefixCount = input.messageCount - (state === undefined ? 0 : 1);
+      if (
+        compactionRevision(rows, state) !== input.revision ||
+        physicalPrefixCount < 0 ||
+        physicalPrefixCount > activeRows.length
+      ) {
         db.exec("ROLLBACK");
         return { status: "conflict" };
       }
-      const sessionId = this.upsertSession(db, input.scope, scopeKey);
-      const deleteMessage = db.prepare(`DELETE FROM ${this.tables.messages} WHERE id = $id`);
-      for (const row of rows.slice(0, input.messageCount)) {
-        deleteMessage.run({ $id: row.id });
+      const summarizedThroughPosition =
+        physicalPrefixCount === 0
+          ? state?.summarizedThroughPosition
+          : activeRows[physicalPrefixCount - 1]?.position;
+      if (summarizedThroughPosition === undefined) {
+        db.exec("ROLLBACK");
+        return { status: "conflict" };
       }
+      const nextState: StoredCompactionState = {
+        version: 1,
+        generation: (state?.generation ?? 0) + 1,
+        summary: input.replacement,
+        summarizedThroughPosition,
+      };
       db.prepare(
-        `INSERT INTO ${this.tables.messages} (
-          id,
-          memory_session_id,
-          run_id,
-          turn,
-          position,
-          role,
-          message_json,
-          created_at
-        ) VALUES (
-          $id,
-          $memorySessionId,
-          $runId,
-          0,
-          $position,
-          $role,
-          $messageJson,
-          $now
-        )`,
+        `UPDATE ${this.tables.sessions}
+         SET compaction_state_json = $compactionStateJson,
+             updated_at = $now
+         WHERE id = $id`,
       ).run({
-        $id: randomUUID(),
-        $memorySessionId: sessionId,
-        $runId: input.runId,
-        $position: boundary.position,
-        $role: input.replacement.role,
-        $messageJson: JSON.stringify(input.replacement),
+        $id: session.id,
+        $compactionStateJson: JSON.stringify(nextState),
         $now: new Date().toISOString(),
       });
       db.exec("COMMIT");
@@ -488,6 +499,33 @@ export class SqliteMemoryStore implements MemoryStore {
     return this.options.validateMessages ? parseMemoryMessage(value) : (value as Message);
   }
 
+  private compactionStateFromJson(raw: string | null): StoredCompactionState | undefined {
+    if (raw === null) return undefined;
+    return parseCompactionState(JSON.parse(raw) as unknown, (message) =>
+      this.options.validateMessages ? parseMemoryMessage(message) : (message as Message),
+    );
+  }
+
+  private compactionRows(
+    database: SqliteMemoryDatabaseLike,
+    sessionId: string,
+    state: StoredCompactionState | undefined,
+  ): CompactionMessageRow[] {
+    const boundaryClause = state === undefined ? "" : "AND position >= $boundary";
+    const statement = database.prepare(
+      `SELECT id, position, message_json
+       FROM ${this.tables.messages}
+       WHERE memory_session_id = $memorySessionId
+         ${boundaryClause}
+       ORDER BY position ASC`,
+    );
+    return statement.all(
+      state === undefined
+        ? { $memorySessionId: sessionId }
+        : { $memorySessionId: sessionId, $boundary: state.summarizedThroughPosition },
+    ) as CompactionMessageRow[];
+  }
+
   private validateInputMessages(messages: Message[]): void {
     if (this.options.validateMessages) {
       for (const message of messages) {
@@ -516,7 +554,8 @@ export class SqliteMemoryStore implements MemoryStore {
     database
       .prepare(
         `SELECT
-           s.id, s.scope_key, s.session_id, s.user_id, s.metadata_json, s.created_at, s.updated_at,
+           s.id, s.scope_key, s.session_id, s.user_id, s.metadata_json,
+           s.compaction_state_json, s.created_at, s.updated_at,
            m.id, m.memory_session_id, m.run_id, m.turn, m.position, m.role, m.message_json, m.created_at
          FROM ${this.tables.sessions} s
          LEFT JOIN ${this.tables.messages} m ON m.memory_session_id = s.id
@@ -573,6 +612,7 @@ function sqliteMemorySchemaSql(tables: ResolvedSqliteMemoryTables): string {
   session_id TEXT NOT NULL,
   user_id TEXT,
   metadata_json TEXT NOT NULL,
+  compaction_state_json TEXT,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL
 );
@@ -631,8 +671,73 @@ function quoteIdentifier(identifier: string): string {
   return `"${identifier.replaceAll('"', '""')}"`;
 }
 
-function compactionRevision(rows: CompactionMessageRow[]): string {
-  return JSON.stringify(rows.map((row) => row.id));
+function compactionRevision(
+  rows: CompactionMessageRow[],
+  state: StoredCompactionState | undefined,
+): string {
+  return JSON.stringify([state?.generation ?? 0, rows.map((row) => row.id)]);
+}
+
+function projectedMessages(
+  rows: CompactionMessageRow[],
+  state: StoredCompactionState | undefined,
+  message: (row: CompactionMessageRow) => Message,
+): Message[] {
+  if (state === undefined) return rows.map(message);
+  return [state.summary, ...activeCompactionRows(rows, state).map(message)];
+}
+
+function activeCompactionRows(
+  rows: CompactionMessageRow[],
+  state: StoredCompactionState | undefined,
+): CompactionMessageRow[] {
+  if (state === undefined) return rows;
+  const boundaryIndex = rows.findIndex((row) => row.position === state.summarizedThroughPosition);
+  if (boundaryIndex === -1) {
+    throw new Error("Sqlite memory compaction state boundary is invalid.");
+  }
+  return rows.slice(boundaryIndex + 1);
+}
+
+function parseCompactionState(
+  value: unknown,
+  parseMessage: (message: unknown) => Message,
+): StoredCompactionState {
+  if (typeof value !== "object" || value === null) {
+    throw new Error("Sqlite memory compaction state must be an object.");
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    record.version !== 1 ||
+    !Number.isSafeInteger(record.generation) ||
+    (record.generation as number) < 1 ||
+    !Number.isSafeInteger(record.summarizedThroughPosition) ||
+    (record.summarizedThroughPosition as number) < 0
+  ) {
+    throw new Error("Sqlite memory compaction state is invalid.");
+  }
+  const summary = parseMessage(record.summary);
+  if (!isMemoryCompactionMessage(summary)) {
+    throw new Error("Sqlite memory compaction state summary is invalid.");
+  }
+  return {
+    version: 1,
+    generation: record.generation as number,
+    summarizedThroughPosition: record.summarizedThroughPosition as number,
+    summary: summary as MemoryCompactionMessage,
+  };
+}
+
+function ensureCompactionStateColumn(
+  database: SqliteMemoryDatabaseLike,
+  sessionsTable: string,
+): void {
+  const columns = database.prepare(`PRAGMA table_info(${sessionsTable})`).all() as Array<{
+    name: string;
+  }>;
+  if (!columns.some((column) => column.name === "compaction_state_json")) {
+    database.exec(`ALTER TABLE ${sessionsTable} ADD COLUMN compaction_state_json TEXT`);
+  }
 }
 
 function assertCompactionMessageCount(value: number): void {

--- a/packages/memory-sqlite/test/client.test.ts
+++ b/packages/memory-sqlite/test/client.test.ts
@@ -131,6 +131,25 @@ describe("SqliteMemoryClient", () => {
     await client.close();
   });
 
+  it("upgrades existing session tables with compaction checkpoint storage", async () => {
+    const database = new DatabaseSync(":memory:");
+    database.exec(createSqliteMemorySchemaSql().replace("  compaction_state_json TEXT,\n", ""));
+    const client = new SqliteMemoryClient({ database });
+    const store = client.memoryStore();
+
+    await expect(store.validate()).rejects.toThrow("compaction_state_json");
+    await store.ensure();
+    expect(
+      database
+        .prepare("PRAGMA table_info('anvia_memory_sessions')")
+        .all()
+        .some((column) => (column as { name: string }).name === "compaction_state_json"),
+    ).toBe(true);
+
+    await client.close();
+    database.close();
+  });
+
   it("rejects removed construction and provisioning options at compile time", () => {
     if (Date.now() === Number.NEGATIVE_INFINITY) {
       // @ts-expect-error Native stores are created by SqliteMemoryClient.

--- a/packages/memory-sqlite/test/store.test.ts
+++ b/packages/memory-sqlite/test/store.test.ts
@@ -169,10 +169,14 @@ describe("SqliteMemoryStore", () => {
       }),
     ).resolves.toEqual({ status: "committed" });
     await expect(store.load({ scope: context })).resolves.toEqual([
-      replacement,
+      userMessage,
+      assistantMessage,
       userMessage,
       assistantMessage,
     ]);
+    await expect(store.compaction.snapshot({ scope: context })).resolves.toMatchObject({
+      messages: [replacement, userMessage, assistantMessage],
+    });
 
     const [conversation] = await store.inspector.listConversations({ limit: 1 });
     const inspected =
@@ -180,13 +184,67 @@ describe("SqliteMemoryStore", () => {
         ? undefined
         : await store.inspector.getConversation({ ref: conversation.ref });
     expect(inspected).toMatchObject({
-      messageCount: 3,
+      messageCount: 4,
       messages: [
-        { position: 1, runId: "memory-compaction:2", turn: 0, message: replacement },
+        { position: 0, runId: "run-1", turn: 1, message: userMessage },
+        { position: 1, runId: "run-1", turn: 1, message: assistantMessage },
         { position: 2, runId: "run-2", turn: 1, message: userMessage },
         { position: 3, runId: "run-2", turn: 2, message: assistantMessage },
       ],
     });
+
+    await store.append({
+      scope: context,
+      runId: "run-3",
+      turn: 1,
+      messages: [userMessage, assistantMessage],
+    });
+    const repeated = await store.compaction.snapshot({ scope: context });
+    const updatedReplacement = memoryCompactionMessage("Updated conversation summary", 4);
+    await expect(
+      store.compaction.replacePrefix({
+        scope: context,
+        revision: repeated.revision,
+        messageCount: 3,
+        replacement: updatedReplacement,
+        runId: "memory-compaction:3",
+      }),
+    ).resolves.toEqual({ status: "committed" });
+    await expect(store.load({ scope: context })).resolves.toHaveLength(6);
+    await expect(store.compaction.snapshot({ scope: context })).resolves.toMatchObject({
+      messages: [updatedReplacement, userMessage, assistantMessage],
+    });
+  });
+
+  it("rejects a compaction checkpoint whose boundary is not in canonical history", async () => {
+    const store = await createTestMemoryStore();
+    const context = { sessionId: "thread-invalid-checkpoint", userId: "user-1" };
+    await store.append({
+      scope: context,
+      runId: "run-1",
+      turn: 1,
+      messages: [userMessage],
+    });
+    sqliteDatabase(store)
+      .prepare(
+        `UPDATE anvia_memory_sessions
+         SET compaction_state_json = $state
+         WHERE scope_key = $scopeKey`,
+      )
+      .run({
+        $scopeKey: createMemoryScopeKey({ scope: context }),
+        $state: JSON.stringify({
+          version: 1,
+          generation: 1,
+          summary: memoryCompactionMessage("Invalid boundary", 1),
+          summarizedThroughPosition: 999,
+        }),
+      });
+
+    await expect(store.compaction.snapshot({ scope: context })).rejects.toThrow(
+      "compaction state boundary is invalid",
+    );
+    await expect(store.load({ scope: context })).resolves.toEqual([userMessage]);
   });
 
   it("inspects persisted conversations by opaque row reference", async () => {

--- a/packages/tool-studio/src/storage/compaction-state.ts
+++ b/packages/tool-studio/src/storage/compaction-state.ts
@@ -1,0 +1,74 @@
+import { parseMessage, type Message } from "@anvia/core/completion";
+import { isMemoryCompactionMessage, type MemoryCompactionMessage } from "@anvia/core/memory";
+
+export type StoredStudioCompactionState = {
+  version: 1;
+  generation: number;
+  summary: MemoryCompactionMessage;
+  summarizedThroughPosition: number;
+};
+
+export type StudioCompactionMessageRow = {
+  position: number;
+  message: Message;
+};
+
+export function parseStudioCompactionState(
+  value: string | null,
+): StoredStudioCompactionState | undefined {
+  if (value === null) return undefined;
+  const parsed: unknown = JSON.parse(value);
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error("Stored Studio memory compaction state is invalid.");
+  }
+  const record = parsed as Record<string, unknown>;
+  let summary: Message;
+  try {
+    summary = parseMessage(record.summary);
+  } catch (cause) {
+    throw new Error("Stored Studio memory compaction state summary is invalid.", { cause });
+  }
+  if (
+    record.version !== 1 ||
+    !Number.isSafeInteger(record.generation) ||
+    (record.generation as number) < 1 ||
+    !isMemoryCompactionMessage(summary) ||
+    !Number.isSafeInteger(record.summarizedThroughPosition) ||
+    (record.summarizedThroughPosition as number) < 0
+  ) {
+    throw new Error("Stored Studio memory compaction state is invalid.");
+  }
+  return {
+    version: 1,
+    generation: record.generation as number,
+    summary,
+    summarizedThroughPosition: record.summarizedThroughPosition as number,
+  };
+}
+
+export function projectStudioCompactionMessages(
+  rows: StudioCompactionMessageRow[],
+  state: StoredStudioCompactionState | undefined,
+): Message[] {
+  if (state === undefined) return rows.map((row) => row.message);
+  return [state.summary, ...activeStudioCompactionMessages(rows, state).map((row) => row.message)];
+}
+
+export function activeStudioCompactionMessages(
+  rows: StudioCompactionMessageRow[],
+  state: StoredStudioCompactionState | undefined,
+): StudioCompactionMessageRow[] {
+  if (state === undefined) return rows;
+  const boundaryIndex = rows.findIndex((row) => row.position === state.summarizedThroughPosition);
+  if (boundaryIndex === -1) {
+    throw new Error("Stored Studio memory compaction state boundary is invalid.");
+  }
+  return rows.slice(boundaryIndex + 1);
+}
+
+export function studioCompactionRevision(
+  rows: StudioCompactionMessageRow[],
+  state: StoredStudioCompactionState | undefined,
+): string {
+  return JSON.stringify([state?.generation ?? 0, rows]);
+}

--- a/packages/tool-studio/src/storage/memory-store.ts
+++ b/packages/tool-studio/src/storage/memory-store.ts
@@ -2,6 +2,7 @@ import type { JsonObject, JsonValue, Message } from "@anvia/core/completion";
 import type {
   MemoryAppendOptions,
   MemoryCompactionCapability,
+  MemoryCompactionMessage,
   MemoryCompactionReplacePrefixOptions,
   MemoryErrorOptions,
   MemoryScope,
@@ -36,8 +37,16 @@ import type {
 
 type MemorySessionRecord = StudioSessionSummary & {
   messages: Message[];
+  compactionState?: StudioCompactionState | undefined;
+  storeRevision: number;
   runs: Array<StudioSessionRunTranscriptInput & { createdAt: string; updatedAt: string }>;
   logs: StudioSessionLogEntry[];
+};
+
+type StudioCompactionState = {
+  generation: number;
+  summary: MemoryCompactionMessage;
+  summarizedThroughPosition: number;
 };
 
 export function createInMemoryStudioStore(): StudioSessionStore &
@@ -53,10 +62,11 @@ class InMemoryStudioStore
   readonly kind = "memory";
   readonly compaction: MemoryCompactionCapability = {
     snapshot: ({ scope }) => {
-      const messages = this.sessions.get(scope.sessionId)?.messages ?? [];
+      const session = this.sessions.get(scope.sessionId);
+      const messages = session?.messages ?? [];
       return Promise.resolve({
-        revision: memoryRevision(messages),
-        messages: cloneMessages(messages),
+        revision: String(session?.storeRevision ?? 0),
+        messages: projectedMessages(messages, session?.compactionState),
       });
     },
     replacePrefix: (options) => this.replaceCompactionPrefix(options),
@@ -83,6 +93,7 @@ class InMemoryStudioStore
       updatedAt: now,
       messageCount: 0,
       messages: [],
+      storeRevision: 0,
       runs: [],
       logs: [],
     };
@@ -119,6 +130,7 @@ class InMemoryStudioStore
     const session = this.sessions.get(input.scope.sessionId);
     if (session !== undefined) {
       session.messages.push(...cloneMessages(input.messages));
+      session.storeRevision += 1;
       session.messageCount = session.messages.length;
       session.updatedAt = new Date().toISOString();
     }
@@ -129,6 +141,8 @@ class InMemoryStudioStore
     const session = this.sessions.get(scope.sessionId);
     if (session !== undefined) {
       session.messages = [];
+      delete session.compactionState;
+      session.storeRevision += 1;
       session.runs = [];
       session.messageCount = 0;
       session.updatedAt = new Date().toISOString();
@@ -153,15 +167,23 @@ class InMemoryStudioStore
       throw new RangeError("messageCount must be a positive integer.");
     }
     const session = this.sessions.get(input.scope.sessionId);
-    if (
-      session === undefined ||
-      memoryRevision(session.messages) !== input.revision ||
-      input.messageCount > session.messages.length
-    ) {
+    if (session === undefined || String(session.storeRevision) !== input.revision) {
       return Promise.resolve({ status: "conflict" });
     }
-    session.messages.splice(0, input.messageCount, structuredClone(input.replacement));
-    session.messageCount = session.messages.length;
+    const physicalPrefixCount =
+      input.messageCount - (session.compactionState === undefined ? 0 : 1);
+    const activeMessageCount =
+      session.messages.length - (session.compactionState?.summarizedThroughPosition ?? -1) - 1;
+    if (physicalPrefixCount < 0 || physicalPrefixCount > activeMessageCount) {
+      return Promise.resolve({ status: "conflict" });
+    }
+    session.compactionState = {
+      generation: (session.compactionState?.generation ?? 0) + 1,
+      summary: structuredClone(input.replacement),
+      summarizedThroughPosition:
+        (session.compactionState?.summarizedThroughPosition ?? -1) + physicalPrefixCount,
+    };
+    session.storeRevision += 1;
     session.updatedAt = new Date().toISOString();
     return Promise.resolve({ status: "committed" });
   }
@@ -342,8 +364,15 @@ function studioRunId(scope: MemoryScope): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
-function memoryRevision(messages: Message[]): string {
-  return JSON.stringify(messages);
+function projectedMessages(
+  messages: Message[],
+  state: StudioCompactionState | undefined,
+): Message[] {
+  if (state === undefined) return cloneMessages(messages);
+  return [
+    structuredClone(state.summary),
+    ...cloneMessages(messages.slice(state.summarizedThroughPosition + 1)),
+  ];
 }
 
 function serializeJsonError(error: unknown): JsonValue {

--- a/packages/tool-studio/src/storage/sqlite-store.ts
+++ b/packages/tool-studio/src/storage/sqlite-store.ts
@@ -10,6 +10,14 @@ import type {
   MemoryErrorOptions,
   MemoryScope,
 } from "@anvia/core/memory";
+import {
+  activeStudioCompactionMessages,
+  parseStudioCompactionState,
+  projectStudioCompactionMessages,
+  studioCompactionRevision,
+  type StoredStudioCompactionState,
+  type StudioCompactionMessageRow,
+} from "./compaction-state";
 import { renumberTranscript, transcriptFromMessages } from "../runtime/transcript";
 import type {
   StudioPipelineLogAppendInput,
@@ -53,6 +61,11 @@ type SessionRow = {
   metadata_json: string | null;
   created_at: string;
   updated_at: string;
+};
+
+type CompactionSessionRow = {
+  id: string;
+  compaction_state_json: string | null;
 };
 
 type SessionSummaryRow = SessionRow & {
@@ -164,8 +177,13 @@ class SqliteSessionStore
   readonly kind = "sqlite";
   readonly compaction: MemoryCompactionCapability = {
     snapshot: ({ scope }) => {
-      const messages = this.listSessionMessages(scope.sessionId);
-      return Promise.resolve({ revision: memoryRevision(messages), messages });
+      const session = this.getCompactionSessionRow(scope.sessionId);
+      const state = parseStudioCompactionState(session?.compaction_state_json ?? null);
+      const rows = this.listCompactionMessages(scope.sessionId, state);
+      return Promise.resolve({
+        revision: studioCompactionRevision(rows, state),
+        messages: projectStudioCompactionMessages(rows, state),
+      });
     },
     replacePrefix: (options) => this.replaceCompactionPrefix(options),
   };
@@ -309,7 +327,8 @@ class SqliteSessionStore
       db.exec("BEGIN IMMEDIATE");
       db.prepare(
         `UPDATE anvia_studio_sessions
-         SET updated_at = $updatedAt
+         SET compaction_state_json = NULL,
+             updated_at = $updatedAt
          WHERE id = $id`,
       ).run({
         $id: scope.sessionId,
@@ -357,30 +376,44 @@ class SqliteSessionStore
     const db = this.database();
     try {
       db.exec("BEGIN IMMEDIATE");
-      const messages = this.listSessionMessages(input.scope.sessionId);
-      if (
-        memoryRevision(messages) !== input.revision ||
-        input.messageCount > messages.length ||
-        this.getSessionRow(input.scope.sessionId) === undefined
-      ) {
+      const session = this.getCompactionSessionRow(input.scope.sessionId);
+      const state = parseStudioCompactionState(session?.compaction_state_json ?? null);
+      const rows = this.listCompactionMessages(input.scope.sessionId, state);
+      if (session === undefined || studioCompactionRevision(rows, state) !== input.revision) {
         db.exec("ROLLBACK");
         return Promise.resolve({ status: "conflict" });
       }
-      db.prepare("DELETE FROM anvia_studio_session_messages WHERE session_id = $id").run({
-        $id: input.scope.sessionId,
-      });
+      const physicalPrefixCount = input.messageCount - (state === undefined ? 0 : 1);
+      const activeRows = activeStudioCompactionMessages(rows, state);
+      if (physicalPrefixCount < 0 || physicalPrefixCount > activeRows.length) {
+        db.exec("ROLLBACK");
+        return Promise.resolve({ status: "conflict" });
+      }
+      const summarizedThroughPosition =
+        physicalPrefixCount === 0
+          ? state?.summarizedThroughPosition
+          : activeRows[physicalPrefixCount - 1]?.position;
+      if (summarizedThroughPosition === undefined) {
+        db.exec("ROLLBACK");
+        return Promise.resolve({ status: "conflict" });
+      }
+      const nextState: StoredStudioCompactionState = {
+        version: 1,
+        generation: (state?.generation ?? 0) + 1,
+        summary: input.replacement,
+        summarizedThroughPosition,
+      };
       const updatedAt = new Date().toISOString();
-      this.insertMessages(
-        input.scope.sessionId,
-        [input.replacement, ...messages.slice(input.messageCount)],
-        0,
-        updatedAt,
-      );
       db.prepare(
         `UPDATE anvia_studio_sessions
-         SET updated_at = $updatedAt
+         SET compaction_state_json = $compactionState,
+             updated_at = $updatedAt
          WHERE id = $id`,
-      ).run({ $id: input.scope.sessionId, $updatedAt: updatedAt });
+      ).run({
+        $id: input.scope.sessionId,
+        $compactionState: JSON.stringify(nextState),
+        $updatedAt: updatedAt,
+      });
       db.exec("COMMIT");
       return Promise.resolve({ status: "committed" });
     } catch (error) {
@@ -937,6 +970,7 @@ class SqliteSessionStore
         agent_id TEXT NOT NULL,
         title TEXT,
         metadata_json TEXT,
+        compaction_state_json TEXT,
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL
       ) STRICT;
@@ -1042,6 +1076,7 @@ class SqliteSessionStore
       CREATE INDEX IF NOT EXISTS anvia_studio_traces_session_started_idx
         ON anvia_studio_traces(session_id, started_at DESC);
     `);
+    ensureSessionCompactionStateColumn(db);
     ensureMessageMetadataColumn(db);
 
     this.db = db;
@@ -1056,6 +1091,16 @@ class SqliteSessionStore
          WHERE id = $id`,
       )
       .get({ $id: id }) as SessionRow | undefined;
+  }
+
+  private getCompactionSessionRow(id: string): CompactionSessionRow | undefined {
+    return this.database()
+      .prepare(
+        `SELECT id, compaction_state_json
+         FROM anvia_studio_sessions
+         WHERE id = $id`,
+      )
+      .get({ $id: id }) as CompactionSessionRow | undefined;
   }
 
   private getSessionRun(sessionId: string, runId: string): SessionRunRow | undefined {
@@ -1102,15 +1147,35 @@ class SqliteSessionStore
   }
 
   private listSessionMessages(sessionId: string): Message[] {
+    return this.listSessionMessageEntries(sessionId).map((entry) => entry.message);
+  }
+
+  private listCompactionMessages(
+    sessionId: string,
+    state: StoredStudioCompactionState | undefined,
+  ): StudioCompactionMessageRow[] {
+    return this.listSessionMessageEntries(sessionId, state?.summarizedThroughPosition);
+  }
+
+  private listSessionMessageEntries(
+    sessionId: string,
+    minimumIndex?: number,
+  ): StudioCompactionMessageRow[] {
     const db = this.database();
+    const boundaryClause = minimumIndex === undefined ? "" : "AND message_index >= $minimumIndex";
+    const parameters =
+      minimumIndex === undefined
+        ? { $sessionId: sessionId }
+        : { $sessionId: sessionId, $minimumIndex: minimumIndex };
     const messageRows = db
       .prepare(
         `SELECT session_id, message_index, role, message_id, metadata_json, created_at
          FROM anvia_studio_session_messages
          WHERE session_id = $sessionId
+           ${boundaryClause}
          ORDER BY message_index ASC`,
       )
-      .all({ $sessionId: sessionId }) as MessageRow[];
+      .all(parameters) as MessageRow[];
 
     if (messageRows.length === 0) {
       return [];
@@ -1121,9 +1186,10 @@ class SqliteSessionStore
         `SELECT session_id, message_index, part_index, type, part_json
          FROM anvia_studio_session_message_parts
          WHERE session_id = $sessionId
+           ${boundaryClause}
          ORDER BY message_index ASC, part_index ASC`,
       )
-      .all({ $sessionId: sessionId }) as MessagePartRow[];
+      .all(parameters) as MessagePartRow[];
     const partsByMessage = new Map<number, MessagePartRow[]>();
     for (const partRow of partRows) {
       const parts = partsByMessage.get(partRow.message_index) ?? [];
@@ -1131,9 +1197,10 @@ class SqliteSessionStore
       partsByMessage.set(partRow.message_index, parts);
     }
 
-    return messageRows.map((row) =>
-      messageFromRows(row, partsByMessage.get(row.message_index) ?? []),
-    );
+    return messageRows.map((row) => ({
+      position: row.message_index,
+      message: messageFromRows(row, partsByMessage.get(row.message_index) ?? []),
+    }));
   }
 
   private nextMessageIndex(sessionId: string): number {
@@ -1380,6 +1447,13 @@ function ensureMessageMetadataColumn(db: DatabaseSyncType): void {
   }
 }
 
+function ensureSessionCompactionStateColumn(db: DatabaseSyncType): void {
+  const columns = db.prepare("PRAGMA table_info('anvia_studio_sessions')").all() as TableInfoRow[];
+  if (!columns.some((column) => column.name === "compaction_state_json")) {
+    db.exec("ALTER TABLE anvia_studio_sessions ADD COLUMN compaction_state_json TEXT");
+  }
+}
+
 function loadDatabaseSync(): DatabaseSyncConstructor {
   if (DatabaseSync !== undefined) {
     return DatabaseSync;
@@ -1448,10 +1522,6 @@ function parseJsonValue<T>(value: string | null): T | undefined {
 function studioRunId(scope: MemoryScope): string | undefined {
   const value = scope.metadata?.studioRunId;
   return typeof value === "string" && value.length > 0 ? value : undefined;
-}
-
-function memoryRevision(messages: Message[]): string {
-  return JSON.stringify(messages);
 }
 
 function serializeJsonError(error: unknown): JsonValue {

--- a/packages/tool-studio/test/runner.test.ts
+++ b/packages/tool-studio/test/runner.test.ts
@@ -3318,6 +3318,14 @@ describe("Anvia studio", () => {
     );
 
     await expect(store.load({ scope: { sessionId: "compaction-session" } })).resolves.toEqual([
+      Message.user("first"),
+      Message.assistant("first answer"),
+      Message.user("recent"),
+      Message.assistant("recent answer"),
+      Message.user("next"),
+      expect.objectContaining(Message.assistant("done")),
+    ]);
+    expect(model.requests[0]?.chatHistory).toEqual([
       expect.objectContaining({
         role: "system",
         content: "Earlier discussion.",
@@ -3330,7 +3338,6 @@ describe("Anvia studio", () => {
       Message.user("recent"),
       Message.assistant("recent answer"),
       Message.user("next"),
-      expect.objectContaining(Message.assistant("done")),
     ]);
     const logs = await runner.fetch(
       new Request("http://runner.test/sessions/compaction-session/logs"),
@@ -3396,7 +3403,8 @@ describe("Anvia studio", () => {
     await expect(
       store.load({ scope: { sessionId: "failed-compaction-session" } }),
     ).resolves.toEqual([
-      expect.objectContaining({ role: "system", content: "Earlier discussion." }),
+      Message.user("first"),
+      Message.assistant("first answer"),
       Message.user("recent"),
       Message.assistant("recent answer"),
       Message.user("next"),
@@ -4524,6 +4532,12 @@ describe("Anvia studio", () => {
         runId: "compaction_1",
       }),
     ).resolves.toEqual({ status: "committed" });
+    await expect(store.load({ scope: { sessionId: "session_1" } })).resolves.toEqual([
+      Message.user([{ type: "text", text: "original" }]),
+    ]);
+    await expect(
+      store.compaction.snapshot({ scope: { sessionId: "session_1" } }),
+    ).resolves.toMatchObject({ messages: [replacement] });
   });
 
   it("uses the SQLite session store as a core memory store", async () => {
@@ -4598,7 +4612,7 @@ describe("Anvia studio", () => {
     });
   });
 
-  it("atomically replaces SQLite memory prefixes and exposes compaction messages", async () => {
+  it("atomically checkpoints SQLite memory prefixes without replacing canonical messages", async () => {
     const store = createSqliteSessionStore({ path: ":memory:" });
     store.createSession({ id: "session_1", agentId: "support" });
     const retained = [
@@ -4645,13 +4659,42 @@ describe("Anvia studio", () => {
       }),
     ).resolves.toEqual({ status: "conflict" });
     await expect(store.load({ scope: { sessionId: "session_1" } })).resolves.toEqual([
-      replacement,
+      Message.user([{ type: "text", text: "old" }]),
+      Message.assistant("old answer"),
       ...retained,
     ]);
     expect(await store.getSession("session_1")).toMatchObject({
-      messageCount: 3,
-      messages: [replacement, ...retained],
+      messageCount: 4,
+      messages: [
+        Message.user([{ type: "text", text: "old" }]),
+        Message.assistant("old answer"),
+        ...retained,
+      ],
     });
+    await expect(
+      store.compaction.snapshot({ scope: { sessionId: "session_1" } }),
+    ).resolves.toMatchObject({ messages: [replacement, ...retained] });
+
+    await store.append({
+      scope: { sessionId: "session_1" },
+      runId: "run_2",
+      turn: 1,
+      messages: [Message.user("after compaction")],
+    });
+    await expect(
+      store.compaction.snapshot({ scope: { sessionId: "session_1" } }),
+    ).resolves.toMatchObject({
+      messages: [
+        replacement,
+        ...retained,
+        Message.user([{ type: "text", text: "after compaction" }]),
+      ],
+    });
+
+    await store.clear({ scope: { sessionId: "session_1" } });
+    await expect(
+      store.compaction.snapshot({ scope: { sessionId: "session_1" } }),
+    ).resolves.toMatchObject({ messages: [] });
   });
 
   it("rejects non-JSON message metadata in the SQLite session store", async () => {
@@ -4834,6 +4877,10 @@ describe("Anvia studio", () => {
       .prepare("PRAGMA table_info('anvia_studio_session_messages')")
       .all() as Array<{ name: string }>;
     expect(columns.map((column) => column.name)).toContain("metadata_json");
+    const sessionColumns = migrated
+      .prepare("PRAGMA table_info('anvia_studio_sessions')")
+      .all() as Array<{ name: string }>;
+    expect(sessionColumns.map((column) => column.name)).toContain("compaction_state_json");
     migrated.close();
   });
 


### PR DESCRIPTION
## Summary

- preserve canonical conversation messages during memory compaction
- store the latest summary as a separate checkpoint and project model history as summary plus unsummarized tail
- support repeated compactions without losing replayable history
- add additive checkpoint persistence for SQLite, Postgres, Drizzle, Prisma, and Studio stores
- validate persisted checkpoint summaries and boundaries
- avoid loading already-summarized history after a checkpoint exists
- document the behavior and add a patch changeset

## Validation

- pnpm check
- typecheck: core, memory-sqlite, memory-postgres, memory-drizzle, memory-prisma, studio
- build: core, memory-sqlite, memory-postgres, memory-drizzle, memory-prisma, studio
- tests: 935 passing across 77 affected test files
- git diff --check

## Notes

Canonical load and inspector APIs continue to return complete replayable history. Only the model-facing compaction snapshot uses the summary checkpoint plus unsummarized tail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compaction now preserves the complete canonical message history.
  * Model snapshots use the latest summary checkpoint together with the unsummarized message tail.
  * Memory adapters persist compaction checkpoints for reliable loading, inspection, and repeated compaction.
  * Existing managed SQLite schemas are upgraded automatically with the required compaction state.

* **Documentation**
  * Updated memory adapter documentation to explain canonical history, checkpoint snapshots, schema changes, and inspection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->