### PR TITLE
feat(graph): improve ingestion and tenant DX

### DIFF
--- a/.changeset/tidy-graphs-listen.md
+++ b/.changeset/tidy-graphs-listen.md
@@ -1,0 +1,9 @@
+---
+"@anvia/graph": patch
+"@anvia/neo4j": patch
+"@anvia/qdrant": patch
+---
+
+Add configurable property-level graph extraction conflict resolution with structured warnings and
+errors, durable ingestion receipts with optional graph-plus-vector orchestration, explorer source
+provenance, and shared-resource tenant namespaces for managed Neo4j graphs and Qdrant stores.

--- a/packages/graph-neo4j/README.md
+++ b/packages/graph-neo4j/README.md
@@ -111,6 +111,37 @@ const searchGraph = createGraphSearchTool({
 const agent = new Agent({ id: "support", model: chatModel, tools: [searchGraph] });
 ```
 
+Call `ensure()` once during application startup or deployment initialization, then reuse the graph
+handle in jobs. It is idempotent, but calling it for every ingestion job adds version, schema, and
+index checks to the hot path. Call `validate()` for readiness checks that must never provision.
+
+## Tenant namespaces
+
+Reuse the same labels, indexes, and Qdrant collection across tenants without constructing resource
+names from user input:
+
+```ts
+const tenant = client.tenant(userId);
+const graph = tenant.managedKnowledgeGraph({ name: "support", schema, resources });
+
+const qdrantTenant = qdrant.tenant(userId);
+const vectors = qdrantTenant.vectorStore({
+  collectionName: "support_documents",
+  dimensions: 1536,
+});
+```
+
+Both adapters hash the tenant ID using the same deterministic namespace. Neo4j includes that
+namespace in managed uniqueness constraints, indexed vector filtering, writes, retrieval,
+traversal, evidence, deletion, and exploration. Do not mix namespaced and non-namespaced handles
+with the same Neo4j resource definitions; `validate()` reports the incompatible constraint or
+index so it can be migrated explicitly.
+
+Tenant handles scope Anvia's managed lifecycle, retrieval, and exploration APIs; they are not a
+database authorization boundary. `graph.query()` and `client.nativeDriver()` intentionally expose
+raw Cypher access. Use separate Neo4j credentials or databases when untrusted callers require a
+hard security boundary.
+
 The application owns file discovery, reading, model loading, retry policy, and Agent lifecycle.
 `ingestGraphText()` and `ingestGraphDocuments()` provide the convenient end-to-end path. Advanced
 callers can compose `prepareGraphDocuments()`, `extractGraphFacts()`, `embedDocuments()`, and
@@ -182,6 +213,21 @@ const neighborhood = await graph.explore({
   maxDepth: 1,
 });
 ```
+
+Pass `includeProvenance: true` to expose supported source document and chunk IDs on explorer nodes
+and relationships. This can drive article-to-entity UI links without a separate identity mapping
+table; Neo4j element IDs remain opaque expansion cursors.
+
+## Production ingestion workflow
+
+For a queue worker (including BullMQ), use stable document IDs, attach a monotonic revision, and
+call `ingestGraphTextToStores({ graph, vectorStore, ... })`. Persist its receipt as the job result.
+Retry extraction/provider failures as a whole. If `GraphIngestionStageError.stage === "vector"`,
+the graph transaction already committed; re-run the idempotent job with `conflict: "overwrite"`.
+Refresh by replacing the same document ID;
+delete from both stores and record each completed stage. Pass the queue cancellation signal through
+`abortSignal`, create tenant-scoped handles before processing user-owned jobs, and request explorer
+provenance for source attribution.
 
 The explorer returns Neo4j element IDs as opaque strings, limits every query, and omits embeddings
 and other `__anvia_*` properties. Use stable graph identity properties for application logic; use the

--- a/packages/graph-neo4j/src/client.ts
+++ b/packages/graph-neo4j/src/client.ts
@@ -1,5 +1,11 @@
+import { createHash } from "node:crypto";
 import { auth, driver as createDriver, type Driver } from "neo4j-driver";
-import { ManagedNeo4jKnowledgeGraph, Neo4jKnowledgeGraph } from "./graph.js";
+import {
+  ManagedNeo4jKnowledgeGraph,
+  neo4jTenantScope,
+  Neo4jKnowledgeGraph,
+  type Neo4jTenantScope,
+} from "./graph.js";
 import type {
   ManagedNeo4jKnowledgeGraphOptions,
   Neo4jClientOptions,
@@ -44,6 +50,11 @@ export class Neo4jClient {
     return new ManagedNeo4jKnowledgeGraph(this, options);
   }
 
+  tenant(tenantId: string): Neo4jTenant {
+    this.assertOpen();
+    return new Neo4jTenant(this, neo4jTenantScope(tenantNamespace(tenantId)));
+  }
+
   knowledgeGraph<Schema extends Neo4jGraphSchema>(
     options: Neo4jKnowledgeGraphOptions<Schema>,
   ): Neo4jKnowledgeGraph<Schema> {
@@ -69,4 +80,28 @@ export class Neo4jClient {
   private assertOpen(): void {
     if (this.closed) throw new Error("Neo4jClient is closed.");
   }
+}
+
+export class Neo4jTenant {
+  constructor(
+    private readonly owner: Neo4jClient,
+    private readonly scope: Neo4jTenantScope,
+  ) {}
+
+  get namespace(): string {
+    return this.scope.namespace;
+  }
+
+  managedKnowledgeGraph<Schema extends Neo4jGraphSchema>(
+    options: ManagedNeo4jKnowledgeGraphOptions<Schema>,
+  ): ManagedNeo4jKnowledgeGraph<Schema> {
+    this.owner.nativeDriver();
+    return new ManagedNeo4jKnowledgeGraph(this.owner, options, this.scope);
+  }
+}
+
+function tenantNamespace(tenantId: string): string {
+  if (typeof tenantId !== "string" || tenantId.trim().length === 0)
+    throw new TypeError("Neo4j tenant id must be a non-empty string.");
+  return createHash("sha256").update(tenantId).digest("hex");
 }

--- a/packages/graph-neo4j/src/explore.ts
+++ b/packages/graph-neo4j/src/explore.ts
@@ -7,7 +7,14 @@ import {
   type ResolvedGraphExploreExpandOptions,
 } from "@anvia/graph";
 import { int, type Record as Neo4jRecord } from "neo4j-driver";
-import { Neo4jKnowledgeGraphBase } from "./graph.js";
+import { ManagedNeo4jKnowledgeGraph, Neo4jKnowledgeGraphBase } from "./graph.js";
+import { quoteIdentifier } from "./helpers.js";
+import {
+  managedPathPredicate,
+  managedScopeParameters,
+  managedScopePredicate,
+  type Neo4jManagedScope,
+} from "./managed-scope.js";
 import { parseNeo4jProperties } from "./schema.js";
 import type { Neo4jGraphSchema, Neo4jNodeIdentity } from "./types.js";
 
@@ -23,13 +30,16 @@ export async function exploreGraph<Schema extends Neo4jGraphSchema>(
     resolved.mode === "overview"
       ? await overviewNodes(graph, resolved)
       : await expandedNodes(graph, resolved);
-  const nodes = uniqueNodes(records.map((record) => nodeFromRecord(record, graph.schema)));
+  const nodes = uniqueNodes(
+    records.map((record) => nodeFromRecord(record, graph.schema, resolved.includeProvenance)),
+  );
   const visibleNodes = nodes.slice(0, resolved.maxNodes);
   const relationships = await relationshipsBetween(
     graph,
     visibleNodes.map((node) => node.id),
     resolved.relationships,
     resolved.maxRelationships,
+    resolved.includeProvenance,
     resolved.abortSignal,
   );
   return {
@@ -47,12 +57,15 @@ async function overviewNodes(
   options: ReturnType<typeof resolveGraphExploreOptions> & { mode: "overview" },
 ): Promise<readonly Neo4jRecord[]> {
   const result = await graph.query(
-    `MATCH (node)
-WHERE any(type IN labels(node) WHERE type IN $nodeTypes)
+    `MATCH (node${managedEntityLabel(graph)})
+WHERE any(type IN labels(node) WHERE type IN $nodeTypes)${managedAndPredicate(graph, "node")}
 RETURN elementId(node) AS id, labels(node) AS labels, properties(node) AS properties
 ORDER BY elementId(node)
 LIMIT $nodeLimit`,
-    { nodeTypes: options.nodeTypes, nodeLimit: int(options.maxNodes + 1) },
+    managedParameters(graph, {
+      nodeTypes: options.nodeTypes,
+      nodeLimit: int(options.maxNodes + 1),
+    }),
     options.abortSignal,
   );
   return result.records;
@@ -63,11 +76,11 @@ async function expandedNodes(
   options: ResolvedGraphExploreExpandOptions,
 ): Promise<readonly Neo4jRecord[]> {
   const roots = await graph.query(
-    `MATCH (node)
+    `MATCH (node${managedEntityLabel(graph)})
 WHERE elementId(node) IN $nodeIds
-  AND any(type IN labels(node) WHERE type IN $nodeTypes)
+  AND any(type IN labels(node) WHERE type IN $nodeTypes)${managedAndPredicate(graph, "node")}
 RETURN elementId(node) AS id, labels(node) AS labels, properties(node) AS properties`,
-    { nodeIds: options.nodeIds, nodeTypes: options.nodeTypes },
+    managedParameters(graph, { nodeIds: options.nodeIds, nodeTypes: options.nodeTypes }),
     options.abortSignal,
   );
   if (options.relationships.length === 0) return roots.records;
@@ -75,18 +88,18 @@ RETURN elementId(node) AS id, labels(node) AS labels, properties(node) AS proper
   if (remainingNodeLimit <= 0) return roots.records;
   const pattern = traversalPattern(options.direction, options.maxDepth);
   const neighbors = await graph.query(
-    `MATCH (root) WHERE elementId(root) IN $nodeIds
+    `MATCH (root${managedEntityLabel(graph)}) WHERE elementId(root) IN $nodeIds${managedAndPredicate(graph, "root")}
 MATCH path = ${pattern}
 WHERE all(rel IN relationships(path) WHERE type(rel) IN $relationshipTypes)
-  AND any(type IN labels(node) WHERE type IN $nodeTypes)
+  AND any(type IN labels(node) WHERE type IN $nodeTypes)${managedAndPredicate(graph, "node")}${managedPathAndPredicate(graph)}
 RETURN elementId(node) AS id, labels(node) AS labels, properties(node) AS properties
 LIMIT $nodeLimit`,
-    {
+    managedParameters(graph, {
       nodeIds: options.nodeIds,
       nodeTypes: options.nodeTypes,
       relationshipTypes: options.relationships,
       nodeLimit: int(remainingNodeLimit),
-    },
+    }),
     options.abortSignal,
   );
   return [...roots.records, ...neighbors.records];
@@ -97,6 +110,7 @@ async function relationshipsBetween(
   nodeIds: readonly string[],
   relationshipTypes: readonly string[],
   maxRelationships: number,
+  includeProvenance: boolean,
   abortSignal?: AbortSignal,
 ): Promise<GraphExploreRelationship[]> {
   if (nodeIds.length === 0 || relationshipTypes.length === 0) return [];
@@ -104,7 +118,7 @@ async function relationshipsBetween(
     `MATCH (from)-[relationship]->(to)
 WHERE elementId(from) IN $nodeIds
   AND elementId(to) IN $nodeIds
-  AND type(relationship) IN $relationshipTypes
+  AND type(relationship) IN $relationshipTypes${managedAndPredicate(graph, "from")}${managedAndPredicate(graph, "to")}${managedAndPredicate(graph, "relationship")}
 RETURN elementId(relationship) AS id,
        type(relationship) AS type,
        elementId(from) AS source,
@@ -112,17 +126,21 @@ RETURN elementId(relationship) AS id,
        properties(relationship) AS properties
 ORDER BY elementId(relationship)
 LIMIT $relationshipLimit`,
-    {
+    managedParameters(graph, {
       nodeIds,
       relationshipTypes,
       relationshipLimit: int(maxRelationships + 1),
-    },
+    }),
     abortSignal,
   );
-  return result.records.map(relationshipFromRecord);
+  return result.records.map((record) => relationshipFromRecord(record, includeProvenance));
 }
 
-function nodeFromRecord(record: Neo4jRecord, schema: Neo4jGraphSchema): GraphExploreNode {
+function nodeFromRecord(
+  record: Neo4jRecord,
+  schema: Neo4jGraphSchema,
+  includeProvenance: boolean,
+): GraphExploreNode {
   const id = stringValue(record.get("id"), "Neo4j explorer node id");
   const labels = stringArray(record.get("labels"), "Neo4j explorer node labels");
   const raw = objectValue(record.get("properties"), "Neo4j explorer node properties");
@@ -135,6 +153,7 @@ function nodeFromRecord(record: Neo4jRecord, schema: Neo4jGraphSchema): GraphExp
     type: string;
     identity: Neo4jNodeIdentity;
     properties: typeof properties;
+    provenance?: { documentIds: string[]; chunkIds: string[] } | undefined;
   } = {
     id,
     type,
@@ -143,10 +162,14 @@ function nodeFromRecord(record: Neo4jRecord, schema: Neo4jGraphSchema): GraphExp
   };
   const key = raw.__anvia_key;
   if (typeof key === "string") node.key = key;
+  if (includeProvenance) node.provenance = provenanceProperties(raw);
   return node;
 }
 
-function relationshipFromRecord(record: Neo4jRecord): GraphExploreRelationship {
+function relationshipFromRecord(
+  record: Neo4jRecord,
+  includeProvenance: boolean,
+): GraphExploreRelationship {
   const raw = objectValue(record.get("properties"), "Neo4j explorer relationship properties");
   const relationship: {
     id: string;
@@ -155,6 +178,7 @@ function relationshipFromRecord(record: Neo4jRecord): GraphExploreRelationship {
     from: string;
     to: string;
     properties: ReturnType<typeof applicationProperties>;
+    provenance?: { documentIds: string[]; chunkIds: string[] } | undefined;
   } = {
     id: stringValue(record.get("id"), "Neo4j explorer relationship id"),
     type: stringValue(record.get("type"), "Neo4j explorer relationship type"),
@@ -164,7 +188,20 @@ function relationshipFromRecord(record: Neo4jRecord): GraphExploreRelationship {
   };
   const key = raw.__anvia_key;
   if (typeof key === "string") relationship.key = key;
+  if (includeProvenance) relationship.provenance = provenanceProperties(raw);
   return relationship;
+}
+
+function provenanceProperties(value: Record<string, unknown>) {
+  return {
+    documentIds: optionalStringArray(value.__anvia_source_document_ids),
+    chunkIds: optionalStringArray(value.__anvia_source_chunk_ids),
+  };
+}
+
+function optionalStringArray(value: unknown): string[] {
+  if (value === undefined) return [];
+  return stringArray(value, "Neo4j explorer provenance");
 }
 
 function identityProperties(
@@ -199,6 +236,33 @@ function traversalPattern(direction: "outgoing" | "incoming" | "both", maxDepth:
   if (direction === "outgoing") return `(root)-[*1..${maxDepth}]->(node)`;
   if (direction === "incoming") return `(root)<-[*1..${maxDepth}]-(node)`;
   return `(root)-[*1..${maxDepth}]-(node)`;
+}
+
+function managedEntityLabel(graph: Neo4jKnowledgeGraphBase): string {
+  return graph instanceof ManagedNeo4jKnowledgeGraph
+    ? `:${quoteIdentifier(graph.resources.labels.entity)}`
+    : "";
+}
+
+function managedParameters(
+  graph: Neo4jKnowledgeGraphBase,
+  parameters: Record<string, unknown>,
+): Record<string, unknown> {
+  return managedScopeParameters(managedScope(graph), parameters);
+}
+
+function managedAndPredicate(graph: Neo4jKnowledgeGraphBase, variable: string): string {
+  return managedScopePredicate(managedScope(graph), variable, " AND");
+}
+
+function managedPathAndPredicate(graph: Neo4jKnowledgeGraphBase): string {
+  return managedPathPredicate(managedScope(graph), true);
+}
+
+function managedScope(graph: Neo4jKnowledgeGraphBase): Neo4jManagedScope | undefined {
+  return graph instanceof ManagedNeo4jKnowledgeGraph
+    ? { graph: graph.name, namespace: graph.namespace }
+    : undefined;
 }
 
 function stringValue(value: unknown, label: string): string {

--- a/packages/graph-neo4j/src/graph.ts
+++ b/packages/graph-neo4j/src/graph.ts
@@ -20,6 +20,14 @@ import {
   throwIfAborted,
 } from "./helpers.js";
 import {
+  managedScopeParameters,
+  namespaceMapEntry as scopeNamespaceMapEntry,
+  namespacePredicate as scopeNamespacePredicate,
+  tenantMapEntries as scopeTenantMapEntries,
+  tenantRelationshipProperties as scopeTenantRelationshipProperties,
+  tenantScopePredicate,
+} from "./managed-scope.js";
+import {
   assertName,
   assertPropertyName,
   parseNeo4jProperties,
@@ -46,6 +54,7 @@ import type {
 type SeedRegistration = Readonly<{
   labels: readonly string[];
   vectorIndex: Neo4jVectorIndex & Readonly<{ property: string }>;
+  vectorFilterProperties?: readonly string[] | undefined;
   fulltextIndex?: (Neo4jFulltextIndex & Readonly<{ properties: readonly string[] }>) | undefined;
   entryRelationshipType?: string | undefined;
 }>;
@@ -58,6 +67,17 @@ type ExpectedConstraint = Readonly<{
 
 type GraphTransaction = Pick<ManagedTransaction, "run">;
 
+const tenantScopeBrand: unique symbol = Symbol("Neo4jTenantScope");
+
+export type Neo4jTenantScope = Readonly<{
+  namespace: string;
+  [tenantScopeBrand]: true;
+}>;
+
+export function neo4jTenantScope(namespace: string): Neo4jTenantScope {
+  return Object.freeze({ namespace, [tenantScopeBrand]: true as const });
+}
+
 export abstract class Neo4jKnowledgeGraphBase<
   Schema extends Neo4jGraphSchema = Neo4jGraphSchema,
   Evidence extends Neo4jGraphEvidenceCapability = Neo4jGraphEvidenceCapability,
@@ -68,6 +88,7 @@ export abstract class Neo4jKnowledgeGraphBase<
   protected constructor(
     protected readonly owner: Neo4jClient,
     readonly schema: Schema,
+    readonly namespace?: string | undefined,
   ) {
     if (schema.kind !== "neo4j-graph-schema" && schema.kind !== "graph-schema") {
       throw new TypeError(
@@ -221,11 +242,17 @@ export class ManagedNeo4jKnowledgeGraph<
   readonly evidenceCapability = "chunks" as const;
   readonly seeds: Readonly<Record<string, SeedRegistration>>;
   readonly resources: ManagedNeo4jKnowledgeGraphOptions<Schema>["resources"];
-  private readonly name: string;
+  readonly name: string;
 
-  constructor(owner: Neo4jClient, options: ManagedNeo4jKnowledgeGraphOptions<Schema>) {
-    super(owner, options.schema);
+  constructor(
+    owner: Neo4jClient,
+    options: ManagedNeo4jKnowledgeGraphOptions<Schema>,
+    tenantScope?: Neo4jTenantScope,
+  ) {
+    const namespace = tenantScope?.namespace;
+    super(owner, options.schema, namespace);
     assertName(options.name, "Managed Neo4j graph name");
+    if (namespace !== undefined) assertName(namespace, "Managed Neo4j namespace");
     this.name = options.name;
     this.resources = validateManagedResources(options.resources);
     let chunks: SeedRegistration = {
@@ -234,6 +261,8 @@ export class ManagedNeo4jKnowledgeGraph<
         ...this.resources.indexes.chunks.vector,
         property: "__anvia_embedding",
       }),
+      vectorFilterProperties:
+        this.namespace === undefined ? undefined : Object.freeze(["__anvia_namespace"]),
       entryRelationshipType: "ANVIA_MENTIONS",
     };
     if (this.resources.indexes.chunks.fulltext !== undefined) {
@@ -241,7 +270,10 @@ export class ManagedNeo4jKnowledgeGraph<
         ...chunks,
         fulltextIndex: Object.freeze({
           ...this.resources.indexes.chunks.fulltext,
-          properties: Object.freeze(["__anvia_text"]),
+          properties: Object.freeze([
+            "__anvia_text",
+            ...(this.namespace === undefined ? [] : ["__anvia_namespace"]),
+          ]),
         }),
       };
     }
@@ -251,15 +283,18 @@ export class ManagedNeo4jKnowledgeGraph<
         ...this.resources.indexes.entities.vector,
         property: "__anvia_embedding",
       }),
+      vectorFilterProperties:
+        this.namespace === undefined ? undefined : Object.freeze(["__anvia_namespace"]),
     };
     if (this.resources.indexes.entities.fulltext !== undefined) {
       entities = {
         ...entities,
         fulltextIndex: Object.freeze({
           ...this.resources.indexes.entities.fulltext,
-          properties: Object.freeze(
-            Array.from(this.resources.indexes.entities.fulltext.properties ?? []),
-          ),
+          properties: Object.freeze([
+            ...(this.resources.indexes.entities.fulltext.properties ?? []),
+            ...(this.namespace === undefined ? [] : ["__anvia_namespace"]),
+          ]),
         }),
       };
     }
@@ -273,30 +308,43 @@ export class ManagedNeo4jKnowledgeGraph<
     positiveInteger(options.indexTimeoutMs, "Neo4j index timeout");
     throwIfAborted(options.abortSignal);
     const { labels, indexes } = this.resources;
+    const identityPrefix = this.namespace === undefined ? [] : ["__anvia_namespace"];
     const statements = [
-      uniquenessConstraint(constraintName(this.name, "document"), labels.document, ["__anvia_id"]),
-      uniquenessConstraint(constraintName(this.name, "chunk"), labels.chunk, ["__anvia_id"]),
-      uniquenessConstraint(constraintName(this.name, "entity"), labels.entity, ["__anvia_key"]),
+      uniquenessConstraint(constraintName(this.name, "document"), labels.document, [
+        ...identityPrefix,
+        "__anvia_id",
+      ]),
+      uniquenessConstraint(constraintName(this.name, "chunk"), labels.chunk, [
+        ...identityPrefix,
+        "__anvia_id",
+      ]),
+      uniquenessConstraint(constraintName(this.name, "entity"), labels.entity, [
+        ...identityPrefix,
+        "__anvia_key",
+      ]),
       ...Object.entries(this.schema.nodes).map(([type, definition]) =>
-        uniquenessConstraint(
-          constraintName(this.name, `entity_${type}`),
-          type,
-          definition.identity,
-        ),
+        uniquenessConstraint(constraintName(this.name, `entity_${type}`), type, [
+          ...identityPrefix,
+          ...definition.identity,
+        ]),
       ),
-      vectorIndex(indexes.chunks.vector, labels.chunk),
-      vectorIndex(indexes.entities.vector, labels.entity),
+      vectorIndex(indexes.chunks.vector, labels.chunk, this.namespace !== undefined),
+      vectorIndex(indexes.entities.vector, labels.entity, this.namespace !== undefined),
     ];
     if (indexes.chunks.fulltext !== undefined) {
-      statements.push(fulltextIndex(indexes.chunks.fulltext.name, labels.chunk, ["__anvia_text"]));
+      statements.push(
+        fulltextIndex(indexes.chunks.fulltext.name, labels.chunk, [
+          "__anvia_text",
+          ...(this.namespace === undefined ? [] : ["__anvia_namespace"]),
+        ]),
+      );
     }
     if (indexes.entities.fulltext !== undefined) {
       statements.push(
-        fulltextIndex(
-          indexes.entities.fulltext.name,
-          labels.entity,
-          indexes.entities.fulltext.properties ?? [],
-        ),
+        fulltextIndex(indexes.entities.fulltext.name, labels.entity, [
+          ...(indexes.entities.fulltext.properties ?? []),
+          ...(this.namespace === undefined ? [] : ["__anvia_namespace"]),
+        ]),
       );
     }
     for (const statement of statements)
@@ -355,30 +403,52 @@ export class ManagedNeo4jKnowledgeGraph<
       const before = await snapshotGraphState(
         transaction,
         this.name,
+        this.namespace,
         this.resources.labels,
         targets,
       );
       await removeDocuments(
         transaction,
         this.name,
+        this.namespace,
         this.resources.labels,
         documentIds,
         options.orphanEntities,
       );
-      await writeDocuments(transaction, this.resources.labels, options.documents);
-      await writeChunks(transaction, this.resources.labels, options.chunks);
+      await writeDocuments(
+        transaction,
+        this.name,
+        this.namespace,
+        this.resources.labels,
+        options.documents,
+      );
+      await writeChunks(
+        transaction,
+        this.name,
+        this.namespace,
+        this.resources.labels,
+        options.chunks,
+      );
       await writeEntities(
         transaction,
         this.name,
+        this.namespace,
         this.resources.labels.entity,
         options.entities,
         options.conflict,
         sourceDocuments,
       );
-      await writeMentions(transaction, this.resources.labels, options.mentions);
+      await writeMentions(
+        transaction,
+        this.name,
+        this.namespace,
+        this.resources.labels,
+        options.mentions,
+      );
       await writeRelationships(
         transaction,
         this.name,
+        this.namespace,
         this.resources.labels.entity,
         options.relationships,
         options.conflict,
@@ -387,6 +457,7 @@ export class ManagedNeo4jKnowledgeGraph<
       const after = await snapshotGraphState(
         transaction,
         this.name,
+        this.namespace,
         this.resources.labels,
         expandSnapshotTargets(targets, before),
       );
@@ -403,12 +474,14 @@ export class ManagedNeo4jKnowledgeGraph<
       const before = await snapshotGraphState(
         transaction,
         this.name,
+        this.namespace,
         this.resources.labels,
         targets,
       );
       await removeDocuments(
         transaction,
         this.name,
+        this.namespace,
         this.resources.labels,
         ids,
         options.orphanEntities,
@@ -416,6 +489,7 @@ export class ManagedNeo4jKnowledgeGraph<
       const after = await snapshotGraphState(
         transaction,
         this.name,
+        this.namespace,
         this.resources.labels,
         expandSnapshotTargets(targets, before),
       );
@@ -424,26 +498,27 @@ export class ManagedNeo4jKnowledgeGraph<
   }
 
   private expectedConstraints(): readonly ExpectedConstraint[] {
+    const identityPrefix = this.namespace === undefined ? [] : ["__anvia_namespace"];
     return [
       {
         name: constraintName(this.name, "document"),
         label: this.resources.labels.document,
-        properties: ["__anvia_id"],
+        properties: [...identityPrefix, "__anvia_id"],
       },
       {
         name: constraintName(this.name, "chunk"),
         label: this.resources.labels.chunk,
-        properties: ["__anvia_id"],
+        properties: [...identityPrefix, "__anvia_id"],
       },
       {
         name: constraintName(this.name, "entity"),
         label: this.resources.labels.entity,
-        properties: ["__anvia_key"],
+        properties: [...identityPrefix, "__anvia_key"],
       },
       ...Object.entries(this.schema.nodes).map(([type, definition]) => ({
         name: constraintName(this.name, `entity_${type}`),
         label: type,
-        properties: definition.identity,
+        properties: [...identityPrefix, ...definition.identity],
       })),
     ];
   }
@@ -606,7 +681,7 @@ function expectedIndexes(
       kind: "vector",
       name: seed.vectorIndex.name,
       labels: seed.labels,
-      properties: [seed.vectorIndex.property],
+      properties: [seed.vectorIndex.property, ...(seed.vectorFilterProperties ?? [])],
       dimensions: seed.vectorIndex.dimensions,
       similarity: seed.vectorIndex.similarity,
     });
@@ -740,8 +815,9 @@ function uniquenessConstraint(name: string, label: string, properties: readonly 
   return `CREATE CONSTRAINT ${quoteIdentifier(name)} IF NOT EXISTS FOR (n:${quoteIdentifier(label)}) REQUIRE ${expression} IS UNIQUE`;
 }
 
-function vectorIndex(index: Neo4jVectorIndex, label: string): string {
-  return `CREATE VECTOR INDEX ${quoteIdentifier(index.name)} IF NOT EXISTS FOR (n:${quoteIdentifier(label)}) ON (n.${quoteIdentifier("__anvia_embedding")}) OPTIONS {indexConfig: {\`vector.dimensions\`: ${index.dimensions}, \`vector.similarity_function\`: '${index.similarity}'}}`;
+function vectorIndex(index: Neo4jVectorIndex, label: string, namespaced: boolean): string {
+  const filterProperties = namespaced ? ` WITH [n.${quoteIdentifier("__anvia_namespace")}]` : "";
+  return `CREATE VECTOR INDEX ${quoteIdentifier(index.name)} IF NOT EXISTS FOR (n:${quoteIdentifier(label)}) ON (n.${quoteIdentifier("__anvia_embedding")})${filterProperties} OPTIONS {indexConfig: {\`vector.dimensions\`: ${index.dimensions}, \`vector.similarity_function\`: '${index.similarity}'}}`;
 }
 
 function fulltextIndex(name: string, label: string, properties: readonly string[]): string {
@@ -1085,34 +1161,41 @@ function expandSnapshotTargets(targets: SnapshotTargets, snapshot: GraphSnapshot
 async function snapshotGraphState(
   transaction: GraphTransaction,
   graphName: string,
+  namespace: string | undefined,
   labels: { document: string; chunk: string; entity: string },
   targets: SnapshotTargets,
 ): Promise<GraphSnapshot> {
   const documentsResult = await transaction.run(
     `MATCH (d:${quoteIdentifier(labels.document)})
-WHERE d.${quoteIdentifier("__anvia_id")} IN $documentIds
+WHERE d.${quoteIdentifier("__anvia_id")} IN $documentIds${tenantPredicate("d", namespace, " AND")}
 RETURN d.${quoteIdentifier("__anvia_id")} AS key, properties(d) AS properties`,
-    { documentIds: targets.documentIds },
+    managedParameters(graphName, namespace, { documentIds: targets.documentIds }),
   );
   const chunksResult = await transaction.run(
     `MATCH (c:${quoteIdentifier(labels.chunk)})
 OPTIONAL MATCH (d:${quoteIdentifier(labels.document)})-[:${quoteIdentifier("ANVIA_HAS_CHUNK")}]->(c)
-WITH c, d WHERE c.${quoteIdentifier("__anvia_id")} IN $chunkIds OR d.${quoteIdentifier("__anvia_id")} IN $documentIds
+WITH c, d WHERE (c.${quoteIdentifier("__anvia_id")} IN $chunkIds OR d.${quoteIdentifier("__anvia_id")} IN $documentIds)${tenantPredicate("c", namespace, " AND")}
 RETURN c.${quoteIdentifier("__anvia_id")} AS key, properties(c) AS properties`,
-    { chunkIds: targets.chunkIds, documentIds: targets.documentIds },
+    managedParameters(graphName, namespace, {
+      chunkIds: targets.chunkIds,
+      documentIds: targets.documentIds,
+    }),
   );
   const entitiesResult = await transaction.run(
     `MATCH (e:${quoteIdentifier(labels.entity)})
-WHERE e.${quoteIdentifier("__anvia_graph")} = $graph AND (
+WHERE e.${quoteIdentifier("__anvia_graph")} = $graph${namespacePredicate("e", namespace, " AND")} AND (
   e.${quoteIdentifier("__anvia_key")} IN $entityKeys OR
   any(id IN coalesce(e.${quoteIdentifier("__anvia_source_document_ids")}, []) WHERE id IN $documentIds)
 )
 RETURN e.${quoteIdentifier("__anvia_key")} AS key, labels(e) AS labels, properties(e) AS properties`,
-    { graph: graphName, entityKeys: targets.entityKeys, documentIds: targets.documentIds },
+    managedParameters(graphName, namespace, {
+      entityKeys: targets.entityKeys,
+      documentIds: targets.documentIds,
+    }),
   );
   const relationshipsResult = await transaction.run(
     `MATCH ()-[r]->()
-WHERE r.${quoteIdentifier("__anvia_graph")} = $graph AND (
+WHERE r.${quoteIdentifier("__anvia_graph")} = $graph${namespacePredicate("r", namespace, " AND")} AND (
   r.${quoteIdentifier("__anvia_key")} IN $relationshipKeys OR
   any(id IN coalesce(r.${quoteIdentifier("__anvia_source_document_ids")}, []) WHERE id IN $documentIds)
 )
@@ -1121,19 +1204,22 @@ RETURN r.${quoteIdentifier("__anvia_key")} AS key,
        startNode(r).${quoteIdentifier("__anvia_key")} AS source,
        endNode(r).${quoteIdentifier("__anvia_key")} AS target,
        properties(r) AS properties`,
-    {
-      graph: graphName,
+    managedParameters(graphName, namespace, {
       relationshipKeys: targets.relationshipKeys,
       documentIds: targets.documentIds,
-    },
+    }),
   );
   const mentionsResult = await transaction.run(
     `MATCH (c:${quoteIdentifier(labels.chunk)})-[:${quoteIdentifier("ANVIA_MENTIONS")}]->(e:${quoteIdentifier(labels.entity)})
 OPTIONAL MATCH (d:${quoteIdentifier(labels.document)})-[:${quoteIdentifier("ANVIA_HAS_CHUNK")}]->(c)
-WITH c, e, d WHERE d.${quoteIdentifier("__anvia_id")} IN $documentIds OR
+WITH c, e, d WHERE (d.${quoteIdentifier("__anvia_id")} IN $documentIds OR
   any(item IN $mentions WHERE item.chunkId = c.${quoteIdentifier("__anvia_id")} AND item.entityKey = e.${quoteIdentifier("__anvia_key")})
+)${tenantPredicate("c", namespace, " AND")}
 RETURN c.${quoteIdentifier("__anvia_id")} AS chunkId, e.${quoteIdentifier("__anvia_key")} AS entityKey`,
-    { documentIds: targets.documentIds, mentions: targets.mentions },
+    managedParameters(graphName, namespace, {
+      documentIds: targets.documentIds,
+      mentions: targets.mentions,
+    }),
   );
   return {
     documents: snapshotProperties(documentsResult.records, "document"),
@@ -1279,67 +1365,107 @@ function emptyWriteResult(): Neo4jGraphWriteResult {
   };
 }
 
+function managedParameters(
+  graph: string,
+  namespace: string | undefined,
+  parameters: Record<string, unknown>,
+): Record<string, unknown> {
+  return managedScopeParameters({ graph, namespace }, parameters);
+}
+
+function namespacePredicate(
+  variable: string,
+  namespace: string | undefined,
+  prefix: " AND" | " WHERE",
+): string {
+  return scopeNamespacePredicate({ graph: "", namespace }, variable, prefix);
+}
+
+function tenantPredicate(
+  variable: string,
+  namespace: string | undefined,
+  prefix: " AND" | " WHERE",
+): string {
+  return tenantScopePredicate({ graph: "", namespace }, variable, prefix);
+}
+
+function namespaceMapEntry(namespace: string | undefined): string {
+  return scopeNamespaceMapEntry({ graph: "", namespace });
+}
+
+function tenantMapEntries(namespace: string | undefined): string {
+  return scopeTenantMapEntries({ graph: "", namespace });
+}
+
+function tenantRelationshipProperties(namespace: string | undefined): string {
+  return scopeTenantRelationshipProperties({ graph: "", namespace });
+}
+
 async function removeDocuments(
   transaction: GraphTransaction,
   graphName: string,
+  namespace: string | undefined,
   labels: { document: string; chunk: string; entity: string },
   documentIds: readonly string[],
   orphanEntities: "delete" | "keep",
 ): Promise<void> {
   const chunks = await transaction.run(
-    `MATCH (d:${quoteIdentifier(labels.document)})-[:${quoteIdentifier("ANVIA_HAS_CHUNK")}]->(c:${quoteIdentifier(labels.chunk)}) WHERE d.${quoteIdentifier("__anvia_id")} IN $documentIds RETURN collect(c.${quoteIdentifier("__anvia_id")}) AS chunkIds`,
-    { documentIds },
+    `MATCH (d:${quoteIdentifier(labels.document)})-[:${quoteIdentifier("ANVIA_HAS_CHUNK")}]->(c:${quoteIdentifier(labels.chunk)}) WHERE d.${quoteIdentifier("__anvia_id")} IN $documentIds${tenantPredicate("d", namespace, " AND")} RETURN collect(c.${quoteIdentifier("__anvia_id")}) AS chunkIds`,
+    managedParameters(graphName, namespace, { documentIds }),
   );
   const chunkIdsValue = chunks.records[0]?.get("chunkIds");
   const chunkIds = requiredStringArray(chunkIdsValue, "Neo4j replacement chunk ids");
   await transaction.run(
-    `MATCH ()-[r]->() WHERE r.${quoteIdentifier("__anvia_graph")} = $graph AND any(id IN r.${quoteIdentifier("__anvia_source_document_ids")} WHERE id IN $documentIds)
+    `MATCH ()-[r]->() WHERE r.${quoteIdentifier("__anvia_graph")} = $graph${namespacePredicate("r", namespace, " AND")} AND any(id IN r.${quoteIdentifier("__anvia_source_document_ids")} WHERE id IN $documentIds)
 SET r.${quoteIdentifier("__anvia_source_document_ids")} = [id IN r.${quoteIdentifier("__anvia_source_document_ids")} WHERE NOT id IN $documentIds]
 SET r.${quoteIdentifier("__anvia_source_chunk_ids")} = [id IN coalesce(r.${quoteIdentifier("__anvia_source_chunk_ids")}, []) WHERE NOT id IN $chunkIds]
 WITH r WHERE size(r.${quoteIdentifier("__anvia_source_document_ids")}) = 0 DELETE r`,
-    { graph: graphName, documentIds, chunkIds },
+    managedParameters(graphName, namespace, { documentIds, chunkIds }),
   );
   await transaction.run(
-    `MATCH (d:${quoteIdentifier(labels.document)}) WHERE d.${quoteIdentifier("__anvia_id")} IN $documentIds
+    `MATCH (d:${quoteIdentifier(labels.document)}) WHERE d.${quoteIdentifier("__anvia_id")} IN $documentIds${tenantPredicate("d", namespace, " AND")}
 OPTIONAL MATCH (d)-[:${quoteIdentifier("ANVIA_HAS_CHUNK")}]->(c:${quoteIdentifier(labels.chunk)})
 DETACH DELETE c, d`,
-    { documentIds },
+    managedParameters(graphName, namespace, { documentIds }),
   );
   await transaction.run(
     `MATCH (e:${quoteIdentifier(labels.entity)})
-WHERE e.${quoteIdentifier("__anvia_graph")} = $graph AND
+WHERE e.${quoteIdentifier("__anvia_graph")} = $graph${namespacePredicate("e", namespace, " AND")} AND
       any(id IN coalesce(e.${quoteIdentifier("__anvia_source_document_ids")}, []) WHERE id IN $documentIds)
 SET e.${quoteIdentifier("__anvia_source_document_ids")} = [id IN e.${quoteIdentifier("__anvia_source_document_ids")} WHERE NOT id IN $documentIds],
     e.${quoteIdentifier("__anvia_source_chunk_ids")} = [id IN coalesce(e.${quoteIdentifier("__anvia_source_chunk_ids")}, []) WHERE NOT id IN $chunkIds]
 WITH e WHERE $deleteOrphans AND size(e.${quoteIdentifier("__anvia_source_document_ids")}) = 0
 DETACH DELETE e`,
-    {
-      graph: graphName,
+    managedParameters(graphName, namespace, {
       documentIds,
       chunkIds,
       deleteOrphans: orphanEntities === "delete",
-    },
+    }),
   );
 }
 
 async function writeDocuments(
   transaction: GraphTransaction,
+  graphName: string,
+  namespace: string | undefined,
   labels: { document: string },
   documents: readonly { id: string; properties?: Neo4jProperties | undefined }[],
 ): Promise<void> {
   await transaction.run(
-    `UNWIND $rows AS row MERGE (d:${quoteIdentifier(labels.document)} {${quoteIdentifier("__anvia_id")}: row.id}) SET d += row.properties`,
-    {
+    `UNWIND $rows AS row MERGE (d:${quoteIdentifier(labels.document)} {${quoteIdentifier("__anvia_id")}: row.id${namespaceMapEntry(namespace)}}) ${namespace === undefined ? "SET d += row.properties" : `SET d.${quoteIdentifier("__anvia_graph")} = $graph, d += row.properties`}`,
+    managedParameters(graphName, namespace, {
       rows: documents.map((document) => ({
         id: document.id,
         properties: document.properties ?? {},
       })),
-    },
+    }),
   );
 }
 
 async function writeChunks(
   transaction: GraphTransaction,
+  graphName: string,
+  namespace: string | undefined,
   labels: { document: string; chunk: string },
   chunks: ReplaceNeo4jDocumentsOptions<Neo4jGraphSchema>["chunks"],
 ): Promise<void> {
@@ -1354,10 +1480,11 @@ async function writeChunks(
   await transaction.run(
     `UNWIND $rows AS row
 MATCH (d:${quoteIdentifier(labels.document)} {${quoteIdentifier("__anvia_id")}: row.documentId})
-CREATE (c:${quoteIdentifier(labels.chunk)} {${quoteIdentifier("__anvia_id")}: row.id, ${quoteIdentifier("__anvia_document_id")}: row.documentId, ${quoteIdentifier("__anvia_index")}: row.index, ${quoteIdentifier("__anvia_text")}: row.text, ${quoteIdentifier("__anvia_embedding")}: row.embedding})
+${tenantPredicate("d", namespace, " WHERE")}
+CREATE (c:${quoteIdentifier(labels.chunk)} {${quoteIdentifier("__anvia_id")}: row.id, ${quoteIdentifier("__anvia_document_id")}: row.documentId, ${quoteIdentifier("__anvia_index")}: row.index, ${quoteIdentifier("__anvia_text")}: row.text, ${quoteIdentifier("__anvia_embedding")}: row.embedding${tenantMapEntries(namespace)}})
 SET c += row.metadata
-CREATE (d)-[:${quoteIdentifier("ANVIA_HAS_CHUNK")}]->(c)`,
-    { rows },
+CREATE (d)-[:${quoteIdentifier("ANVIA_HAS_CHUNK")}${tenantRelationshipProperties(namespace)}]->(c)`,
+    managedParameters(graphName, namespace, { rows }),
   );
   const pairs = [...rows]
     .sort(
@@ -1371,8 +1498,8 @@ CREATE (d)-[:${quoteIdentifier("ANVIA_HAS_CHUNK")}]->(c)`,
     });
   if (pairs.length > 0) {
     await transaction.run(
-      `UNWIND $rows AS row MATCH (a:${quoteIdentifier(labels.chunk)} {${quoteIdentifier("__anvia_id")}: row.from}), (b:${quoteIdentifier(labels.chunk)} {${quoteIdentifier("__anvia_id")}: row.to}) CREATE (a)-[:${quoteIdentifier("ANVIA_NEXT_CHUNK")}]->(b)`,
-      { rows: pairs },
+      `UNWIND $rows AS row MATCH (a:${quoteIdentifier(labels.chunk)} {${quoteIdentifier("__anvia_id")}: row.from${namespaceMapEntry(namespace)}}), (b:${quoteIdentifier(labels.chunk)} {${quoteIdentifier("__anvia_id")}: row.to${namespaceMapEntry(namespace)}}) CREATE (a)-[:${quoteIdentifier("ANVIA_NEXT_CHUNK")}${tenantRelationshipProperties(namespace)}]->(b)`,
+      managedParameters(graphName, namespace, { rows: pairs }),
     );
   }
 }
@@ -1380,6 +1507,7 @@ CREATE (d)-[:${quoteIdentifier("ANVIA_HAS_CHUNK")}]->(c)`,
 async function writeEntities<Schema extends Neo4jGraphSchema>(
   transaction: GraphTransaction,
   graphName: string,
+  namespace: string | undefined,
   entityLabel: string,
   entities: ReplaceNeo4jDocumentsOptions<Schema>["entities"],
   conflict: ReplaceNeo4jDocumentsOptions<Schema>["conflict"],
@@ -1394,31 +1522,35 @@ async function writeEntities<Schema extends Neo4jGraphSchema>(
       sourceDocumentIds: sourceDocuments(entity.document.sourceChunkIds),
       sourceChunkIds: entity.document.sourceChunkIds,
     }));
-    if (conflict === "error") await assertEntityConflicts(transaction, entityLabel, rows);
+    if (conflict === "error")
+      await assertEntityConflicts(transaction, graphName, namespace, entityLabel, rows);
     const propertySet = conflictPropertySet("e", conflict);
     const embedding = entityEmbeddingExpression(conflict);
     await transaction.run(
       `UNWIND $rows AS row
-MERGE (e:${quoteIdentifier(entityLabel)}:${quoteIdentifier(type)} {${quoteIdentifier("__anvia_key")}: row.key})
+MERGE (e:${quoteIdentifier(entityLabel)}:${quoteIdentifier(type)} {${quoteIdentifier("__anvia_key")}: row.key${namespaceMapEntry(namespace)}})
 ${propertySet}
 SET e.${quoteIdentifier("__anvia_key")} = row.key,
     e.${quoteIdentifier("__anvia_graph")} = $graph,
+    e.${quoteIdentifier("__anvia_namespace")} = coalesce($namespace, e.${quoteIdentifier("__anvia_namespace")}),
     e.${quoteIdentifier("__anvia_embedding")} = ${embedding},
     e.${quoteIdentifier("__anvia_source_document_ids")} = reduce(all = existingDocumentIds, id IN row.sourceDocumentIds | CASE WHEN id IN all THEN all ELSE all + id END),
     e.${quoteIdentifier("__anvia_source_chunk_ids")} = reduce(all = existingChunkIds, id IN row.sourceChunkIds | CASE WHEN id IN all THEN all ELSE all + id END)`,
-      { rows, graph: graphName },
+      managedParameters(graphName, namespace, { rows }),
     );
   }
 }
 
 async function assertEntityConflicts(
   transaction: GraphTransaction,
+  graphName: string,
+  namespace: string | undefined,
   entityLabel: string,
   rows: readonly { key: string; properties: Neo4jProperties }[],
 ): Promise<void> {
   const result = await transaction.run(
-    `UNWIND $keys AS key MATCH (e:${quoteIdentifier(entityLabel)} {${quoteIdentifier("__anvia_key")}: key}) RETURN key, properties(e) AS properties`,
-    { keys: rows.map((row) => row.key) },
+    `UNWIND $keys AS key MATCH (e:${quoteIdentifier(entityLabel)} {${quoteIdentifier("__anvia_key")}: key${namespaceMapEntry(namespace)}}) WHERE e.${quoteIdentifier("__anvia_graph")} = $graph RETURN key, properties(e) AS properties`,
+    managedParameters(graphName, namespace, { keys: rows.map((row) => row.key) }),
   );
   const incoming = new Map(rows.map((row) => [row.key, row.properties]));
   for (const record of result.records) {
@@ -1432,21 +1564,25 @@ async function assertEntityConflicts(
 
 async function writeMentions(
   transaction: GraphTransaction,
+  graphName: string,
+  namespace: string | undefined,
   labels: { chunk: string; entity: string },
   mentions: readonly { chunkId: string; entityKey: string }[],
 ): Promise<void> {
   if (mentions.length === 0) return;
   await transaction.run(
     `UNWIND $rows AS row
-MATCH (c:${quoteIdentifier(labels.chunk)} {${quoteIdentifier("__anvia_id")}: row.chunkId}), (e:${quoteIdentifier(labels.entity)} {${quoteIdentifier("__anvia_key")}: row.entityKey})
-MERGE (c)-[:${quoteIdentifier("ANVIA_MENTIONS")}]->(e)`,
-    { rows: mentions },
+MATCH (c:${quoteIdentifier(labels.chunk)} {${quoteIdentifier("__anvia_id")}: row.chunkId${namespaceMapEntry(namespace)}}), (e:${quoteIdentifier(labels.entity)} {${quoteIdentifier("__anvia_key")}: row.entityKey${namespaceMapEntry(namespace)}})
+${namespace === undefined ? "" : `WHERE c.${quoteIdentifier("__anvia_graph")} = $graph AND e.${quoteIdentifier("__anvia_graph")} = $graph`}
+MERGE (c)-[:${quoteIdentifier("ANVIA_MENTIONS")}${tenantRelationshipProperties(namespace)}]->(e)`,
+    managedParameters(graphName, namespace, { rows: mentions }),
   );
 }
 
 async function writeRelationships<Schema extends Neo4jGraphSchema>(
   transaction: GraphTransaction,
   graphName: string,
+  namespace: string | undefined,
   entityLabel: string,
   relationships: readonly import("./types.js").Neo4jGraphRelationship<Schema>[],
   conflict: ReplaceNeo4jDocumentsOptions<Schema>["conflict"],
@@ -1464,8 +1600,8 @@ async function writeRelationships<Schema extends Neo4jGraphSchema>(
     }));
     if (conflict === "error") {
       const existing = await transaction.run(
-        `UNWIND $keys AS key MATCH ()-[r:${quoteIdentifier(type)} {${quoteIdentifier("__anvia_key")}: key}]->() RETURN key, properties(r) AS properties`,
-        { keys: rows.map((row) => row.key) },
+        `UNWIND $keys AS key MATCH ()-[r:${quoteIdentifier(type)} {${quoteIdentifier("__anvia_key")}: key${namespaceMapEntry(namespace)}}]->() WHERE r.${quoteIdentifier("__anvia_graph")} = $graph RETURN key, properties(r) AS properties`,
+        managedParameters(graphName, namespace, { keys: rows.map((row) => row.key) }),
       );
       const incoming = new Map(rows.map((row) => [row.key, row.properties]));
       for (const record of existing.records) {
@@ -1481,14 +1617,16 @@ async function writeRelationships<Schema extends Neo4jGraphSchema>(
     const propertySet = conflictPropertySet("r", conflict);
     await transaction.run(
       `UNWIND $rows AS row
-MATCH (a:${quoteIdentifier(entityLabel)} {${quoteIdentifier("__anvia_key")}: row.from}), (b:${quoteIdentifier(entityLabel)} {${quoteIdentifier("__anvia_key")}: row.to})
-MERGE (a)-[r:${quoteIdentifier(type)} {${quoteIdentifier("__anvia_key")}: row.key}]->(b)
+MATCH (a:${quoteIdentifier(entityLabel)} {${quoteIdentifier("__anvia_key")}: row.from${namespaceMapEntry(namespace)}}), (b:${quoteIdentifier(entityLabel)} {${quoteIdentifier("__anvia_key")}: row.to${namespaceMapEntry(namespace)}})
+WHERE a.${quoteIdentifier("__anvia_graph")} = $graph AND b.${quoteIdentifier("__anvia_graph")} = $graph
+MERGE (a)-[r:${quoteIdentifier(type)} {${quoteIdentifier("__anvia_key")}: row.key${namespaceMapEntry(namespace)}}]->(b)
 ${propertySet}
 SET r.${quoteIdentifier("__anvia_key")} = row.key,
     r.${quoteIdentifier("__anvia_graph")} = $graph,
+    r.${quoteIdentifier("__anvia_namespace")} = coalesce($namespace, r.${quoteIdentifier("__anvia_namespace")}),
     r.${quoteIdentifier("__anvia_source_document_ids")} = reduce(all = existingDocumentIds, id IN row.sourceDocumentIds | CASE WHEN id IN all THEN all ELSE all + id END),
     r.${quoteIdentifier("__anvia_source_chunk_ids")} = reduce(all = existingChunkIds, id IN row.sourceChunkIds | CASE WHEN id IN all THEN all ELSE all + id END)`,
-      { rows, graph: graphName },
+      managedParameters(graphName, namespace, { rows }),
     );
   }
 }

--- a/packages/graph-neo4j/src/index.ts
+++ b/packages/graph-neo4j/src/index.ts
@@ -1,4 +1,4 @@
-export { Neo4jClient } from "./client.js";
+export { Neo4jClient, Neo4jTenant } from "./client.js";
 export { exploreGraph } from "./explore.js";
 export { extractGraphFacts, GraphFactConflictError } from "./extract.js";
 export { ManagedNeo4jKnowledgeGraph, Neo4jKnowledgeGraph } from "./graph.js";

--- a/packages/graph-neo4j/src/managed-scope.ts
+++ b/packages/graph-neo4j/src/managed-scope.ts
@@ -1,0 +1,70 @@
+import { quoteIdentifier } from "./helpers.js";
+
+export type Neo4jManagedScope = Readonly<{
+  graph: string;
+  namespace?: string | undefined;
+}>;
+
+export function managedScopeParameters(
+  scope: Neo4jManagedScope | undefined,
+  parameters: Record<string, unknown>,
+): Record<string, unknown> {
+  return scope === undefined
+    ? parameters
+    : { graph: scope.graph, namespace: scope.namespace ?? null, ...parameters };
+}
+
+export function managedScopePredicate(
+  scope: Neo4jManagedScope | undefined,
+  variable: string,
+  prefix: " WHERE" | " AND" | "WHERE" | "AND",
+): string {
+  if (scope === undefined) return "";
+  return `${prefix} ${variable}.${quoteIdentifier("__anvia_graph")} = $graph${namespacePredicate(scope, variable, " AND")}`;
+}
+
+export function namespacePredicate(
+  scope: Neo4jManagedScope,
+  variable: string,
+  prefix: " WHERE" | " AND" | "WHERE" | "AND",
+): string {
+  return scope.namespace === undefined
+    ? ""
+    : `${prefix} ${variable}.${quoteIdentifier("__anvia_namespace")} = $namespace`;
+}
+
+export function tenantScopePredicate(
+  scope: Neo4jManagedScope,
+  variable: string,
+  prefix: " WHERE" | " AND" | "WHERE" | "AND",
+): string {
+  return scope.namespace === undefined ? "" : managedScopePredicate(scope, variable, prefix);
+}
+
+export function managedPathPredicate(
+  scope: Neo4jManagedScope | undefined,
+  relationships: boolean,
+): string {
+  if (scope === undefined) return "";
+  const item = `item.${quoteIdentifier("__anvia_graph")} = $graph${namespacePredicate(scope, "item", " AND")}`;
+  const nodes = ` AND all(item IN nodes(path) WHERE ${item})`;
+  return relationships ? `${nodes}\n  AND all(item IN relationships(path) WHERE ${item})` : nodes;
+}
+
+export function namespaceMapEntry(scope: Neo4jManagedScope): string {
+  return scope.namespace === undefined
+    ? ""
+    : `, ${quoteIdentifier("__anvia_namespace")}: $namespace`;
+}
+
+export function tenantMapEntries(scope: Neo4jManagedScope): string {
+  return scope.namespace === undefined
+    ? ""
+    : `, ${quoteIdentifier("__anvia_graph")}: $graph, ${quoteIdentifier("__anvia_namespace")}: $namespace`;
+}
+
+export function tenantRelationshipProperties(scope: Neo4jManagedScope): string {
+  return scope.namespace === undefined
+    ? ""
+    : ` {${quoteIdentifier("__anvia_graph")}: $graph, ${quoteIdentifier("__anvia_namespace")}: $namespace}`;
+}

--- a/packages/graph-neo4j/src/retrieve.ts
+++ b/packages/graph-neo4j/src/retrieve.ts
@@ -8,6 +8,13 @@ import {
   strictProperties,
   throwIfAborted,
 } from "./helpers.js";
+import {
+  managedPathPredicate,
+  managedScopeParameters,
+  managedScopePredicate,
+  tenantScopePredicate,
+  type Neo4jManagedScope,
+} from "./managed-scope.js";
 import type {
   Neo4jGraphContext,
   Neo4jGraphContextNode,
@@ -131,12 +138,22 @@ async function vectorSearch(
   abortSignal?: AbortSignal,
 ): Promise<SearchHit[]> {
   const labelExpression = labels.map(quoteIdentifier).join("|");
+  const vectorFilter =
+    graph instanceof ManagedNeo4jKnowledgeGraph && graph.namespace !== undefined
+      ? ` WHERE seed.${quoteIdentifier("__anvia_namespace")} = $namespace`
+      : "";
+  const postFilter = managedSearchPredicate(
+    graph,
+    "seed",
+    entryRelationshipType === "ANVIA_MENTIONS",
+  );
   const result = await graph.query(
     `CYPHER 25
 MATCH (seed:${labelExpression})
-SEARCH seed IN (VECTOR INDEX ${quoteIdentifier(indexName)} FOR $vector LIMIT $limit) SCORE AS score
+SEARCH seed IN (VECTOR INDEX ${quoteIdentifier(indexName)} FOR $vector${vectorFilter} LIMIT $limit) SCORE AS score
+${postFilter}
 RETURN elementId(seed) AS elementId, labels(seed) AS labels, properties(seed) AS properties, score`,
-    { vector, limit: int(limit) },
+    managedQueryParameters(graph, { vector, limit: int(limit) }),
     abortSignal,
   );
   return result.records.map((record) => ({ ...parseSearchHit(record), entryRelationshipType }));
@@ -152,8 +169,13 @@ async function fulltextSearch(
 ): Promise<SearchHit[]> {
   const result = await graph.query(
     `CALL db.index.fulltext.queryNodes($indexName, $query, {limit: $limit}) YIELD node AS seed, score
+${managedSearchPredicate(graph, "seed", entryRelationshipType === "ANVIA_MENTIONS")}
 RETURN elementId(seed) AS elementId, labels(seed) AS labels, properties(seed) AS properties, score`,
-    { indexName, query: escapeLucene(query), limit: int(limit) },
+    managedQueryParameters(graph, {
+      indexName,
+      query: scopedFulltextQuery(graph, query),
+      limit: int(limit),
+    }),
     abortSignal,
   );
   return result.records.map((record) => ({ ...parseSearchHit(record), entryRelationshipType }));
@@ -227,12 +249,13 @@ async function hydrateEvidence(
   const result = await graph.query(
     `MATCH (d:${quoteIdentifier(graph.resources.labels.document)})-[:${quoteIdentifier("ANVIA_HAS_CHUNK")}]->(c:${quoteIdentifier(graph.resources.labels.chunk)})
 WHERE c.${quoteIdentifier("__anvia_id")} IN $chunkIds
+  ${tenantNodeAndPredicate(graph, "d")}${tenantNodeAndPredicate(graph, "c")}
 RETURN c.${quoteIdentifier("__anvia_id")} AS chunkId,
        d.${quoteIdentifier("__anvia_id")} AS documentId,
        c.${quoteIdentifier("__anvia_index")} AS index,
        c.${quoteIdentifier("__anvia_text")} AS text,
        properties(c) AS properties`,
-    { chunkIds },
+    managedQueryParameters(graph, { chunkIds }),
     abortSignal,
   );
   const byId = new Map<string, Neo4jGraphEvidence>();
@@ -311,9 +334,11 @@ async function traverse<Schema extends Neo4jGraphSchema>(
   for (const [relationshipType, group] of entryGroups) {
     const entries = await graph.query(
       `MATCH (seed) WHERE elementId(seed) IN $seedIds
-MATCH (seed)-[:${quoteIdentifier(relationshipType)}]->(entry)
+  ${tenantNodePredicate(graph, "seed", "AND")}
+MATCH (seed)-[entryRelationship:${quoteIdentifier(relationshipType)}]->(entry)
+WHERE true${managedNodeAndPredicate(graph, "entry")}${tenantNodeAndPredicate(graph, "entryRelationship")}
 RETURN DISTINCT elementId(entry) AS elementId`,
-      { seedIds: group.map((seed) => seed.elementId) },
+      managedQueryParameters(graph, { seedIds: group.map((seed) => seed.elementId) }),
       abortSignal,
     );
     for (const record of entries.records) {
@@ -326,22 +351,24 @@ RETURN DISTINCT elementId(entry) AS elementId`,
   const pathLimit = Math.max(options.maxNodes, options.maxRelationships);
   const seedNodes = await graph.query(
     `MATCH (node) WHERE elementId(node) IN $seedIds
+  ${managedNodePredicate(graph, "node", "AND")}
 RETURN {elementId: elementId(node), labels: labels(node), properties: properties(node)} AS node`,
-    { seedIds: limitedSeedIds },
+    managedQueryParameters(graph, { seedIds: limitedSeedIds }),
     abortSignal,
   );
   const result = await graph.query(
     `MATCH (seed) WHERE elementId(seed) IN $seedIds
+  ${managedNodePredicate(graph, "seed", "AND")}
 MATCH path = ${pattern}
-WHERE all(rel IN relationships(path) WHERE type(rel) IN $relationshipTypes)
+WHERE all(rel IN relationships(path) WHERE type(rel) IN $relationshipTypes${managedRelationshipAndPredicate(graph, "rel")})${managedPathAndPredicate(graph)}
 RETURN [item IN nodes(path) | {elementId: elementId(item), labels: labels(item), properties: properties(item)}] AS nodes,
        [item IN relationships(path) | {elementId: elementId(item), type: type(item), properties: properties(item), from: elementId(startNode(item)), to: elementId(endNode(item))}] AS relationships
 LIMIT $pathLimit`,
-    {
+    managedQueryParameters(graph, {
       seedIds: limitedSeedIds,
       relationshipTypes: options.relationships,
       pathLimit: int(pathLimit),
-    },
+    }),
     abortSignal,
   );
   const nodes = new Map<string, Neo4jGraphContextNode>();
@@ -395,6 +422,63 @@ function traversalPattern(direction: "outgoing" | "incoming" | "both", maxDepth:
     return `(seed)<-[*1..${maxDepth}]-(node)`;
   }
   return `(seed)-[*1..${maxDepth}]-(node)`;
+}
+
+function managedQueryParameters(
+  graph: Neo4jKnowledgeGraphBase,
+  parameters: Record<string, unknown>,
+): Record<string, unknown> {
+  return managedScopeParameters(managedScope(graph), parameters);
+}
+
+function managedNodePredicate(
+  graph: Neo4jKnowledgeGraphBase,
+  variable: string,
+  prefix: "WHERE" | "AND",
+): string {
+  return managedScopePredicate(managedScope(graph), variable, prefix);
+}
+
+function managedSearchPredicate(
+  graph: Neo4jKnowledgeGraphBase,
+  variable: string,
+  chunkSeed: boolean,
+): string {
+  return chunkSeed && graph.namespace === undefined
+    ? ""
+    : managedNodePredicate(graph, variable, "WHERE");
+}
+
+function managedNodeAndPredicate(graph: Neo4jKnowledgeGraphBase, variable: string): string {
+  return managedScopePredicate(managedScope(graph), variable, " AND");
+}
+
+function managedRelationshipAndPredicate(graph: Neo4jKnowledgeGraphBase, variable: string): string {
+  return managedNodeAndPredicate(graph, variable);
+}
+
+function tenantNodePredicate(
+  graph: Neo4jKnowledgeGraphBase,
+  variable: string,
+  prefix: "WHERE" | "AND",
+): string {
+  const scope = managedScope(graph);
+  return scope === undefined ? "" : tenantScopePredicate(scope, variable, prefix);
+}
+
+function tenantNodeAndPredicate(graph: Neo4jKnowledgeGraphBase, variable: string): string {
+  const predicate = tenantNodePredicate(graph, variable, "AND");
+  return predicate.length === 0 ? "" : ` ${predicate}`;
+}
+
+function managedPathAndPredicate(graph: Neo4jKnowledgeGraphBase): string {
+  return managedPathPredicate(managedScope(graph), false);
+}
+
+function managedScope(graph: Neo4jKnowledgeGraphBase): Neo4jManagedScope | undefined {
+  return graph instanceof ManagedNeo4jKnowledgeGraph
+    ? { graph: graph.name, namespace: graph.namespace }
+    : undefined;
 }
 
 function contextNode(
@@ -577,6 +661,13 @@ function escapeLucene(value: string): string {
     escaped += specialCharacters.has(character) ? `\\${character}` : character;
   }
   return escaped;
+}
+
+function scopedFulltextQuery(graph: Neo4jKnowledgeGraphBase, value: string): string {
+  const query = escapeLucene(value);
+  return graph instanceof ManagedNeo4jKnowledgeGraph && graph.namespace !== undefined
+    ? `(${query}) AND __anvia_namespace:${escapeLucene(graph.namespace)}`
+    : query;
 }
 
 function groupBy<Value, Key>(

--- a/packages/graph-neo4j/test/neo4j.test.ts
+++ b/packages/graph-neo4j/test/neo4j.test.ts
@@ -109,8 +109,8 @@ function existingVectorIndex(name: string) {
   };
 }
 
-function managed(client: Neo4jClient) {
-  return client.managedKnowledgeGraph({
+function managedOptions() {
+  return {
     name: "support",
     schema,
     resources: {
@@ -130,7 +130,11 @@ function managed(client: Neo4jClient) {
         },
       },
     },
-  });
+  } as const;
+}
+
+function managed(client: Neo4jClient) {
+  return client.managedKnowledgeGraph(managedOptions());
 }
 
 function replacement() {
@@ -467,6 +471,112 @@ describe("Neo4j schema and lifecycle", () => {
     expect(driver.executeQuery).not.toHaveBeenCalled();
   });
 
+  it("provisions reusable tenant-scoped constraints and vector indexes", async () => {
+    const driver = fakeDriver({
+      transactionRun: async (query) => {
+        if (query.includes("dbms.components")) {
+          return { records: [record({ version: "2026.01.0" })] };
+        }
+        if (query.startsWith("SHOW INDEXES")) {
+          return {
+            records: [
+              ["support_chunks_vector", "SupportChunk"],
+              ["support_entities_vector", "SupportEntity"],
+            ]
+              .map(([name, label]) =>
+                record({
+                  name,
+                  state: "ONLINE",
+                  type: "VECTOR",
+                  entityType: "NODE",
+                  labelsOrTypes: [label],
+                  properties: ["__anvia_embedding", "__anvia_namespace"],
+                  options: {
+                    indexConfig: {
+                      "vector.dimensions": 2,
+                      "vector.similarity_function": "cosine",
+                    },
+                  },
+                }),
+              )
+              .concat([
+                record({
+                  name: "support_chunks_text",
+                  state: "ONLINE",
+                  type: "FULLTEXT",
+                  entityType: "NODE",
+                  labelsOrTypes: ["SupportChunk"],
+                  properties: ["__anvia_text", "__anvia_namespace"],
+                  options: {},
+                }),
+                record({
+                  name: "support_entities_text",
+                  state: "ONLINE",
+                  type: "FULLTEXT",
+                  entityType: "NODE",
+                  labelsOrTypes: ["SupportEntity"],
+                  properties: ["name", "title", "__anvia_namespace"],
+                  options: {},
+                }),
+              ]),
+          };
+        }
+        if (query.startsWith("SHOW CONSTRAINTS")) {
+          return {
+            records: [
+              ["document", "SupportDocument", ["__anvia_namespace", "__anvia_id"]],
+              ["chunk", "SupportChunk", ["__anvia_namespace", "__anvia_id"]],
+              ["entity", "SupportEntity", ["__anvia_namespace", "__anvia_key"]],
+              ["entity_Product", "Product", ["__anvia_namespace", "id"]],
+              ["entity_Incident", "Incident", ["__anvia_namespace", "id"]],
+            ].map(([suffix, label, properties]) =>
+              record({
+                name: `anvia_support_${suffix}_identity`,
+                type: "UNIQUENESS",
+                entityType: "NODE",
+                labelsOrTypes: [label],
+                properties,
+              }),
+            ),
+          };
+        }
+        return { records: [] };
+      },
+    });
+    const client = new Neo4jClient({ driver: driver.value });
+    const tenant = client.tenant("user-a");
+    const graph = tenant.managedKnowledgeGraph(managedOptions());
+
+    expect(tenant.namespace).toMatch(/^[a-f0-9]{64}$/);
+    expect(tenant.namespace).toBe(
+      "fc95297aa4f56781f0decb7d4bf59b1447f09b3611039b80188b1c6beb03ee6a",
+    );
+    expect(client.tenant("user-a").namespace).toBe(tenant.namespace);
+    await graph.ensure({ indexTimeoutMs: 1_000 });
+
+    const statements = driver.run.mock.calls.map(([query]) => String(query));
+    expect(
+      statements
+        .filter((query) => query.startsWith("CREATE CONSTRAINT"))
+        .every((query) => query.includes("__anvia_namespace")),
+    ).toBe(true);
+    expect(
+      statements
+        .filter((query) => query.startsWith("CREATE VECTOR INDEX"))
+        .every((query) => query.includes("WITH [n.`__anvia_namespace`]")),
+    ).toBe(true);
+    expect(
+      statements
+        .filter((query) => query.startsWith("CREATE FULLTEXT INDEX"))
+        .every((query) => query.includes("n.`__anvia_namespace`")),
+    ).toBe(true);
+  });
+
+  it("rejects empty tenant identifiers", () => {
+    const client = new Neo4jClient({ driver: fakeDriver().value });
+    expect(() => client.tenant("  ")).toThrow("tenant id must be a non-empty string");
+  });
+
   it("rejects an online index whose definition does not match the registration", async () => {
     const driver = fakeDriver({
       transactionRun: async (query) => {
@@ -638,6 +748,89 @@ describe("extractGraphFacts", () => {
 });
 
 describe("managed graph writes", () => {
+  it("scopes writes, retrieval, and exploration to one tenant", async () => {
+    const driver = fakeDriver({
+      transactionRun: async (query) =>
+        query.includes("collect(c.") ? { records: [record({ chunkIds: [] })] } : { records: [] },
+    });
+    const client = new Neo4jClient({ driver: driver.value });
+    const tenant = client.tenant("user-a");
+    const graph = tenant.managedKnowledgeGraph(managedOptions());
+
+    await graph.replaceDocuments(replacement());
+    await graph.retrieve({
+      model: {
+        provider: "test",
+        modelId: "embedding",
+        dimensions: 2,
+        async embedTexts(texts) {
+          return texts.map((document) => ({ document, vector: [1, 0] }));
+        },
+      },
+      query: "checkout",
+      search: {
+        type: "hybrid",
+        seeds: ["entities"],
+        topK: 1,
+        candidatesPerSeed: 2,
+        rrfK: 60,
+      },
+      traversal: {
+        relationships: ["AFFECTS"],
+        direction: "both",
+        maxDepth: 1,
+        maxNodes: 1,
+        maxRelationships: 1,
+      },
+      evidence: { type: "none" },
+    });
+    await graph.explore({ mode: "overview", maxNodes: 1, maxRelationships: 1 });
+    await graph.explore({
+      mode: "expand",
+      nodeIds: ["4:node"],
+      relationships: ["AFFECTS"],
+      maxDepth: 1,
+      maxNodes: 2,
+      maxRelationships: 2,
+    });
+
+    const calls = driver.run.mock.calls.map(([query, parameters]) => ({
+      query: String(query),
+      parameters,
+    }));
+    for (const marker of ["MERGE (d:", "CREATE (c:", "MERGE (e:", "MERGE (a)-[r:"]) {
+      const call = calls.find(({ query }) => query.includes(marker));
+      expect(call?.query).toContain("__anvia_namespace");
+      expect(call?.parameters).toMatchObject({ namespace: tenant.namespace });
+    }
+    const search = calls.find(({ query }) => query.includes("SEARCH seed"));
+    expect(search?.query).toContain("WHERE seed.`__anvia_namespace` = $namespace");
+    expect(search?.parameters).toMatchObject({ namespace: tenant.namespace });
+    const fulltextSearch = calls.find(({ query }) => query.includes("fulltext.queryNodes"));
+    expect(fulltextSearch?.parameters).toMatchObject({
+      query: `(checkout) AND __anvia_namespace:${tenant.namespace}`,
+      namespace: tenant.namespace,
+    });
+    const overview = calls.find(({ query }) => query.includes("RETURN elementId(node) AS id"));
+    expect(overview?.query).toContain("node:`SupportEntity`");
+    expect(overview?.query).toContain("node.`__anvia_namespace` = $namespace");
+    expect(overview?.query).toContain("node.`__anvia_graph` = $graph");
+    expect(overview?.parameters).toMatchObject({
+      graph: "support",
+      namespace: tenant.namespace,
+    });
+    const explorerCalls = calls.filter(
+      ({ query }) => query.includes("elementId(node)") || query.includes("MATCH path ="),
+    );
+    expect(explorerCalls.length).toBeGreaterThan(2);
+    expect(
+      explorerCalls.every(
+        ({ query, parameters }) =>
+          query.includes("__anvia_namespace") && parameters.namespace === tenant.namespace,
+      ),
+    ).toBe(true);
+  });
+
   it("replaces document-scoped graph state in one transaction", async () => {
     const driver = fakeDriver({
       transactionRun: async (query) =>
@@ -658,6 +851,11 @@ describe("managed graph writes", () => {
     expect(
       driver.run.mock.calls.some(([query]) => String(query).includes("SET r = row.properties")),
     ).toBe(true);
+    const documentWrite = driver.run.mock.calls.find(([query]) =>
+      String(query).includes("MERGE (d:"),
+    );
+    expect(documentWrite?.[0]).toContain("SET d += row.properties");
+    expect(documentWrite?.[0]).not.toContain("__anvia_namespace");
     expect(driver.sessionClose).toHaveBeenCalledOnce();
   });
 
@@ -1291,7 +1489,8 @@ describe("graph retrieval", () => {
         return { records: [] };
       },
     });
-    const graph = managed(new Neo4jClient({ driver: driver.value }));
+    const tenant = new Neo4jClient({ driver: driver.value }).tenant("user-a");
+    const graph = tenant.managedKnowledgeGraph(managedOptions());
     const context = await retrieveGraphContext({
       graph,
       model,
@@ -1333,6 +1532,18 @@ describe("graph retrieval", () => {
     expect(
       driver.run.mock.calls.filter(([query]) => String(query).includes("AS chunkId")),
     ).toHaveLength(1);
+    const scopedCalls = driver.run.mock.calls.filter(([query]) =>
+      ["SEARCH seed", "RETURN {elementId", "MATCH path", "AS chunkId"].some((marker) =>
+        String(query).includes(marker),
+      ),
+    );
+    expect(scopedCalls).toHaveLength(4);
+    expect(
+      scopedCalls.every(
+        ([query, parameters]) =>
+          String(query).includes("__anvia_namespace") && parameters.namespace === tenant.namespace,
+      ),
+    ).toBe(true);
   });
 
   it("rejects invalid or missing managed evidence", async () => {
@@ -1518,6 +1729,8 @@ describe("graph retrieval", () => {
                   title: "Checkout unavailable",
                   __anvia_key: 'Incident:{"id":"INC-1"}',
                   __anvia_embedding: [1, 0],
+                  __anvia_source_document_ids: ["article-1"],
+                  __anvia_source_chunk_ids: ["article-1:0"],
                 },
               }),
               record({
@@ -1536,7 +1749,12 @@ describe("graph retrieval", () => {
                 type: "AFFECTS",
                 source: "node-1",
                 target: "node-2",
-                properties: { severity: "high", __anvia_graph: "support" },
+                properties: {
+                  severity: "high",
+                  __anvia_graph: "support",
+                  __anvia_source_document_ids: ["article-1"],
+                  __anvia_source_chunk_ids: ["article-1:0"],
+                },
               }),
             ],
           };
@@ -1546,6 +1764,7 @@ describe("graph retrieval", () => {
     });
     const result = await managed(new Neo4jClient({ driver: driver.value })).explore({
       mode: "overview",
+      includeProvenance: true,
       maxNodes: 10,
       maxRelationships: 10,
     });
@@ -1555,6 +1774,7 @@ describe("graph retrieval", () => {
       type: "Incident",
       identity: { id: "INC-1" },
       properties: { id: "INC-1", title: "Checkout unavailable" },
+      provenance: { documentIds: ["article-1"], chunkIds: ["article-1:0"] },
     });
     expect(result.nodes[0]?.properties).not.toHaveProperty("__anvia_embedding");
     expect(result.relationships[0]).toMatchObject({
@@ -1562,6 +1782,7 @@ describe("graph retrieval", () => {
       from: "node-1",
       to: "node-2",
       properties: { severity: "high" },
+      provenance: { documentIds: ["article-1"], chunkIds: ["article-1:0"] },
     });
   });
 });

--- a/packages/graph-neo4j/test/public-types.ts
+++ b/packages/graph-neo4j/test/public-types.ts
@@ -1,11 +1,13 @@
 import type { EmbeddingModel } from "@anvia/core/embeddings";
 import { ingestGraphText, type CreateGraphSearchToolOptions } from "@anvia/graph";
-import type {
-  ManagedNeo4jKnowledgeGraph,
-  Neo4jGraphSchema,
-  Neo4jKnowledgeGraph,
-  Neo4jPropertyValue,
-  RetrieveGraphContextOptions,
+import {
+  ManagedNeo4jKnowledgeGraph as ManagedNeo4jKnowledgeGraphValue,
+  type ManagedNeo4jKnowledgeGraph,
+  type Neo4jClient,
+  type Neo4jGraphSchema,
+  type Neo4jKnowledgeGraph,
+  type Neo4jPropertyValue,
+  type RetrieveGraphContextOptions,
 } from "../src/index.js";
 
 const strings: Neo4jPropertyValue = ["one", "two"];
@@ -20,6 +22,17 @@ void [strings, numbers, booleans, mixed];
 declare const model: EmbeddingModel;
 declare const existing: Neo4jKnowledgeGraph<Neo4jGraphSchema>;
 declare const managed: ManagedNeo4jKnowledgeGraph<Neo4jGraphSchema>;
+declare const client: Neo4jClient;
+declare const managedOptions: Parameters<Neo4jClient["managedKnowledgeGraph"]>[0];
+const tenantGraph = client.tenant("user-1").managedKnowledgeGraph(managedOptions);
+tenantGraph.explore({ mode: "overview", includeProvenance: true });
+client.managedKnowledgeGraph({
+  ...managedOptions,
+  // @ts-expect-error Namespaces are created only through client.tenant().
+  namespace: "raw-user-id",
+});
+// @ts-expect-error Raw namespaces cannot bypass client.tenant().
+new ManagedNeo4jKnowledgeGraphValue(client, managedOptions, "raw-user-id");
 declare const forged: {
   readonly schema: Neo4jGraphSchema;
   readonly evidenceCapability: "chunks";

--- a/packages/graph/README.md
+++ b/packages/graph/README.md
@@ -47,8 +47,25 @@ const ingestion = await ingestGraphText({
   },
   conflict: "error",
   orphanEntities: "delete",
+  factConflicts: {
+    entity: {
+      properties: {
+        summary: "prefer-longest",
+        aliases: "union",
+        confidence: "max",
+      },
+    },
+  },
 });
 ```
+
+Extraction conflicts and stored-graph write conflicts are separate policies. `factConflicts`
+resolves disagreements between chunks before persistence; `conflict` controls collisions with facts
+already stored by the graph adapter. Extraction rejects disagreements by default. Built-in
+property strategies include `prefer-first`, `prefer-last`, `prefer-defined`, `prefer-longest`,
+`union`, `max`, and `min`; a custom resolver receives structured candidate and source chunk data.
+Conflict errors and resolved warnings include the fact type, stable key, parsed identity, property,
+candidate values, and source chunk IDs. Resolved disagreements are returned in `warnings`.
 
 Use `ingestGraphDocuments()` for a batch. Both functions extract facts, embed chunks and entities,
 and atomically replace each source document in the managed graph. Existing graph registrations are
@@ -60,6 +77,12 @@ reuse the chunk embeddings without another model call:
 ```ts
 await vectorStore.upsert({ documents: ingestion.vectorDocuments });
 ```
+
+Every ingestion result includes a `receipt` with document, entity, relationship, and vector IDs,
+the graph write counts, warnings, an optional caller-supplied `revision`, and vector-stage status.
+Use `ingestGraphTextToStores()` or `ingestGraphDocumentsToStores()` to write the graph followed by
+the vector store. If the second stage fails, `GraphIngestionStageError` exposes a receipt with a
+completed graph stage and failed vector stage for queue reconciliation.
 
 The graph and vector writes are separate transactions. Applications that require cross-store
 reconciliation should persist their own ingestion status and retry the incomplete write. Advanced
@@ -105,6 +128,7 @@ Adapters implementing `GraphExplorer` expose a portable, bounded view for visual
 const overview = await graph.explore({
   mode: "overview",
   nodeTypes: ["Product"],
+  includeProvenance: true,
   maxNodes: 100,
   maxRelationships: 200,
 });
@@ -120,3 +144,6 @@ const neighborhood = await graph.explore({
 Explorer IDs are opaque and provider-specific. They are intended for follow-up expansion within the
 same graph, not persistence or cross-provider migration. Adapters cap overview and expansion requests,
 return truncation metadata, and omit reserved Anvia properties such as stored embeddings.
+
+When `includeProvenance` is true, supported adapters attach source `documentIds` and `chunkIds` to
+nodes and relationships.

--- a/packages/graph/src/explore.ts
+++ b/packages/graph/src/explore.ts
@@ -13,6 +13,7 @@ type ResolvedGraphExploreBase = Readonly<{
   relationships: readonly string[];
   maxNodes: number;
   maxRelationships: number;
+  includeProvenance: boolean;
   abortSignal?: AbortSignal | undefined;
 }>;
 
@@ -47,6 +48,7 @@ export function resolveGraphExploreOptions<Schema extends GraphSchemaLike>(
     relationships: string[];
     maxNodes: number;
     maxRelationships: number;
+    includeProvenance: boolean;
     abortSignal?: AbortSignal | undefined;
   } = {
     nodeTypes,
@@ -58,6 +60,7 @@ export function resolveGraphExploreOptions<Schema extends GraphSchemaLike>(
       maximumRelationships,
       "maxRelationships",
     ),
+    includeProvenance: options.includeProvenance ?? false,
   };
   if (options.abortSignal !== undefined) base.abortSignal = options.abortSignal;
   if (options.mode === "overview") {

--- a/packages/graph/src/extract.ts
+++ b/packages/graph/src/extract.ts
@@ -1,15 +1,21 @@
 import { Usage } from "@anvia/core";
 import { extract } from "@anvia/core/extractor";
 import { z } from "zod";
-import { parseGraphProperties } from "./schema.js";
+import { parseGraphProperties, parseGraphPropertyValue } from "./schema.js";
 import type {
   ExtractGraphFactsOptions,
   ExtractGraphFactsResult,
   GraphEntity,
+  GraphExtractionWarning,
+  GraphFactConflictCandidate,
+  GraphFactConflictPolicy,
+  GraphFactPropertyConflict,
+  GraphFactPropertyConflictStrategy,
   GraphFacts,
   GraphMention,
   GraphNodeIdentity,
   GraphProperties,
+  GraphPropertyValue,
   GraphRelationship,
   GraphSchemaLike,
 } from "./types.js";
@@ -23,6 +29,22 @@ type RawRelationship = {
 };
 type RawChunkFacts = { entities: RawEntity[]; relationships: RawRelationship[] };
 type ChunkExtraction = { chunkId: string; output: RawChunkFacts; usage: Usage };
+type EntityCandidate = Readonly<{
+  key: string;
+  type: string;
+  identity: GraphNodeIdentity;
+  properties: GraphProperties;
+  chunkId: string;
+}>;
+type RelationshipCandidate = Readonly<{
+  key: string;
+  type: string;
+  from: string;
+  to: string;
+  identity: GraphNodeIdentity;
+  properties: GraphProperties;
+  chunkId: string;
+}>;
 
 export async function extractGraphFacts<
   Schema extends GraphSchemaLike,
@@ -58,7 +80,7 @@ export async function extractGraphFacts<
     },
   );
   return {
-    output: normalizeFacts(options.schema, extractions),
+    ...normalizeFacts(options.schema, extractions, options.conflicts),
     usage: extractions.reduce((usage, item) => Usage.add(usage, item.usage), Usage.empty()),
   };
 }
@@ -114,13 +136,14 @@ function graphInstructions(schema: GraphSchemaLike, extra: string | undefined): 
 function normalizeFacts<Schema extends GraphSchemaLike>(
   schema: Schema,
   extractions: readonly ChunkExtraction[],
-): GraphFacts<Schema> {
-  const entities = new Map<string, GraphEntity<Schema>>();
-  const relationships = new Map<string, GraphRelationship<Schema>>();
+  conflicts: ExtractGraphFactsOptions<Schema, import("@anvia/core").CompletionModel>["conflicts"],
+): Readonly<{ output: GraphFacts<Schema>; warnings: readonly GraphExtractionWarning[] }> {
+  const entityCandidates = new Map<string, EntityCandidate[]>();
+  const relationshipCandidates = new Map<string, RelationshipCandidate[]>();
   const mentions = new Map<string, GraphMention>();
 
   for (const extraction of extractions) {
-    const refs = new Map<string, GraphEntity<Schema>>();
+    const refs = new Map<string, EntityCandidate>();
     for (const raw of extraction.output.entities) {
       if (refs.has(raw.ref)) {
         throw new TypeError(`Duplicate entity ref ${raw.ref} in chunk ${extraction.chunkId}.`);
@@ -133,32 +156,15 @@ function normalizeFacts<Schema extends GraphSchemaLike>(
       );
       const identity = identityFromProperties(definition.identity, properties, raw.type);
       const key = `${raw.type}:${stableObject(identity)}`;
-      const current = entities.get(key);
-      const next = {
+      const candidate: EntityCandidate = {
         key,
         type: raw.type,
         identity,
         properties,
-        sourceChunkIds: [extraction.chunkId],
-      } as unknown as GraphEntity<Schema>;
-      if (current === undefined) {
-        entities.set(key, next);
-        refs.set(raw.ref, next);
-      } else {
-        assertSameProperties(
-          current.properties,
-          properties,
-          key,
-          current.sourceChunkIds,
-          extraction.chunkId,
-        );
-        const merged = {
-          ...current,
-          sourceChunkIds: [...current.sourceChunkIds, extraction.chunkId],
-        } as GraphEntity<Schema>;
-        entities.set(key, merged);
-        refs.set(raw.ref, merged);
-      }
+        chunkId: extraction.chunkId,
+      };
+      appendCandidate(entityCandidates, key, candidate);
+      refs.set(raw.ref, candidate);
       mentions.set(`${extraction.chunkId}\u0000${key}`, {
         chunkId: extraction.chunkId,
         entityKey: key,
@@ -188,36 +194,205 @@ function normalizeFacts<Schema extends GraphSchemaLike>(
       );
       const identity = identityFromProperties(definition.identity ?? [], properties, raw.type);
       const key = `${raw.type}:${from.key}->${to.key}:${stableObject(identity)}`;
-      const current = relationships.get(key);
-      const next = {
+      appendCandidate(relationshipCandidates, key, {
         key,
         type: raw.type,
         from: from.key,
         to: to.key,
+        identity,
         properties,
-        sourceChunkIds: [extraction.chunkId],
-      } as unknown as GraphRelationship<Schema>;
-      if (current === undefined) relationships.set(key, next);
-      else {
-        assertSameProperties(
-          current.properties,
-          properties,
-          key,
-          current.sourceChunkIds,
-          extraction.chunkId,
-        );
-        relationships.set(key, {
-          ...current,
-          sourceChunkIds: [...current.sourceChunkIds, extraction.chunkId],
-        } as GraphRelationship<Schema>);
-      }
+        chunkId: extraction.chunkId,
+      });
     }
   }
+  const warnings: GraphExtractionWarning[] = [];
+  const entities = [...entityCandidates.values()].map((candidates) => {
+    const first = requiredCandidate(candidates);
+    const definition = schema.nodes[first.type];
+    if (definition === undefined) throw new TypeError(`Unknown graph entity type: ${first.type}`);
+    const properties = parseGraphProperties(
+      definition.properties.parse(
+        resolveFactProperties(
+          "entity",
+          first.key,
+          first.type,
+          first.identity,
+          candidates,
+          conflicts?.entity,
+          warnings,
+        ),
+      ),
+      `entity ${first.type}`,
+    );
+    return {
+      key: first.key,
+      type: first.type,
+      identity: first.identity,
+      properties,
+      sourceChunkIds: uniqueChunkIds(candidates),
+    } as GraphEntity<Schema>;
+  });
+  const relationships = [...relationshipCandidates.values()].map((candidates) => {
+    const first = requiredCandidate(candidates);
+    const definition = schema.relationships[first.type];
+    if (definition === undefined) {
+      throw new TypeError(`Unknown graph relationship type: ${first.type}`);
+    }
+    const properties = parseGraphProperties(
+      definition.properties.parse(
+        resolveFactProperties(
+          "relationship",
+          first.key,
+          first.type,
+          first.identity,
+          candidates,
+          conflicts?.relationship,
+          warnings,
+        ),
+      ),
+      `relationship ${first.type}`,
+    );
+    return {
+      key: first.key,
+      type: first.type,
+      from: first.from,
+      to: first.to,
+      properties,
+      sourceChunkIds: uniqueChunkIds(candidates),
+    } as GraphRelationship<Schema>;
+  });
   return {
-    entities: [...entities.values()],
-    relationships: [...relationships.values()],
-    mentions: [...mentions.values()],
+    output: { entities, relationships, mentions: [...mentions.values()] },
+    warnings,
   };
+}
+
+function appendCandidate<Candidate>(
+  candidates: Map<string, Candidate[]>,
+  key: string,
+  candidate: Candidate,
+): void {
+  const current = candidates.get(key);
+  if (current === undefined) candidates.set(key, [candidate]);
+  else current.push(candidate);
+}
+
+function requiredCandidate<Candidate>(candidates: readonly Candidate[]): Candidate {
+  const candidate = candidates[0];
+  if (candidate === undefined) throw new TypeError("Graph fact candidate group cannot be empty.");
+  return candidate;
+}
+
+function uniqueChunkIds(candidates: readonly { chunkId: string }[]): readonly string[] {
+  return [...new Set(candidates.map((candidate) => candidate.chunkId))];
+}
+
+function resolveFactProperties(
+  kind: "entity" | "relationship",
+  key: string,
+  type: string,
+  identity: GraphNodeIdentity,
+  candidates: readonly { chunkId: string; properties: GraphProperties }[],
+  policy: GraphFactConflictPolicy | undefined,
+  warnings: GraphExtractionWarning[],
+): GraphProperties {
+  const propertyNames = [
+    ...new Set(candidates.flatMap((candidate) => Object.keys(candidate.properties))),
+  ].sort();
+  const properties: Record<string, GraphPropertyValue> = {};
+  for (const property of propertyNames) {
+    const propertyCandidates: GraphFactConflictCandidate[] = candidates.map((candidate) => ({
+      chunkId: candidate.chunkId,
+      properties: candidate.properties,
+      value: candidate.properties[property],
+    }));
+    const firstValue = propertyCandidates[0]?.value;
+    if (
+      propertyCandidates.every(
+        (candidate) => stableValue(candidate.value) === stableValue(firstValue),
+      )
+    ) {
+      if (firstValue !== undefined) properties[property] = firstValue;
+      continue;
+    }
+    const conflict: GraphFactPropertyConflict = {
+      code: "GRAPH_FACT_CONFLICT",
+      kind,
+      key,
+      type,
+      identity,
+      property,
+      candidates: propertyCandidates,
+      sourceChunkIds: uniqueChunkIds(propertyCandidates),
+    };
+    const strategy =
+      policy?.properties?.[property] ?? policy?.resolve ?? policy?.default ?? "reject";
+    if (strategy === "reject") throw new GraphFactConflictError(conflict);
+    const resolvedValue = validateResolvedValue(
+      resolvePropertyConflict(strategy, conflict),
+      conflict,
+    );
+    if (resolvedValue !== undefined) properties[property] = resolvedValue;
+    warnings.push({
+      ...conflict,
+      code: "GRAPH_FACT_CONFLICT_RESOLVED",
+      strategy: typeof strategy === "function" ? "custom" : strategy,
+      resolvedValue,
+    });
+  }
+  return properties;
+}
+
+function resolvePropertyConflict(
+  strategy: Exclude<GraphFactPropertyConflictStrategy, "reject">,
+  conflict: GraphFactPropertyConflict,
+): GraphPropertyValue | undefined {
+  if (typeof strategy === "function") {
+    return strategy(conflict);
+  }
+  const values = conflict.candidates.map((candidate) => candidate.value);
+  if (strategy === "prefer-first") return values[0];
+  if (strategy === "prefer-last") return values.at(-1);
+  if (strategy === "prefer-defined") return values.find((value) => value !== undefined);
+  if (strategy === "prefer-longest") {
+    const strings = definedValues(values, "string", conflict, strategy);
+    return strings.reduce((longest, value) => (value.length > longest.length ? value : longest));
+  }
+  if (strategy === "union") {
+    const arrays = values.filter((value) => value !== undefined);
+    if (!arrays.every(Array.isArray)) throw incompatibleStrategy(conflict, strategy);
+    return [...new Set(arrays.flat())] as string[] | number[] | boolean[];
+  }
+  const numbers = definedValues(values, "number", conflict, strategy);
+  return strategy === "max" ? Math.max(...numbers) : Math.min(...numbers);
+}
+
+function definedValues<Type extends "string" | "number">(
+  values: readonly (GraphPropertyValue | undefined)[],
+  type: Type,
+  conflict: GraphFactPropertyConflict,
+  strategy: string,
+): Type extends "string" ? string[] : number[] {
+  const defined = values.filter((value) => value !== undefined);
+  if (defined.length === 0 || !defined.every((value) => typeof value === type)) {
+    throw incompatibleStrategy(conflict, strategy);
+  }
+  return defined as Type extends "string" ? string[] : number[];
+}
+
+function validateResolvedValue(
+  value: GraphPropertyValue | undefined,
+  conflict: GraphFactPropertyConflict,
+): GraphPropertyValue | undefined {
+  return value === undefined
+    ? undefined
+    : parseGraphPropertyValue(value, `Resolved graph fact ${conflict.key}.${conflict.property}`);
+}
+
+function incompatibleStrategy(conflict: GraphFactPropertyConflict, strategy: string): TypeError {
+  return new TypeError(
+    `Graph fact conflict strategy ${strategy} is incompatible with ${conflict.key}.${conflict.property}.`,
+  );
 }
 
 function identityFromProperties(
@@ -245,27 +420,50 @@ function stableObject(value: Readonly<Record<string, unknown>>): string {
   );
 }
 
-function assertSameProperties(
-  left: GraphProperties,
-  right: GraphProperties,
-  key: string,
-  sourceChunkIds: readonly string[],
-  nextChunkId: string,
-): void {
-  if (stableObject(left) !== stableObject(right)) {
-    throw new GraphFactConflictError(key, [...sourceChunkIds, nextChunkId]);
-  }
+function stableValue(value: unknown): string {
+  return value === undefined ? "undefined" : stableObject({ value });
 }
 
 export class GraphFactConflictError extends Error {
+  readonly code = "GRAPH_FACT_CONFLICT" as const;
+  readonly kind: "entity" | "relationship";
+  readonly factKey: string;
+  readonly type: string;
+  readonly identity: GraphNodeIdentity;
+  readonly property: string;
+  readonly candidates: readonly GraphFactConflictCandidate[];
+  readonly sourceChunkIds: readonly string[];
+
+  constructor(conflict: GraphFactPropertyConflict);
+  constructor(factKey: string, sourceChunkIds: readonly string[]);
   constructor(
-    readonly factKey: string,
-    readonly sourceChunkIds: readonly string[],
+    conflictOrKey: GraphFactPropertyConflict | string,
+    legacyChunkIds: readonly string[] = [],
   ) {
+    const conflict =
+      typeof conflictOrKey === "string"
+        ? {
+            code: "GRAPH_FACT_CONFLICT" as const,
+            kind: "entity" as const,
+            key: conflictOrKey,
+            type: conflictOrKey.split(":", 1)[0] ?? "unknown",
+            identity: {},
+            property: "unknown",
+            candidates: [],
+            sourceChunkIds: legacyChunkIds,
+          }
+        : conflictOrKey;
     super(
-      `Conflicting graph fact ${factKey} was extracted from chunks ${sourceChunkIds.join(", ")}.`,
+      `Conflicting graph fact ${conflict.key}.${conflict.property} was extracted from chunks ${conflict.sourceChunkIds.join(", ")}.`,
     );
     this.name = "GraphFactConflictError";
+    this.kind = conflict.kind;
+    this.factKey = conflict.key;
+    this.type = conflict.type;
+    this.identity = conflict.identity;
+    this.property = conflict.property;
+    this.candidates = conflict.candidates;
+    this.sourceChunkIds = conflict.sourceChunkIds;
   }
 }
 

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -1,11 +1,18 @@
 export { extractGraphFacts, GraphFactConflictError } from "./extract.js";
 export {
   ingestGraphDocuments,
+  ingestGraphDocumentsToStores,
   ingestGraphText,
+  ingestGraphTextToStores,
   prepareGraphDocuments,
+  GraphIngestionStageError,
+  type GraphIngestionReceipt,
+  type GraphVectorWriter,
   type IngestGraphDocumentsOptions,
   type IngestGraphDocumentsResult,
+  type IngestGraphDocumentsToStoresOptions,
   type IngestGraphTextOptions,
+  type IngestGraphTextToStoresOptions,
   type PreparedGraphDocuments,
   type PrepareGraphDocumentsOptions,
 } from "./ingest.js";

--- a/packages/graph/src/ingest.ts
+++ b/packages/graph/src/ingest.ts
@@ -1,4 +1,4 @@
-import type { CompletionModel, RetrySetting, Usage } from "@anvia/core";
+import type { CompletionModel, JsonObject, RetrySetting, Usage } from "@anvia/core";
 import {
   chunkTextDocuments,
   type TextDocument,
@@ -14,6 +14,8 @@ import type {
   GraphDocument,
   GraphDocumentWriter,
   GraphEntity,
+  GraphExtractionWarning,
+  GraphFactConflictOptions,
   GraphMention,
   GraphOrphanEntityPolicy,
   GraphProperties,
@@ -37,6 +39,8 @@ type GraphPreparationOptions<
   retries?: RetrySetting | undefined;
   concurrency?: number | undefined;
   abortSignal?: AbortSignal | undefined;
+  factConflicts?: GraphFactConflictOptions | undefined;
+  revision?: string | undefined;
 }>;
 
 export type PrepareGraphDocumentsOptions<
@@ -71,10 +75,58 @@ export type PreparedGraphDocuments<Schema extends GraphSchemaLike> = Readonly<{
   relationships: readonly GraphRelationship<Schema>[];
   mentions: readonly GraphMention[];
   usage: Usage;
+  warnings: readonly GraphExtractionWarning[];
 }>;
 
 export type IngestGraphDocumentsResult<Schema extends GraphSchemaLike> =
-  PreparedGraphDocuments<Schema> & Readonly<{ write: GraphWriteResult }>;
+  PreparedGraphDocuments<Schema> &
+    Readonly<{ write: GraphWriteResult; receipt: GraphIngestionReceipt }>;
+
+export type GraphIngestionReceipt = Readonly<{
+  documentIds: readonly string[];
+  revision?: string | undefined;
+  entityKeys: readonly string[];
+  relationshipKeys: readonly string[];
+  vectorDocumentIds: readonly string[];
+  graphWrite: Readonly<{ status: "completed"; result: GraphWriteResult }>;
+  vectorWrite: Readonly<{ status: "not-requested" | "completed" | "failed" }>;
+  warnings: readonly GraphExtractionWarning[];
+}>;
+
+export type GraphVectorWriter = Readonly<{
+  upsert(options: {
+    documents: Array<EmbeddedDocument<TextDocument<TextDocumentMetadata>, TextDocumentMetadata>>;
+    providerOptions?: JsonObject | undefined;
+  }): Promise<void>;
+}>;
+
+export type IngestGraphDocumentsToStoresOptions<
+  Schema extends GraphSchemaLike,
+  ExtractionModel extends CompletionModel = CompletionModel,
+> = IngestGraphDocumentsOptions<Schema, ExtractionModel> &
+  Readonly<{
+    vectorStore: GraphVectorWriter;
+    vectorProviderOptions?: JsonObject | undefined;
+  }>;
+
+export type IngestGraphTextToStoresOptions<
+  Schema extends GraphSchemaLike,
+  ExtractionModel extends CompletionModel = CompletionModel,
+> = Omit<IngestGraphDocumentsToStoresOptions<Schema, ExtractionModel>, "documents"> &
+  Readonly<{ document: TextDocument<TextDocumentMetadata> }>;
+
+export class GraphIngestionStageError extends Error {
+  readonly code = "GRAPH_INGESTION_STAGE_FAILED" as const;
+  readonly stage = "vector" as const;
+
+  constructor(
+    readonly receipt: GraphIngestionReceipt,
+    cause: unknown,
+  ) {
+    super("Graph ingestion completed, but the vector write failed.", { cause });
+    this.name = "GraphIngestionStageError";
+  }
+}
 
 export async function ingestGraphText<
   Schema extends GraphSchemaLike,
@@ -93,6 +145,8 @@ export async function ingestGraphText<
     retries: options.retries,
     concurrency: options.concurrency,
     abortSignal: options.abortSignal,
+    factConflicts: options.factConflicts,
+    revision: options.revision,
     conflict: options.conflict,
     orphanEntities: options.orphanEntities,
   });
@@ -115,7 +169,44 @@ export async function ingestGraphDocuments<
     orphanEntities: options.orphanEntities,
     abortSignal: options.abortSignal,
   });
-  return { ...prepared, write };
+  return {
+    ...prepared,
+    write,
+    receipt: ingestionReceipt(prepared, write, options.revision, "not-requested"),
+  };
+}
+
+export async function ingestGraphTextToStores<
+  Schema extends GraphSchemaLike,
+  ExtractionModel extends CompletionModel,
+>(
+  options: IngestGraphTextToStoresOptions<Schema, ExtractionModel>,
+): Promise<IngestGraphDocumentsResult<Schema>> {
+  return ingestGraphDocumentsToStores({ ...options, documents: [options.document] });
+}
+
+export async function ingestGraphDocumentsToStores<
+  Schema extends GraphSchemaLike,
+  ExtractionModel extends CompletionModel,
+>(
+  options: IngestGraphDocumentsToStoresOptions<Schema, ExtractionModel>,
+): Promise<IngestGraphDocumentsResult<Schema>> {
+  const result = await ingestGraphDocuments(options);
+  try {
+    await options.vectorStore.upsert({
+      documents: [...result.vectorDocuments],
+      providerOptions: options.vectorProviderOptions,
+    });
+  } catch (error) {
+    throw new GraphIngestionStageError(
+      { ...result.receipt, vectorWrite: { status: "failed" } },
+      error,
+    );
+  }
+  return {
+    ...result,
+    receipt: { ...result.receipt, vectorWrite: { status: "completed" } },
+  };
 }
 
 export async function prepareGraphDocuments<
@@ -124,6 +215,9 @@ export async function prepareGraphDocuments<
 >(
   options: PrepareGraphDocumentsOptions<Schema, ExtractionModel>,
 ): Promise<PreparedGraphDocuments<Schema>> {
+  if (options.revision !== undefined && options.revision.trim().length === 0) {
+    throw new TypeError("Graph ingestion revision must be a non-empty string.");
+  }
   validatePortableMetadata(options.documents);
   const chunks = chunkTextDocuments({
     documents: options.documents,
@@ -139,6 +233,7 @@ export async function prepareGraphDocuments<
       retries: options.retries,
       concurrency: options.concurrency,
       abortSignal: options.abortSignal,
+      conflicts: options.factConflicts,
     }),
     embedDocuments({
       model: options.embeddingModel,
@@ -169,6 +264,25 @@ export async function prepareGraphDocuments<
     relationships: facts.output.relationships,
     mentions: facts.output.mentions,
     usage: facts.usage,
+    warnings: facts.warnings,
+  };
+}
+
+function ingestionReceipt<Schema extends GraphSchemaLike>(
+  prepared: PreparedGraphDocuments<Schema>,
+  write: GraphWriteResult,
+  revision: string | undefined,
+  vectorStatus: GraphIngestionReceipt["vectorWrite"]["status"],
+): GraphIngestionReceipt {
+  return {
+    documentIds: prepared.documents.map((document) => document.id),
+    ...(revision === undefined ? {} : { revision }),
+    entityKeys: prepared.entities.map((entity) => entity.id),
+    relationshipKeys: prepared.relationships.map((relationship) => relationship.key),
+    vectorDocumentIds: prepared.vectorDocuments.map((document) => document.id),
+    graphWrite: { status: "completed", result: write },
+    vectorWrite: { status: vectorStatus },
+    warnings: prepared.warnings,
   };
 }
 

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -71,6 +71,60 @@ export type GraphFacts<Schema extends GraphSchemaLike = GraphSchemaLike> = Reado
   mentions: readonly GraphMention[];
 }>;
 
+export type GraphFactKind = "entity" | "relationship";
+
+export type GraphFactConflictCandidate = Readonly<{
+  chunkId: string;
+  properties: GraphProperties;
+  value: GraphPropertyValue | undefined;
+}>;
+
+export type GraphFactPropertyConflict = Readonly<{
+  code: "GRAPH_FACT_CONFLICT";
+  kind: GraphFactKind;
+  key: string;
+  type: string;
+  identity: GraphNodeIdentity;
+  property: string;
+  candidates: readonly GraphFactConflictCandidate[];
+  sourceChunkIds: readonly string[];
+}>;
+
+export type GraphFactPropertyConflictResolver = (
+  conflict: GraphFactPropertyConflict,
+) => GraphPropertyValue | undefined;
+
+export type GraphFactPropertyConflictStrategy =
+  | "reject"
+  | "prefer-first"
+  | "prefer-last"
+  | "prefer-defined"
+  | "prefer-longest"
+  | "union"
+  | "max"
+  | "min"
+  | GraphFactPropertyConflictResolver;
+
+export type GraphFactConflictPolicy = Readonly<{
+  default?: GraphFactPropertyConflictStrategy | undefined;
+  properties?: Readonly<Record<string, GraphFactPropertyConflictStrategy>> | undefined;
+  resolve?: GraphFactPropertyConflictResolver | undefined;
+}>;
+
+export type GraphFactConflictOptions = Readonly<{
+  entity?: GraphFactConflictPolicy | undefined;
+  relationship?: GraphFactConflictPolicy | undefined;
+}>;
+
+export type GraphFactConflictWarning = Omit<GraphFactPropertyConflict, "code"> &
+  Readonly<{
+    code: "GRAPH_FACT_CONFLICT_RESOLVED";
+    strategy: string;
+    resolvedValue: GraphPropertyValue | undefined;
+  }>;
+
+export type GraphExtractionWarning = GraphFactConflictWarning;
+
 export type GraphChunk<Metadata extends GraphProperties = GraphProperties> = Readonly<{
   id: string;
   documentId: string;
@@ -95,11 +149,13 @@ export type ExtractGraphFactsOptions<
   retries?: RetrySetting | undefined;
   concurrency?: number | undefined;
   abortSignal?: AbortSignal | undefined;
+  conflicts?: GraphFactConflictOptions | undefined;
 }>;
 
 export type ExtractGraphFactsResult<Schema extends GraphSchemaLike> = Readonly<{
   output: GraphFacts<Schema>;
   usage: Usage;
+  warnings: readonly GraphExtractionWarning[];
 }>;
 
 export type GraphVectorSearchOptions = Readonly<{
@@ -203,6 +259,7 @@ export type GraphExploreOverviewOptions<Schema extends GraphSchemaLike> = Readon
   mode: "overview";
   nodeTypes?: readonly (keyof Schema["nodes"] & string)[] | undefined;
   relationships?: readonly (keyof Schema["relationships"] & string)[] | undefined;
+  includeProvenance?: boolean | undefined;
   maxNodes?: number | undefined;
   maxRelationships?: number | undefined;
   abortSignal?: AbortSignal | undefined;
@@ -213,6 +270,7 @@ export type GraphExploreExpandOptions<Schema extends GraphSchemaLike> = Readonly
   nodeIds: readonly string[];
   nodeTypes?: readonly (keyof Schema["nodes"] & string)[] | undefined;
   relationships?: readonly (keyof Schema["relationships"] & string)[] | undefined;
+  includeProvenance?: boolean | undefined;
   direction?: GraphExploreDirection | undefined;
   maxDepth?: number | undefined;
   maxNodes?: number | undefined;
@@ -230,6 +288,7 @@ export type GraphExploreNode = Readonly<{
   type: string;
   identity: GraphNodeIdentity;
   properties: GraphProperties;
+  provenance?: GraphExploreProvenance | undefined;
 }>;
 
 export type GraphExploreRelationship = Readonly<{
@@ -239,6 +298,12 @@ export type GraphExploreRelationship = Readonly<{
   from: string;
   to: string;
   properties: GraphProperties;
+  provenance?: GraphExploreProvenance | undefined;
+}>;
+
+export type GraphExploreProvenance = Readonly<{
+  documentIds: readonly string[];
+  chunkIds: readonly string[];
 }>;
 
 export type GraphExploreResult = Readonly<{

--- a/packages/graph/test/graph.test.ts
+++ b/packages/graph/test/graph.test.ts
@@ -8,8 +8,8 @@ vi.mock("@anvia/core/extractor", () => ({ extract: extractMock }));
 import {
   defineGraphSchema,
   extractGraphFacts,
-  GraphFactConflictError,
   ingestGraphText,
+  ingestGraphTextToStores,
   prepareGraphDocuments,
   resolveGraphExploreOptions,
 } from "../src/index.js";
@@ -92,7 +92,140 @@ describe("provider-neutral graph primitives", () => {
           { id: "two", documentId: "doc", index: 1, text: "two" },
         ],
       }),
-    ).rejects.toBeInstanceOf(GraphFactConflictError);
+    ).rejects.toMatchObject({
+      name: "GraphFactConflictError",
+      code: "GRAPH_FACT_CONFLICT",
+      kind: "entity",
+      factKey: 'Product:{"id":"one"}',
+      type: "Product",
+      identity: { id: "one" },
+      property: "name",
+      sourceChunkIds: ["one", "two"],
+      candidates: [
+        { chunkId: "one", value: "One" },
+        { chunkId: "two", value: "Changed" },
+      ],
+    });
+  });
+
+  it("resolves property-level fact conflicts and returns structured warnings", async () => {
+    const conflictSchema = defineGraphSchema({
+      nodes: {
+        Product: {
+          description: "A product.",
+          identity: ["id"],
+          properties: z.strictObject({
+            id: z.string(),
+            summary: z.string(),
+            aliases: z.array(z.string()),
+            confidence: z.number(),
+          }),
+        },
+      },
+      relationships: {
+        REFERENCES: {
+          description: "A product references itself.",
+          from: "Product",
+          to: "Product",
+          properties: z.strictObject({ note: z.string() }),
+        },
+      },
+    });
+    extractMock
+      .mockResolvedValueOnce({
+        output: {
+          entities: [
+            {
+              ref: "sqlite",
+              type: "Product",
+              properties: {
+                id: "sqlite",
+                summary: "Database",
+                aliases: ["sqlite"],
+                confidence: 0.6,
+              },
+            },
+          ],
+          relationships: [
+            { type: "REFERENCES", from: "sqlite", to: "sqlite", properties: { note: "first" } },
+          ],
+        },
+        usage: Usage.empty(),
+      })
+      .mockResolvedValueOnce({
+        output: {
+          entities: [
+            {
+              ref: "sqlite",
+              type: "Product",
+              properties: {
+                id: "sqlite",
+                summary: "Embedded SQL database",
+                aliases: ["SQLite", "sqlite"],
+                confidence: 0.9,
+              },
+            },
+          ],
+          relationships: [
+            { type: "REFERENCES", from: "sqlite", to: "sqlite", properties: { note: "second" } },
+          ],
+        },
+        usage: Usage.empty(),
+      });
+
+    const result = await extractGraphFacts({
+      model: {} as never,
+      schema: conflictSchema,
+      chunks: [
+        { id: "one", documentId: "doc", index: 0, text: "one" },
+        { id: "two", documentId: "doc", index: 1, text: "two" },
+      ],
+      conflicts: {
+        entity: {
+          properties: {
+            summary: "prefer-longest",
+            aliases: "union",
+            confidence: "max",
+          },
+        },
+        relationship: {
+          resolve: (conflict) => conflict.candidates.at(-1)?.value,
+        },
+      },
+    });
+
+    expect(result.output.entities[0]).toMatchObject({
+      properties: {
+        id: "sqlite",
+        summary: "Embedded SQL database",
+        aliases: ["sqlite", "SQLite"],
+        confidence: 0.9,
+      },
+      sourceChunkIds: ["one", "two"],
+    });
+    expect(result.output.relationships[0]).toMatchObject({
+      properties: { note: "second" },
+      sourceChunkIds: ["one", "two"],
+    });
+    expect(result.warnings).toHaveLength(4);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "GRAPH_FACT_CONFLICT_RESOLVED",
+          kind: "entity",
+          property: "summary",
+          strategy: "prefer-longest",
+          resolvedValue: "Embedded SQL database",
+        }),
+        expect.objectContaining({
+          code: "GRAPH_FACT_CONFLICT_RESOLVED",
+          kind: "relationship",
+          property: "note",
+          strategy: "custom",
+          resolvedValue: "second",
+        }),
+      ]),
+    );
   });
 
   it("prepares and writes text with reusable vector documents", async () => {
@@ -143,6 +276,108 @@ describe("provider-neutral graph primitives", () => {
     expect(replaceDocuments).toHaveBeenCalledWith(
       expect.objectContaining({ conflict: "keep-existing", orphanEntities: "keep" }),
     );
+    expect(result.receipt).toMatchObject({
+      documentIds: ["incident"],
+      entityKeys: ['Product:{"id":"one"}'],
+      vectorDocumentIds: ["incident"],
+      graphWrite: { status: "completed" },
+      vectorWrite: { status: "not-requested" },
+    });
+  });
+
+  it("reports vector-stage partial failures with a reconciliation receipt", async () => {
+    extractMock.mockResolvedValue({
+      output: { entities: [], relationships: [] },
+      usage: Usage.empty(),
+    });
+    const graph = {
+      schema,
+      replaceDocuments: vi.fn(async () => ({
+        documents: { created: 1, updated: 0, deleted: 0, unchanged: 0 },
+        chunks: { created: 1, updated: 0, deleted: 0, unchanged: 0 },
+        entities: { created: 0, updated: 0, deleted: 0, unchanged: 0 },
+        relationships: { created: 0, updated: 0, deleted: 0, unchanged: 0 },
+        mentions: { created: 0, updated: 0, deleted: 0, unchanged: 0 },
+      })),
+    };
+    const vectorStore = { upsert: vi.fn(async () => Promise.reject(new Error("qdrant down"))) };
+
+    await expect(
+      ingestGraphTextToStores({
+        graph,
+        vectorStore,
+        document: { id: "article-1", text: "Product One" },
+        revision: "rev-2",
+        extractionModel: {} as never,
+        embeddingModel: {
+          provider: "test",
+          modelId: "test",
+          async embedTexts(texts: string[]) {
+            return texts.map((document) => ({ document, vector: [1] }));
+          },
+        },
+        conflict: "overwrite",
+        orphanEntities: "delete",
+      }),
+    ).rejects.toMatchObject({
+      code: "GRAPH_INGESTION_STAGE_FAILED",
+      stage: "vector",
+      receipt: {
+        documentIds: ["article-1"],
+        revision: "rev-2",
+        graphWrite: { status: "completed" },
+        vectorWrite: { status: "failed" },
+      },
+    });
+    expect(graph.replaceDocuments).toHaveBeenCalledOnce();
+    expect(vectorStore.upsert).toHaveBeenCalledOnce();
+  });
+
+  it("returns a completed receipt after writing graph and vector stores", async () => {
+    extractMock.mockResolvedValue({
+      output: { entities: [], relationships: [] },
+      usage: Usage.empty(),
+    });
+    const graph = {
+      schema,
+      replaceDocuments: vi.fn(async () => ({
+        documents: { created: 1, updated: 0, deleted: 0, unchanged: 0 },
+        chunks: { created: 1, updated: 0, deleted: 0, unchanged: 0 },
+        entities: { created: 0, updated: 0, deleted: 0, unchanged: 0 },
+        relationships: { created: 0, updated: 0, deleted: 0, unchanged: 0 },
+        mentions: { created: 0, updated: 0, deleted: 0, unchanged: 0 },
+      })),
+    };
+    const vectorStore = { upsert: vi.fn(async () => undefined) };
+
+    const result = await ingestGraphTextToStores({
+      graph,
+      vectorStore,
+      vectorProviderOptions: { wait: true },
+      document: { id: "article-1", text: "Product One" },
+      revision: "rev-3",
+      extractionModel: {} as never,
+      embeddingModel: {
+        provider: "test",
+        modelId: "test",
+        async embedTexts(texts: string[]) {
+          return texts.map((document) => ({ document, vector: [1] }));
+        },
+      },
+      conflict: "overwrite",
+      orphanEntities: "delete",
+    });
+
+    expect(vectorStore.upsert).toHaveBeenCalledWith({
+      documents: result.vectorDocuments,
+      providerOptions: { wait: true },
+    });
+    expect(result.receipt).toMatchObject({
+      documentIds: ["article-1"],
+      revision: "rev-3",
+      graphWrite: { status: "completed" },
+      vectorWrite: { status: "completed" },
+    });
   });
 
   it("lets advanced callers prepare graph data without writing", async () => {
@@ -184,6 +419,7 @@ describe("provider-neutral graph primitives", () => {
       relationships: [],
       maxNodes: 100,
       maxRelationships: 200,
+      includeProvenance: false,
     });
     expect(() =>
       resolveGraphExploreOptions(schema, {

--- a/packages/graph/test/public-types.ts
+++ b/packages/graph/test/public-types.ts
@@ -2,6 +2,7 @@ import type { EmbeddingModel } from "@anvia/core/embeddings";
 import {
   createGraphSearchTool,
   ingestGraphText,
+  ingestGraphTextToStores,
   type GraphContextRetriever,
   type GraphDocumentWriter,
   type GraphSchemaLike,
@@ -11,6 +12,7 @@ declare const model: EmbeddingModel;
 declare const existing: GraphContextRetriever<GraphSchemaLike, "none">;
 declare const managed: GraphContextRetriever<GraphSchemaLike, "chunks">;
 declare const writer: GraphDocumentWriter<GraphSchemaLike>;
+declare const vectorStore: { upsert(options: { documents: unknown[] }): Promise<void> };
 
 const retrieval = {
   name: "search_graph",
@@ -37,7 +39,23 @@ ingestGraphText({
   document: { id: "one", text: "Product One" },
   extractionModel: {} as never,
   embeddingModel: model,
+  factConflicts: {
+    entity: {
+      properties: { summary: "prefer-longest", aliases: "union", confidence: "max" },
+    },
+  },
   conflict: "error",
+  orphanEntities: "delete",
+});
+
+ingestGraphTextToStores({
+  graph: writer,
+  vectorStore,
+  document: { id: "one", text: "Product One" },
+  revision: "revision-2",
+  extractionModel: {} as never,
+  embeddingModel: model,
+  conflict: "overwrite",
   orphanEntities: "delete",
 });
 

--- a/packages/vector-qdrant/README.md
+++ b/packages/vector-qdrant/README.md
@@ -52,6 +52,21 @@ Constructing a client or store performs no I/O. `ensure()` creates or validates 
 `validate()` only validates it. `upsert()` replaces all points previously stored for each incoming
 document ID, preventing stale chunks. Raw `store.search()` accepts vectors and never embeds text.
 
+For shared collections, create tenant-scoped handles instead of generating one collection name per
+user:
+
+```ts
+const tenant = qdrant.tenant(userId);
+const store = tenant.vectorStore({ collectionName: "docs", dimensions: 1536 });
+```
+
+The tenant ID is deterministically hashed. The namespace is included in point identities and in
+every replacement, search, hybrid search, inspection, lookup, and deletion filter. Different
+tenant handles can therefore reuse one collection without colliding on logical document IDs.
+
+Tenant handles scope Anvia's vector-store operations; they are not an authorization boundary for
+code that can access the underlying Qdrant client or collection credentials.
+
 ## Hybrid usage
 
 `mode: "hybrid"` returns a hybrid-capable store. Dense stores do not expose `searchHybrid()`.

--- a/packages/vector-qdrant/src/client.ts
+++ b/packages/vector-qdrant/src/client.ts
@@ -1,6 +1,12 @@
+import { createHash } from "node:crypto";
 import type { VectorMetadata } from "@anvia/core/embeddings";
 import { defaultQdrantClient } from "./helpers.js";
-import { QdrantHybridVectorStore, QdrantVectorStore } from "./store.js";
+import {
+  QdrantHybridVectorStore,
+  qdrantTenantScope,
+  QdrantVectorStore,
+  type QdrantTenantScope,
+} from "./store.js";
 import type {
   QdrantClientLike,
   QdrantDenseVectorStoreOptions,
@@ -29,6 +35,10 @@ export class QdrantVectorClient {
       ? new QdrantHybridVectorStore<T, Metadata>(this, options)
       : new QdrantVectorStore<T, Metadata>(this, options);
   }
+  tenant(tenantId: string): QdrantTenant {
+    this.assertOpen();
+    return new QdrantTenant(this, qdrantTenantScope(tenantNamespace(tenantId)));
+  }
   nativeClient(): Promise<QdrantClientLike> {
     this.assertOpen();
     const { client: _client, ...clientOptions } = this.options;
@@ -44,4 +54,35 @@ export class QdrantVectorClient {
   private assertOpen(): void {
     if (this.closed) throw new Error("QdrantVectorClient is closed.");
   }
+}
+
+export class QdrantTenant {
+  constructor(
+    private readonly owner: QdrantVectorClient,
+    private readonly scope: QdrantTenantScope,
+  ) {}
+
+  get namespace(): string {
+    return this.scope.namespace;
+  }
+
+  vectorStore<T, Metadata extends VectorMetadata = VectorMetadata>(
+    options: QdrantHybridVectorStoreOptions,
+  ): QdrantHybridVectorStore<T, Metadata>;
+  vectorStore<T, Metadata extends VectorMetadata = VectorMetadata>(
+    options: QdrantDenseVectorStoreOptions,
+  ): QdrantVectorStore<T, Metadata>;
+  vectorStore<T, Metadata extends VectorMetadata = VectorMetadata>(
+    options: QdrantVectorStoreOptions,
+  ): QdrantVectorStore<T, Metadata> | QdrantHybridVectorStore<T, Metadata> {
+    return options.mode === "hybrid"
+      ? new QdrantHybridVectorStore<T, Metadata>(this.owner, options, this.scope)
+      : new QdrantVectorStore<T, Metadata>(this.owner, options, this.scope);
+  }
+}
+
+function tenantNamespace(tenantId: string): string {
+  if (typeof tenantId !== "string" || tenantId.trim().length === 0)
+    throw new TypeError("Qdrant tenant id must be a non-empty string.");
+  return createHash("sha256").update(tenantId).digest("hex");
 }

--- a/packages/vector-qdrant/src/helpers.ts
+++ b/packages/vector-qdrant/src/helpers.ts
@@ -11,6 +11,7 @@ import {
   defaultSparseVectorName,
   documentIdPayloadKey,
   documentPayloadKey,
+  namespacePayloadKey,
   type QdrantClientLike,
   type QdrantDistance,
   type QdrantMutationOptions,
@@ -57,6 +58,7 @@ export function qdrantPoints<T, Metadata extends VectorMetadata>(
     hybrid?: boolean | undefined;
     denseVectorName?: string | undefined;
     sparseVectorName?: string | undefined;
+    namespace?: string | undefined;
   } = {},
 ): Array<{
   id: string;
@@ -88,11 +90,12 @@ export function qdrantPoints<T, Metadata extends VectorMetadata>(
       [documentIdPayloadKey]: document.id,
       [documentPayloadKey]: serializeDocument(document.document),
     };
+    if (options.namespace !== undefined) payload[namespacePayloadKey] = options.namespace;
     Object.assign(payload, document.metadata);
 
     if (!hybrid) {
       return {
-        id: pointId(logicalId),
+        id: pointId(scopedLogicalId(logicalId, options.namespace)),
         vector: embedding.vector,
         payload,
       };
@@ -105,7 +108,7 @@ export function qdrantPoints<T, Metadata extends VectorMetadata>(
       );
     }
     return {
-      id: pointId(logicalId),
+      id: pointId(scopedLogicalId(logicalId, options.namespace)),
       vector: {
         [denseName]: embedding.vector,
         [sparseName]: {
@@ -248,15 +251,34 @@ export function qdrantMutationRequest(
   return request;
 }
 
-export function qdrantDocumentFilter(documentIds: string[]): Record<string, unknown> {
+export function qdrantDocumentFilter(
+  documentIds: string[],
+  namespace?: string | undefined,
+): Record<string, unknown> {
+  const must: Array<Record<string, unknown>> = [
+    {
+      key: documentIdPayloadKey,
+      match: { any: documentIds },
+    },
+  ];
+  if (namespace !== undefined) must.push(namespaceCondition(namespace));
   return {
-    must: [
-      {
-        key: documentIdPayloadKey,
-        match: { any: documentIds },
-      },
-    ],
+    must,
   };
+}
+
+export function qdrantScopedFilter(namespace: string | undefined, filter: unknown): unknown {
+  if (namespace === undefined) return filter;
+  const condition = namespaceCondition(namespace);
+  return filter === undefined ? { must: [condition] } : { must: [condition, filter] };
+}
+
+function namespaceCondition(namespace: string): Record<string, unknown> {
+  return { key: namespacePayloadKey, match: { value: namespace } };
+}
+
+function scopedLogicalId(logicalId: string, namespace: string | undefined): string {
+  return namespace === undefined ? logicalId : `${namespace}\u0000${logicalId}`;
 }
 
 export function validateQdrantCollection(

--- a/packages/vector-qdrant/src/index.ts
+++ b/packages/vector-qdrant/src/index.ts
@@ -1,4 +1,4 @@
-export { QdrantVectorClient } from "./client.js";
+export { QdrantTenant, QdrantVectorClient } from "./client.js";
 export { filterToQdrantFilter } from "./filters.js";
 export { QdrantHybridVectorStore, QdrantVectorStore } from "./store.js";
 export type {

--- a/packages/vector-qdrant/src/store.ts
+++ b/packages/vector-qdrant/src/store.ts
@@ -21,6 +21,7 @@ import {
   qdrantMutationRequest,
   qdrantPoints,
   qdrantResultCount,
+  qdrantScopedFilter,
   validateQdrantCollection,
 } from "./helpers.js";
 import {
@@ -32,6 +33,17 @@ import {
   type QdrantVectorStoreOptions,
 } from "./types.js";
 
+const tenantScopeBrand: unique symbol = Symbol("QdrantTenantScope");
+
+export type QdrantTenantScope = Readonly<{
+  namespace: string;
+  [tenantScopeBrand]: true;
+}>;
+
+export function qdrantTenantScope(namespace: string): QdrantTenantScope {
+  return Object.freeze({ namespace, [tenantScopeBrand]: true as const });
+}
+
 export class QdrantVectorStore<
   T,
   Metadata extends VectorMetadata = VectorMetadata,
@@ -39,10 +51,13 @@ export class QdrantVectorStore<
   readonly mode: "dense" | "hybrid";
   readonly denseVectorName: string;
   readonly sparseVectorName: string;
+  readonly namespace?: string | undefined;
   constructor(
     protected readonly owner: QdrantVectorClient,
     readonly options: QdrantVectorStoreOptions,
+    tenantScope?: QdrantTenantScope,
   ) {
+    this.namespace = tenantScope?.namespace;
     assertDimensions(options.dimensions);
     this.mode = options.mode ?? "dense";
     this.denseVectorName = options.denseVectorName ?? defaultDenseVectorName;
@@ -85,9 +100,13 @@ export class QdrantVectorStore<
         hybrid: this.mode === "hybrid",
         denseVectorName: this.denseVectorName,
         sparseVectorName: this.sparseVectorName,
+        namespace: this.namespace,
       }),
     );
-    const filter = qdrantDocumentFilter(options.documents.map((document) => document.id));
+    const filter = qdrantDocumentFilter(
+      options.documents.map((document) => document.id),
+      this.namespace,
+    );
     const providerOptions = qdrantMutationRequest(
       (options.providerOptions ?? {}) as QdrantMutationOptions,
     );
@@ -107,7 +126,7 @@ export class QdrantVectorStore<
   async search(request: VectorSearchRequest): Promise<Array<VectorSearchResult<T, Metadata>>> {
     validateSearchRequest(request, this.options.dimensions);
     const client = await this.owner.nativeClient();
-    const filter = filterToQdrantFilter(request.filter);
+    const filter = qdrantScopedFilter(this.namespace, filterToQdrantFilter(request.filter));
     const metric = distanceName(this.options.metric);
     let candidateLimit = request.topK;
     for (;;) {
@@ -184,13 +203,13 @@ export class QdrantVectorStore<
             query: request.vector,
             using: this.denseVectorName,
             limit: prefetchLimit,
-            filter: filterToQdrantFilter(request.filter),
+            filter: qdrantScopedFilter(this.namespace, filterToQdrantFilter(request.filter)),
           },
           {
             query: request.sparseVector,
             using: this.sparseVectorName,
             limit: prefetchLimit,
-            filter: filterToQdrantFilter(request.filter),
+            filter: qdrantScopedFilter(this.namespace, filterToQdrantFilter(request.filter)),
           },
         ],
         query: { fusion: request.fusion ?? "rrf" },
@@ -219,7 +238,7 @@ export class QdrantVectorStore<
       this.options.collectionName,
       {
         ...request,
-        filter: filterToQdrantFilter(request.filter),
+        filter: qdrantScopedFilter(this.namespace, filterToQdrantFilter(request.filter)),
       },
     );
     throwIfAborted(request.abortSignal);
@@ -235,7 +254,7 @@ export class QdrantVectorStore<
     if (client.delete === undefined) throw new TypeError("Qdrant deletion requires delete(...).");
     await client.delete(this.options.collectionName, {
       ...qdrantMutationRequest(options.providerOptions ?? {}),
-      filter: qdrantDocumentFilter(ids),
+      filter: qdrantDocumentFilter(ids, this.namespace),
     });
   }
   async get(options: { documentIds: string[] }): Promise<Array<VectorInspectItem<T, Metadata>>> {
@@ -244,7 +263,7 @@ export class QdrantVectorStore<
     const page = await qdrantDocumentPage<T, Metadata>(
       await this.owner.nativeClient(),
       this.options.collectionName,
-      { limit: ids.length, filter: qdrantDocumentFilter(ids) },
+      { limit: ids.length, filter: qdrantDocumentFilter(ids, this.namespace) },
     );
     const byId = new Map(page.items.map((item) => [item.id, item]));
     return ids.flatMap((id) => {
@@ -298,8 +317,12 @@ export class QdrantHybridVectorStore<T, Metadata extends VectorMetadata = Vector
   implements HybridVectorStore<T, Metadata>
 {
   // oxlint-disable-next-line eslint/no-useless-constructor -- Narrows the public constructor to hybrid options.
-  constructor(owner: QdrantVectorClient, options: QdrantHybridVectorStoreOptions) {
-    super(owner, options);
+  constructor(
+    owner: QdrantVectorClient,
+    options: QdrantHybridVectorStoreOptions,
+    tenantScope?: QdrantTenantScope,
+  ) {
+    super(owner, options, tenantScope);
   }
 
   searchHybrid(

--- a/packages/vector-qdrant/src/types.ts
+++ b/packages/vector-qdrant/src/types.ts
@@ -3,6 +3,7 @@ import type { VectorFusion, VectorMetric } from "@anvia/core/vector-store";
 import type { QdrantClientParams } from "@qdrant/js-client-rest";
 export const documentIdPayloadKey = "__anvia_document_id";
 export const documentPayloadKey = "__anvia_document";
+export const namespacePayloadKey = "__anvia_namespace";
 export const reservedPayloadPrefix = "__anvia_";
 export const defaultDenseVectorName = "dense";
 export const defaultSparseVectorName = "sparse";

--- a/packages/vector-qdrant/test/public-types.ts
+++ b/packages/vector-qdrant/test/public-types.ts
@@ -1,0 +1,12 @@
+import {
+  QdrantVectorClient,
+  QdrantVectorStore,
+  type QdrantDenseVectorStoreOptions,
+} from "../src/index.js";
+
+declare const client: QdrantVectorClient;
+declare const options: QdrantDenseVectorStoreOptions;
+
+new QdrantVectorStore(client, options);
+// @ts-expect-error Raw namespaces cannot bypass client.tenant().
+new QdrantVectorStore(client, options, "raw-user-id");

--- a/packages/vector-qdrant/test/qdrant-vector-store.test.ts
+++ b/packages/vector-qdrant/test/qdrant-vector-store.test.ts
@@ -87,9 +87,105 @@ describe("QdrantVectorClient", () => {
     ]);
   });
 
+  it("isolates tenant handles within a shared collection", async () => {
+    const client = fixture();
+    const owner = new QdrantVectorClient({ client });
+    const tenantA = owner.tenant("user-a");
+    const tenantB = owner.tenant("user-b");
+    const storeA = tenantA.vectorStore<string>({ collectionName: "docs", dimensions: 2 });
+    const storeB = tenantB.vectorStore<string>({ collectionName: "docs", dimensions: 2 });
+
+    expect(tenantA.namespace).toMatch(/^[a-f0-9]{64}$/);
+    expect(tenantA.namespace).toBe(
+      "fc95297aa4f56781f0decb7d4bf59b1447f09b3611039b80188b1c6beb03ee6a",
+    );
+    expect(tenantB.namespace).not.toBe(tenantA.namespace);
+    expect(owner.tenant("user-a").namespace).toBe(tenantA.namespace);
+
+    await storeA.upsert({
+      documents: [{ id: "doc", document: "A", embeddings: [{ document: "A", vector: [1, 0] }] }],
+    });
+    await storeB.upsert({
+      documents: [{ id: "doc", document: "B", embeddings: [{ document: "B", vector: [1, 0] }] }],
+    });
+
+    const operations = (client.batchUpdate as ReturnType<typeof vi.fn>).mock.calls.map(
+      ([, request]) => request.operations,
+    );
+    expect(operations[0][0].delete.filter).toEqual({
+      must: [
+        { key: "__anvia_document_id", match: { any: ["doc"] } },
+        { key: "__anvia_namespace", match: { value: tenantA.namespace } },
+      ],
+    });
+    expect(operations[0][1].upsert.points[0].payload.__anvia_namespace).toBe(tenantA.namespace);
+    expect(operations[1][1].upsert.points[0].payload.__anvia_namespace).toBe(tenantB.namespace);
+    expect(operations[0][1].upsert.points[0].id).not.toBe(operations[1][1].upsert.points[0].id);
+
+    await storeA.search({
+      vector: [1, 0],
+      topK: 1,
+      filter: { type: "eq", key: "source", value: "test" },
+    });
+    expect(client.query).toHaveBeenLastCalledWith(
+      "docs",
+      expect.objectContaining({
+        filter: {
+          must: [
+            { key: "__anvia_namespace", match: { value: tenantA.namespace } },
+            { must: [{ key: "source", match: { value: "test" } }] },
+          ],
+        },
+      }),
+    );
+
+    await storeA.delete({ documentIds: ["doc"] });
+    expect(client.delete).toHaveBeenLastCalledWith(
+      "docs",
+      expect.objectContaining({
+        filter: {
+          must: [
+            { key: "__anvia_document_id", match: { any: ["doc"] } },
+            { key: "__anvia_namespace", match: { value: tenantA.namespace } },
+          ],
+        },
+      }),
+    );
+
+    await storeA.inspect({ limit: 10 });
+    expect(client.scroll).toHaveBeenLastCalledWith(
+      "docs",
+      expect.objectContaining({
+        filter: {
+          must: [{ key: "__anvia_namespace", match: { value: tenantA.namespace } }],
+        },
+      }),
+    );
+
+    await storeA.get({ documentIds: ["doc"] });
+    expect(client.scroll).toHaveBeenLastCalledWith(
+      "docs",
+      expect.objectContaining({
+        filter: {
+          must: [
+            { key: "__anvia_document_id", match: { any: ["doc"] } },
+            { key: "__anvia_namespace", match: { value: tenantA.namespace } },
+          ],
+        },
+      }),
+    );
+  });
+
+  it("rejects empty tenant identifiers", () => {
+    const owner = new QdrantVectorClient({ client: fixture() });
+    expect(() => owner.tenant("  ")).toThrow("tenant id must be a non-empty string");
+  });
+
   it("keeps hybrid search an explicit capability", async () => {
     const client = fixture(true);
-    const store = new QdrantVectorClient({ client }).vectorStore({
+    const owner = new QdrantVectorClient({ client });
+    const tenant = owner.tenant("user-a");
+    const store = tenant.vectorStore({
       collectionName: "docs",
       dimensions: 2,
       mode: "hybrid",
@@ -101,10 +197,17 @@ describe("QdrantVectorClient", () => {
       fusion: "rrf",
       topK: 2,
     });
-    expect(client.query).toHaveBeenCalledWith(
-      "docs",
-      expect.objectContaining({ prefetch: expect.any(Array), query: { fusion: "rrf" } }),
-    );
+    const request = (client.query as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1];
+    expect(request).toMatchObject({ prefetch: expect.any(Array), query: { fusion: "rrf" } });
+    expect(
+      request.prefetch.every(
+        (prefetch: { filter: unknown }) =>
+          JSON.stringify(prefetch.filter) ===
+          JSON.stringify({
+            must: [{ key: "__anvia_namespace", match: { value: tenant.namespace } }],
+          }),
+      ),
+    ).toBe(true);
   });
 
   it("normalizes Euclidean distance and translates minScore for Qdrant", async () => {


### PR DESCRIPTION
## Summary

- add configurable property-level graph extraction conflict resolution with structured errors and warnings
- add ingestion receipts and optional graph-to-vector orchestration with partial-failure reporting
- add source provenance to graph exploration
- add hashed tenant namespaces across managed Neo4j graphs and Qdrant stores
- close tenant full-text filtering and raw namespace construction gaps found during code review
- document production lifecycle, reconciliation, and authorization boundaries

## Validation

- `pnpm check`
- `pnpm --filter @anvia/graph typecheck`
- `pnpm --filter @anvia/graph test`
- `pnpm --filter @anvia/graph build`
- `pnpm --filter @anvia/neo4j typecheck`
- `pnpm --filter @anvia/neo4j test`
- `pnpm --filter @anvia/neo4j build`
- `pnpm --filter @anvia/qdrant typecheck`
- `pnpm --filter @anvia/qdrant test`
- `pnpm --filter @anvia/qdrant build`
- full workspace `pnpm typecheck` and `pnpm test` completed before the final clean rebase

## Release

Patch changesets for `@anvia/graph`, `@anvia/neo4j`, and `@anvia/qdrant`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable graph-fact conflict resolution with structured warnings and errors.
  * Added durable ingestion receipts, revision tracking, retry-friendly status, and optional graph/vector-store ingestion.
  * Added source provenance to graph exploration results.
  * Added tenant-scoped Neo4j and Qdrant handles with namespace-isolated reads and writes.
* **Documentation**
  * Added guidance for tenant setup, readiness checks, isolation limitations, provenance, and production ingestion workflows.
* **Bug Fixes**
  * Prevented cross-tenant identifier collisions and unscoped managed graph or vector-store operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->