### PR TITLE
Improve core evaluation developer experience

### DIFF
--- a/.changeset/calm-evals-improve.md
+++ b/.changeset/calm-evals-improve.md
@@ -1,0 +1,8 @@
+---
+"@anvia/core": patch
+---
+
+Improve evaluation developer experience with structural exact matching, explicit target status,
+structured invalid errors, per-case timing/usage/cost diagnostics, typed case requirements and CI
+expectations, safe result formatting, progress events, timeouts, abort signals, independent target
+and metric concurrency, filtering, sharding, fail-fast execution, and rerun case selection.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -649,6 +649,158 @@ Import `McpClient` and `McpClientGroup` from `@anvia/mcp`, connect them, and pas
 `servers` to `new Agent({ mcpServers })`. See the `@anvia/mcp` README for transport configuration,
 connection ownership, URL safety, and cleanup.
 
+## Evaluations
+
+Import evaluation APIs from `@anvia/core/evals`. A suite contains cases, a target, and one or more
+metrics. Required metric failures make a case fail; infrastructure or evaluation errors produce an
+`invalid` outcome.
+
+```ts
+import { contains, exactMatch, runEvalSuite } from "@anvia/core/evals";
+
+const result = await runEvalSuite({
+  name: "support answers",
+  cases: [
+    {
+      id: "refund-window",
+      input: "When can I request a refund?",
+      expected: "Refunds are available for 30 days.",
+    },
+  ],
+  target: async (input) => answerSupportQuestion(input),
+  metrics: [exactMatch(), contains({ expected: "30 days" })],
+});
+
+console.log(result.cases);
+console.log(result.results[0]?.scores.exact_match);
+```
+
+`runEvalSuite` infers the case input, target output, expected value, metric names, and score types.
+Metrics that implicitly read `case.expected`, `case.context`, or `case.retrievalContext` require
+those fields at compile time. Supplying an explicit metric value or selector removes the matching
+case requirement.
+
+### Built-in metrics
+
+Deterministic metrics do not call a model:
+
+- `exactMatch`, `contains`, `notContains`, `containsAll`, and `containsAny`
+- `matches`, `doesNotMatch`, `maxLength`, and `requiredFields`
+- `semanticSimilarity`, which uses an embedding model
+
+Judge metrics call a completion model and record their evaluation token usage:
+
+- `llmJudge` and `llmScore`
+- `answerRelevancy`, `promptAlignment`, `jsonCorrectness`, and `summarization`
+- `hallucination`, `faithfulness`, and `abstention`
+- `gEval`, `turnRelevancy`, and `knowledgeRetention`
+
+Numeric thresholds use values from `0` through `1`. `strictMode` requires a perfect higher-is-better
+score or a zero lower-is-better score. Judge metrics default to including a final explanation;
+setting `includeReason: false` saves that extra judge call when the explanation is unnecessary.
+
+### Typed custom metrics
+
+Use `createEvalTypes` to bind input, output, and expected types once when defining multiple custom
+metrics:
+
+```ts
+import { createEvalTypes, EvalOutcome } from "@anvia/core/evals";
+
+const supportEvals = createEvalTypes<string, { answer: string }, string>();
+
+const noHandoff = supportEvals.defineMetric({
+  name: "no_handoff",
+  dataType: "BOOLEAN",
+  evaluate: ({ output, signal }) =>
+    signal.aborted || output.answer.includes("contact support")
+      ? EvalOutcome.fail(false)
+      : EvalOutcome.pass(true),
+});
+```
+
+Custom metrics return `EvalOutcome.pass`, `EvalOutcome.fail`, or `EvalOutcome.invalid`. Thrown metric
+errors are converted to structured invalid outcomes containing the error kind and original error.
+
+### Execution controls
+
+Evaluation targets receive an optional third argument containing the case `AbortSignal`.
+
+```ts
+const result = await runEvalSuite({
+  // cases, target, and metrics...
+  name: "release gate",
+  cases,
+  target: async (input, testCase, context) =>
+    generateAnswer(input, { signal: context?.signal, metadata: testCase.metadata }),
+  metrics,
+  targetConcurrency: 4,
+  metricConcurrency: 2,
+  caseTimeoutMs: 30_000,
+  signal: deploymentSignal,
+  failFast: true,
+  caseIds: ["refund-window", "billing-owner"],
+  shard: { index: 0, count: 4 },
+  onProgress(event) {
+    console.log(event.type);
+  },
+});
+```
+
+- `concurrency` remains the shorthand for both target and metric concurrency.
+- `targetConcurrency` and `metricConcurrency` can limit them independently.
+- `caseTimeoutMs` covers the target and its metrics. Cooperative targets and metrics should observe
+  the supplied signal; the runner still stops awaiting work that ignores it.
+- Aborting the suite-level `signal` stops scheduling cases and rejects the run with the abort reason.
+- `caseIds`, `caseFilter`, and `shard` select cases before execution.
+- `failFast` throws `EvalFailFastError` after the first completed required failure or invalid case.
+- `onProgress` receives case, target, metric, and case-completion events.
+
+Use `selectEvalCaseIds(previousResult)` to select failed and invalid cases for a rerun.
+
+### Results, usage, and failures
+
+Every case result includes `targetStatus`, target and total durations, per-case usage and optional
+cost. Every metric result includes its duration, optional cost, outcome, and reporter errors. A
+successful target that returns `undefined` has `targetStatus: "succeeded"` and retains its `output`
+property, so it is distinct from a failed target.
+
+The suite aggregates metric totals, case totals, target and evaluation usage, costs, duration, and
+all reporter errors. Invalid outcomes may include these `kind` values: `target`, `metric`,
+`configuration`, `provider`, or `timeout`.
+
+### CI output and expectations
+
+`runEvalCli` prints a result and can set `process.exitCode`. Exit code `1` means a required metric
+failed; `2` means a required metric was invalid. Use `defineEvalExpectations` with a defined suite to
+type-check case and metric names.
+
+```ts
+import { defineEvalExpectations, defineEvalSuite, exactMatch, runEvalCli } from "@anvia/core/evals";
+
+const suite = defineEvalSuite({
+  name: "release gate",
+  cases: [{ id: "refund", input: "refund", expected: "30 days" }],
+  target: async () => "30 days",
+  metrics: [exactMatch({ name: "correct" })],
+});
+
+await runEvalCli({
+  ...suite,
+  expectations: defineEvalExpectations(suite, {
+    outcomes: { refund: { correct: "pass" } },
+  }),
+  exitCode: true,
+  maxValueLength: 2_000,
+  redact: (value, context) => (context.kind === "input" ? "[redacted]" : value),
+});
+```
+
+Use `formatEvalResult` for pure pretty or JSON formatting without writing to stdout. Both
+`formatEvalResult` and `runEvalCli` support value truncation and redaction. JSON output otherwise
+contains cases, outputs, metadata, and error details, so redact sensitive data before writing it to
+shared CI logs.
+
 ## Public Areas
 
 - `agent`: typed Agent runtime, retries, and stream events

--- a/packages/core/src/evals/advanced-metrics.ts
+++ b/packages/core/src/evals/advanced-metrics.ts
@@ -130,7 +130,7 @@ export function answerRelevancy<
         usage,
       });
     } catch (error) {
-      return EvalOutcome.invalid(errorMessage(error));
+      return EvalOutcome.fromError(error);
     }
   });
 }
@@ -189,7 +189,7 @@ export function promptAlignment<
         usage,
       });
     } catch (error) {
-      return EvalOutcome.invalid(errorMessage(error));
+      return EvalOutcome.fromError(error);
     }
   });
 }
@@ -275,7 +275,7 @@ export function jsonCorrectness<
           usage,
         });
       } catch (error) {
-        return EvalOutcome.invalid(errorMessage(error));
+        return EvalOutcome.fromError(error);
       }
     },
   );
@@ -353,7 +353,7 @@ export function hallucination<
         usage,
       });
     } catch (error) {
-      return EvalOutcome.invalid(errorMessage(error));
+      return EvalOutcome.fromError(error);
     }
   });
 }
@@ -459,7 +459,7 @@ export function faithfulness<Input, Output, Expected = unknown, const Name exten
         usage,
       });
     } catch (error) {
-      return EvalOutcome.invalid(errorMessage(error));
+      return EvalOutcome.fromError(error);
     }
   });
 }
@@ -531,7 +531,7 @@ export function abstention<Input, Output, Expected = unknown, const Name extends
           ? EvalOutcome.pass(category, outcomeOptions)
           : EvalOutcome.fail(category, outcomeOptions);
       } catch (error) {
-        return EvalOutcome.invalid(errorMessage(error));
+        return EvalOutcome.fromError(error);
       }
     },
   };
@@ -727,7 +727,7 @@ export function summarization<
         usage,
       });
     } catch (error) {
-      return EvalOutcome.invalid(errorMessage(error));
+      return EvalOutcome.fromError(error);
     }
   });
 }
@@ -759,6 +759,57 @@ export type GEvalOptions<Input, Output, Expected = unknown> = Omit<
   retrievalContext?: SelectorOrValue<Input, Output, Expected, string[]> | undefined;
 };
 
+type GEvalCaseRequirements<
+  Params extends readonly GEvalParameter[],
+  ExpectedSelector,
+  ContextSelector,
+  RetrievalContextSelector,
+> = ("expectedOutput" extends Params[number]
+  ? [ExpectedSelector] extends [undefined]
+    ? { expected: unknown }
+    : Record<never, never>
+  : Record<never, never>) &
+  ("context" extends Params[number]
+    ? [ContextSelector] extends [undefined]
+      ? { context: string[] }
+      : Record<never, never>
+    : Record<never, never>) &
+  ("retrievalContext" extends Params[number]
+    ? [RetrievalContextSelector] extends [undefined]
+      ? { retrievalContext: string[] }
+      : Record<never, never>
+    : Record<never, never>);
+
+export function gEval<
+  Input,
+  Output,
+  Expected = unknown,
+  const Name extends string = string,
+  const Params extends readonly GEvalParameter[] = readonly GEvalParameter[],
+  ExpectedSelector extends ValueSelector<Input, Output, Expected, unknown> | undefined = undefined,
+  ContextSelector extends SelectorOrValue<Input, Output, Expected, string[]> | undefined =
+    undefined,
+  RetrievalContextSelector extends SelectorOrValue<Input, Output, Expected, string[]> | undefined =
+    undefined,
+>(
+  options: Omit<
+    GEvalOptions<Input, Output, Expected>,
+    "evaluationParams" | "expected" | "context" | "retrievalContext"
+  > & {
+    name: Name;
+    evaluationParams: Params;
+    expected?: ExpectedSelector;
+    context?: ContextSelector;
+    retrievalContext?: RetrievalContextSelector;
+  },
+): EvalMetric<
+  Input,
+  Output,
+  number,
+  Expected,
+  Name,
+  GEvalCaseRequirements<Params, ExpectedSelector, ContextSelector, RetrievalContextSelector>
+>;
 export function gEval<Input, Output, Expected = unknown, const Name extends string = string>(
   options: GEvalOptions<Input, Output, Expected> & { name: Name },
 ): EvalMetric<Input, Output, number, Expected, Name> {
@@ -855,7 +906,7 @@ export function gEval<Input, Output, Expected = unknown, const Name extends stri
         usage,
       });
     } catch (error) {
-      return EvalOutcome.invalid(errorMessage(error));
+      return EvalOutcome.fromError(error);
     }
   });
 }
@@ -934,7 +985,7 @@ export function turnRelevancy<
         usage,
       });
     } catch (error) {
-      return EvalOutcome.invalid(errorMessage(error));
+      return EvalOutcome.fromError(error);
     }
   });
 }
@@ -1029,7 +1080,7 @@ export function knowledgeRetention<
         usage,
       });
     } catch (error) {
-      return EvalOutcome.invalid(errorMessage(error));
+      return EvalOutcome.fromError(error);
     }
   });
 }

--- a/packages/core/src/evals/cli.ts
+++ b/packages/core/src/evals/cli.ts
@@ -26,9 +26,47 @@ export type EvalOutputWriters = {
   stderr?(text: string): void;
 };
 
+export type EvalRedactionContext = {
+  kind:
+    | "input"
+    | "expected"
+    | "context"
+    | "retrievalContext"
+    | "output"
+    | "score"
+    | "comment"
+    | "metadata"
+    | "error";
+  caseId?: string | undefined;
+  metricName?: string | undefined;
+};
+
+export type EvalRedactor = (value: unknown, context: EvalRedactionContext) => unknown;
+
 export type PrintEvalResultOptions = {
   format?: EvalOutputFormat | undefined;
   output?: EvalOutputWriters | undefined;
+  maxValueLength?: number | undefined;
+  redact?: EvalRedactor | undefined;
+};
+
+type EvalSuiteShape = {
+  cases: readonly { id: string }[];
+  metrics: readonly { name: string }[];
+};
+
+export type EvalExpectedOutcomesFor<Suite extends EvalSuiteShape> = Partial<
+  Record<
+    Suite["cases"][number]["id"],
+    Partial<Record<Suite["metrics"][number]["name"], EvalOutcomeStatus>>
+  >
+>;
+
+export type EvalExpectationsFor<Suite extends EvalSuiteShape> = Omit<
+  EvalExpectations,
+  "outcomes"
+> & {
+  outcomes?: EvalExpectedOutcomesFor<Suite> | undefined;
 };
 
 export type RunEvalCliOptions<
@@ -47,6 +85,8 @@ export type RunEvalCliOptions<
   exitCode?: boolean | undefined;
   expectations?: EvalExpectations | undefined;
   output?: EvalOutputWriters | undefined;
+  maxValueLength?: number | undefined;
+  redact?: EvalRedactor | undefined;
 };
 
 export class EvalAssertionError extends Error {
@@ -59,6 +99,23 @@ export class EvalAssertionError extends Error {
   }
 }
 
+export function defineEvalExpectations<const Suite extends EvalSuiteShape>(
+  _suite: Suite,
+  expectations: EvalExpectationsFor<NoInfer<Suite>>,
+): EvalExpectationsFor<Suite> {
+  return expectations;
+}
+
+export function formatEvalResult(
+  result: EvalSuiteResult<unknown, unknown, unknown>,
+  options: Omit<PrintEvalResultOptions, "output"> = {},
+): string {
+  const format = options.format ?? "pretty";
+  if (format === "quiet") return "";
+  validatePrintOptions(options);
+  return format === "json" ? jsonResult(result, options) : prettyResult(result, options);
+}
+
 export function printEvalResult(
   result: EvalSuiteResult<unknown, unknown, unknown>,
   options: PrintEvalResultOptions = {},
@@ -66,7 +123,7 @@ export function printEvalResult(
   const format = options.format ?? "pretty";
   if (format === "quiet") return;
   const write = options.output?.stdout ?? ((text: string) => process.stdout.write(text));
-  write(`${format === "json" ? jsonResult(result) : prettyResult(result)}\n`);
+  write(`${formatEvalResult(result, options)}\n`);
 }
 
 export function evalExitCode(
@@ -117,11 +174,12 @@ export async function runEvalCli<
 >(
   options: RunEvalCliOptions<Input, Output, Expected, Metrics>,
 ): Promise<EvalSuiteResult<Input, Output, Expected, Metrics>> {
-  const { format, exitCode, expectations, output, ...suiteOptions } = options;
+  const { format, exitCode, expectations, output, maxValueLength, redact, ...suiteOptions } =
+    options;
   const result = await runEvalSuite(
     suiteOptions as RunEvalSuiteOptions<Input, Output, Expected, Metrics>,
   );
-  printEvalResult(result, { format, output });
+  printEvalResult(result, { format, output, maxValueLength, redact });
   const code = evalExitCode(result, expectations);
   const mismatches = expectationMismatches(result, expectations);
   if (mismatches.length > 0 && format !== "quiet") {
@@ -136,7 +194,10 @@ export async function runEvalCli<
   return result;
 }
 
-function prettyResult(result: EvalSuiteResult<unknown, unknown, unknown>): string {
+function prettyResult(
+  result: EvalSuiteResult<unknown, unknown, unknown>,
+  options: Omit<PrintEvalResultOptions, "output">,
+): string {
   const lines = [
     `${result.name} (${result.run.id})`,
     `Cases: ${totalsText(result.cases)}`,
@@ -144,14 +205,36 @@ function prettyResult(result: EvalSuiteResult<unknown, unknown, unknown>): strin
   ];
   for (const caseResult of result.results) {
     lines.push(``, `[${caseResult.outcome.toUpperCase()}] ${caseResult.case.id}`);
-    if (caseResult.output !== undefined) lines.push(`  output: ${displayValue(caseResult.output)}`);
-    if (caseResult.targetError !== undefined) {
-      lines.push(`  target error: ${errorText(caseResult.targetError)}`);
+    if (caseResult.targetStatus === "succeeded") {
+      lines.push(
+        `  output: ${displayValue(
+          redact(caseResult.output, options, { kind: "output", caseId: caseResult.case.id }),
+          options.maxValueLength,
+        )}`,
+      );
+    }
+    if (caseResult.targetStatus === "failed") {
+      lines.push(
+        `  target error: ${errorText(
+          redact(caseResult.targetError, options, { kind: "error", caseId: caseResult.case.id }),
+          options.maxValueLength,
+        )}`,
+      );
     }
     for (const metric of caseResult.metrics) {
       const parts = [`  - ${metric.metricName}: ${metric.outcome.outcome}`];
-      if (metric.outcome.score !== undefined)
-        parts.push(`score=${displayValue(metric.outcome.score)}`);
+      if (metric.outcome.score !== undefined) {
+        parts.push(
+          `score=${displayValue(
+            redact(metric.outcome.score, options, {
+              kind: "score",
+              caseId: caseResult.case.id,
+              metricName: metric.metricName,
+            }),
+            options.maxValueLength,
+          )}`,
+        );
+      }
       if (metric.threshold !== undefined) parts.push(`threshold=${metric.threshold}`);
       if (metric.direction !== undefined) parts.push(`direction=${metric.direction}`);
       if (!metric.required) parts.push("optional");
@@ -159,7 +242,18 @@ function prettyResult(result: EvalSuiteResult<unknown, unknown, unknown>): strin
       const explanation =
         metric.outcome.comment ??
         (metric.outcome.outcome === "invalid" ? metric.outcome.reason : undefined);
-      if (explanation !== undefined) lines.push(`    ${explanation}`);
+      if (explanation !== undefined) {
+        lines.push(
+          `    ${displayValue(
+            redact(explanation, options, {
+              kind: "comment",
+              caseId: caseResult.case.id,
+              metricName: metric.metricName,
+            }),
+            options.maxValueLength,
+          )}`,
+        );
+      }
     }
   }
   lines.push(
@@ -175,14 +269,18 @@ function prettyResult(result: EvalSuiteResult<unknown, unknown, unknown>): strin
   return lines.join("\n");
 }
 
-function jsonResult(result: EvalSuiteResult<unknown, unknown, unknown>): string {
+function jsonResult(
+  result: EvalSuiteResult<unknown, unknown, unknown>,
+  options: Omit<PrintEvalResultOptions, "output">,
+): string {
   return JSON.stringify(
-    result,
+    redactJsonResult(result, options),
     (_key, value: unknown) => {
       if (value instanceof Error) {
         return { name: value.name, message: value.message, stack: value.stack };
       }
       if (value instanceof RegExp) return String(value);
+      if (typeof value === "string") return truncate(value, options.maxValueLength);
       return value;
     },
     2,
@@ -308,15 +406,154 @@ function totalsText(totals: EvalTotals): string {
   return `${totals.total} total / ${totals.passed} pass / ${totals.failed} fail / ${totals.invalid} invalid`;
 }
 
-function displayValue(value: unknown): string {
-  if (typeof value === "string") return value;
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return String(value);
+function displayValue(value: unknown, maxValueLength?: number): string {
+  let text: string;
+  if (typeof value === "string") text = value;
+  else {
+    try {
+      text = JSON.stringify(value) ?? String(value);
+    } catch {
+      text = String(value);
+    }
   }
+  return truncate(text, maxValueLength);
 }
 
-function errorText(error: unknown): string {
-  return error instanceof Error ? error.message : displayValue(error);
+function errorText(error: unknown, maxValueLength?: number): string {
+  return truncate(error instanceof Error ? error.message : displayValue(error), maxValueLength);
+}
+
+function truncate(value: string, maxValueLength: number | undefined): string {
+  return maxValueLength !== undefined && value.length > maxValueLength
+    ? `${value.slice(0, maxValueLength)}…`
+    : value;
+}
+
+function redact(
+  value: unknown,
+  options: Omit<PrintEvalResultOptions, "output">,
+  context: EvalRedactionContext,
+): unknown {
+  return options.redact === undefined ? value : options.redact(value, context);
+}
+
+function redactJsonResult(
+  result: EvalSuiteResult<unknown, unknown, unknown>,
+  options: Omit<PrintEvalResultOptions, "output">,
+): unknown {
+  return {
+    ...result,
+    run: {
+      ...result.run,
+      metadata:
+        result.run.metadata === undefined
+          ? undefined
+          : (redact(result.run.metadata, options, {
+              kind: "metadata",
+            }) as typeof result.run.metadata),
+    },
+    results: result.results.map((caseResult) => ({
+      ...caseResult,
+      case: {
+        ...caseResult.case,
+        input: redact(caseResult.case.input, options, {
+          kind: "input",
+          caseId: caseResult.case.id,
+        }),
+        expected: redact(caseResult.case.expected, options, {
+          kind: "expected",
+          caseId: caseResult.case.id,
+        }),
+        context: redact(caseResult.case.context, options, {
+          kind: "context",
+          caseId: caseResult.case.id,
+        }),
+        retrievalContext: redact(caseResult.case.retrievalContext, options, {
+          kind: "retrievalContext",
+          caseId: caseResult.case.id,
+        }),
+        metadata:
+          caseResult.case.metadata === undefined
+            ? undefined
+            : (redact(caseResult.case.metadata, options, {
+                kind: "metadata",
+                caseId: caseResult.case.id,
+              }) as typeof caseResult.case.metadata),
+      },
+      output:
+        caseResult.targetStatus === "succeeded"
+          ? redact(caseResult.output, options, { kind: "output", caseId: caseResult.case.id })
+          : undefined,
+      targetError:
+        caseResult.targetStatus === "failed"
+          ? redact(caseResult.targetError, options, {
+              kind: "error",
+              caseId: caseResult.case.id,
+            })
+          : undefined,
+      metrics: caseResult.metrics.map((metric) => ({
+        ...metric,
+        reporterErrors: metric.reporterErrors.map((error) =>
+          redact(error, options, {
+            kind: "error",
+            caseId: caseResult.case.id,
+            metricName: metric.metricName,
+          }),
+        ),
+        outcome: redactOutcome(metric.outcome, options, caseResult.case.id, metric.metricName),
+      })),
+      scores: Object.fromEntries(
+        caseResult.metrics.map((metric) => [
+          metric.metricName,
+          redactOutcome(metric.outcome, options, caseResult.case.id, metric.metricName),
+        ]),
+      ),
+    })),
+    reporterErrors: result.reporterErrors.map((error) => redact(error, options, { kind: "error" })),
+  };
+}
+
+function redactOutcome(
+  outcome: EvalSuiteResult<
+    unknown,
+    unknown,
+    unknown
+  >["results"][number]["metrics"][number]["outcome"],
+  options: Omit<PrintEvalResultOptions, "output">,
+  caseId: string,
+  metricName: string,
+): unknown {
+  return {
+    ...outcome,
+    ...(outcome.score === undefined
+      ? {}
+      : { score: redact(outcome.score, options, { kind: "score", caseId, metricName }) }),
+    ...(outcome.comment === undefined
+      ? {}
+      : { comment: redact(outcome.comment, options, { kind: "comment", caseId, metricName }) }),
+    ...(!("reason" in outcome) || outcome.reason === undefined
+      ? {}
+      : { reason: redact(outcome.reason, options, { kind: "comment", caseId, metricName }) }),
+    ...(outcome.metadata === undefined
+      ? {}
+      : {
+          metadata: redact(outcome.metadata, options, {
+            kind: "metadata",
+            caseId,
+            metricName,
+          }),
+        }),
+    ...(!("error" in outcome) || outcome.error === undefined
+      ? {}
+      : { error: redact(outcome.error, options, { kind: "error", caseId, metricName }) }),
+  };
+}
+
+function validatePrintOptions(options: Omit<PrintEvalResultOptions, "output">): void {
+  if (
+    options.maxValueLength !== undefined &&
+    (!Number.isSafeInteger(options.maxValueLength) || options.maxValueLength < 1)
+  ) {
+    throw new RangeError("Evaluation maxValueLength must be a positive integer.");
+  }
 }

--- a/packages/core/src/evals/execution.ts
+++ b/packages/core/src/evals/execution.ts
@@ -1,0 +1,80 @@
+export class EvalTimeoutError extends Error {
+  constructor(readonly timeoutMs: number) {
+    super(`Evaluation case exceeded its timeout of ${timeoutMs}ms.`);
+    this.name = "EvalTimeoutError";
+  }
+}
+
+export class EvalAbortError extends Error {
+  constructor(message = "Evaluation run was aborted.") {
+    super(message);
+    this.name = "EvalAbortError";
+  }
+}
+
+export type EvalCaseSignal = {
+  signal: AbortSignal;
+  dispose(): void;
+};
+
+export function createEvalCaseSignal(
+  parent: AbortSignal | undefined,
+  timeoutMs: number | undefined,
+): EvalCaseSignal {
+  const controller = new AbortController();
+  const abortFromParent = () => controller.abort(parent?.reason ?? new EvalAbortError());
+  if (parent?.aborted === true) abortFromParent();
+  else parent?.addEventListener("abort", abortFromParent, { once: true });
+  const timeout =
+    timeoutMs === undefined
+      ? undefined
+      : setTimeout(() => controller.abort(new EvalTimeoutError(timeoutMs)), timeoutMs);
+  return {
+    signal: controller.signal,
+    dispose() {
+      if (timeout !== undefined) clearTimeout(timeout);
+      parent?.removeEventListener("abort", abortFromParent);
+    },
+  };
+}
+
+export function abortable<T>(signal: AbortSignal, operation: Promise<T>): Promise<T> {
+  if (signal.aborted) return Promise.reject(abortReason(signal));
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(abortReason(signal));
+    signal.addEventListener("abort", onAbort, { once: true });
+    operation.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
+export type ConcurrencyLimiter = <T>(operation: () => Promise<T>) => Promise<T>;
+
+export function createConcurrencyLimiter(concurrency: number): ConcurrencyLimiter {
+  let active = 0;
+  const waiting: Array<() => void> = [];
+  return async <T>(operation: () => Promise<T>): Promise<T> => {
+    if (active >= concurrency) {
+      await new Promise<void>((resolve) => waiting.push(resolve));
+    }
+    active += 1;
+    try {
+      return await operation();
+    } finally {
+      active -= 1;
+      waiting.shift()?.();
+    }
+  };
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new EvalAbortError();
+}

--- a/packages/core/src/evals/format.ts
+++ b/packages/core/src/evals/format.ts
@@ -5,11 +5,8 @@ export function defaultOutputValue(output: unknown): unknown {
   return output;
 }
 
-export function stableComparable(value: unknown): string {
-  if (typeof value === "string") {
-    return value;
-  }
-  return JSON.stringify(value);
+export function evalValuesEqual(left: unknown, right: unknown): boolean {
+  return deepEqual(left, right, new WeakMap<object, object>());
 }
 
 export function formatValue(value: unknown): string {
@@ -17,7 +14,7 @@ export function formatValue(value: unknown): string {
     return value;
   }
   try {
-    return JSON.stringify(value);
+    return JSON.stringify(value) ?? String(value);
   } catch {
     return String(value);
   }
@@ -25,4 +22,39 @@ export function formatValue(value: unknown): string {
 
 export function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function deepEqual(left: unknown, right: unknown, seen: WeakMap<object, object>): boolean {
+  if (Object.is(left, right)) return true;
+  if (typeof left !== "object" || left === null || typeof right !== "object" || right === null) {
+    return false;
+  }
+  if (Object.getPrototypeOf(left) !== Object.getPrototypeOf(right)) return false;
+  if (left instanceof Date && right instanceof Date) return left.getTime() === right.getTime();
+  if (left instanceof RegExp && right instanceof RegExp) return String(left) === String(right);
+  if (
+    !Array.isArray(left) &&
+    Object.getPrototypeOf(left) !== Object.prototype &&
+    Object.getPrototypeOf(left) !== null
+  ) {
+    return false;
+  }
+  if (seen.get(left) === right) return true;
+  seen.set(left, right);
+  const leftKeys = Reflect.ownKeys(left);
+  const rightKeys = Reflect.ownKeys(right);
+  if (leftKeys.length !== rightKeys.length) return false;
+  for (const key of leftKeys) {
+    if (!Object.hasOwn(right, key)) return false;
+    if (
+      !deepEqual(
+        (left as Record<PropertyKey, unknown>)[key],
+        (right as Record<PropertyKey, unknown>)[key],
+        seen,
+      )
+    ) {
+      return false;
+    }
+  }
+  return true;
 }

--- a/packages/core/src/evals/index.ts
+++ b/packages/core/src/evals/index.ts
@@ -1,12 +1,13 @@
 export * from "./advanced-metrics";
 export * from "./agent-target";
 export * from "./cli";
+export { EvalAbortError, EvalTimeoutError } from "./execution";
 export { defineMetric } from "./metric";
 export * from "./metrics";
 export * from "./outcome";
 export { defaultEvalTraceSelector, projectEvalOutcome, resolveEvalTraceRef } from "./reporting";
-export { EvalReporterDispatchError, runEvalSuite } from "./runner";
-export { selectPromptOutput } from "./selectors";
+export { EvalFailFastError, EvalReporterDispatchError, runEvalSuite } from "./runner";
+export { selectEvalCaseIds, selectPromptOutput } from "./selectors";
 export * from "./suite";
 export type {
   AnyEvalMetric,
@@ -14,11 +15,13 @@ export type {
   EvalCase,
   EvalCaseRequirements,
   EvalCaseResult,
+  EvalCasesForMetrics,
   EvalCostCalculatorArgs,
   EvalCostOptions,
   EvalCostSummary,
   EvalDataType,
   EvalMetadata,
+  EvalInvalidKind,
   EvalMetric,
   EvalMetricArgs,
   EvalMetricDescriptor,
@@ -29,6 +32,7 @@ export type {
   EvalReportArgs,
   EvalReporter,
   EvalReporterErrorPolicy,
+  EvalProgressEvent,
   EvalRunContext,
   EvalRunEndArgs,
   EvalRunOptions,
@@ -38,12 +42,14 @@ export type {
   EvalScoreProjection,
   EvalSuiteResult,
   EvalTarget,
+  EvalTargetContext,
   EvalTargetUsageSelector,
   EvalTotals,
   EvalTraceCarrier,
   EvalTraceRef,
   EvalTraceSelector,
   EvalTraceSelectorArgs,
+  EvalShard,
   EvalTurn,
   EvalUsageSummary,
   RunEvalSuiteOptions,

--- a/packages/core/src/evals/metrics.ts
+++ b/packages/core/src/evals/metrics.ts
@@ -3,7 +3,7 @@ import type { CompletionModel } from "../completion";
 import { cosineSimilarity, type EmbeddingModel, embedText } from "../embeddings";
 import { extract } from "../extractor";
 import type { ZodSchema } from "../schema";
-import { errorMessage, formatValue, stableComparable } from "./format";
+import { evalValuesEqual, formatValue } from "./format";
 import { EvalOutcome } from "./outcome";
 import { resolveActual, resolveActualText, resolveExpected, resolveJudgePrompt } from "./selectors";
 import type { EvalCaseRequirements, EvalMetric, SelectorOrValue, ValueSelector } from "./types";
@@ -42,7 +42,7 @@ export function exactMatch<Input, Output, Expected = unknown, const Name extends
       if (expected === undefined) {
         return EvalOutcome.invalid("No expected value provided for exact match.");
       }
-      const passed = stableComparable(actual) === stableComparable(expected);
+      const passed = evalValuesEqual(actual, expected);
       return passed
         ? EvalOutcome.pass(true)
         : EvalOutcome.fail(false, { comment: `Expected ${formatValue(expected)}.` });
@@ -103,8 +103,20 @@ export type NotContainsOptions<Input, Output, Expected = unknown> = ContainsOpti
 >;
 
 export function notContains<Input, Output, Expected = unknown, const Name extends string = string>(
+  options: NotContainsOptions<Input, Output, Expected> & {
+    expected: Exclude<NotContainsOptions<Input, Output, Expected>["expected"], undefined>;
+    name?: Name | undefined;
+  },
+): EvalMetric<Input, Output, boolean, Expected, Name>;
+export function notContains<Input, Output, Expected = unknown, const Name extends string = string>(
+  options?: Omit<NotContainsOptions<Input, Output, Expected>, "expected"> & {
+    expected?: undefined;
+    name?: Name | undefined;
+  },
+): EvalMetric<Input, Output, boolean, Expected, Name, { expected: string | RegExp }>;
+export function notContains<Input, Output, Expected = unknown, const Name extends string = string>(
   options: NotContainsOptions<Input, Output, Expected> & { name?: Name | undefined } = {},
-): EvalMetric<Input, Output, boolean, Expected, Name> {
+): EvalMetric<Input, Output, boolean, Expected, Name, EvalCaseRequirements> {
   return {
     name: (options.name ?? "not_contains") as Name,
     required: options.required ?? true,
@@ -144,8 +156,20 @@ export type ContainsAllOptions<Input, Output, Expected = unknown> = ContainsList
 >;
 
 export function containsAll<Input, Output, Expected = unknown, const Name extends string = string>(
+  options: ContainsAllOptions<Input, Output, Expected> & {
+    expected: Exclude<ContainsAllOptions<Input, Output, Expected>["expected"], undefined>;
+    name?: Name | undefined;
+  },
+): EvalMetric<Input, Output, boolean, Expected, Name>;
+export function containsAll<Input, Output, Expected = unknown, const Name extends string = string>(
+  options: Omit<ContainsAllOptions<Input, Output, Expected>, "expected"> & {
+    expected?: undefined;
+    name?: Name | undefined;
+  },
+): EvalMetric<Input, Output, boolean, Expected, Name, { expected: ReadonlyArray<string | RegExp> }>;
+export function containsAll<Input, Output, Expected = unknown, const Name extends string = string>(
   options: ContainsAllOptions<Input, Output, Expected> & { name?: Name | undefined },
-): EvalMetric<Input, Output, boolean, Expected, Name> {
+): EvalMetric<Input, Output, boolean, Expected, Name, EvalCaseRequirements> {
   return containsListMetric("contains_all", "all", options);
 }
 
@@ -156,8 +180,20 @@ export type ContainsAnyOptions<Input, Output, Expected = unknown> = ContainsList
 >;
 
 export function containsAny<Input, Output, Expected = unknown, const Name extends string = string>(
+  options: ContainsAnyOptions<Input, Output, Expected> & {
+    expected: Exclude<ContainsAnyOptions<Input, Output, Expected>["expected"], undefined>;
+    name?: Name | undefined;
+  },
+): EvalMetric<Input, Output, boolean, Expected, Name>;
+export function containsAny<Input, Output, Expected = unknown, const Name extends string = string>(
+  options: Omit<ContainsAnyOptions<Input, Output, Expected>, "expected"> & {
+    expected?: undefined;
+    name?: Name | undefined;
+  },
+): EvalMetric<Input, Output, boolean, Expected, Name, { expected: ReadonlyArray<string | RegExp> }>;
+export function containsAny<Input, Output, Expected = unknown, const Name extends string = string>(
   options: ContainsAnyOptions<Input, Output, Expected> & { name?: Name | undefined },
-): EvalMetric<Input, Output, boolean, Expected, Name> {
+): EvalMetric<Input, Output, boolean, Expected, Name, EvalCaseRequirements> {
   return containsListMetric("contains_any", "any", options);
 }
 
@@ -202,8 +238,20 @@ export type MatchesOptions<Input, Output, Expected = unknown> = {
 };
 
 export function matches<Input, Output, Expected = unknown, const Name extends string = string>(
+  options: MatchesOptions<Input, Output, Expected> & {
+    expected: Exclude<MatchesOptions<Input, Output, Expected>["expected"], undefined>;
+    name?: Name | undefined;
+  },
+): EvalMetric<Input, Output, boolean, Expected, Name>;
+export function matches<Input, Output, Expected = unknown, const Name extends string = string>(
+  options: Omit<MatchesOptions<Input, Output, Expected>, "expected"> & {
+    expected?: undefined;
+    name?: Name | undefined;
+  },
+): EvalMetric<Input, Output, boolean, Expected, Name, { expected: RegExp }>;
+export function matches<Input, Output, Expected = unknown, const Name extends string = string>(
   options: MatchesOptions<Input, Output, Expected> & { name?: Name | undefined },
-): EvalMetric<Input, Output, boolean, Expected, Name> {
+): EvalMetric<Input, Output, boolean, Expected, Name, EvalCaseRequirements> {
   return regexMetric("matches", false, options);
 }
 
@@ -214,8 +262,20 @@ export type DoesNotMatchOptions<Input, Output, Expected = unknown> = MatchesOpti
 >;
 
 export function doesNotMatch<Input, Output, Expected = unknown, const Name extends string = string>(
+  options: DoesNotMatchOptions<Input, Output, Expected> & {
+    expected: Exclude<DoesNotMatchOptions<Input, Output, Expected>["expected"], undefined>;
+    name?: Name | undefined;
+  },
+): EvalMetric<Input, Output, boolean, Expected, Name>;
+export function doesNotMatch<Input, Output, Expected = unknown, const Name extends string = string>(
+  options: Omit<DoesNotMatchOptions<Input, Output, Expected>, "expected"> & {
+    expected?: undefined;
+    name?: Name | undefined;
+  },
+): EvalMetric<Input, Output, boolean, Expected, Name, { expected: RegExp }>;
+export function doesNotMatch<Input, Output, Expected = unknown, const Name extends string = string>(
   options: DoesNotMatchOptions<Input, Output, Expected> & { name?: Name | undefined },
-): EvalMetric<Input, Output, boolean, Expected, Name> {
+): EvalMetric<Input, Output, boolean, Expected, Name, EvalCaseRequirements> {
   return regexMetric("does_not_match", true, options);
 }
 
@@ -382,12 +442,13 @@ export function semanticSimilarity<
 >(
   options: SemanticSimilarityOptions<Input, Output, Expected> & { name?: Name | undefined },
 ): EvalMetric<Input, Output, number, Expected, Name, EvalCaseRequirements> {
+  const threshold = unitInterval(options.threshold, "semanticSimilarity threshold");
   return {
     name: (options.name ?? "semantic_similarity") as Name,
     required: options.required ?? true,
     dataType: "NUMERIC",
     direction: "higher_is_better",
-    threshold: options.threshold,
+    threshold,
     async evaluate(args) {
       const actual = await resolveActualText(options.actual, args);
       const expected = await resolveExpected(options.expected, args);
@@ -402,9 +463,9 @@ export function semanticSimilarity<
         embedText({ model: options.model, text: expected }),
       ]);
       const score = cosineSimilarity(actualEmbedding.vector, expectedEmbedding.vector);
-      return score >= options.threshold
+      return score >= threshold
         ? EvalOutcome.pass(score)
-        : EvalOutcome.fail(score, { comment: `Similarity below threshold ${options.threshold}.` });
+        : EvalOutcome.fail(score, { comment: `Similarity below threshold ${threshold}.` });
     },
   };
 }
@@ -429,6 +490,7 @@ export function llmJudge<
 >(
   options: LlmJudgeOptions<Input, Output, SchemaOutput, Expected> & { name?: Name | undefined },
 ): EvalMetric<Input, Output, SchemaOutput, Expected, Name> {
+  const retries = extractionRetries(options.retries);
   return {
     name: (options.name ?? "llm_judge") as Name,
     required: options.required ?? true,
@@ -441,13 +503,13 @@ export function llmJudge<
             options.instructions ??
             "Judge the eval case by the requested schema. Submit the judgment using the schema.",
           text: await resolveJudgePrompt(options.prompt, args),
-          retries: evalExtractionRetries(options.retries),
+          retries,
         });
         return options.passes(result.output)
           ? EvalOutcome.pass(result.output, { usage: result.usage })
           : EvalOutcome.fail(result.output, { usage: result.usage });
       } catch (error) {
-        return EvalOutcome.invalid(errorMessage(error));
+        return EvalOutcome.fromError(error);
       }
     },
   };
@@ -473,13 +535,16 @@ export function llmScore<Input, Output, Expected = unknown, const Name extends s
   options: LlmScoreOptions<Input, Output, Expected> & { name?: Name | undefined },
 ): EvalMetric<Input, Output, LlmScoreMetricScore, Expected, Name> {
   const criteria = Array.isArray(options.criteria) ? options.criteria.join("\n") : options.criteria;
+  if (criteria.trim().length === 0) throw new TypeError("llmScore criteria must not be empty.");
+  const threshold = unitInterval(options.threshold, "llmScore threshold");
+  const retries = extractionRetries(options.retries);
   return {
     name: (options.name ?? "llm_score") as Name,
     required: options.required ?? true,
     dataType: "NUMERIC",
     projectScore: (score) => score.score,
     direction: "higher_is_better",
-    threshold: options.threshold,
+    threshold,
     async evaluate(args) {
       try {
         const result = await extract({
@@ -492,7 +557,7 @@ export function llmScore<Input, Output, Expected = unknown, const Name extends s
             options.instructions ??
             `Score the eval case against these criteria:\n${criteria}\n\nReturn a score between 0 and 1 and brief feedback.`,
           text: await resolveJudgePrompt(options.prompt, args),
-          retries: evalExtractionRetries(options.retries),
+          retries,
         });
         const score = result.output;
         if (score.score < 0 || score.score > 1) {
@@ -501,20 +566,30 @@ export function llmScore<Input, Output, Expected = unknown, const Name extends s
             usage: result.usage,
           });
         }
-        return score.score >= options.threshold
+        return score.score >= threshold
           ? EvalOutcome.pass(score, { comment: score.feedback, usage: result.usage })
           : EvalOutcome.fail(score, { comment: score.feedback, usage: result.usage });
       } catch (error) {
-        return EvalOutcome.invalid(errorMessage(error));
+        return EvalOutcome.fromError(error);
       }
     },
   };
 }
 
-function evalExtractionRetries(retries: number | undefined): { maxAttempts: number } | undefined {
-  const retryCount = Math.max(0, Math.trunc(retries ?? 0));
+function extractionRetries(retries: number | undefined): { maxAttempts: number } | undefined {
+  const retryCount = retries ?? 0;
+  if (!Number.isInteger(retryCount) || retryCount < 0) {
+    throw new RangeError("Eval metric retries must be a non-negative integer.");
+  }
   if (retryCount === 0) {
     return undefined;
   }
   return { maxAttempts: retryCount + 1 };
+}
+
+function unitInterval(value: number, label: string): number {
+  if (!Number.isFinite(value) || value < 0 || value > 1) {
+    throw new RangeError(`${label} must be between 0 and 1.`);
+  }
+  return value;
 }

--- a/packages/core/src/evals/outcome.ts
+++ b/packages/core/src/evals/outcome.ts
@@ -1,5 +1,11 @@
 import type { Usage } from "../completion";
-import type { EvalMetadata } from "./types";
+import type { EvalInvalidKind, EvalMetadata } from "./types";
+
+type EvalOutcomeOptions = {
+  comment?: string | undefined;
+  metadata?: EvalMetadata | undefined;
+  usage?: Usage | undefined;
+};
 
 export type EvalOutcome<Score = unknown> =
   | {
@@ -19,6 +25,8 @@ export type EvalOutcome<Score = unknown> =
   | {
       outcome: "invalid";
       reason: string;
+      kind?: EvalInvalidKind | undefined;
+      error?: unknown;
       score?: Score | undefined;
       comment?: string | undefined;
       metadata?: EvalMetadata | undefined;
@@ -26,14 +34,7 @@ export type EvalOutcome<Score = unknown> =
     };
 
 export const EvalOutcome = {
-  pass<Score>(
-    score?: Score,
-    options: {
-      comment?: string | undefined;
-      metadata?: EvalMetadata | undefined;
-      usage?: Usage | undefined;
-    } = {},
-  ): EvalOutcome<Score> {
+  pass<Score>(score?: Score, options: EvalOutcomeOptions = {}): EvalOutcome<Score> {
     const outcome: EvalOutcome<Score> = {
       outcome: "pass" as const,
     };
@@ -52,14 +53,7 @@ export const EvalOutcome = {
     return outcome;
   },
 
-  fail<Score>(
-    score?: Score,
-    options: {
-      comment?: string | undefined;
-      metadata?: EvalMetadata | undefined;
-      usage?: Usage | undefined;
-    } = {},
-  ): EvalOutcome<Score> {
+  fail<Score>(score?: Score, options: EvalOutcomeOptions = {}): EvalOutcome<Score> {
     const outcome: EvalOutcome<Score> = {
       outcome: "fail" as const,
     };
@@ -80,11 +74,10 @@ export const EvalOutcome = {
 
   invalid<Score = never>(
     reason: string,
-    options: {
+    options: EvalOutcomeOptions & {
       score?: Score | undefined;
-      comment?: string | undefined;
-      metadata?: EvalMetadata | undefined;
-      usage?: Usage | undefined;
+      kind?: EvalInvalidKind | undefined;
+      error?: unknown;
     } = {},
   ): EvalOutcome<Score> {
     const outcome: EvalOutcome<Score> = {
@@ -94,15 +87,16 @@ export const EvalOutcome = {
     if (options.score !== undefined) {
       outcome.score = options.score;
     }
-    if (options.comment !== undefined) {
-      outcome.comment = options.comment;
-    }
-    if (options.metadata !== undefined) {
-      outcome.metadata = options.metadata;
-    }
-    if (options.usage !== undefined) {
-      outcome.usage = options.usage;
-    }
+    if (options.comment !== undefined) outcome.comment = options.comment;
+    if (options.metadata !== undefined) outcome.metadata = options.metadata;
+    if (options.usage !== undefined) outcome.usage = options.usage;
+    if (options.kind !== undefined) outcome.kind = options.kind;
+    if (options.error !== undefined) outcome.error = options.error;
     return outcome;
+  },
+
+  fromError(error: unknown, kind: EvalInvalidKind = "metric"): EvalOutcome<never> {
+    const reason = error instanceof Error ? error.message : String(error);
+    return EvalOutcome.invalid(reason, { kind, error });
   },
 };

--- a/packages/core/src/evals/runner.ts
+++ b/packages/core/src/evals/runner.ts
@@ -1,4 +1,12 @@
 import { type Usage, Usage as UsageValue } from "../completion";
+import {
+  abortable,
+  type ConcurrencyLimiter,
+  createConcurrencyLimiter,
+  createEvalCaseSignal,
+  EvalAbortError,
+  EvalTimeoutError,
+} from "./execution";
 import { errorMessage } from "./format";
 import { EvalOutcome, type EvalOutcome as EvalOutcomeType } from "./outcome";
 import { defaultEvalTraceSelector } from "./reporting";
@@ -15,6 +23,7 @@ import type {
   EvalSuiteResult,
   EvalTotals,
   EvalTraceRef,
+  EvalProgressEvent,
   RunEvalSuiteOptions,
 } from "./types";
 
@@ -25,6 +34,16 @@ export class EvalReporterDispatchError extends AggregateError {
     super(errors, `Evaluation reporter ${phase} failed ${errors.length} time(s).`);
     this.name = "EvalReporterDispatchError";
     this.phase = phase;
+  }
+}
+
+export class EvalFailFastError extends Error {
+  constructor(
+    readonly caseId: string,
+    readonly outcome: "fail" | "invalid",
+  ) {
+    super(`Evaluation stopped after case ${caseId} produced a required ${outcome} outcome.`);
+    this.name = "EvalFailFastError";
   }
 }
 
@@ -51,13 +70,18 @@ export async function runEvalSuite<
   options: RunEvalSuiteOptions<Input, Output, Expected, Metrics>,
 ): Promise<EvalSuiteResult<Input, Output, Expected, Metrics>> {
   validateSuiteOptions(options);
+  const selectedCases = selectCases(options);
+  const selectedOptions = {
+    ...options,
+    cases: selectedCases,
+  } as unknown as RunEvalSuiteOptions<Input, Output, Expected, Metrics>;
   const startedAtMs = Date.now();
-  const run = resolveRun(options, startedAtMs);
+  const run = resolveRun(selectedOptions, startedAtMs);
   const reporters = options.reporters ?? [];
   const lifecycle = {
     run,
     suiteName: options.name,
-    caseCount: options.cases.length,
+    caseCount: selectedCases.length,
     metricNames: options.metrics.map((metric) => metric.name),
   } satisfies EvalRunStartArgs;
   let reporterErrors: unknown[];
@@ -80,8 +104,8 @@ export async function runEvalSuite<
   let results: Array<EvalCaseResult<Input, Output, Expected, Metrics>>;
   let aggregates: Awaited<ReturnType<typeof aggregateResult>>;
   try {
-    results = await runEvalCases(options, run);
-    aggregates = await aggregateResult(options, results);
+    results = await runEvalCases(selectedOptions, run);
+    aggregates = await aggregateResult(selectedOptions, results);
   } catch (error) {
     await notifyRunEnd(reporters, {
       ...lifecycle,
@@ -103,6 +127,11 @@ export async function runEvalSuite<
     durationMs: Date.now() - startedAtMs,
     reporterErrors,
   };
+  result.reporterErrors.push(
+    ...results.flatMap((caseResult) =>
+      caseResult.metrics.flatMap((metricResult) => metricResult.reporterErrors),
+    ),
+  );
   if (aggregates.cost !== undefined) {
     result.cost = aggregates.cost;
   }
@@ -133,13 +162,22 @@ async function runEvalCases<
   options: RunEvalSuiteOptions<Input, Output, Expected, Metrics>,
   run: EvalRunContext,
 ): Promise<Array<EvalCaseResult<Input, Output, Expected, Metrics>>> {
-  const concurrency = Math.max(1, Math.trunc(options.concurrency ?? 1));
+  const targetConcurrency = options.targetConcurrency ?? options.concurrency ?? 1;
+  const metricConcurrency = options.metricConcurrency ?? options.concurrency ?? 1;
+  const workerConcurrency = Math.max(targetConcurrency, metricConcurrency);
+  const targetLimit = createConcurrencyLimiter(targetConcurrency);
+  const metricLimit = createConcurrencyLimiter(metricConcurrency);
   const results = Array<EvalCaseResult<Input, Output, Expected, Metrics>>(options.cases.length);
   let nextIndex = 0;
+  let completedCases = 0;
   let failure: { error: unknown } | undefined;
 
   async function worker(): Promise<void> {
     while (failure === undefined && nextIndex < options.cases.length) {
+      if (isAborted(options.signal)) {
+        failure ??= { error: suiteAbortReason(options.signal) };
+        break;
+      }
       const index = nextIndex;
       nextIndex += 1;
       try {
@@ -147,7 +185,20 @@ async function runEvalCases<
           options,
           options.cases[index] as EvalCase<Input, Expected>,
           run,
+          targetLimit,
+          metricLimit,
+          () => completedCases,
         );
+        completedCases += 1;
+        if (isAborted(options.signal)) {
+          failure ??= { error: suiteAbortReason(options.signal) };
+        }
+        if (options.failFast === true && results[index]?.outcome !== "pass") {
+          const result = results[index];
+          if (result !== undefined && result.outcome !== "pass") {
+            failure ??= { error: new EvalFailFastError(result.case.id, result.outcome) };
+          }
+        }
       } catch (error) {
         failure ??= { error };
       }
@@ -155,7 +206,7 @@ async function runEvalCases<
   }
 
   await Promise.all(
-    Array.from({ length: Math.min(concurrency, options.cases.length) }, () => worker()),
+    Array.from({ length: Math.min(workerConcurrency, options.cases.length) }, () => worker()),
   );
   if (failure !== undefined) throw failure.error;
   return results;
@@ -170,62 +221,148 @@ async function runEvalCase<
   options: RunEvalSuiteOptions<Input, Output, Expected, Metrics>,
   testCase: EvalCase<Input, Expected>,
   run: EvalRunContext,
+  targetLimit: ConcurrencyLimiter,
+  metricLimit: ConcurrencyLimiter,
+  completedCases: () => number,
 ): Promise<EvalCaseResult<Input, Output, Expected, Metrics>> {
-  let output: Output | undefined;
-  let targetError: unknown;
+  const caseStartedAt = performance.now();
+  const caseSignal = createEvalCaseSignal(options.signal, options.caseTimeoutMs);
   try {
-    output = await options.target(testCase.input, testCase);
-  } catch (error) {
-    targetError = error;
-  }
-  const traceResult = await resolveTrace(options, testCase, output, targetError);
-
-  const metrics: EvalMetricResult[] = [];
-  for (const metric of options.metrics) {
-    const outcome =
-      targetError === undefined
-        ? await safeEvaluate(options.name, testCase, output as Output, metric)
-        : EvalOutcome.invalid(`Target failed: ${errorMessage(targetError)}`);
-    const reporterErrors = await reportOutcome({
-      run,
+    const progress = (event: EvalProgressEvent<Input, Output, Expected>) =>
+      notifyProgress(options, event);
+    await progress({
+      type: "case-start",
       suiteName: options.name,
-      testCase,
-      output,
-      targetError,
-      metric,
-      outcome,
-      trace: traceResult.trace,
-      traceError: traceResult.error,
-      reporters: options.reporters ?? [],
-      reporterErrorPolicy: options.reporterErrorPolicy ?? "collect",
+      case: testCase,
+      completedCases: completedCases(),
+      totalCases: options.cases.length,
     });
-    const metricResult: EvalMetricResult = {
-      metricName: metric.name,
-      required: metric.required ?? true,
-      outcome,
-      reporterErrors,
-    };
-    if (metric.direction !== undefined) metricResult.direction = metric.direction;
-    if (metric.threshold !== undefined) metricResult.threshold = metric.threshold;
-    metrics.push(metricResult);
-  }
+    let output: Output | undefined;
+    let targetError: unknown;
+    let targetStatus: "succeeded" | "failed" = "succeeded";
+    let targetDurationMs = 0;
+    try {
+      output = await targetLimit(async () => {
+        const targetStartedAt = performance.now();
+        try {
+          return await (caseSignal.signal.aborted
+            ? Promise.reject(caseSignal.signal.reason)
+            : abortable(
+                caseSignal.signal,
+                Promise.resolve(
+                  options.target(testCase.input, testCase, { signal: caseSignal.signal }),
+                ),
+              ));
+        } finally {
+          targetDurationMs = performance.now() - targetStartedAt;
+        }
+      });
+    } catch (error) {
+      if (options.signal?.aborted === true) {
+        throw options.signal.reason ?? new EvalAbortError();
+      }
+      targetStatus = "failed";
+      targetError = error;
+    }
+    await progress({
+      type: "target-complete",
+      suiteName: options.name,
+      case: testCase,
+      targetStatus,
+      output,
+      error: targetError,
+      durationMs: targetDurationMs,
+      completedCases: completedCases(),
+      totalCases: options.cases.length,
+    });
+    const traceResult = await resolveTrace(options, testCase, output, targetError, targetStatus);
 
-  const scores = Object.fromEntries(
-    metrics.map((metric) => [metric.metricName, metric.outcome]),
-  ) as EvalCaseResult<Input, Output, Expected, Metrics>["scores"];
-  const result: EvalCaseResult<Input, Output, Expected, Metrics> = {
-    case: testCase,
-    outcome: caseOutcome(targetError, metrics),
-    metrics: metrics as EvalCaseResult<Input, Output, Expected, Metrics>["metrics"],
-    scores,
-  };
-  if (output !== undefined) {
-    result.output = output;
+    const metrics = await Promise.all(
+      options.metrics.map((metric) =>
+        metricLimit(async () => {
+          const metricStartedAt = performance.now();
+          const outcome =
+            targetStatus === "succeeded"
+              ? await safeEvaluate(
+                  options.name,
+                  testCase,
+                  output as Output,
+                  metric,
+                  caseSignal.signal,
+                )
+              : EvalOutcome.invalid(`Target failed: ${errorMessage(targetError)}`, {
+                  kind: targetError instanceof EvalTimeoutError ? "timeout" : "target",
+                  error: targetError,
+                });
+          const durationMs = performance.now() - metricStartedAt;
+          const reporterErrors = await reportOutcome({
+            run,
+            suiteName: options.name,
+            testCase,
+            output,
+            targetError,
+            targetStatus,
+            metric,
+            outcome,
+            trace: traceResult.trace,
+            traceError: traceResult.error,
+            reporters: options.reporters ?? [],
+            reporterErrorPolicy: options.reporterErrorPolicy ?? "collect",
+          });
+          await progress({
+            type: "metric-complete",
+            suiteName: options.name,
+            case: testCase,
+            metricName: metric.name,
+            outcome,
+            durationMs,
+            completedCases: completedCases(),
+            totalCases: options.cases.length,
+          });
+          const metricResult: EvalMetricResult = {
+            metricName: metric.name,
+            required: metric.required ?? true,
+            outcome,
+            durationMs,
+            reporterErrors,
+          };
+          if (metric.direction !== undefined) metricResult.direction = metric.direction;
+          if (metric.threshold !== undefined) metricResult.threshold = metric.threshold;
+          return metricResult;
+        }),
+      ),
+    );
+
+    const scores = Object.fromEntries(
+      metrics.map((metric) => [metric.metricName, metric.outcome]),
+    ) as EvalCaseResult<Input, Output, Expected, Metrics>["scores"];
+    const result: EvalCaseResult<Input, Output, Expected, Metrics> = {
+      case: testCase,
+      outcome: caseOutcome(targetStatus, metrics),
+      targetStatus,
+      targetDurationMs,
+      durationMs: performance.now() - caseStartedAt,
+      metrics: metrics as EvalCaseResult<Input, Output, Expected, Metrics>["metrics"],
+      scores,
+      usage: emptyUsageSummary(),
+    };
+    if (targetStatus === "succeeded") {
+      result.output = output;
+    }
+    if (targetStatus === "failed") {
+      result.targetError = targetError;
+    }
+    await progress({
+      type: "case-complete",
+      suiteName: options.name,
+      result,
+      completedCases: completedCases() + 1,
+      totalCases: options.cases.length,
+    });
+    return result;
+  } finally {
+    caseSignal.dispose();
   }
-  if (targetError !== undefined) {
-    result.targetError = targetError;
-  }
-  return result;
 }
 
 async function resolveTrace<Input, Output, Expected>(
@@ -233,6 +370,7 @@ async function resolveTrace<Input, Output, Expected>(
   testCase: EvalCase<Input, Expected>,
   output: Output | undefined,
   targetError: unknown,
+  targetStatus: "succeeded" | "failed",
 ): Promise<{ trace?: EvalTraceRef | undefined; error?: unknown }> {
   try {
     const selector = options.trace ?? defaultEvalTraceSelector;
@@ -241,6 +379,7 @@ async function resolveTrace<Input, Output, Expected>(
       case: testCase,
       output,
       targetError,
+      targetStatus,
     });
     return trace === undefined ? {} : { trace };
   } catch (error) {
@@ -253,11 +392,21 @@ async function safeEvaluate<Input, Output, Expected>(
   testCase: EvalCase<Input, Expected>,
   output: Output,
   metric: EvalMetric<Input, Output, unknown, Expected>,
+  signal: AbortSignal,
 ): Promise<EvalOutcomeType> {
+  if (signal.aborted) {
+    return EvalOutcome.fromError(
+      signal.reason,
+      signal.reason instanceof EvalTimeoutError ? "timeout" : "metric",
+    );
+  }
   try {
-    return await metric.evaluate({ suiteName, case: testCase, output });
+    return await abortable(
+      signal,
+      Promise.resolve(metric.evaluate({ suiteName, case: testCase, output, signal })),
+    );
   } catch (error) {
-    return EvalOutcome.invalid(errorMessage(error));
+    return EvalOutcome.fromError(error, error instanceof EvalTimeoutError ? "timeout" : "metric");
   }
 }
 
@@ -267,6 +416,7 @@ async function reportOutcome<Input, Output, Expected>(args: {
   testCase: EvalCase<Input, Expected>;
   output: Output | undefined;
   targetError: unknown;
+  targetStatus: "succeeded" | "failed";
   metric: EvalMetric<Input, Output, unknown, Expected>;
   outcome: EvalOutcomeType;
   trace: EvalTraceRef | undefined;
@@ -286,6 +436,7 @@ async function reportOutcome<Input, Output, Expected>(args: {
         case: args.testCase,
         output: args.output,
         targetError: args.targetError,
+        targetStatus: args.targetStatus,
         trace: args.trace,
         metric: args.metric,
         outcome: args.outcome,
@@ -396,6 +547,14 @@ function emptyTotals(): EvalTotals {
   return { total: 0, passed: 0, failed: 0, invalid: 0 };
 }
 
+function emptyUsageSummary() {
+  return {
+    target: UsageValue.empty(),
+    evaluation: UsageValue.empty(),
+    total: UsageValue.empty(),
+  };
+}
+
 function statusKey(status: "pass" | "fail" | "invalid"): "passed" | "failed" | "invalid" {
   if (status === "pass") return "passed";
   if (status === "fail") return "failed";
@@ -403,10 +562,10 @@ function statusKey(status: "pass" | "fail" | "invalid"): "passed" | "failed" | "
 }
 
 function caseOutcome(
-  targetError: unknown,
+  targetStatus: "succeeded" | "failed",
   metrics: EvalMetricResult[],
 ): "pass" | "fail" | "invalid" {
-  if (targetError !== undefined) return "invalid";
+  if (targetStatus === "failed") return "invalid";
   const required = metrics.filter((metric) => metric.required);
   if (required.some((metric) => metric.outcome.outcome === "invalid")) return "invalid";
   if (required.some((metric) => metric.outcome.outcome === "fail")) return "fail";
@@ -433,20 +592,26 @@ async function aggregateResult<
   let evaluationCost = 0;
 
   for (const result of results) {
-    if (result.output !== undefined) {
-      const usage = await resolveTargetUsage(options, result.case, result.output);
+    let caseTargetUsage = UsageValue.empty();
+    let caseEvaluationUsage = UsageValue.empty();
+    let caseTargetCost = 0;
+    let caseEvaluationCost = 0;
+    if (result.targetStatus === "succeeded") {
+      const usage = await resolveTargetUsage(options, result.case, result.output as Output);
       if (usage !== undefined) {
+        caseTargetUsage = usage;
         targetUsage = UsageValue.add(targetUsage, usage);
         if (options.cost !== undefined) {
-          targetCost += await calculateCost(
+          caseTargetCost = await calculateCost(
             options.cost.calculate({
               kind: "target",
               suiteName: options.name,
               case: result.case,
-              output: result.output,
+              output: result.output as Output,
               usage,
             }),
           );
+          targetCost += caseTargetCost;
         }
       }
     }
@@ -454,24 +619,41 @@ async function aggregateResult<
       const usage = metricResult.outcome.usage;
       if (usage === undefined) continue;
       assertUsage(usage, `Evaluation usage for metric ${metricResult.metricName}`);
+      caseEvaluationUsage = UsageValue.add(caseEvaluationUsage, usage);
       evaluationUsage = UsageValue.add(evaluationUsage, usage);
-      if (options.cost !== undefined && result.output !== undefined) {
+      if (options.cost !== undefined && result.targetStatus === "succeeded") {
         const metric = options.metrics.find(
           (candidate) => candidate.name === metricResult.metricName,
         );
         if (metric !== undefined) {
-          evaluationCost += await calculateCost(
+          const metricCost = await calculateCost(
             options.cost.calculate({
               kind: "evaluation",
               suiteName: options.name,
               case: result.case,
-              output: result.output,
+              output: result.output as Output,
               metric,
               usage,
             }),
           );
+          metricResult.cost = metricCost;
+          caseEvaluationCost += metricCost;
+          evaluationCost += metricCost;
         }
       }
+    }
+    result.usage = {
+      target: caseTargetUsage,
+      evaluation: caseEvaluationUsage,
+      total: UsageValue.add(caseTargetUsage, caseEvaluationUsage),
+    };
+    if (options.cost !== undefined) {
+      result.cost = {
+        currency: options.cost.currency,
+        target: caseTargetCost,
+        evaluation: caseEvaluationCost,
+        total: caseTargetCost + caseEvaluationCost,
+      };
     }
   }
 
@@ -509,7 +691,12 @@ async function resolveTargetUsage<Input, Output, Expected>(
   const usage =
     options.targetUsage === undefined
       ? usageFromOutput(output)
-      : await options.targetUsage({ suiteName: options.name, case: testCase, output });
+      : await options.targetUsage({
+          suiteName: options.name,
+          case: testCase,
+          output,
+          signal: new AbortController().signal,
+        });
   if (usage !== undefined) assertUsage(usage, `Target usage for case ${testCase.id}`);
   return usage;
 }
@@ -539,6 +726,25 @@ async function calculateCost(value: number | Promise<number>): Promise<number> {
 function validateSuiteOptions<Input, Output, Expected>(
   options: RunEvalSuiteOptions<Input, Output, Expected>,
 ): void {
+  if (options.name.trim().length === 0) {
+    throw new TypeError("Evaluation suite name must not be empty");
+  }
+  if (options.cases.length === 0) {
+    throw new TypeError("Evaluation suite must contain at least one case");
+  }
+  if (options.metrics.length === 0) {
+    throw new TypeError("Evaluation suite must contain at least one metric");
+  }
+  for (const testCase of options.cases) {
+    if (testCase.id.trim().length === 0) {
+      throw new TypeError("Evaluation case id must not be empty");
+    }
+  }
+  for (const metric of options.metrics) {
+    if (metric.name.trim().length === 0) {
+      throw new TypeError("Evaluation metric name must not be empty");
+    }
+  }
   assertUnique(
     options.cases.map((testCase) => testCase.id),
     "Evaluation case id",
@@ -550,6 +756,33 @@ function validateSuiteOptions<Input, Output, Expected>(
   if (options.cost !== undefined && options.cost.currency.trim().length === 0) {
     throw new TypeError("Evaluation cost currency must not be empty");
   }
+  for (const [label, value] of [
+    ["concurrency", options.concurrency],
+    ["targetConcurrency", options.targetConcurrency],
+    ["metricConcurrency", options.metricConcurrency],
+  ] as const) {
+    if (value !== undefined && (!Number.isSafeInteger(value) || value < 1)) {
+      throw new RangeError(`Evaluation ${label} must be a positive integer`);
+    }
+  }
+  if (
+    options.caseTimeoutMs !== undefined &&
+    (!Number.isSafeInteger(options.caseTimeoutMs) || options.caseTimeoutMs < 1)
+  ) {
+    throw new RangeError("Evaluation caseTimeoutMs must be a positive integer");
+  }
+  if (options.shard !== undefined) {
+    if (!Number.isSafeInteger(options.shard.count) || options.shard.count < 1) {
+      throw new RangeError("Evaluation shard count must be a positive integer");
+    }
+    if (
+      !Number.isSafeInteger(options.shard.index) ||
+      options.shard.index < 0 ||
+      options.shard.index >= options.shard.count
+    ) {
+      throw new RangeError("Evaluation shard index must be between 0 and count - 1");
+    }
+  }
 }
 
 function assertUnique(values: string[], label: string): void {
@@ -558,4 +791,40 @@ function assertUnique(values: string[], label: string): void {
     if (seen.has(value)) throw new TypeError(`${label} must be unique: ${value}`);
     seen.add(value);
   }
+}
+
+function selectCases<Input, Output, Expected>(
+  options: RunEvalSuiteOptions<Input, Output, Expected>,
+): readonly EvalCase<Input, Expected>[] {
+  const requested = options.caseIds === undefined ? undefined : new Set(options.caseIds);
+  if (requested !== undefined) {
+    assertUnique([...options.caseIds!], "Evaluation selected case id");
+    const available = new Set(options.cases.map((testCase) => testCase.id));
+    for (const id of requested) {
+      if (!available.has(id))
+        throw new TypeError(`Evaluation selected case id was not found: ${id}`);
+    }
+  }
+  const filtered = options.cases.filter(
+    (testCase, index) =>
+      (requested === undefined || requested.has(testCase.id)) &&
+      (options.caseFilter === undefined || options.caseFilter(testCase, index)),
+  );
+  if (options.shard === undefined) return filtered;
+  return filtered.filter((_, index) => index % options.shard!.count === options.shard!.index);
+}
+
+async function notifyProgress<Input, Output, Expected>(
+  options: RunEvalSuiteOptions<Input, Output, Expected>,
+  event: EvalProgressEvent<Input, Output, Expected>,
+): Promise<void> {
+  await options.onProgress?.(event);
+}
+
+function isAborted(signal: AbortSignal | undefined): boolean {
+  return signal?.aborted === true;
+}
+
+function suiteAbortReason(signal: AbortSignal | undefined): unknown {
+  return signal?.reason ?? new EvalAbortError();
 }

--- a/packages/core/src/evals/selectors.ts
+++ b/packages/core/src/evals/selectors.ts
@@ -1,5 +1,11 @@
 import { defaultOutputValue, formatValue } from "./format";
-import type { EvalMetricArgs, SelectorOrValue, ValueSelector } from "./types";
+import type {
+  EvalMetricArgs,
+  EvalOutcomeStatus,
+  EvalSuiteResult,
+  SelectorOrValue,
+  ValueSelector,
+} from "./types";
 
 export function selectPromptOutput(args: EvalMetricArgs<unknown, unknown, unknown>): string {
   if (
@@ -11,6 +17,16 @@ export function selectPromptOutput(args: EvalMetricArgs<unknown, unknown, unknow
     throw new TypeError("selectPromptOutput requires an output object with a string output field.");
   }
   return args.output.output;
+}
+
+export function selectEvalCaseIds(
+  result: EvalSuiteResult<unknown, unknown, unknown>,
+  outcomes: readonly EvalOutcomeStatus[] = ["fail", "invalid"],
+): string[] {
+  const selected = new Set(outcomes);
+  return result.results
+    .filter((caseResult) => selected.has(caseResult.outcome))
+    .map((caseResult) => caseResult.case.id);
 }
 
 export async function resolveActual<Input, Output, Expected>(
@@ -25,7 +41,14 @@ export async function resolveActualText<Input, Output, Expected>(
   args: EvalMetricArgs<Input, Output, Expected>,
 ): Promise<string> {
   const value = selector === undefined ? defaultOutputValue(args.output) : await selector(args);
-  return typeof value === "string" ? value : JSON.stringify(value);
+  if (typeof value === "string") return value;
+  try {
+    const serialized = JSON.stringify(value);
+    if (serialized !== undefined) return serialized;
+  } catch {
+    // The caller receives one consistent boundary error below.
+  }
+  throw new TypeError("Text metric actual value must be a string or JSON-serializable value.");
 }
 
 export async function resolveExpected<Input, Output, Expected, Value>(

--- a/packages/core/src/evals/suite.ts
+++ b/packages/core/src/evals/suite.ts
@@ -1,4 +1,12 @@
-import type { EvalCase, EvalMetric, EvalTarget, RunEvalSuiteOptions } from "./types";
+import type {
+  EvalCase,
+  EvalCasesForMetrics,
+  EvalMetric,
+  EvalTarget,
+  RunEvalSuiteOptions,
+} from "./types";
+
+export type { EvalCasesForMetrics } from "./types";
 
 type EvalCaseLike = EvalCase<unknown, unknown>;
 
@@ -9,50 +17,6 @@ type EvalCaseExpected<Case> = Case extends { expected: infer Expected } ? Expect
 export type EvalCasesExpected<Cases extends readonly EvalCaseLike[]> = EvalCaseExpected<
   Cases[number]
 >;
-
-type EvalMetricRequirements<Metric> =
-  Metric extends EvalMetric<
-    infer _Input,
-    infer _Output,
-    infer _Score,
-    infer _Expected,
-    infer _Name,
-    infer Requirements
-  >
-    ? Requirements
-    : Record<never, never>;
-
-type RequiredExpected<Metrics extends readonly EvalMetric<never, never>[]> = Extract<
-  EvalMetricRequirements<Metrics[number]>,
-  { expected: unknown }
->;
-
-type RequiredContext<Metrics extends readonly EvalMetric<never, never>[]> = Extract<
-  EvalMetricRequirements<Metrics[number]>,
-  { context: string[] }
->;
-
-type RequiredRetrievalContext<Metrics extends readonly EvalMetric<never, never>[]> = Extract<
-  EvalMetricRequirements<Metrics[number]>,
-  { retrievalContext: string[] }
->;
-
-type EvalCaseFieldsForMetrics<Metrics extends readonly EvalMetric<never, never>[]> = ([
-  RequiredExpected<Metrics>,
-] extends [never]
-  ? Record<never, never>
-  : { expected: RequiredExpected<Metrics>["expected"] }) &
-  ([RequiredContext<Metrics>] extends [never] ? Record<never, never> : { context: string[] }) &
-  ([RequiredRetrievalContext<Metrics>] extends [never]
-    ? Record<never, never>
-    : { retrievalContext: string[] });
-
-export type EvalCasesForMetrics<
-  Cases extends readonly EvalCaseLike[],
-  Metrics extends readonly EvalMetric<never, never>[],
-> = {
-  readonly [Index in keyof Cases]: Cases[Index] & EvalCaseFieldsForMetrics<Metrics>;
-};
 
 export type DefinedEvalSuite<
   Cases extends readonly EvalCaseLike[],
@@ -66,9 +30,10 @@ export type DefinedEvalSuite<
   >[],
 > = Omit<
   RunEvalSuiteOptions<EvalCasesInput<Cases>, Output, EvalCasesExpected<Cases>, Metrics>,
-  "cases" | "target" | "metrics"
+  "caseIds" | "cases" | "target" | "metrics"
 > & {
   cases: Cases & EvalCasesForMetrics<NoInfer<Cases>, NoInfer<Metrics>>;
+  caseIds?: readonly Cases[number]["id"][] | undefined;
   target: EvalTarget<EvalCasesInput<Cases>, Output, EvalCasesExpected<Cases>>;
   metrics: Metrics;
 };
@@ -110,6 +75,19 @@ export function defineEvalCases<const Cases extends readonly EvalCaseLike[]>(cas
   return cases;
 }
 
+export function createEvalTypes<Input, Output, Expected = unknown>(): EvalMetricFactory<
+  Input,
+  Output,
+  Expected
+> {
+  return {
+    defineMetric(metric: EvalMetric<Input, Output>) {
+      return metric;
+    },
+  } as EvalMetricFactory<Input, Output, Expected>;
+}
+
+/** @deprecated Use createEvalTypes() when defining typed custom metrics. */
 export function defineEvalSuite<Input, Output, Expected = unknown>(): EvalMetricFactory<
   Input,
   Output,
@@ -141,9 +119,5 @@ export function defineEvalSuite(
   | DefinedEvalSuite<readonly EvalCaseLike[], unknown, readonly EvalMetric<unknown, unknown>[]>
   | EvalMetricFactory<unknown, unknown, unknown> {
   if (options !== undefined) return options;
-  return {
-    defineMetric(metric: EvalMetric<unknown, unknown>) {
-      return metric;
-    },
-  } as EvalMetricFactory<unknown, unknown, unknown>;
+  return createEvalTypes();
 }

--- a/packages/core/src/evals/types.ts
+++ b/packages/core/src/evals/types.ts
@@ -3,6 +3,7 @@ import type { EvalOutcome } from "./outcome";
 
 export type EvalMetadata = JsonObject;
 export type EvalReporterErrorPolicy = "collect" | "throw";
+export type EvalInvalidKind = "target" | "metric" | "configuration" | "provider" | "timeout";
 
 export type EvalRunOptions = {
   id?: string | undefined;
@@ -44,7 +45,12 @@ export type EvalTraceRef = {
 export type EvalTarget<Input, Output, Expected = unknown> = (
   input: Input,
   testCase: EvalCase<Input, Expected>,
+  context?: EvalTargetContext,
 ) => Output | Promise<Output>;
+
+export type EvalTargetContext = {
+  signal: AbortSignal;
+};
 
 export type EvalOutcomeStatus = "pass" | "fail" | "invalid";
 
@@ -99,6 +105,7 @@ export type EvalMetricArgs<Input, Output, Expected = unknown> = {
   suiteName: string;
   case: EvalCase<Input, Expected>;
   output: Output;
+  signal: AbortSignal;
 };
 
 export type EvalMetric<
@@ -130,6 +137,8 @@ export type EvalMetricResult<Score = unknown, Name extends string = string> = {
   direction?: EvalScoreDirection | undefined;
   threshold?: number | undefined;
   outcome: EvalOutcome<Score>;
+  durationMs: number;
+  cost?: number | undefined;
   reporterErrors: unknown[];
 };
 
@@ -159,10 +168,15 @@ export type EvalCaseResult<
 > = {
   case: EvalCase<Input, Expected>;
   outcome: EvalOutcomeStatus;
+  targetStatus: "succeeded" | "failed";
   output?: Output | undefined;
   targetError?: unknown;
+  targetDurationMs: number;
+  durationMs: number;
   metrics: Array<EvalMetricResultFor<Metrics[number]>>;
   scores: EvalScoreMap<Metrics>;
+  usage: EvalUsageSummary;
+  cost?: EvalCostSummary | undefined;
 };
 
 export type EvalSuiteResult<
@@ -195,6 +209,7 @@ export type EvalReportArgs<Input, Output, Score = unknown, Expected = unknown> =
   case: EvalCase<Input, Expected>;
   output?: Output | undefined;
   targetError?: unknown;
+  targetStatus?: "succeeded" | "failed" | undefined;
   trace?: EvalTraceRef | undefined;
   metric: EvalMetricDescriptor<Score>;
   outcome: EvalOutcome<Score>;
@@ -223,6 +238,7 @@ export type EvalTraceSelectorArgs<Input, Output, Expected = unknown> = {
   case: EvalCase<Input, Expected>;
   output?: Output | undefined;
   targetError?: unknown;
+  targetStatus?: "succeeded" | "failed" | undefined;
 };
 
 export type EvalTraceSelector<Input, Output, Expected = unknown> = (
@@ -261,6 +277,96 @@ export type EvalCostOptions<Input, Output, Expected = unknown> = {
   calculate(args: EvalCostCalculatorArgs<Input, Output, Expected>): number | Promise<number>;
 };
 
+type EvalCaseLike = EvalCase<unknown, unknown>;
+
+type EvalMetricRequirements<Metric> =
+  Metric extends EvalMetric<
+    infer _Input,
+    infer _Output,
+    infer _Score,
+    infer _Expected,
+    infer _Name,
+    infer Requirements
+  >
+    ? Requirements
+    : Record<never, never>;
+
+type RequiredExpected<Metrics extends readonly EvalMetric<never, never>[]> = Extract<
+  EvalMetricRequirements<Metrics[number]>,
+  { expected: unknown }
+>;
+
+type RequiredContext<Metrics extends readonly EvalMetric<never, never>[]> = Extract<
+  EvalMetricRequirements<Metrics[number]>,
+  { context: string[] }
+>;
+
+type RequiredRetrievalContext<Metrics extends readonly EvalMetric<never, never>[]> = Extract<
+  EvalMetricRequirements<Metrics[number]>,
+  { retrievalContext: string[] }
+>;
+
+type EvalCaseFieldsForMetrics<Metrics extends readonly EvalMetric<never, never>[]> = ([
+  RequiredExpected<Metrics>,
+] extends [never]
+  ? Record<never, never>
+  : { expected: RequiredExpected<Metrics>["expected"] }) &
+  ([RequiredContext<Metrics>] extends [never] ? Record<never, never> : { context: string[] }) &
+  ([RequiredRetrievalContext<Metrics>] extends [never]
+    ? Record<never, never>
+    : { retrievalContext: string[] });
+
+export type EvalCasesForMetrics<
+  Cases extends readonly EvalCaseLike[],
+  Metrics extends readonly EvalMetric<never, never>[],
+> = {
+  readonly [Index in keyof Cases]: Cases[Index] extends EvalCaseLike
+    ? Cases[Index] & EvalCaseFieldsForMetrics<Metrics>
+    : Cases[Index];
+};
+
+export type EvalShard = {
+  index: number;
+  count: number;
+};
+
+export type EvalProgressEvent<Input, Output, Expected = unknown> =
+  | {
+      type: "case-start";
+      suiteName: string;
+      case: EvalCase<Input, Expected>;
+      completedCases: number;
+      totalCases: number;
+    }
+  | {
+      type: "target-complete";
+      suiteName: string;
+      case: EvalCase<Input, Expected>;
+      targetStatus: "succeeded" | "failed";
+      output?: Output | undefined;
+      error?: unknown;
+      durationMs: number;
+      completedCases: number;
+      totalCases: number;
+    }
+  | {
+      type: "metric-complete";
+      suiteName: string;
+      case: EvalCase<Input, Expected>;
+      metricName: string;
+      outcome: EvalOutcome<unknown>;
+      durationMs: number;
+      completedCases: number;
+      totalCases: number;
+    }
+  | {
+      type: "case-complete";
+      suiteName: string;
+      result: EvalCaseResult<Input, Output, Expected>;
+      completedCases: number;
+      totalCases: number;
+    };
+
 export type RunEvalSuiteOptions<
   Input,
   Output,
@@ -275,10 +381,20 @@ export type RunEvalSuiteOptions<
 > = {
   name: string;
   run?: EvalRunOptions | undefined;
-  cases: readonly EvalCase<Input, Expected>[];
+  cases: readonly EvalCase<Input, Expected>[] &
+    EvalCasesForMetrics<readonly EvalCase<Input, Expected>[], Metrics>;
   target: EvalTarget<Input, Output, Expected>;
   metrics: Metrics;
   concurrency?: number | undefined;
+  targetConcurrency?: number | undefined;
+  metricConcurrency?: number | undefined;
+  caseTimeoutMs?: number | undefined;
+  signal?: AbortSignal | undefined;
+  failFast?: boolean | undefined;
+  caseIds?: readonly string[] | undefined;
+  caseFilter?(testCase: EvalCase<Input, Expected>, index: number): boolean;
+  shard?: EvalShard | undefined;
+  onProgress?(event: EvalProgressEvent<Input, Output, Expected>): void | Promise<void>;
   trace?: EvalTraceSelector<NoInfer<Input>, NoInfer<Output>, NoInfer<Expected>> | undefined;
   reporters?:
     | readonly EvalReporter<NoInfer<Input>, NoInfer<Output>, NoInfer<Expected>>[]

--- a/packages/core/test/advanced-evals.test.ts
+++ b/packages/core/test/advanced-evals.test.ts
@@ -561,6 +561,7 @@ describe("advanced eval metrics", () => {
 
     const missingContext = await runEvalSuite({
       name: "missing-context",
+      // @ts-expect-error this test exercises runtime validation for missing implicit contexts.
       cases: [{ id: "case", input: "Question" }],
       target: () => "Answer",
       metrics: [

--- a/packages/core/test/eval-cli.test.ts
+++ b/packages/core/test/eval-cli.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   assertEvalOutcomes,
   assertEvalTotals,
+  defineEvalExpectations,
   evalExitCode,
   exactMatch,
+  formatEvalResult,
   printEvalResult,
   runEvalCli,
   runEvalSuite,
@@ -46,6 +48,7 @@ describe("eval CLI result handling", () => {
 
     const invalid = await runEvalSuite({
       name: "invalid",
+      // @ts-expect-error direct suite definitions require implicit metric case fields.
       cases: [{ id: "missing-expected", input: "a" }],
       target: (input) => input,
       metrics: [exactMatch()],
@@ -66,6 +69,64 @@ describe("eval CLI result handling", () => {
 
     expect(result.cases.passed).toBe(1);
     expect(output).toBe("");
+  });
+
+  it("formats results without writing and supports truncation and redaction", async () => {
+    const result = await runEvalSuite({
+      name: "safe-output",
+      cases: [{ id: "secret", input: "private input", expected: "private output" }],
+      target: () => "private output with extra text",
+      metrics: [exactMatch()],
+    });
+
+    const pretty = formatEvalResult(result, { maxValueLength: 12 });
+    const json = formatEvalResult(result, {
+      format: "json",
+      redact: (value, context) =>
+        ["input", "score", "comment"].includes(context.kind) ? `[${context.kind}]` : value,
+    });
+    const parsed = JSON.parse(json);
+
+    expect(pretty).toContain("private outp…");
+    expect(json).not.toContain("private input");
+    expect(parsed.results[0].case.input).toBe("[input]");
+    expect(parsed.results[0].metrics[0].outcome).toMatchObject({
+      score: "[score]",
+      comment: "[comment]",
+    });
+    expect(parsed.results[0].scores.exact_match).toMatchObject({
+      score: "[score]",
+      comment: "[comment]",
+    });
+  });
+
+  it("defines expectations from suite case and metric names", () => {
+    const suite = {
+      name: "typed",
+      cases: [{ id: "known", input: "x", expected: "x" }] as const,
+      target: (input: string) => input,
+      metrics: [exactMatch({ name: "correct" })] as const,
+    };
+
+    const expectations = defineEvalExpectations(suite, {
+      outcomes: { known: { correct: "pass" } },
+    });
+    expect(expectations.outcomes?.known?.correct).toBe("pass");
+
+    defineEvalExpectations(suite, {
+      outcomes: {
+        // @ts-expect-error expectations only accept suite case ids.
+        missing: { correct: "pass" },
+      },
+    });
+    defineEvalExpectations(suite, {
+      outcomes: {
+        known: {
+          // @ts-expect-error expectations only accept suite metric names.
+          missing: "pass",
+        },
+      },
+    });
   });
 });
 

--- a/packages/core/test/eval-types.test.ts
+++ b/packages/core/test/eval-types.test.ts
@@ -5,6 +5,8 @@ import {
   answerRelevancy,
   type CompletionModel,
   contains,
+  containsAll,
+  createEvalTypes,
   defineEvalCases,
   defineEvalSuite,
   type EvalCasesForMetrics,
@@ -12,7 +14,10 @@ import {
   type EvalReporter,
   exactMatch,
   faithfulness,
+  gEval,
   hallucination,
+  matches,
+  notContains,
   runEvalSuite,
   selectPromptOutput,
 } from "./helpers/imports";
@@ -61,7 +66,7 @@ describe("eval type safety", () => {
   });
 
   it("binds custom metric input, output, and expected types once", () => {
-    const typedSuite = defineEvalSuite<string, PromptResult, string>();
+    const typedSuite = createEvalTypes<string, PromptResult, string>();
     const noLeak = typedSuite.defineMetric({
       name: "no_secret_leak",
       dataType: "BOOLEAN",
@@ -82,6 +87,34 @@ describe("eval type safety", () => {
       // @ts-expect-error BOOLEAN metrics must produce boolean scores.
       dataType: "BOOLEAN",
       evaluate: () => EvalOutcome.pass("good"),
+    });
+  });
+
+  it("applies implicit case requirements consistently through runEvalSuite", () => {
+    const cases = defineEvalCases([{ id: "case", input: "hello" }]);
+
+    runEvalSuite({
+      name: "missing expected",
+      // @ts-expect-error notContains() reads case.expected when no expected option is configured.
+      cases,
+      target: (input) => input,
+      metrics: [notContains()],
+    });
+
+    defineEvalSuite({
+      name: "missing lists",
+      // @ts-expect-error containsAll() reads case.expected when no expected option is configured.
+      cases,
+      target: (input) => input,
+      metrics: [containsAll({})],
+    });
+
+    defineEvalSuite({
+      name: "missing regex",
+      // @ts-expect-error matches() reads case.expected when no expected option is configured.
+      cases,
+      target: (input) => input,
+      metrics: [matches({})],
     });
   });
 
@@ -158,6 +191,42 @@ describe("eval type safety", () => {
       metrics: [
         hallucination({ model, context: ["Coverage lasts 30 days."] }),
         faithfulness({ model, retrievalContext: ["Coverage lasts 30 days."] }),
+      ],
+    });
+  });
+
+  it("derives G-Eval case requirements from selected parameters", () => {
+    const model = null as unknown as CompletionModel;
+    const cases = defineEvalCases([{ id: "correctness", input: "question" }]);
+
+    defineEvalSuite({
+      name: "missing G-Eval references",
+      // @ts-expect-error expectedOutput and context require matching case fields.
+      cases,
+      target: () => "answer",
+      metrics: [
+        gEval({
+          name: "correctness",
+          model,
+          evaluationParams: ["actualOutput", "expectedOutput", "context"],
+          criteria: "Be correct and grounded.",
+        }),
+      ],
+    });
+
+    defineEvalSuite({
+      name: "explicit G-Eval references",
+      cases,
+      target: () => "answer",
+      metrics: [
+        gEval({
+          name: "correctness",
+          model,
+          evaluationParams: ["actualOutput", "expectedOutput", "context"],
+          criteria: "Be correct and grounded.",
+          expected: () => "answer",
+          context: ["answer"],
+        }),
       ],
     });
   });

--- a/packages/core/test/evals.test.ts
+++ b/packages/core/test/evals.test.ts
@@ -18,6 +18,7 @@ import {
   type EmbeddingModel,
   type EvalMetricArgs,
   EvalOutcome,
+  EvalFailFastError,
   exactMatch,
   llmJudge,
   llmScore,
@@ -28,6 +29,7 @@ import {
   requiredFields,
   resolveEvalTraceRef,
   runEvalSuite,
+  selectEvalCaseIds,
   semanticSimilarity,
   Usage,
 } from "./helpers/imports";
@@ -86,6 +88,56 @@ describe("evals", () => {
     expect(result.results[1]?.metrics[0]?.outcome.outcome).toBe("fail");
   });
 
+  it("compares structured exact-match values independently of object key order", async () => {
+    const result = await runEvalSuite({
+      name: "structured-exact-match",
+      cases: [{ id: "same-object", input: null, expected: { answer: "yes", confidence: 1 } }],
+      target: () => ({ confidence: 1, answer: "yes" }),
+      metrics: [exactMatch()],
+    });
+
+    expect(result.results[0]?.scores.exact_match?.outcome).toBe("pass");
+  });
+
+  it("preserves successful undefined outputs and their usage", async () => {
+    const result = await runEvalSuite({
+      name: "undefined-output",
+      cases: [{ id: "undefined", input: null }],
+      target: () => undefined,
+      metrics: [contains({ expected: "value" })],
+      targetUsage: () => usage(1, 0),
+    });
+    const caseResult = result.results[0];
+
+    expect(caseResult).toMatchObject({ targetStatus: "succeeded", output: undefined });
+    expect(caseResult !== undefined && "output" in caseResult).toBe(true);
+    expect(caseResult?.scores.contains).toMatchObject({
+      outcome: "invalid",
+      kind: "metric",
+      reason: "Text metric actual value must be a string or JSON-serializable value.",
+    });
+    expect(result.usage.target.totalTokens).toBe(1);
+  });
+
+  it("distinguishes a rejected undefined value from a successful undefined output", async () => {
+    const result = await runEvalSuite({
+      name: "undefined-target-error",
+      cases: [{ id: "undefined-error", input: null, expected: undefined }],
+      target: () => Promise.reject(undefined),
+      metrics: [exactMatch()],
+    });
+
+    expect(result.results[0]).toMatchObject({
+      targetStatus: "failed",
+      outcome: "invalid",
+    });
+    expect(result.results[0] !== undefined && "targetError" in result.results[0]).toBe(true);
+    expect(result.results[0]?.scores.exact_match).toMatchObject({
+      outcome: "invalid",
+      kind: "target",
+    });
+  });
+
   it("preserves result order with concurrent targets", async () => {
     const result = await runEvalSuite({
       name: "concurrent",
@@ -104,6 +156,45 @@ describe("evals", () => {
     expect(result.results.map((caseResult) => caseResult.case.id)).toEqual(["slow", "fast"]);
   });
 
+  it("limits target and metric concurrency independently", async () => {
+    let activeTargets = 0;
+    let activeMetrics = 0;
+    let maxTargets = 0;
+    let maxMetrics = 0;
+    await runEvalSuite({
+      name: "independent-concurrency",
+      cases: [
+        { id: "a", input: "a" },
+        { id: "b", input: "b" },
+        { id: "c", input: "c" },
+      ],
+      target: async (input) => {
+        activeTargets += 1;
+        maxTargets = Math.max(maxTargets, activeTargets);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        activeTargets -= 1;
+        return input;
+      },
+      metrics: [
+        {
+          name: "slow_metric",
+          evaluate: async () => {
+            activeMetrics += 1;
+            maxMetrics = Math.max(maxMetrics, activeMetrics);
+            await new Promise((resolve) => setTimeout(resolve, 5));
+            activeMetrics -= 1;
+            return EvalOutcome.pass(true);
+          },
+        },
+      ],
+      targetConcurrency: 2,
+      metricConcurrency: 1,
+    });
+
+    expect(maxTargets).toBe(2);
+    expect(maxMetrics).toBe(1);
+  });
+
   it("turns target errors into invalid metric results", async () => {
     const result = await runEvalSuite({
       name: "target-error",
@@ -116,10 +207,126 @@ describe("evals", () => {
 
     expect(result.metrics.invalid).toBe(2);
     expect(result.results[0]?.targetError).toBeInstanceOf(Error);
+    expect(result.results[0]?.targetStatus).toBe("failed");
     expect(result.results[0]?.metrics.map((metric) => metric.outcome.outcome)).toEqual([
       "invalid",
       "invalid",
     ]);
+  });
+
+  it("retains structured metric errors and per-case diagnostics", async () => {
+    const metricError = new Error("judge unavailable");
+    const result = await runEvalSuite({
+      name: "diagnostics",
+      cases: [{ id: "case", input: "x" }],
+      target: (input) => input,
+      metrics: [
+        {
+          name: "throws",
+          evaluate: () => {
+            throw metricError;
+          },
+        },
+      ],
+    });
+
+    expect(result.results[0]).toMatchObject({
+      targetStatus: "succeeded",
+      targetDurationMs: expect.any(Number),
+      durationMs: expect.any(Number),
+      usage: {
+        target: expect.any(Object),
+        evaluation: expect.any(Object),
+        total: expect.any(Object),
+      },
+    });
+    expect(result.results[0]?.metrics[0]).toMatchObject({
+      durationMs: expect.any(Number),
+      outcome: { outcome: "invalid", kind: "metric", error: metricError },
+    });
+  });
+
+  it("supports case timeouts, case selection, sharding, and progress events", async () => {
+    const progress: string[] = [];
+    const selected = await runEvalSuite({
+      name: "selected",
+      cases: [
+        { id: "a", input: "a", expected: "a" },
+        { id: "b", input: "b", expected: "b" },
+        { id: "c", input: "c", expected: "c" },
+      ],
+      caseIds: ["a", "c"],
+      shard: { index: 1, count: 2 },
+      target: (input) => input,
+      metrics: [exactMatch()],
+      onProgress: (event) => {
+        progress.push(event.type);
+      },
+    });
+
+    expect(selected.results.map((result) => result.case.id)).toEqual(["c"]);
+    expect(progress).toEqual(["case-start", "target-complete", "metric-complete", "case-complete"]);
+
+    const timedOut = await runEvalSuite({
+      name: "timeout",
+      cases: [{ id: "slow", input: "x", expected: "x" }],
+      target: async (_input, _case, context) =>
+        new Promise<string>((_resolve, reject) => {
+          const signal = context?.signal;
+          if (signal === undefined) throw new Error("Expected an eval target signal.");
+          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        }),
+      metrics: [exactMatch()],
+      caseTimeoutMs: 5,
+    });
+
+    expect(timedOut.results[0]).toMatchObject({
+      targetStatus: "failed",
+      targetError: expect.objectContaining({ name: "EvalTimeoutError" }),
+    });
+  });
+
+  it("supports aborting runs, fail-fast gates, and rerun selection", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("cancelled by caller"));
+    await expect(
+      runEvalSuite({
+        name: "aborted",
+        cases: [{ id: "case", input: "x", expected: "x" }],
+        target: (input) => input,
+        metrics: [exactMatch()],
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow("cancelled by caller");
+
+    const completed: string[] = [];
+    await expect(
+      runEvalSuite({
+        name: "fail-fast",
+        cases: [
+          { id: "first", input: "wrong", expected: "right" },
+          { id: "second", input: "right", expected: "right" },
+        ],
+        target: (input) => input,
+        metrics: [exactMatch()],
+        failFast: true,
+        onProgress: (event) => {
+          if (event.type === "case-complete") completed.push(event.result.case.id);
+        },
+      }),
+    ).rejects.toBeInstanceOf(EvalFailFastError);
+    expect(completed).toEqual(["first"]);
+
+    const previous = await runEvalSuite({
+      name: "rerun-source",
+      cases: [
+        { id: "pass", input: "yes", expected: "yes" },
+        { id: "fail", input: "no", expected: "yes" },
+      ],
+      target: (input) => input,
+      metrics: [exactMatch()],
+    });
+    expect(selectEvalCaseIds(previous)).toEqual(["fail"]);
   });
 
   it("supports exact and contains selector functions", async () => {
@@ -621,6 +828,9 @@ describe("evals", () => {
       evaluation: 0.01,
       total: 0.015,
     });
+    expect(result.results[0]?.usage.total.totalTokens).toBe(10);
+    expect(result.results[0]?.cost).toEqual(result.cost);
+    expect(result.results[0]?.metrics[0]?.cost).toBe(0.01);
   });
 
   it("rejects duplicate case ids and metric names before running targets", async () => {
@@ -635,6 +845,28 @@ describe("evals", () => {
         metrics: [exactMatch({ expected: "a" })],
       }),
     ).rejects.toThrow("Evaluation case id must be unique");
+  });
+
+  it("rejects invalid suite names, empty inputs, and concurrency values", async () => {
+    const base = {
+      name: "valid",
+      cases: [{ id: "case", input: "x", expected: "x" }],
+      target: (input: string) => input,
+      metrics: [exactMatch<string, string, string>()],
+    };
+
+    await expect(runEvalSuite({ ...base, name: " " })).rejects.toThrow(
+      "Evaluation suite name must not be empty",
+    );
+    await expect(runEvalSuite({ ...base, cases: [] })).rejects.toThrow(
+      "Evaluation suite must contain at least one case",
+    );
+    await expect(runEvalSuite({ ...base, metrics: [] })).rejects.toThrow(
+      "Evaluation suite must contain at least one metric",
+    );
+    await expect(runEvalSuite({ ...base, concurrency: Number.NaN })).rejects.toThrow(
+      "Evaluation concurrency must be a positive integer",
+    );
   });
 });
 
@@ -656,6 +888,7 @@ describe("defineMetric", () => {
       suiteName: "qa",
       case: { id: "c", input: "x" },
       output: "x",
+      signal: new AbortController().signal,
     };
     await expect(Promise.resolve(metric.evaluate(args))).resolves.toEqual({
       outcome: "pass",

--- a/packages/core/test/public-exports.test.ts
+++ b/packages/core/test/public-exports.test.ts
@@ -339,6 +339,13 @@ describe("public exports", () => {
     expect(embeddings).toHaveProperty("embedDocuments");
     expect(embeddings).not.toHaveProperty("embedHybridDocuments");
     expect(evals).toHaveProperty("runEvalSuite");
+    expect(evals).toHaveProperty("createEvalTypes");
+    expect(evals).toHaveProperty("defineEvalExpectations");
+    expect(evals).toHaveProperty("formatEvalResult");
+    expect(evals).toHaveProperty("selectEvalCaseIds");
+    expect(evals).toHaveProperty("EvalTimeoutError");
+    expect(evals).toHaveProperty("EvalAbortError");
+    expect(evals).toHaveProperty("EvalFailFastError");
     expect(evals).toHaveProperty("EvalOutcome");
     expect(evals).toHaveProperty("defaultEvalTraceSelector");
     expect(evals).toHaveProperty("projectEvalOutcome");


### PR DESCRIPTION
## Summary

- make exact matching structural and distinguish successful `undefined` outputs from target failures
- add typed metric case requirements, structured invalid errors, per-case diagnostics, and safer custom metric helpers
- add timeouts, abort signals, independent target/metric concurrency, progress events, filtering, sharding, fail-fast execution, and rerun selection
- add pure CLI formatting with typed expectations, truncation, and redaction across metric and score views
- document the eval workflow and add an `@anvia/core` patch changeset

## Validation

- `pnpm check`
- `pnpm --filter @anvia/core typecheck`
- `pnpm --filter @anvia/core test` (589 tests after rebasing onto current `main`)
- `pnpm --filter @anvia/core build`
- full package typecheck, build, and test sweeps completed before the final rebase
- cookbook typecheck completed

Docker-gated sandbox/browser integration tests were not enabled. No Studio UI changed, so visual verification was not required.