### PR TITLE
feat(browser): harden runtime lifecycle and concurrency

### DIFF
--- a/.changeset/steady-browser-runtime.md
+++ b/.changeset/steady-browser-runtime.md
@@ -1,0 +1,11 @@
+---
+"@anvia/browser": major
+---
+
+Add supervised Playwright process isolation, capability readiness, bounded lifecycle cancellation,
+per-tab concurrent tool scheduling, explicit tab targeting, race-safe human control, and structured
+recovery errors while preserving serial selected-tab compatibility.
+
+This is a major change because a browser handle now permits one active or pending automation connection,
+and structural `BrowserControlSnapshot` implementations must provide the new arbitration and
+availability fields.

--- a/cookbook/09_studio/16-browser-desktop.ts
+++ b/cookbook/09_studio/16-browser-desktop.ts
@@ -23,8 +23,14 @@ const browser = await browserClient.createBrowser({
 });
 
 try {
-  await browser.waitUntilReady({ timeoutMs: 30_000 });
-  const connection = await browser.connect();
+  await browser.waitForCapabilities({
+    capabilities: ["automation", "desktop"],
+    timeoutMs: 30_000,
+  });
+  const connection = await browser.connect({
+    timeoutMs: 30_000,
+    scheduling: { mode: "per-tab", maxConcurrentTabs: 8 },
+  });
   const browserTools = createBrowserTools({
     connection,
     tools: [

--- a/packages/tool-browser/MIGRATION.md
+++ b/packages/tool-browser/MIGRATION.md
@@ -1,0 +1,68 @@
+# `@anvia/browser` migration notes
+
+## Selected-tab tools to explicit tabs
+
+Existing tools remain source compatible and connections still default to serial scheduling. Calls that
+omit `tabId` continue using the selected tab.
+
+To opt into independent-tab concurrency:
+
+```ts
+const connection = await browser.connect({
+  scheduling: { mode: "per-tab", maxConcurrentTabs: 8 },
+});
+
+const [{ id: first }, { id: second }] = await connection.listTabs();
+
+await Promise.all([
+  snapshot.call({ tabId: first }),
+  navigate.call({ tabId: second, url: "https://example.com" }),
+]);
+```
+
+Add `tabId` to `browser_navigate`, `browser_snapshot`, `browser_click`, `browser_type`,
+`browser_press_key`, and `browser_screenshot`. `browser_open_tab` returns the new stable ID. Selection is
+still useful for human-oriented or legacy serial workflows, but should not be shared mutable targeting
+state for concurrent agents. IDs are scoped to one connection; call `browser_list_tabs` after reconnect.
+
+A browser handle now allows one active or pending automation connection. Share that connection between
+agents that use the same browser, and disconnect it before reconnecting. This is required so one
+resource scheduler and navigation policy arbitrate the shared Chromium context deterministically.
+
+## All-or-nothing readiness to capabilities
+
+`waitUntilReady({ timeoutMs })` still waits for all runtime, browser, automation, and desktop
+capabilities. Consumers that do not require every capability should migrate to:
+
+```ts
+await browser.waitForCapabilities({
+  capabilities: ["desktop"],
+  timeoutMs: 10_000,
+  abortSignal,
+});
+
+const { capabilities } = browser.readiness();
+```
+
+Handle `BrowserError.capability` and preserve healthy capabilities when another is degraded.
+
+## Cancellation and errors
+
+Connection cancellation now terminates and joins an isolated Playwright worker. Cancelling an active
+page tool closes that tab because Playwright page actions do not accept `AbortSignal`; obtain a fresh tab
+ID before retrying. If page cleanup cannot finish, the entire connection closes and must be recreated.
+
+`destroy({ timeoutMs, abortSignal })` starts an irreversible terminal transition. If Docker cleanup
+cannot be cancelled, the caller now stops waiting at its own deadline while the handle remains
+`destroying` and retains ownership of the shared cleanup. A later `destroy()` call joins that operation;
+control cannot become active again while cleanup finishes.
+
+Prefer `error.retryable` and `error.recovery` over a closed switch on `error.code`. Legacy
+`human_controlled` remains active for an acquired lease; pending acquisition now uses
+`human_control_conflict`. Legacy `not_ready` remains available, while bounded connection and readiness
+operations use the more specific `connection_timeout` and `readiness_timeout` codes.
+
+`BrowserControlSnapshot` now includes required `state`, `availability`, `activeAgentActions`, and
+`humanPending` fields in addition to the existing mode and optional lease metadata. Consumers that
+provide a structural browser-control test double should add those fields; consumers that only read the
+snapshot remain source compatible.

--- a/packages/tool-browser/README.md
+++ b/packages/tool-browser/README.md
@@ -1,7 +1,8 @@
 # `@anvia/browser`
 
-Visible Chromium ownership and semantic browser tools for Anvia agents. Docker infrastructure remains
-owned by `@anvia/sandbox`; this package owns the browser workload running inside that sandbox.
+Visible Chromium ownership and semantic browser tools for concurrent Anvia agents and human viewers.
+Docker infrastructure remains owned by `@anvia/sandbox`; this package owns the browser workload,
+capability readiness, isolated Playwright connection, action scheduling, and control arbitration.
 
 ```ts
 import { DockerBrowserClient, createBrowserTools } from "@anvia/browser";
@@ -13,7 +14,7 @@ const browserClient = new DockerBrowserClient({
   image: "ghcr.io/anvia-hq/browser@sha256:...",
 });
 
-await browserClient.pullImage();
+await browserClient.pullImage({ timeoutMs: 120_000 });
 await using browser = await browserClient.createBrowser({
   workspace: { type: "ephemeral" },
   network: { mode: "bridge" },
@@ -24,8 +25,19 @@ await using browser = await browserClient.createBrowser({
   },
 });
 
-await browser.waitUntilReady({ timeoutMs: 30_000 });
-await using connection = await browser.connect();
+await browser.waitForCapabilities({
+  capabilities: ["automation", "desktop"],
+  timeoutMs: 30_000,
+});
+
+await using connection = await browser.connect({
+  timeoutMs: 30_000,
+  scheduling: {
+    mode: "per-tab",
+    maxConcurrentTabs: 8,
+    maxQueuedActions: 1_000,
+  },
+});
 
 const tools = createBrowserTools({
   connection,
@@ -47,34 +59,196 @@ const tools = createBrowserTools({
 const agent = new Agent({ id: "browser-agent", model, tools });
 ```
 
-The client constructor performs no I/O. `pullImage()`, `createBrowser()`, readiness, and CDP
-connection are separate operations. `DockerBrowser` owns the underlying sandbox. A
-`PlaywrightBrowserConnection` owns only its CDP connection and never destroys the browser.
+The client constructor performs no I/O. Image pull, create/resume, readiness, and CDP connection are
+separate bounded operations. `DockerBrowser` owns the sandbox; a `PlaywrightBrowserConnection` owns
+only its automation worker and CDP connection. Disconnecting automation never destroys Chromium.
 
-`stop()` preserves the container. `resumeBrowser({ id })` starts a fresh browser service and requires
-a new readiness check and CDP connection. A named Docker volume preserves Chromium profile state even
-when the browser container is destroyed and later recreated with that volume.
+## Lifecycle and cancellation
 
-The browser tools use ARIA state and strict Playwright locators. They do not expose JavaScript
-evaluation, raw CDP, coordinate input, shell access, hidden retries, or automatic reconnection.
-Aborting an action that Playwright cannot cancel closes the CDP connection and leaves the browser
-running. The selected navigation policy is installed across the connection, so top-level navigation
-from links, forms, redirects, popups, and direct navigation is checked consistently. It does not block
-third-party subresources; Docker bridge networking remains outside that policy.
+Playwright and its CDP protocol state run in a supervised child process, one per connection. This is an
+intentional fault-containment boundary: Playwright 1.62.1 normally aborts its progress scope and closes
+the transport on timeout, but an internal exception raised by a late protocol message is outside the
+rejected `connectOverCDP()` promise. An in-process wrapper cannot guarantee host survival in that case.
+The child boundary contains that exception without installing process-global `uncaughtException` or
+`unhandledRejection` handlers.
 
-The image runs Chromium as a non-root user with Chromium sandboxing, the pinned Playwright seccomp
-profile, every Linux capability dropped except the explicit `SYS_CHROOT` capability required by the
-namespace sandbox, no-new-privileges, and private shared memory. Startup fails rather than silently
-switching Chromium to `--no-sandbox`. Docker bridge networking is not an SSRF boundary; use
-infrastructure network policy where browsing untrusted destinations requires isolation.
+`connect()` defaults to 30 seconds and passes the remaining budget to Playwright. Caller cancellation,
+timeout, stop, and destroy terminate and join the worker before the attempt rejects. A worker response
+that loses the cancellation race is ignored. A failed attempt owns no state in `DockerBrowser`, so a
+later call starts a clean attempt.
+
+Image pull, create, resume, stop, and destroy accept `timeoutMs` and `abortSignal`; their default budget
+is 120 seconds. `disconnect()` defaults to 10 seconds. Docker sandbox destruction is irreversible and
+cannot currently be cancelled. Once it starts, timeout or cancellation bounds only that caller's wait:
+the browser remains visibly `destroying`, owns the eventual completion, and makes later `destroy()`
+calls join the same cleanup. Late completion can only transition the terminal handle to `destroyed` or
+`error`; it cannot restore agent or human control.
+Timeout values are integer milliseconds from 1 through `2_147_483_647`, matching Node's timer range.
+
+`stop()` first cancels pending readiness/connect work, disconnects all automation workers, and then
+stops the sandbox. It also cancels pending human acquisition and releases an active lease, while
+preserving the container. `resumeBrowser({ id })` returns a new handle and requires new readiness and
+automation connections. `destroy()` is idempotent, joins pending work, invalidates human-control leases,
+and removes the sandbox. Destroy remains available after a failed stop.
+Concurrent stop, destroy, or disconnect calls join the first shared transition. A later caller's own
+timeout or cancellation bounds its wait without rolling back that already-visible `stopping`,
+`destroying`, or closed transition.
+
+## Capability readiness
+
+Readiness is not all-or-nothing:
+
+| Capability   | What is proven                                                                                            |
+| ------------ | --------------------------------------------------------------------------------------------------------- |
+| `runtime`    | The Docker browser handle and sandbox are running.                                                        |
+| `browser`    | Chromium's CDP port is reachable and `/json/version` exposes a WebSocket debugger URL.                    |
+| `automation` | An isolated Playwright CDP connection initializes, exposes a context, and completes `Browser.getVersion`. |
+| `desktop`    | The noVNC port and HTTP client page respond successfully.                                                 |
+
+Use `waitForCapabilities()` to wait only for required capabilities and receive a
+`BrowserReadinessSnapshot`. `waitUntilReady()` remains available and defaults to all four capabilities.
+Both accept a required timeout and optional `AbortSignal`. `readiness()` is synchronous and reports
+`unknown`, `checking`, `partial`, `ready`, `degraded`, `failed`, `stopped`, or `destroyed` state
+without probing. `partial` means some capabilities are ready while others have not been checked;
+`degraded` means at least one checked capability failed while another remains usable.
+
+Desktop probing never establishes Playwright. A failed automation probe can therefore leave desktop
+ready and the runtime degraded. Retrying readiness replaces the requested capabilities' prior failed
+state. Caller cancellation restores their previous state. Stop and destroy abort and join every probe.
+
+```ts
+await browser.waitForCapabilities({ capabilities: ["desktop"], timeoutMs: 10_000 });
+const snapshot = browser.readiness();
+
+if (snapshot.capabilities.automation.state === "failed") {
+  // The desktop may still be offered to a human while automation is retried or restarted.
+}
+```
+
+## Concurrency guarantees
+
+The default `{ mode: "serial" }` scheduling preserves the original selected-tab behavior: every tool
+call on the connection executes in one bounded FIFO queue. This is the compatibility mode.
+
+`{ mode: "per-tab" }` enables resource-scoped scheduling:
+
+- Mutating operations for the same tab are FIFO and never overlap.
+- Operations for different explicit tab IDs may overlap up to `maxConcurrentTabs` (default 8).
+- Tab creation, listing, selection, and closure use a browser-context lock where necessary.
+- A close marks its tab as closing before it queues. Work already queued runs first; later work is
+  rejected with `invalid_state`.
+- One failed operation releases its queue. Cancelling one tab closes that page to stop uncancellable
+  Playwright work, then releases only that tab queue.
+- If page cleanup itself cannot settle within five seconds, the worker is terminated and consumers
+  reconnect. This fail-closed fallback can interrupt other tabs on that connection.
+- Queue admission is bounded by `maxQueuedActions` (default 1,000) and ready tab queues are scheduled
+  FIFO, one operation per turn, to avoid starvation.
+- Disconnect, stop, or destroy reject queued work with a structured lifecycle error.
+
+Concurrent tool dispatch does not imply concurrent execution when calls contend for the same tab,
+browser-context state, selected-tab compatibility lock, or human-control gate.
+
+Page tools now accept an optional `tabId`: `browser_navigate`, `browser_snapshot`, `browser_click`,
+`browser_type`, `browser_press_key`, and `browser_screenshot`. Omitting it uses selected-tab compatibility
+behavior. Obtain stable IDs from `browser_list_tabs` or `browser_open_tab`.
+Tab IDs are stable for one automation connection; reconnecting creates a fresh ID namespace, so list
+tabs again after reconnect.
+
+The scheduling domain is one connection, and a `DockerBrowser` handle permits one active or pending
+automation connection at a time. A second `connect()` rejects with `agent_action_busy`; share the first
+connection among agents and dispatch explicit-tab work through it. This prevents independent workers,
+ID namespaces, navigation-policy installations, and queues from racing over the same Chromium context.
+Disconnect before creating a replacement connection. Automation readiness may use a short-lived,
+non-mutating probe connection. Human control remains runtime-wide.
+
+```ts
+await Promise.all([
+  snapshotTool.call({ tabId: researchTabId }),
+  navigateTool.call({ tabId: monitoringTabId, url: "https://status.example.com" }),
+]);
+```
+
+## Human and agent control
+
+Human control is browser-wide and exclusive. Acquisition defaults to a 30-second wait and also accepts
+`timeoutMs` and `abortSignal`. The arbitration policy is:
+
+- Acquisition waits for active agent operations to finish.
+- Pending acquisition rejects work that has not entered the control gate, including queued and newly
+  dispatched work, with `human_control_conflict`.
+- An active lease rejects agent work with the backward-compatible `human_controlled` code.
+- A second acquisition is rejected; there is never more than one pending waiter or active lease.
+- Cancellation/timeout removes pending state before rejecting.
+- Renewal replaces the expiration timer atomically. Release, expiration, and destroy are idempotent.
+- Agent work resumes after release or expiration.
+
+`browser.desktop.control.snapshot()` reports `state` (`agent`, `agent-active`, `human-pending`, or
+`human`), `activeAgentActions`, `humanPending`, lease data, and availability (`available`, `degraded`,
+`disconnected`, or `destroyed`).
+
+## Errors and recovery
+
+Operational failures from public browser lifecycle/tool wrappers reject with `BrowserError`. Invalid
+API arguments still throw `TypeError` or `RangeError`. The original operational error is retained as
+`cause`; `code`, `retryable`, `recovery`, `phase`, and optional readiness `capability` support policy
+decisions.
+
+`retryable` describes whether the runtime has a documented recovery path; it does not make a mutating
+tool call idempotent. After a timeout or transport loss, inspect or refresh tab state before deciding
+whether replaying navigation, typing, clicking, or key input is safe.
+
+| Codes                                                                   | Typical recovery                                                    |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `cancelled`, `action_timeout`, `lifecycle_timeout`, `agent_action_busy` | Retry the operation when appropriate.                               |
+| `human_control_conflict`, `human_controlled`                            | Wait for acquisition/lease release or expiration.                   |
+| `readiness_timeout`, `not_ready`                                        | Retry the failed capability; inspect `capability`.                  |
+| `connection_timeout`, `connection_closed`, `transport_failure`          | Disconnect if needed, then create a new connection.                 |
+| `tool_failed`                                                           | Retry the tool if its inputs and tab are still valid.               |
+| `invalid_state`                                                         | Refresh tabs/state; restart when the runtime is stopped or errored. |
+| `navigation_blocked`                                                    | Do not retry unchanged input; update the explicit policy or URL.    |
+| `startup_failed`                                                        | Recreate the runtime after fixing image/runtime configuration.      |
+| `runtime_destroyed`                                                     | Create or resume a new runtime handle.                              |
+
+The legacy `not_ready` and `human_controlled` codes remain in the public union. New code should use
+`retryable` and `recovery` rather than hard-coding all recovery policy.
+
+## Browser tools and security
+
+The tools use ARIA state and strict Playwright locators. They do not expose JavaScript evaluation, raw
+CDP, coordinate input, shell access, hidden action retries, or automatic reconnection. The navigation
+policy is installed across the default browser context, so top-level navigation from links, forms,
+redirects, popups, and direct navigation is checked consistently. It does not block third-party
+subresources; Docker bridge networking remains outside that policy.
+
+The image runs Chromium as a non-root user with Chromium sandboxing, the Playwright seccomp profile,
+every Linux capability dropped except `SYS_CHROOT`, no-new-privileges, and private shared memory.
+Startup fails rather than switching Chromium to `--no-sandbox`. Docker bridge networking is not an SSRF
+boundary; use infrastructure network policy for untrusted destinations.
+
+The automation child process is a crash-containment boundary, not a privilege or tenant-isolation
+boundary. It inherits the host application's OS identity; the Docker browser sandbox and application
+authorization remain the security boundaries.
 
 The VNC protocol uses exactly eight printable ASCII password characters. noVNC is published only on a
 host-loopback Docker port, raw VNC is not published, and the password is not placed in image metadata,
 URLs, environment variables, or logs.
 
+## Playwright and Node compatibility
+
+The host package and browser image pin `playwright-core` 1.62.1 together. Playwright requires matching
+browser/package releases for its bundled browser and declares Node `>=20`; its current system matrix is
+the latest Node 22, 24, or 26. Anvia CI uses Node 24, and the isolation regression test also runs on the
+active host Node version. The package keeps its existing Node `>=20.12` engine for source compatibility,
+but production deployments should use a currently supported Node 22, 24, or 26 release. Keep the image
+and package pin aligned when upgrading.
+
+The CDP connection is lower fidelity than Playwright's native protocol, but a native Playwright server
+would conflict with this runtime's persistent, human-visible Chromium ownership. CDP remains the
+appropriate protocol; isolation contains its in-process failure modes.
+
 ## Studio desktop and takeover
 
-`browser.desktop` is structurally compatible with Studio without creating a package dependency:
+`browser.desktop` remains structurally compatible with Studio without a package dependency:
 
 ```ts
 const studio = new Studio([agent], {
@@ -99,8 +273,10 @@ const studio = new Studio([agent], {
 
 Use `{ mode: "authorize", authorize }` when Studio is reachable remotely. The callback is invoked for
 the viewer connection, WebSocket upgrade, and every control operation. When the registered agent uses a
-matching browser tool, Studio opens its clean programmatic noVNC viewer in a resizable Playground panel;
+matching browser tool, Studio opens its programmatic noVNC viewer in a resizable Playground panel;
 there is no stock noVNC toolbar, splash, or password prompt. Closing the panel restores Sessions and an
-**Open browser** action restores the current desktop. Studio human takeover waits for an active agent
-action, blocks new browser tool actions, and expires unless the Studio viewer renews its lease. Takeover
+**Open browser** action restores the current desktop. Studio human takeover waits for active agent
+actions, blocks new browser tool actions, and expires unless the viewer renews its lease. Takeover
 coordinates trusted viewers; application authorization remains the security boundary.
+
+See [MIGRATION.md](./MIGRATION.md) for selected-tab and readiness migration examples.

--- a/packages/tool-browser/package.json
+++ b/packages/tool-browser/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist",
     "image",
-    "security"
+    "security",
+    "MIGRATION.md"
   ],
   "publishConfig": {
     "access": "public"
@@ -28,9 +29,9 @@
     }
   },
   "scripts": {
-    "build": "pnpm run build:deps && tsup src/index.ts --format esm --dts --sourcemap --clean",
+    "build": "pnpm run build:deps && tsup src/index.ts src/automation-worker.ts --format esm --dts --sourcemap --clean",
     "build:deps": "(test -f ../core/dist/index.d.ts || pnpm --filter @anvia/core build) && pnpm --filter @anvia/sandbox build",
-    "test": "pnpm run build:deps && vitest run",
+    "test": "pnpm run build && vitest run",
     "typecheck": "pnpm run build:deps && tsc --noEmit"
   },
   "dependencies": {

--- a/packages/tool-browser/src/automation-client.ts
+++ b/packages/tool-browser/src/automation-client.ts
@@ -1,0 +1,430 @@
+import { fork, type ChildProcess } from "node:child_process";
+import type { AutomationCommand, AutomationRequest, SerializedError } from "./automation-protocol";
+import { isAutomationResponse } from "./automation-protocol";
+import { BrowserError, cancellationError } from "./errors";
+import type { BrowserLifecycleOptions } from "./types";
+
+type PendingRequest = {
+  state: "active" | "cancelling";
+  resolve: (value: unknown) => void;
+  reject: (error: unknown) => void;
+  abortSignal?: AbortSignal;
+  abort?: () => void;
+  abortError?: unknown;
+  cleanupTimer?: ReturnType<typeof setTimeout>;
+};
+
+export type AutomationCommandOptions = Readonly<{
+  abortSignal?: AbortSignal;
+  cancelOperation?: boolean;
+  phase: string;
+}>;
+
+export interface AutomationBackend {
+  readonly closed: boolean;
+  command<T>(command: AutomationCommand, options: AutomationCommandOptions): Promise<T>;
+  disconnect(options?: BrowserLifecycleOptions): Promise<void>;
+  onDisconnected(listener: () => void): () => void;
+}
+
+export type AutomationWorkerFactory = () => ChildProcess;
+
+const cancellationCleanupTimeoutMs = 5_000;
+const workerTerminationTimeoutMs = 3_000;
+const maxWorkerStderrChars = 32_768;
+
+export class AutomationWorkerClient implements AutomationBackend {
+  private readonly child: ChildProcess;
+  private readonly pending = new Map<number, PendingRequest>();
+  private readonly disconnectedListeners = new Set<() => void>();
+  private nextId = 1;
+  private isClosed = false;
+  private disconnecting = false;
+  private termination: Promise<void> | undefined;
+  private workerStderr = "";
+  private readonly onStderrData = (chunk: string) => {
+    this.workerStderr = `${this.workerStderr}${chunk}`.slice(-maxWorkerStderrChars);
+  };
+  private readonly onStderrError = () => {
+    // The diagnostics pipe is optional; its failure must not crash the host process.
+  };
+  private readonly onMessage = (message: unknown) => {
+    try {
+      this.handleMessage(message);
+    } catch (error) {
+      this.handleExit(
+        new BrowserError(
+          "Browser automation worker sent an invalid response.",
+          "transport_failure",
+          {
+            cause: error,
+            phase: "automation-worker",
+          },
+        ),
+      );
+      void this.terminate().catch(() => undefined);
+    }
+  };
+  private readonly onError = (error: Error) => {
+    this.handleExit(error);
+    void this.terminate().catch(() => undefined);
+  };
+  private readonly onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+    const diagnostics = this.workerStderr.trim();
+    this.handleExit(
+      new Error(
+        `Browser automation worker exited: code=${code ?? "null"} signal=${signal ?? "null"}${diagnostics.length === 0 ? "" : `\n${diagnostics}`}`,
+      ),
+    );
+  };
+
+  private constructor(factory: AutomationWorkerFactory) {
+    this.child = factory();
+    this.child.stderr?.setEncoding("utf8");
+    this.child.stderr?.on("data", this.onStderrData);
+    this.child.stderr?.on("error", this.onStderrError);
+    this.child.on("message", this.onMessage);
+    this.child.on("error", this.onError);
+    this.child.once("exit", this.onExit);
+  }
+
+  static async connect(options: {
+    endpointUrl: string;
+    timeoutMs: number;
+    abortSignal?: AbortSignal;
+    workerFactory?: AutomationWorkerFactory;
+  }): Promise<AutomationWorkerClient> {
+    assertPositiveSafeInteger(options.timeoutMs, "timeoutMs");
+    if (options.abortSignal?.aborted) {
+      throw cancellationError(options.abortSignal.reason, "connect");
+    }
+    let client: AutomationWorkerClient;
+    try {
+      client = new AutomationWorkerClient(options.workerFactory ?? spawnAutomationWorker);
+    } catch (error) {
+      throw new BrowserError(
+        "Unable to start the browser automation worker.",
+        "transport_failure",
+        {
+          cause: error,
+          phase: "connect",
+          recovery: "reconnect",
+        },
+      );
+    }
+    const timeoutController = new AbortController();
+    const timer = setTimeout(
+      () =>
+        timeoutController.abort(
+          new BrowserError(
+            "Browser connection did not initialize before the timeout.",
+            "connection_timeout",
+            { phase: "connect" },
+          ),
+        ),
+      options.timeoutMs,
+    );
+    timer.unref?.();
+    const abortSignal =
+      options.abortSignal === undefined
+        ? timeoutController.signal
+        : AbortSignal.any([options.abortSignal, timeoutController.signal]);
+    try {
+      await client.command(
+        {
+          method: "connect",
+          params: { endpointUrl: options.endpointUrl, timeoutMs: options.timeoutMs },
+        },
+        { abortSignal, phase: "connect" },
+      );
+      return client;
+    } catch (error) {
+      await client.terminate();
+      if (options.abortSignal?.aborted) {
+        throw cancellationError(options.abortSignal.reason, "connect");
+      }
+      if (timeoutController.signal.aborted) throw timeoutController.signal.reason;
+      if (
+        error instanceof Error &&
+        (error.name === "TimeoutError" || /timeout/i.test(error.message))
+      ) {
+        throw new BrowserError(
+          "Browser connection did not initialize before the timeout.",
+          "connection_timeout",
+          { cause: error, phase: "connect" },
+        );
+      }
+      throw new BrowserError("Unable to initialize browser automation.", "transport_failure", {
+        cause: error,
+        phase: "connect",
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  get closed(): boolean {
+    return this.isClosed || this.child.exitCode !== null || this.child.signalCode !== null;
+  }
+
+  command<T>(command: AutomationCommand, options: AutomationCommandOptions): Promise<T> {
+    if (this.closed) {
+      return Promise.reject(
+        new BrowserError("Browser automation connection is closed.", "connection_closed", {
+          phase: options.phase,
+        }),
+      );
+    }
+    if (options.abortSignal?.aborted) {
+      return Promise.reject(this.abortError(options.abortSignal, options.phase));
+    }
+    const id = this.nextId++;
+    return new Promise<T>((resolve, reject) => {
+      const pending: PendingRequest = {
+        state: "active",
+        resolve: (value) => resolve(value as T),
+        reject,
+      };
+      if (options.abortSignal !== undefined) {
+        pending.abortSignal = options.abortSignal;
+        pending.abort = () => this.cancelRequest(id, pending, options);
+        options.abortSignal.addEventListener("abort", pending.abort, { once: true });
+      }
+      this.pending.set(id, pending);
+      const request: AutomationRequest = { kind: "request", id, ...command };
+      try {
+        this.child.send(request, (error) => {
+          if (error == null) return;
+          this.rejectSend(options.phase, error);
+        });
+      } catch (error) {
+        this.rejectSend(options.phase, error);
+      }
+    });
+  }
+
+  async disconnect(options: BrowserLifecycleOptions = {}): Promise<void> {
+    if (this.termination !== undefined) return this.termination;
+    this.disconnecting = true;
+    const timeoutMs = options.timeoutMs ?? 10_000;
+    const timeoutController = new AbortController();
+    const timer = setTimeout(
+      () =>
+        timeoutController.abort(
+          new BrowserError("Browser disconnect timed out.", "connection_timeout", {
+            phase: "disconnect",
+          }),
+        ),
+      timeoutMs,
+    );
+    timer.unref?.();
+    const abortSignal =
+      options.abortSignal === undefined
+        ? timeoutController.signal
+        : AbortSignal.any([options.abortSignal, timeoutController.signal]);
+    try {
+      if (!this.closed) {
+        await this.command(
+          { method: "disconnect", params: {} },
+          { abortSignal, phase: "disconnect" },
+        );
+      }
+    } catch (error) {
+      if (options.abortSignal?.aborted) {
+        throw cancellationError(options.abortSignal.reason, "disconnect");
+      }
+      if (timeoutController.signal.aborted) throw timeoutController.signal.reason;
+      if (!this.closed) throw error;
+    } finally {
+      clearTimeout(timer);
+      await this.terminate();
+    }
+  }
+
+  onDisconnected(listener: () => void): () => void {
+    if (this.closed) {
+      queueMicrotask(() => {
+        try {
+          listener();
+        } catch {
+          // A closed backend must not surface callback failures through the host event loop.
+        }
+      });
+      return () => undefined;
+    }
+    this.disconnectedListeners.add(listener);
+    return () => this.disconnectedListeners.delete(listener);
+  }
+
+  async terminate(): Promise<void> {
+    if (this.termination !== undefined) return this.termination;
+    this.termination = this.performTerminate();
+    return this.termination;
+  }
+
+  private async performTerminate(): Promise<void> {
+    this.isClosed = true;
+    if (this.child.exitCode !== null || this.child.signalCode !== null) return;
+    const exited = new Promise<void>((resolve) => this.child.once("exit", () => resolve()));
+    this.child.kill("SIGTERM");
+    let forceTimer: ReturnType<typeof setTimeout> | undefined;
+    await Promise.race([
+      exited,
+      new Promise<void>((resolve) => {
+        forceTimer = setTimeout(() => {
+          this.child.kill("SIGKILL");
+          resolve();
+        }, workerTerminationTimeoutMs);
+        forceTimer.unref?.();
+      }),
+    ]);
+    if (forceTimer !== undefined) clearTimeout(forceTimer);
+    if (this.child.exitCode === null && this.child.signalCode === null) await exited;
+  }
+
+  private cancelRequest(
+    id: number,
+    pending: PendingRequest,
+    options: AutomationCommandOptions,
+  ): void {
+    if (pending.state !== "active") return;
+    pending.state = "cancelling";
+    pending.abortError = this.abortError(pending.abortSignal!, options.phase);
+    if (options.cancelOperation === true && this.child.connected) {
+      try {
+        this.child.send({ kind: "cancel", id }, (error) => {
+          if (error !== null) void this.terminate().catch(() => undefined);
+        });
+      } catch {
+        void this.terminate().catch(() => undefined);
+        return;
+      }
+      pending.cleanupTimer = setTimeout(() => {
+        void this.terminate().catch(() => undefined);
+      }, cancellationCleanupTimeoutMs);
+      pending.cleanupTimer.unref?.();
+      return;
+    }
+    void this.terminate().catch(() => undefined);
+  }
+
+  private abortError(abortSignal: AbortSignal, phase: string): unknown {
+    return abortSignal.reason instanceof BrowserError
+      ? abortSignal.reason
+      : cancellationError(abortSignal.reason, phase);
+  }
+
+  private handleMessage(message: unknown): void {
+    if (!isAutomationResponse(message)) {
+      throw new TypeError("Invalid browser automation worker response.");
+    }
+    if (message.kind === "event") {
+      if (!this.disconnecting) {
+        this.handleExit(
+          new BrowserError("Browser disconnected from CDP.", "connection_closed", {
+            phase: "automation-event",
+          }),
+        );
+        void this.terminate().catch(() => undefined);
+      }
+      return;
+    }
+    const pending = this.pending.get(message.id);
+    if (pending === undefined) return;
+    if (message.kind === "cancelled") {
+      if (pending.state === "cancelling") {
+        this.settle(message.id, pending, () => pending.reject(pending.abortError));
+      }
+      return;
+    }
+    if (pending.state === "cancelling") return;
+    this.settle(message.id, pending, () => {
+      if (message.ok) pending.resolve(message.value);
+      else pending.reject(deserializeError(message.error));
+    });
+  }
+
+  private handleExit(cause: unknown): void {
+    if (this.isClosed && this.pending.size === 0) {
+      this.cleanupChildListeners();
+      return;
+    }
+    this.isClosed = true;
+    const error =
+      cause instanceof BrowserError
+        ? cause
+        : new BrowserError("Browser automation worker terminated.", "transport_failure", {
+            cause,
+            phase: "automation-worker",
+          });
+    for (const [id, pending] of this.pending) {
+      this.settle(id, pending, () =>
+        pending.reject(pending.state === "cancelling" ? pending.abortError : error),
+      );
+    }
+    const listeners = [...this.disconnectedListeners];
+    this.disconnectedListeners.clear();
+    for (const listener of listeners) {
+      try {
+        listener();
+      } catch {
+        // Connection teardown must not throw from a child-process event callback.
+      }
+    }
+    this.cleanupChildListeners();
+  }
+
+  private cleanupChildListeners(): void {
+    this.child.off("message", this.onMessage);
+    this.child.off("exit", this.onExit);
+    this.child.stderr?.off("data", this.onStderrData);
+  }
+
+  private rejectSend(phase: string, cause: unknown): void {
+    this.handleExit(
+      new BrowserError("Unable to send browser automation command.", "transport_failure", {
+        cause,
+        phase,
+      }),
+    );
+    void this.terminate().catch(() => undefined);
+  }
+
+  private settle(id: number, pending: PendingRequest, callback: () => void): void {
+    if (this.pending.get(id) !== pending) return;
+    this.pending.delete(id);
+    if (pending.cleanupTimer !== undefined) clearTimeout(pending.cleanupTimer);
+    if (pending.abort !== undefined) {
+      pending.abortSignal?.removeEventListener("abort", pending.abort);
+    }
+    callback();
+  }
+}
+
+function spawnAutomationWorker(): ChildProcess {
+  return fork(automationWorkerUrl(), [], {
+    execArgv: [],
+    serialization: "advanced",
+    stdio: ["ignore", "ignore", "pipe", "ipc"],
+  });
+}
+
+function automationWorkerUrl(): URL {
+  return import.meta.url.endsWith("/src/automation-client.ts")
+    ? new URL("../dist/automation-worker.js", import.meta.url)
+    : new URL("./automation-worker.js", import.meta.url);
+}
+
+function deserializeError(value: SerializedError): Error {
+  const error = new Error(value.message);
+  error.name = value.name;
+  if (value.stack !== undefined) error.stack = value.stack;
+  if (value.code !== undefined) Object.assign(error, { code: value.code });
+  return error;
+}
+
+function assertPositiveSafeInteger(value: number, name: string): void {
+  if (!Number.isSafeInteger(value) || value <= 0 || value > 2_147_483_647) {
+    throw new RangeError(`${name} must be a positive integer no greater than 2147483647.`);
+  }
+}

--- a/packages/tool-browser/src/automation-protocol.ts
+++ b/packages/tool-browser/src/automation-protocol.ts
@@ -1,0 +1,110 @@
+import type { BrowserNavigationPolicy } from "./types";
+
+export type BrowserTarget =
+  | Readonly<{
+      by: "role";
+      role: string;
+      name?: string | undefined;
+      exact?: boolean | undefined;
+    }>
+  | Readonly<{ by: "text"; text: string; exact?: boolean | undefined }>
+  | Readonly<{ by: "label"; label: string; exact?: boolean | undefined }>
+  | Readonly<{ by: "placeholder"; placeholder: string; exact?: boolean | undefined }>
+  | Readonly<{ by: "test-id"; testId: string }>
+  | Readonly<{ by: "css"; selector: string }>;
+
+export type AutomationCommand =
+  | Readonly<{ method: "connect"; params: { endpointUrl: string; timeoutMs: number } }>
+  | Readonly<{ method: "disconnect"; params: Record<string, never> }>
+  | Readonly<{ method: "listTabs"; params: Record<string, never> }>
+  | Readonly<{ method: "setNavigationPolicy"; params: { policy: BrowserNavigationPolicy } }>
+  | Readonly<{ method: "openTab"; params: Record<string, never> }>
+  | Readonly<{ method: "selectTab"; params: { tabId: string } }>
+  | Readonly<{ method: "closeTab"; params: { tabId: string } }>
+  | Readonly<{
+      method: "navigate";
+      params: {
+        tabId: string;
+        url: string;
+        waitUntil: "commit" | "domcontentloaded" | "load" | "networkidle";
+        timeoutMs: number;
+      };
+    }>
+  | Readonly<{
+      method: "snapshot";
+      params: { tabId: string; timeoutMs: number; maxChars: number };
+    }>
+  | Readonly<{
+      method: "click";
+      params: { tabId: string; target: BrowserTarget; timeoutMs: number };
+    }>
+  | Readonly<{
+      method: "type";
+      params: { tabId: string; target: BrowserTarget; text: string; timeoutMs: number };
+    }>
+  | Readonly<{ method: "pressKey"; params: { tabId: string; key: string } }>
+  | Readonly<{ method: "screenshot"; params: { tabId: string; timeoutMs: number } }>;
+
+export type AutomationRequest = AutomationCommand & Readonly<{ kind: "request"; id: number }>;
+
+export type AutomationCancel = Readonly<{ kind: "cancel"; id: number }>;
+
+export type SerializedError = Readonly<{
+  name: string;
+  message: string;
+  stack?: string;
+  code?: string;
+}>;
+
+export type AutomationResponse =
+  | Readonly<{ kind: "response"; id: number; ok: true; value: unknown }>
+  | Readonly<{ kind: "response"; id: number; ok: false; error: SerializedError }>
+  | Readonly<{ kind: "cancelled"; id: number }>
+  | Readonly<{ kind: "event"; event: "disconnected" }>;
+
+export type AutomationTabResult = Readonly<{
+  tabId: string;
+  title: string;
+  url: string;
+}>;
+
+export type AutomationSnapshotResult = AutomationTabResult &
+  Readonly<{ snapshot: string; truncated: boolean }>;
+
+export type AutomationScreenshotResult = Readonly<{
+  metadata: AutomationTabResult;
+  pngBase64: string;
+}>;
+
+export function isAutomationResponse(value: unknown): value is AutomationResponse {
+  if (!isRecord(value)) return false;
+  switch (value.kind) {
+    case "event":
+      return value.event === "disconnected";
+    case "cancelled":
+      return isRequestId(value.id);
+    case "response":
+      if (!isRequestId(value.id) || typeof value.ok !== "boolean") return false;
+      return value.ok ? Object.hasOwn(value, "value") : isSerializedError(value.error);
+    default:
+      return false;
+  }
+}
+
+function isSerializedError(value: unknown): value is SerializedError {
+  return (
+    isRecord(value) &&
+    typeof value.name === "string" &&
+    typeof value.message === "string" &&
+    (value.stack === undefined || typeof value.stack === "string") &&
+    (value.code === undefined || typeof value.code === "string")
+  );
+}
+
+function isRequestId(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) > 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/tool-browser/src/automation-worker.ts
+++ b/packages/tool-browser/src/automation-worker.ts
@@ -1,0 +1,342 @@
+import { randomUUID } from "node:crypto";
+import type { Browser, Locator, Page, Route } from "playwright-core";
+import { chromium } from "playwright-core";
+import type {
+  AutomationCancel,
+  AutomationCommand,
+  AutomationRequest,
+  AutomationResponse,
+  BrowserTarget,
+  SerializedError,
+} from "./automation-protocol";
+import type { BrowserNavigationPolicy, BrowserTab } from "./types";
+
+type ActiveOperation = {
+  cancelled: boolean;
+  page?: Page;
+  completed: Promise<void>;
+  complete: () => void;
+};
+
+let browser: Browser | undefined;
+let selected: Page | undefined;
+const tabIds = new WeakMap<Page, string>();
+const pagesById = new Map<string, Page>();
+const operations = new Map<number, ActiveOperation>();
+let navigationPolicyKey: string | undefined;
+
+process.once("disconnect", () => {
+  void closeAfterParentExit();
+});
+
+process.on("message", (message: AutomationRequest | AutomationCancel) => {
+  if (message.kind === "cancel") {
+    void cancelOperation(message);
+    return;
+  }
+  void runRequest(message);
+});
+
+async function runRequest(request: AutomationRequest): Promise<void> {
+  let complete: (() => void) | undefined;
+  const operation: ActiveOperation = {
+    cancelled: false,
+    completed: new Promise<void>((resolve) => {
+      complete = resolve;
+    }),
+    complete: () => complete?.(),
+  };
+  operations.set(request.id, operation);
+  try {
+    const value = await execute(request, operation);
+    send({ kind: "response", id: request.id, ok: true, value });
+  } catch (error) {
+    send({ kind: "response", id: request.id, ok: false, error: serializeError(error) });
+  } finally {
+    operation.complete();
+    operations.delete(request.id);
+  }
+}
+
+async function cancelOperation(request: AutomationCancel): Promise<void> {
+  const operation = operations.get(request.id);
+  if (operation !== undefined) {
+    operation.cancelled = true;
+    await operation.page?.close().catch(() => undefined);
+    await operation.completed;
+  }
+  send({ kind: "cancelled", id: request.id });
+}
+
+async function execute(request: AutomationRequest, operation: ActiveOperation): Promise<unknown> {
+  const command: AutomationCommand = request;
+  switch (command.method) {
+    case "connect": {
+      if (browser !== undefined) throw new Error("Automation worker is already connected.");
+      const connected = await chromium.connectOverCDP(command.params.endpointUrl, {
+        timeout: command.params.timeoutMs,
+      });
+      try {
+        if (operation.cancelled) throw new Error("Connection attempt was cancelled.");
+        const context = connected.contexts()[0];
+        if (context === undefined) {
+          throw new Error("CDP connection did not expose a browser context.");
+        }
+        const session = await connected.newBrowserCDPSession();
+        try {
+          await session.send("Browser.getVersion");
+        } finally {
+          await session.detach().catch(() => undefined);
+        }
+        if (operation.cancelled) throw new Error("Connection attempt was cancelled.");
+      } catch (error) {
+        await connected.close().catch(() => undefined);
+        throw error;
+      }
+      browser = connected;
+      selected = pages()[0];
+      for (const page of pages()) idFor(page);
+      connected.once("disconnected", () => {
+        browser = undefined;
+        send({ kind: "event", event: "disconnected" });
+      });
+      return undefined;
+    }
+    case "disconnect": {
+      const connected = browser;
+      browser = undefined;
+      selected = undefined;
+      if (connected !== undefined) await connected.close();
+      return undefined;
+    }
+    case "listTabs":
+      return tabSummaries();
+    case "setNavigationPolicy":
+      await setNavigationPolicy(command.params.policy);
+      return undefined;
+    case "openTab": {
+      const context = assertBrowser().contexts()[0];
+      if (context === undefined) throw new Error("Browser has no CDP context.");
+      const page = await context.newPage();
+      operation.page = page;
+      if (operation.cancelled) {
+        await page.close().catch(() => undefined);
+        throw new Error("Open-tab operation was cancelled.");
+      }
+      selected = page;
+      return tabResult(page);
+    }
+    case "selectTab": {
+      const page = pageFor(command.params.tabId);
+      selected = page;
+      return tabResult(page);
+    }
+    case "closeTab": {
+      const page = pageFor(command.params.tabId);
+      operation.page = page;
+      await page.close();
+      if (page === selected) selected = pages()[0];
+      return { closedTabId: command.params.tabId, tabs: await tabSummaries() };
+    }
+    case "navigate": {
+      const page = targetPage(command.params.tabId, operation);
+      await page.goto(command.params.url, {
+        timeout: command.params.timeoutMs,
+        waitUntil: command.params.waitUntil,
+      });
+      return tabResult(page);
+    }
+    case "snapshot": {
+      const page = targetPage(command.params.tabId, operation);
+      const snapshot = await page.locator("body").ariaSnapshot({
+        timeout: command.params.timeoutMs,
+      });
+      const truncated = snapshot.length > command.params.maxChars;
+      return {
+        ...(await tabResult(page)),
+        snapshot: truncated ? snapshot.slice(0, command.params.maxChars) : snapshot,
+        truncated,
+      };
+    }
+    case "click": {
+      const page = targetPage(command.params.tabId, operation);
+      await locatorFor(page, command.params.target).click({ timeout: command.params.timeoutMs });
+      return tabResult(page);
+    }
+    case "type": {
+      const page = targetPage(command.params.tabId, operation);
+      await locatorFor(page, command.params.target).fill(command.params.text, {
+        timeout: command.params.timeoutMs,
+      });
+      return tabResult(page);
+    }
+    case "pressKey": {
+      const page = targetPage(command.params.tabId, operation);
+      await page.keyboard.press(command.params.key);
+      return tabResult(page);
+    }
+    case "screenshot": {
+      const page = targetPage(command.params.tabId, operation);
+      const png = await page.screenshot({
+        type: "png",
+        fullPage: false,
+        timeout: command.params.timeoutMs,
+      });
+      return { metadata: await tabResult(page), pngBase64: png.toString("base64") };
+    }
+  }
+}
+
+function assertBrowser(): Browser {
+  if (browser === undefined || !browser.isConnected())
+    throw new Error("Browser connection is closed.");
+  return browser;
+}
+
+function pages(): Page[] {
+  return browser?.contexts().flatMap((context) => context.pages()) ?? [];
+}
+
+function idFor(page: Page): string {
+  const existing = tabIds.get(page);
+  if (existing !== undefined) return existing;
+  const id = randomUUID();
+  tabIds.set(page, id);
+  pagesById.set(id, page);
+  page.once("close", () => pagesById.delete(id));
+  return id;
+}
+
+function pageFor(id: string): Page {
+  assertBrowser();
+  const page = pagesById.get(id);
+  if (page === undefined || page.isClosed() || !pages().includes(page)) {
+    throw new Error(`Browser tab does not exist: ${id}`);
+  }
+  return page;
+}
+
+function targetPage(id: string, operation: ActiveOperation): Page {
+  const page = pageFor(id);
+  operation.page = page;
+  return page;
+}
+
+async function tabSummaries(): Promise<readonly BrowserTab[]> {
+  assertBrowser();
+  if (selected?.isClosed()) selected = pages()[0];
+  return Promise.all(
+    pages().map(async (page) => ({
+      id: idFor(page),
+      title: await page.title(),
+      url: page.url(),
+      selected: page === selected,
+    })),
+  );
+}
+
+async function tabResult(page: Page) {
+  return { tabId: idFor(page), title: await page.title(), url: page.url() };
+}
+
+async function setNavigationPolicy(policy: BrowserNavigationPolicy): Promise<void> {
+  const key = JSON.stringify(policy);
+  if (navigationPolicyKey !== undefined) {
+    if (navigationPolicyKey !== key) {
+      throw new TypeError("Browser connection already has a different navigation policy.");
+    }
+    return;
+  }
+  navigationPolicyKey = key;
+  await Promise.all(
+    assertBrowser()
+      .contexts()
+      .map((context) => context.route("**/*", (route) => enforceNavigationPolicy(route, policy))),
+  );
+}
+
+async function enforceNavigationPolicy(
+  route: Route,
+  policy: BrowserNavigationPolicy,
+): Promise<void> {
+  const request = route.request();
+  const frame = request.frame();
+  if (
+    request.isNavigationRequest() &&
+    frame === frame.page().mainFrame() &&
+    !isNavigationAllowed(request.url(), policy)
+  ) {
+    await route.abort("blockedbyclient");
+    return;
+  }
+  await route.continue();
+}
+
+function isNavigationAllowed(value: string, policy: BrowserNavigationPolicy): boolean {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+  if (url.username.length > 0 || url.password.length > 0) return false;
+  return policy.mode === "allow-all-http" || policy.origins.includes(url.origin);
+}
+
+function locatorFor(page: Page, target: BrowserTarget): Locator {
+  switch (target.by) {
+    case "role": {
+      const options: { name?: string; exact?: boolean } = {};
+      if (target.name !== undefined) options.name = target.name;
+      if (target.exact !== undefined) options.exact = target.exact;
+      return page.getByRole(target.role as never, options);
+    }
+    case "text": {
+      const options: { exact?: boolean } = {};
+      if (target.exact !== undefined) options.exact = target.exact;
+      return page.getByText(target.text, options);
+    }
+    case "label": {
+      const options: { exact?: boolean } = {};
+      if (target.exact !== undefined) options.exact = target.exact;
+      return page.getByLabel(target.label, options);
+    }
+    case "placeholder": {
+      const options: { exact?: boolean } = {};
+      if (target.exact !== undefined) options.exact = target.exact;
+      return page.getByPlaceholder(target.placeholder, options);
+    }
+    case "test-id":
+      return page.getByTestId(target.testId);
+    case "css":
+      return page.locator(target.selector);
+  }
+}
+
+function serializeError(error: unknown): SerializedError {
+  if (error instanceof Error) {
+    const value: { name: string; message: string; stack?: string; code?: string } = {
+      name: error.name,
+      message: error.message,
+    };
+    if (error.stack !== undefined) value.stack = error.stack;
+    if ("code" in error && typeof error.code === "string") value.code = error.code;
+    return value;
+  }
+  return { name: "Error", message: String(error) };
+}
+
+function send(message: AutomationResponse): void {
+  if (!process.connected || process.send === undefined) return;
+  process.send(message, () => undefined);
+}
+
+async function closeAfterParentExit(): Promise<void> {
+  const forceExit = setTimeout(() => process.exit(1), 2_000);
+  const connected = browser;
+  browser = undefined;
+  await connected?.close().catch(() => undefined);
+  clearTimeout(forceExit);
+  process.exit(0);
+}

--- a/packages/tool-browser/src/connection.ts
+++ b/packages/tool-browser/src/connection.ts
@@ -1,83 +1,100 @@
-import { randomUUID } from "node:crypto";
-import type { Browser, Page, Route } from "playwright-core";
-import { chromium } from "playwright-core";
+import type { AutomationCommand, AutomationTabResult } from "./automation-protocol";
+import {
+  AutomationWorkerClient,
+  type AutomationBackend,
+  type AutomationWorkerFactory,
+} from "./automation-client";
 import type { BrowserControlState } from "./control";
-import { BrowserError } from "./errors";
-import type { BrowserNavigationPolicy, BrowserTab, PlaywrightBrowserConnection } from "./types";
+import { BrowserError, cancellationError } from "./errors";
+import { AsyncMutex, ResourceScheduler } from "./scheduler";
+import type {
+  BrowserActionOptions,
+  BrowserConnectOptions,
+  BrowserLifecycleOptions,
+  BrowserNavigationPolicy,
+  BrowserTab,
+  PlaywrightBrowserConnection,
+} from "./types";
+
+const defaultConnectionTimeoutMs = 30_000;
+const defaultActionTimeoutMs = 10_000;
+const defaultMaxConcurrentTabs = 8;
+const defaultMaxQueuedActions = 1_000;
+const maxClosedTabTombstones = 10_000;
+const maxTimerMs = 2_147_483_647;
 
 export async function connectPlaywrightBrowser(options: {
   endpointUrl: string;
   control: BrowserControlState;
+  timeoutMs?: number;
   abortSignal?: AbortSignal;
+  scheduling?: BrowserConnectOptions["scheduling"];
+  workerFactory?: AutomationWorkerFactory;
+  onClosed?: (connection: PlaywrightBrowserConnectionImpl) => void;
 }): Promise<PlaywrightBrowserConnectionImpl> {
+  const timeoutMs = options.timeoutMs ?? defaultConnectionTimeoutMs;
+  assertPositiveSafeInteger(timeoutMs, "timeoutMs");
   options.abortSignal?.throwIfAborted();
-  const browser = await chromium.connectOverCDP(options.endpointUrl);
-  if (options.abortSignal?.aborted) {
-    await browser.close().catch(() => undefined);
-    options.abortSignal.throwIfAborted();
-  }
-  return new PlaywrightBrowserConnectionImpl(browser, options.control);
+  const backend = await AutomationWorkerClient.connect({
+    endpointUrl: options.endpointUrl,
+    timeoutMs,
+    ...(options.abortSignal === undefined ? {} : { abortSignal: options.abortSignal }),
+    ...(options.workerFactory === undefined ? {} : { workerFactory: options.workerFactory }),
+  });
+  return new PlaywrightBrowserConnectionImpl({
+    backend,
+    control: options.control,
+    scheduling: options.scheduling,
+    ...(options.onClosed === undefined ? {} : { onClosed: options.onClosed }),
+  });
 }
 
 export class PlaywrightBrowserConnectionImpl implements PlaywrightBrowserConnection {
-  private readonly browser: Browser;
+  private readonly backend: AutomationBackend;
   private readonly control: BrowserControlState;
-  private readonly tabIds = new WeakMap<Page, string>();
-  private selected: Page | undefined;
-  private isClosed = false;
-  private actionTail = Promise.resolve();
+  private readonly scheduler: ResourceScheduler;
+  private readonly compatibilityMutex = new AsyncMutex();
+  private readonly contextMutex = new AsyncMutex();
+  private readonly closingTabs = new Set<string>();
+  private readonly closedTabs = new Set<string>();
   private navigationPolicyKey: string | undefined;
-  private navigationGuard = Promise.resolve();
+  private navigationGuard: Promise<void> = Promise.resolve();
+  private isClosed = false;
+  private disconnectCompleted = false;
+  private disconnectPromise: Promise<void> | undefined;
+  private removeDisconnectedListener: (() => void) | undefined;
+  private readonly onClosed: ((connection: PlaywrightBrowserConnectionImpl) => void) | undefined;
 
-  constructor(browser: Browser, control: BrowserControlState) {
-    this.browser = browser;
-    this.control = control;
-    this.selected = this.pages()[0];
-    this.browser.once("disconnected", () => {
-      this.isClosed = true;
-    });
+  constructor(options: {
+    backend: AutomationBackend;
+    control: BrowserControlState;
+    scheduling?: BrowserConnectOptions["scheduling"];
+    onClosed?: (connection: PlaywrightBrowserConnectionImpl) => void;
+  }) {
+    this.backend = options.backend;
+    this.control = options.control;
+    this.onClosed = options.onClosed;
+    const scheduling = normalizeScheduling(options.scheduling);
+    this.scheduler = new ResourceScheduler(scheduling);
+    this.removeDisconnectedListener = this.backend.onDisconnected(() => this.markClosed());
   }
 
   get closed(): boolean {
-    return this.isClosed || !this.browser.isConnected();
+    return this.isClosed || this.backend.closed;
   }
 
-  async listTabs(): Promise<readonly BrowserTab[]> {
-    return this.runAction(undefined, () => this.tabSummaries());
-  }
-
-  async tabSummaries(): Promise<readonly BrowserTab[]> {
-    return Object.freeze(
-      await Promise.all(
-        this.pages().map(async (page) =>
-          Object.freeze({
-            id: this.idFor(page),
-            title: await page.title(),
-            url: page.url(),
-            selected: page === this.selected,
-          }),
+  async listTabs(options: BrowserActionOptions = {}): Promise<readonly BrowserTab[]> {
+    assertOptionsObject(options);
+    return this.runContextAction(
+      options.abortSignal,
+      options.timeoutMs ?? defaultActionTimeoutMs,
+      "list-tabs",
+      (signal) =>
+        this.backend.command<readonly BrowserTab[]>(
+          { method: "listTabs", params: {} },
+          { abortSignal: signal, cancelOperation: true, phase: "list-tabs" },
         ),
-      ),
     );
-  }
-
-  async runAction<T>(
-    abortSignal: AbortSignal | undefined,
-    operation: () => Promise<T>,
-  ): Promise<T> {
-    const previous = this.actionTail;
-    let release: (() => void) | undefined;
-    this.actionTail = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    await previous;
-    try {
-      this.assertOpen();
-      await this.navigationGuard;
-      return await this.control.runAgentAction(() => this.withAbort(abortSignal, operation));
-    } finally {
-      release?.();
-    }
   }
 
   setNavigationPolicy(policy: BrowserNavigationPolicy): void {
@@ -90,135 +107,450 @@ export class PlaywrightBrowserConnectionImpl implements PlaywrightBrowserConnect
       return;
     }
     this.navigationPolicyKey = key;
-    const routeHandler = (route: Route) => enforceNavigationPolicy(route, policy);
-    this.navigationGuard = Promise.all(
-      this.browser.contexts().map((context) => context.route("**/*", routeHandler)),
-    ).then(() => undefined);
+    const installation = this.withActionTimeout(
+      undefined,
+      defaultActionTimeoutMs,
+      "navigation-policy",
+      (signal) =>
+        this.scheduler.run("browser-context", signal, (scheduledSignal) =>
+          this.contextMutex.run(scheduledSignal, () =>
+            this.control.runAgentAction(async () => {
+              try {
+                await this.backend.command<void>(
+                  { method: "setNavigationPolicy", params: { policy } },
+                  {
+                    abortSignal: scheduledSignal,
+                    cancelOperation: true,
+                    phase: "navigation-policy",
+                  },
+                );
+              } catch (error) {
+                throw normalizeAutomationError(error, "navigation-policy");
+              }
+            }),
+          ),
+        ),
+    );
+    this.navigationGuard = installation.catch(async (error) => {
+      let cleanupError: unknown;
+      try {
+        await this.disconnect();
+      } catch (caught) {
+        cleanupError = caught;
+      }
+      throw new BrowserError(
+        "Unable to install the browser navigation policy.",
+        "transport_failure",
+        {
+          cause: combineCleanupError(error, cleanupError),
+          phase: "navigation-policy",
+        },
+      );
+    });
     void this.navigationGuard.catch(() => undefined);
   }
 
-  selectedPage(): Page {
-    this.assertOpen();
-    if (this.selected !== undefined && !this.selected.isClosed()) return this.selected;
-    const page = this.pages()[0];
-    if (page === undefined) {
-      throw new BrowserError("Browser has no open tabs.", "invalid_state");
+  async openTab(
+    abortSignal: AbortSignal | undefined,
+    timeoutMs: number,
+  ): Promise<AutomationTabResult> {
+    return this.withActionTimeout(abortSignal, timeoutMs, "open-tab", (signal) =>
+      this.compatibilityMutex.run(signal, () =>
+        this.runContextActionScheduled(signal, "open-tab", (scheduledSignal) =>
+          this.backend.command<AutomationTabResult>(
+            { method: "openTab", params: {} },
+            { abortSignal: scheduledSignal, cancelOperation: true, phase: "open-tab" },
+          ),
+        ),
+      ),
+    );
+  }
+
+  async selectTab(
+    tabId: string,
+    abortSignal: AbortSignal | undefined,
+    timeoutMs: number,
+  ): Promise<AutomationTabResult> {
+    this.assertTabUsable(tabId);
+    return this.withActionTimeout(abortSignal, timeoutMs, "select-tab", (signal) =>
+      this.compatibilityMutex.run(signal, () =>
+        this.runContextActionScheduled(signal, "select-tab", (scheduledSignal) =>
+          this.backend.command<AutomationTabResult>(
+            { method: "selectTab", params: { tabId } },
+            { abortSignal: scheduledSignal, cancelOperation: true, phase: "select-tab" },
+          ),
+        ),
+      ),
+    );
+  }
+
+  async closeTab(
+    tabId: string,
+    abortSignal: AbortSignal | undefined,
+    timeoutMs: number,
+  ): Promise<Readonly<{ closedTabId: string; tabs: readonly BrowserTab[] }>> {
+    this.assertTabUsable(tabId);
+    this.closingTabs.add(tabId);
+    let closed = false;
+    try {
+      const result = await this.withActionTimeout(abortSignal, timeoutMs, "close-tab", (signal) =>
+        this.scheduler.run(`tab:${tabId}`, signal, (scheduledSignal) => {
+          return this.contextMutex.run(scheduledSignal, () =>
+            this.control.runAgentAction(async () => {
+              try {
+                return await this.backend.command<
+                  Readonly<{ closedTabId: string; tabs: readonly BrowserTab[] }>
+                >(
+                  { method: "closeTab", params: { tabId } },
+                  { abortSignal: scheduledSignal, cancelOperation: true, phase: "close-tab" },
+                );
+              } catch (error) {
+                throw normalizeAutomationError(error, "close-tab");
+              }
+            }),
+          );
+        }),
+      );
+      closed = true;
+      return result;
+    } finally {
+      this.closingTabs.delete(tabId);
+      if (closed && !this.isClosed) this.rememberClosedTab(tabId);
     }
-    this.selected = page;
-    return page;
   }
 
-  async openTab(): Promise<Page> {
-    const context = this.browser.contexts()[0];
-    if (context === undefined) {
-      throw new BrowserError("Browser has no CDP context.", "invalid_state");
+  async runTabCommand<T>(options: {
+    tabId?: string | undefined;
+    abortSignal?: AbortSignal | undefined;
+    timeoutMs: number;
+    phase: string;
+    command: (tabId: string) => AutomationCommand;
+  }): Promise<T> {
+    return this.withActionTimeout(
+      options.abortSignal,
+      options.timeoutMs,
+      options.phase,
+      async (signal) => {
+        if (options.tabId !== undefined) {
+          this.assertTabUsable(options.tabId);
+          return this.runScheduledTabCommand(options.tabId, options, signal);
+        }
+        return this.compatibilityMutex.run(signal, async () => {
+          const tabId = await this.selectedTabId(signal);
+          this.assertTabUsable(tabId);
+          return this.runScheduledTabCommand(tabId, options, signal);
+        });
+      },
+    );
+  }
+
+  async disconnect(options: BrowserLifecycleOptions = {}): Promise<void> {
+    assertOptionsObject(options);
+    if (options.timeoutMs !== undefined) assertPositiveSafeInteger(options.timeoutMs, "timeoutMs");
+    if (this.disconnectCompleted) return;
+    if (options.abortSignal?.aborted) {
+      throw cancellationError(options.abortSignal.reason, "disconnect");
     }
-    const page = await context.newPage();
-    this.selected = page;
-    this.idFor(page);
-    return page;
-  }
-
-  selectTab(id: string): Page {
-    const page = this.pageFor(id);
-    this.selected = page;
-    return page;
-  }
-
-  async closeTab(id: string): Promise<void> {
-    const page = this.pageFor(id);
-    await page.close();
-    if (page === this.selected) this.selected = this.pages()[0];
-  }
-
-  idFor(page: Page): string {
-    const existing = this.tabIds.get(page);
-    if (existing !== undefined) return existing;
-    const id = randomUUID();
-    this.tabIds.set(page, id);
-    return id;
-  }
-
-  async disconnect(): Promise<void> {
-    if (this.isClosed) return;
-    this.isClosed = true;
-    await this.browser.close().catch(() => undefined);
+    if (this.disconnectPromise !== undefined) {
+      return waitForSharedDisconnect(this.disconnectPromise, options);
+    }
+    this.markClosed();
+    const promise = this.backend.disconnect(options);
+    this.disconnectPromise = promise;
+    try {
+      await promise;
+      this.disconnectCompleted = true;
+    } finally {
+      if (this.disconnectPromise === promise) this.disconnectPromise = undefined;
+    }
   }
 
   async [Symbol.asyncDispose](): Promise<void> {
     await this.disconnect();
   }
 
-  private pages(): Page[] {
-    return this.browser.contexts().flatMap((context) => context.pages());
+  private async runScheduledTabCommand<T>(
+    tabId: string,
+    options: {
+      abortSignal?: AbortSignal | undefined;
+      timeoutMs: number;
+      phase: string;
+      command: (tabId: string) => AutomationCommand;
+    },
+    abortSignal: AbortSignal,
+  ): Promise<T> {
+    return this.scheduler.run(`tab:${tabId}`, abortSignal, (scheduledSignal) =>
+      this.control.runAgentAction(async () => {
+        await waitForOwnedPromise(this.navigationGuard, scheduledSignal);
+        try {
+          return await this.backend.command<T>(options.command(tabId), {
+            abortSignal: scheduledSignal,
+            cancelOperation: true,
+            phase: options.phase,
+          });
+        } catch (error) {
+          throw normalizeAutomationError(error, options.phase);
+        }
+      }),
+    );
   }
 
-  private pageFor(id: string): Page {
-    const page = this.pages().find((candidate) => this.idFor(candidate) === id);
-    if (page === undefined) {
-      throw new BrowserError(`Browser tab does not exist: ${id}`, "invalid_state");
+  private async selectedTabId(abortSignal: AbortSignal): Promise<string> {
+    const tabs = await this.runContextActionScheduled(
+      abortSignal,
+      "selected-tab-lookup",
+      (signal) =>
+        this.backend.command<readonly BrowserTab[]>(
+          { method: "listTabs", params: {} },
+          { abortSignal: signal, cancelOperation: true, phase: "selected-tab-lookup" },
+        ),
+    );
+    const selected = tabs.find((tab) => tab.selected) ?? tabs[0];
+    if (selected === undefined) {
+      throw new BrowserError("Browser has no open tabs.", "invalid_state", {
+        phase: "selected-tab-lookup",
+      });
     }
-    return page;
+    return selected.id;
+  }
+
+  private runContextAction<T>(
+    abortSignal: AbortSignal | undefined,
+    timeoutMs: number,
+    phase: string,
+    operation: (abortSignal: AbortSignal) => Promise<T>,
+  ): Promise<T> {
+    return this.withActionTimeout(abortSignal, timeoutMs, phase, (signal) =>
+      this.runContextActionScheduled(signal, phase, operation),
+    );
+  }
+
+  private runContextActionScheduled<T>(
+    abortSignal: AbortSignal,
+    phase: string,
+    operation: (abortSignal: AbortSignal) => Promise<T>,
+  ): Promise<T> {
+    return this.scheduler.run("browser-context", abortSignal, (scheduledSignal) =>
+      this.contextMutex.run(scheduledSignal, () =>
+        this.control.runAgentAction(async () => {
+          this.assertOpen();
+          await waitForOwnedPromise(this.navigationGuard, scheduledSignal);
+          try {
+            return await operation(scheduledSignal);
+          } catch (error) {
+            throw normalizeAutomationError(error, phase);
+          }
+        }),
+      ),
+    );
+  }
+
+  private async withActionTimeout<T>(
+    abortSignal: AbortSignal | undefined,
+    timeoutMs: number,
+    phase: string,
+    operation: (abortSignal: AbortSignal) => Promise<T>,
+  ): Promise<T> {
+    assertPositiveSafeInteger(timeoutMs, "timeoutMs");
+    if (abortSignal?.aborted) throw cancellationError(abortSignal.reason, phase);
+    const timeoutController = new AbortController();
+    const timer = setTimeout(
+      () =>
+        timeoutController.abort(
+          new BrowserError("Browser action timed out.", "action_timeout", { phase }),
+        ),
+      timeoutMs,
+    );
+    timer.unref?.();
+    const effectiveSignal =
+      abortSignal === undefined
+        ? timeoutController.signal
+        : AbortSignal.any([abortSignal, timeoutController.signal]);
+    try {
+      const value = await operation(effectiveSignal);
+      if (abortSignal?.aborted) throw cancellationError(abortSignal.reason, phase);
+      if (timeoutController.signal.aborted) throw timeoutController.signal.reason;
+      return value;
+    } catch (error) {
+      if (abortSignal?.aborted) throw cancellationError(abortSignal.reason, phase);
+      if (timeoutController.signal.aborted) throw timeoutController.signal.reason;
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private assertTabUsable(tabId: string): void {
+    this.assertOpen();
+    if (this.closingTabs.has(tabId) || this.closedTabs.has(tabId)) {
+      throw new BrowserError(`Browser tab is closing or closed: ${tabId}`, "invalid_state", {
+        phase: "tab-lookup",
+      });
+    }
+  }
+
+  private rememberClosedTab(tabId: string): void {
+    this.closedTabs.add(tabId);
+    if (this.closedTabs.size <= maxClosedTabTombstones) return;
+    const oldest = this.closedTabs.values().next().value;
+    if (oldest !== undefined) this.closedTabs.delete(oldest);
   }
 
   private assertOpen(): void {
-    if (this.closed) throw new BrowserError("Browser connection is closed.", "connection_closed");
+    if (this.closed) {
+      throw new BrowserError("Browser connection is closed.", "connection_closed");
+    }
   }
 
-  private async withAbort<T>(
-    abortSignal: AbortSignal | undefined,
-    operation: () => Promise<T>,
-  ): Promise<T> {
-    abortSignal?.throwIfAborted();
-    if (abortSignal === undefined) return operation();
-    return new Promise<T>((resolve, reject) => {
-      let settled = false;
-      const finish = (callback: () => void) => {
-        if (settled) return;
-        settled = true;
-        abortSignal.removeEventListener("abort", onAbort);
-        callback();
-      };
-      const onAbort = () => {
-        void this.disconnect().finally(() => finish(() => reject(abortSignal.reason)));
-      };
-      abortSignal.addEventListener("abort", onAbort, { once: true });
-      void operation().then(
-        (value) => finish(() => resolve(value)),
-        (error) => finish(() => reject(error)),
-      );
+  private markClosed(): void {
+    if (this.isClosed) return;
+    this.isClosed = true;
+    const error = new BrowserError("Browser connection is closed.", "connection_closed");
+    this.scheduler.close(error);
+    this.compatibilityMutex.close(error);
+    this.contextMutex.close(error);
+    this.closingTabs.clear();
+    this.closedTabs.clear();
+    this.removeDisconnectedListener?.();
+    this.removeDisconnectedListener = undefined;
+    this.onClosed?.(this);
+  }
+}
+
+function normalizeScheduling(
+  value: BrowserConnectOptions["scheduling"],
+): ConstructorParameters<typeof ResourceScheduler>[0] {
+  if (value === undefined) {
+    return {
+      mode: "serial",
+      maxConcurrentResources: 1,
+      maxQueuedActions: defaultMaxQueuedActions,
+    };
+  }
+  assertOptionsObject(value);
+  const maxQueuedActions = value.maxQueuedActions ?? defaultMaxQueuedActions;
+  assertPositiveSafeInteger(maxQueuedActions, "scheduling.maxQueuedActions");
+  if (value.mode === "serial") {
+    return { mode: "serial", maxConcurrentResources: 1, maxQueuedActions };
+  }
+  if (value.mode !== "per-tab") throw new TypeError("Unsupported browser scheduling mode.");
+  const maxConcurrentResources = value.maxConcurrentTabs ?? defaultMaxConcurrentTabs;
+  assertPositiveSafeInteger(maxConcurrentResources, "scheduling.maxConcurrentTabs");
+  return { mode: "per-tab", maxConcurrentResources, maxQueuedActions };
+}
+
+function normalizeAutomationError(error: unknown, phase: string): BrowserError {
+  if (error instanceof BrowserError) return error;
+  if (error instanceof Error && /ERR_BLOCKED_BY_CLIENT|blockedbyclient/i.test(error.message)) {
+    return new BrowserError("Browser navigation was rejected by policy.", "navigation_blocked", {
+      cause: error,
+      phase,
     });
   }
-}
-
-async function enforceNavigationPolicy(
-  route: Route,
-  policy: BrowserNavigationPolicy,
-): Promise<void> {
-  const request = route.request();
-  const frame = request.frame();
+  if (error instanceof Error && error.name === "TimeoutError") {
+    return new BrowserError("Browser action timed out.", "action_timeout", {
+      cause: error,
+      phase,
+    });
+  }
   if (
-    request.isNavigationRequest() &&
-    frame === frame.page().mainFrame() &&
-    !isNavigationAllowed(request.url(), policy)
+    error instanceof Error &&
+    /tab does not exist|has no open tabs|target page.*closed|page has been closed/i.test(
+      error.message,
+    )
   ) {
-    await route.abort("blockedbyclient");
-    return;
+    return new BrowserError(error.message, "invalid_state", { cause: error, phase });
   }
-  await route.continue();
+  if (
+    error instanceof Error &&
+    /browser.*closed|disconnected|connection.*closed|websocket.*closed/i.test(error.message)
+  ) {
+    return new BrowserError("Browser automation connection closed.", "connection_closed", {
+      cause: error,
+      phase,
+    });
+  }
+  return new BrowserError("Browser tool operation failed.", "tool_failed", {
+    cause: error,
+    phase,
+  });
 }
 
-function isNavigationAllowed(value: string, policy: BrowserNavigationPolicy): boolean {
-  let url: URL;
-  try {
-    url = new URL(value);
-  } catch {
-    return false;
+function assertPositiveSafeInteger(value: number, name: string): void {
+  if (!Number.isSafeInteger(value) || value <= 0 || value > maxTimerMs) {
+    throw new RangeError(`${name} must be a positive integer no greater than ${maxTimerMs}.`);
   }
-  if (url.protocol !== "http:" && url.protocol !== "https:") return false;
-  if (url.username.length > 0 || url.password.length > 0) return false;
-  return policy.mode === "allow-all-http" || policy.origins.includes(url.origin);
 }
+
+function assertOptionsObject(value: unknown): asserts value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new TypeError("options must be an object.");
+  }
+}
+
+function combineCleanupError(error: unknown, cleanupError: unknown): unknown {
+  return cleanupError === undefined
+    ? error
+    : new AggregateError([error, cleanupError], "Browser automation cleanup also failed.");
+}
+
+async function waitForOwnedPromise<T>(promise: Promise<T>, abortSignal: AbortSignal): Promise<T> {
+  abortSignal.throwIfAborted();
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      abortSignal.removeEventListener("abort", abort);
+      callback();
+    };
+    const abort = () => finish(() => reject(abortSignal.reason));
+    abortSignal.addEventListener("abort", abort, { once: true });
+    void promise.then(
+      (value) => finish(() => resolve(value)),
+      (error) => finish(() => reject(error)),
+    );
+  });
+}
+
+async function waitForSharedDisconnect(
+  promise: Promise<void>,
+  options: BrowserLifecycleOptions,
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? 10_000;
+  assertPositiveSafeInteger(timeoutMs, "timeoutMs");
+  if (options.abortSignal?.aborted) {
+    throw cancellationError(options.abortSignal.reason, "disconnect");
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () =>
+      controller.abort(
+        new BrowserError("Browser disconnect timed out.", "connection_timeout", {
+          phase: "disconnect",
+        }),
+      ),
+    timeoutMs,
+  );
+  timer.unref?.();
+  const signal =
+    options.abortSignal === undefined
+      ? controller.signal
+      : AbortSignal.any([options.abortSignal, controller.signal]);
+  try {
+    await waitForOwnedPromise(promise, signal);
+  } catch (error) {
+    if (options.abortSignal?.aborted) {
+      throw cancellationError(options.abortSignal.reason, "disconnect");
+    }
+    if (controller.signal.aborted) throw controller.signal.reason;
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export type { AutomationBackend };
 
 export function asConnection(
   connection: PlaywrightBrowserConnection,

--- a/packages/tool-browser/src/control.ts
+++ b/packages/tool-browser/src/control.ts
@@ -1,8 +1,9 @@
 import { randomUUID } from "node:crypto";
-import { BrowserError } from "./errors";
+import { BrowserError, cancellationError } from "./errors";
 import type {
   AcquireBrowserHumanControlOptions,
   BrowserControl,
+  BrowserControlAvailability,
   BrowserControlSnapshot,
   BrowserHumanControlLease,
   RenewBrowserHumanControlOptions,
@@ -13,7 +14,11 @@ type PendingAcquire = {
   reject: (error: unknown) => void;
   abortSignal?: AbortSignal;
   abort?: () => void;
+  timer?: ReturnType<typeof setTimeout>;
 };
+
+const defaultAcquireTimeoutMs = 30_000;
+const maxTimerMs = 2_147_483_647;
 
 export class BrowserControlState implements BrowserControl {
   private activeAgentActions = 0;
@@ -21,16 +26,31 @@ export class BrowserControlState implements BrowserControl {
   private activeLease: BrowserHumanControlLeaseImpl | undefined;
   private humanPending = false;
   private destroyed = false;
+  private availability: BrowserControlAvailability = "available";
 
   snapshot(): BrowserControlSnapshot {
     const lease = this.activeLease;
-    return lease === undefined
-      ? Object.freeze({ mode: "agent" })
-      : Object.freeze({
-          mode: "human",
-          ownerId: lease.ownerId,
-          expiresAt: lease.expiresAt,
-        });
+    const state =
+      lease !== undefined
+        ? "human"
+        : this.humanPending
+          ? "human-pending"
+          : this.activeAgentActions > 0
+            ? "agent-active"
+            : "agent";
+    return Object.freeze({
+      mode: lease === undefined ? "agent" : "human",
+      state,
+      availability: this.availability,
+      activeAgentActions: this.activeAgentActions,
+      humanPending: this.humanPending,
+      ...(lease === undefined
+        ? {}
+        : {
+            ownerId: lease.ownerId,
+            expiresAt: lease.expiresAt,
+          }),
+    });
   }
 
   async acquireHumanControl(
@@ -38,9 +58,20 @@ export class BrowserControlState implements BrowserControl {
   ): Promise<BrowserHumanControlLease> {
     validateAcquireOptions(options);
     this.assertActive();
-    options.abortSignal?.throwIfAborted();
-    if (this.activeLease !== undefined || this.humanPending) {
-      throw new BrowserError("Browser human control is already acquired.", "human_controlled");
+    if (options.abortSignal?.aborted) {
+      throw cancellationError(options.abortSignal.reason, "human-control-acquire");
+    }
+    if (this.activeLease !== undefined) {
+      throw new BrowserError("Browser human control is already acquired.", "human_controlled", {
+        phase: "human-control-acquire",
+      });
+    }
+    if (this.humanPending) {
+      throw new BrowserError(
+        "Browser human control acquisition is already pending.",
+        "human_control_conflict",
+        { phase: "human-control-acquire" },
+      );
     }
     this.humanPending = true;
     try {
@@ -51,17 +82,31 @@ export class BrowserControlState implements BrowserControl {
             pending.abortSignal = options.abortSignal;
             pending.abort = () => {
               if (this.pendingAcquire !== pending) return;
-              this.pendingAcquire = undefined;
-              reject(options.abortSignal?.reason);
+              this.clearPendingAcquire(pending);
+              reject(cancellationError(options.abortSignal?.reason, "human-control-acquire"));
             };
             options.abortSignal.addEventListener("abort", pending.abort, { once: true });
           }
+          pending.timer = setTimeout(() => {
+            if (this.pendingAcquire !== pending) return;
+            this.clearPendingAcquire(pending);
+            reject(
+              new BrowserError(
+                "Timed out waiting to acquire browser human control.",
+                "human_control_conflict",
+                { phase: "human-control-acquire" },
+              ),
+            );
+          }, options.timeoutMs ?? defaultAcquireTimeoutMs);
+          pending.timer.unref?.();
           this.pendingAcquire = pending;
         });
       }
 
       this.assertActive();
-      options.abortSignal?.throwIfAborted();
+      if (options.abortSignal?.aborted) {
+        throw cancellationError(options.abortSignal.reason, "human-control-acquire");
+      }
       const lease = new BrowserHumanControlLeaseImpl({
         owner: this,
         ownerId: options.ownerId,
@@ -76,8 +121,17 @@ export class BrowserControlState implements BrowserControl {
 
   async runAgentAction<T>(operation: () => Promise<T>): Promise<T> {
     this.assertActive();
-    if (this.activeLease !== undefined || this.humanPending) {
-      throw new BrowserError("Browser is controlled by a human viewer.", "human_controlled");
+    if (this.activeLease !== undefined) {
+      throw new BrowserError("Browser is controlled by a human viewer.", "human_controlled", {
+        phase: "agent-action",
+      });
+    }
+    if (this.humanPending) {
+      throw new BrowserError(
+        "Browser human control acquisition is pending.",
+        "human_control_conflict",
+        { phase: "agent-action" },
+      );
     }
     this.activeAgentActions += 1;
     try {
@@ -113,25 +167,54 @@ export class BrowserControlState implements BrowserControl {
     if (this.pendingAcquire !== undefined) {
       const pending = this.pendingAcquire;
       this.pendingAcquire = undefined;
-      if (pending.abort !== undefined) {
-        pending.abortSignal?.removeEventListener("abort", pending.abort);
-      }
-      pending.reject(new BrowserError("Browser was destroyed.", "invalid_state"));
+      this.clearPendingAcquire(pending);
+      pending.reject(new BrowserError("Browser was destroyed.", "runtime_destroyed"));
     }
+    this.humanPending = false;
+    this.availability = "destroyed";
+  }
+
+  setAvailability(availability: BrowserControlAvailability): void {
+    if (this.destroyed) return;
+    if (availability === "destroyed") {
+      this.destroy();
+      return;
+    }
+    this.availability = availability;
+    if (availability !== "disconnected") return;
+    this.activeLease?.release();
+    if (this.pendingAcquire !== undefined) {
+      const pending = this.pendingAcquire;
+      this.clearPendingAcquire(pending);
+      pending.reject(
+        new BrowserError("Browser runtime is disconnected.", "connection_closed", {
+          phase: "human-control-acquire",
+        }),
+      );
+    }
+    this.humanPending = false;
   }
 
   private assertActive(): void {
-    if (this.destroyed) throw new BrowserError("Browser was destroyed.", "invalid_state");
+    if (this.destroyed) throw new BrowserError("Browser was destroyed.", "runtime_destroyed");
+    if (this.availability === "disconnected") {
+      throw new BrowserError("Browser runtime is disconnected.", "connection_closed");
+    }
   }
 
   private resolvePendingAcquire(): void {
     const pending: PendingAcquire | undefined = this.pendingAcquire;
     if (pending === undefined) return;
-    this.pendingAcquire = undefined;
+    this.clearPendingAcquire(pending);
+    pending.resolve();
+  }
+
+  private clearPendingAcquire(pending: PendingAcquire): void {
+    if (this.pendingAcquire === pending) this.pendingAcquire = undefined;
+    if (pending.timer !== undefined) clearTimeout(pending.timer);
     if (pending.abort !== undefined) {
       pending.abortSignal?.removeEventListener("abort", pending.abort);
     }
-    pending.resolve();
   }
 }
 
@@ -189,11 +272,12 @@ function validateAcquireOptions(options: AcquireBrowserHumanControlOptions): voi
     throw new TypeError("ownerId must be a non-empty string.");
   }
   assertPositiveSafeInteger(options.leaseTimeoutMs, "leaseTimeoutMs");
+  if (options.timeoutMs !== undefined) assertPositiveSafeInteger(options.timeoutMs, "timeoutMs");
 }
 
 function assertPositiveSafeInteger(value: number, name: string): void {
-  if (!Number.isSafeInteger(value) || value <= 0) {
-    throw new RangeError(`${name} must be a positive safe integer.`);
+  if (!Number.isSafeInteger(value) || value <= 0 || value > maxTimerMs) {
+    throw new RangeError(`${name} must be a positive integer no greater than ${maxTimerMs}.`);
   }
 }
 

--- a/packages/tool-browser/src/docker-browser-client.ts
+++ b/packages/tool-browser/src/docker-browser-client.ts
@@ -1,0 +1,226 @@
+import { fileURLToPath } from "node:url";
+import type { DockerSandbox, DockerSandboxClient } from "@anvia/sandbox";
+import { DockerBrowserHandle } from "./docker-browser";
+import {
+  assertOptionsObject,
+  assertPositiveSafeInteger,
+  boundedSignal,
+  defaultLifecycleTimeoutMs,
+  isRecord,
+} from "./lifecycle";
+import { cdpPort, noVncPort } from "./readiness";
+import type {
+  CreateDockerBrowserOptions,
+  DockerBrowser,
+  DockerBrowserClientOptions,
+  PullDockerBrowserImageOptions,
+  ResumeDockerBrowserOptions,
+} from "./types";
+
+const browserSchema = "1";
+const defaultSharedMemoryMb = 1024;
+const seccompProfilePath = fileURLToPath(
+  new URL("../security/seccomp_profile.json", import.meta.url),
+);
+
+export class DockerBrowserClient {
+  private readonly sandboxClient: DockerSandboxClient;
+  private readonly image: string;
+
+  constructor(options: DockerBrowserClientOptions) {
+    if (!isRecord(options)) throw new TypeError("options must be an object.");
+    if (!isSandboxClient(options.sandboxClient)) {
+      throw new TypeError("sandboxClient must be a DockerSandboxClient.");
+    }
+    assertNonEmptyString(options.image, "image");
+    this.sandboxClient = options.sandboxClient;
+    this.image = options.image;
+  }
+
+  async pullImage(options: PullDockerBrowserImageOptions = {}): Promise<void> {
+    assertOptionsObject(options);
+    const bounded = boundedSignal(options, defaultLifecycleTimeoutMs, "pull-image");
+    try {
+      await this.sandboxClient.pullImage({ image: this.image, abortSignal: bounded.signal });
+      bounded.throwIfAborted();
+    } catch (error) {
+      throw bounded.normalize(error, "Unable to pull the browser image.", "startup_failed");
+    } finally {
+      bounded.dispose();
+    }
+  }
+
+  async createBrowser(options: CreateDockerBrowserOptions): Promise<DockerBrowser> {
+    validateCreateOptions(options);
+    const bounded = boundedSignal(options, defaultLifecycleTimeoutMs, "create-browser");
+    const resources = {
+      ...options.resources,
+      sharedMemoryMb: options.resources?.sharedMemoryMb ?? defaultSharedMemoryMb,
+    };
+    let sandboxOptions: Parameters<typeof this.sandboxClient.createSandbox>[0] = {
+      image: this.image,
+      workdir: "/workspace",
+      workspace: options.workspace,
+      network: { mode: "bridge", ports: [cdpPort, noVncPort] },
+      user: "pwuser",
+      labels: { "anvia.browser.schema": browserSchema },
+      resources,
+      security: {
+        noNewPrivileges: true,
+        dropCapabilities: ["ALL"],
+        addCapabilities: ["SYS_CHROOT"],
+        seccompProfile: { type: "path", path: seccompProfilePath },
+      },
+      abortSignal: bounded.signal,
+    };
+    if (options.id !== undefined) sandboxOptions = { ...sandboxOptions, id: options.id };
+    if (options.runtime !== undefined) {
+      sandboxOptions = { ...sandboxOptions, runtime: options.runtime };
+    }
+    let sandbox: DockerSandbox | undefined;
+    try {
+      sandbox = await this.sandboxClient.createSandbox(sandboxOptions);
+      await configureBrowser(sandbox, options, bounded.signal);
+      await startBrowserServices(sandbox, bounded.signal);
+      bounded.throwIfAborted();
+      return new DockerBrowserHandle(sandbox);
+    } catch (error) {
+      let cleanupError: unknown;
+      try {
+        await sandbox?.destroy();
+      } catch (caught) {
+        cleanupError = caught;
+      }
+      throw bounded.normalize(
+        combineCleanupError(error, cleanupError, "Browser sandbox cleanup also failed."),
+        "Unable to configure the browser sandbox.",
+        "startup_failed",
+      );
+    } finally {
+      bounded.dispose();
+    }
+  }
+
+  async resumeBrowser(options: ResumeDockerBrowserOptions): Promise<DockerBrowser> {
+    assertOptionsObject(options);
+    assertNonEmptyString(options.id, "id");
+    const bounded = boundedSignal(options, defaultLifecycleTimeoutMs, "resume-browser");
+    let sandbox: DockerSandbox | undefined;
+    try {
+      sandbox = await this.sandboxClient.resumeSandbox({
+        id: options.id,
+        abortSignal: bounded.signal,
+      });
+      await assertBrowserImage(sandbox, bounded.signal);
+      await startBrowserServices(sandbox, bounded.signal);
+      bounded.throwIfAborted();
+      return new DockerBrowserHandle(sandbox);
+    } catch (error) {
+      let cleanupError: unknown;
+      try {
+        await sandbox?.stop();
+      } catch (caught) {
+        cleanupError = caught;
+      }
+      throw bounded.normalize(
+        combineCleanupError(error, cleanupError, "Resumed browser cleanup also failed."),
+        "Unable to resume browser services.",
+        "startup_failed",
+      );
+    } finally {
+      bounded.dispose();
+    }
+  }
+}
+
+async function configureBrowser(
+  sandbox: DockerSandbox,
+  options: CreateDockerBrowserOptions,
+  abortSignal: AbortSignal,
+): Promise<void> {
+  const result = await sandbox.runtime.exec({
+    command: "/usr/local/bin/anvia-browser-configure",
+    input: JSON.stringify({
+      password: options.desktop.password,
+      width: options.desktop.viewport.width,
+      height: options.desktop.viewport.height,
+    }),
+    abortSignal,
+  });
+  if (result.status !== "exited" || result.exitCode !== 0) {
+    throw new Error("Browser image rejected its runtime configuration.");
+  }
+}
+
+async function assertBrowserImage(sandbox: DockerSandbox, abortSignal: AbortSignal): Promise<void> {
+  const result = await sandbox.runtime.exec({
+    command: "/usr/local/bin/anvia-browser-version",
+    abortSignal,
+  });
+  if (
+    result.status !== "exited" ||
+    result.exitCode !== 0 ||
+    new TextDecoder("utf-8", { fatal: true }).decode(result.stdout).trim() !== browserSchema
+  ) {
+    throw new Error("Sandbox does not contain a compatible Anvia browser image.");
+  }
+}
+
+async function startBrowserServices(
+  sandbox: DockerSandbox,
+  abortSignal: AbortSignal,
+): Promise<void> {
+  await sandbox.runtime.startProcess({
+    command: "/usr/local/bin/anvia-browser-start",
+    abortSignal,
+  });
+}
+
+function validateCreateOptions(options: CreateDockerBrowserOptions): void {
+  assertOptionsObject(options);
+  if (options.id !== undefined) assertNonEmptyString(options.id, "id");
+  if (!isRecord(options.workspace)) throw new TypeError("workspace must be an object.");
+  if (!isRecord(options.network) || options.network.mode !== "bridge") {
+    throw new TypeError('network must be { mode: "bridge" }.');
+  }
+  if (!isRecord(options.desktop) || options.desktop.protocol !== "novnc") {
+    throw new TypeError('desktop must use protocol: "novnc".');
+  }
+  if (!/^[\x20-\x7e]{8}$/.test(options.desktop.password)) {
+    throw new TypeError("desktop.password must contain exactly 8 printable ASCII characters.");
+  }
+  if (!isRecord(options.desktop.viewport)) {
+    throw new TypeError("desktop.viewport must be an object.");
+  }
+  assertIntegerInRange(options.desktop.viewport.width, "desktop.viewport.width", 640, 3840);
+  assertIntegerInRange(options.desktop.viewport.height, "desktop.viewport.height", 480, 2160);
+  if (options.timeoutMs !== undefined) assertPositiveSafeInteger(options.timeoutMs, "timeoutMs");
+  if (options.runtime?.maxProcesses !== undefined && options.runtime.maxProcesses < 1) {
+    throw new RangeError("runtime.maxProcesses must allow the browser service process.");
+  }
+}
+
+function assertIntegerInRange(value: number, name: string, min: number, max: number): void {
+  if (!Number.isSafeInteger(value) || value < min || value > max) {
+    throw new RangeError(`${name} must be a safe integer between ${min} and ${max}.`);
+  }
+}
+
+function assertNonEmptyString(value: unknown, name: string): asserts value is string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new TypeError(`${name} must be a non-empty string.`);
+  }
+}
+
+function isSandboxClient(value: unknown): value is DockerSandboxClient {
+  return (
+    isRecord(value) &&
+    typeof value.pullImage === "function" &&
+    typeof value.createSandbox === "function" &&
+    typeof value.resumeSandbox === "function"
+  );
+}
+
+function combineCleanupError(error: unknown, cleanupError: unknown, message: string): unknown {
+  return cleanupError === undefined ? error : new AggregateError([error, cleanupError], message);
+}

--- a/packages/tool-browser/src/docker-browser.ts
+++ b/packages/tool-browser/src/docker-browser.ts
@@ -1,131 +1,76 @@
-import { fileURLToPath } from "node:url";
 import type {
   DockerSandbox,
-  DockerSandboxClient,
   DockerSandboxInspectionOptions,
   DockerSandboxInspector,
-  DockerSandboxPublishedPort,
   DockerSandboxState,
 } from "@anvia/sandbox";
 import { connectPlaywrightBrowser, type PlaywrightBrowserConnectionImpl } from "./connection";
 import { BrowserControlState } from "./control";
-import { BrowserError } from "./errors";
+import { BrowserError, cancellationError } from "./errors";
+import {
+  assertOptionsObject,
+  assertPositiveSafeInteger,
+  boundedSignal,
+  defaultLifecycleTimeoutMs,
+  validateLifecycleOptions,
+  waitForSharedLifecycle,
+} from "./lifecycle";
+import {
+  browserCapabilities,
+  cdpPort,
+  endpointFor,
+  normalizeReadinessError,
+  noVncPort,
+  probeBrowserCapability,
+} from "./readiness";
 import type {
+  BrowserCapability,
+  BrowserCapabilitySnapshot,
   BrowserConnectOptions,
   BrowserDesktopEndpoint,
+  BrowserLifecycleOptions,
+  BrowserReadinessSnapshot,
   BrowserWaitUntilReadyOptions,
-  CreateDockerBrowserOptions,
   DockerBrowser,
-  DockerBrowserClientOptions,
   PlaywrightBrowserConnection,
-  PullDockerBrowserImageOptions,
-  ResumeDockerBrowserOptions,
 } from "./types";
 
-const cdpPort = 9222;
-const noVncPort = 6080;
-const browserSchema = "1";
-const defaultSharedMemoryMb = 1024;
-const seccompProfilePath = fileURLToPath(
-  new URL("../security/seccomp_profile.json", import.meta.url),
-);
+const defaultConnectTimeoutMs = 30_000;
+const capabilities = browserCapabilities;
 
-export class DockerBrowserClient {
-  private readonly sandboxClient: DockerSandboxClient;
-  private readonly image: string;
+type OwnedOperation = {
+  controller: AbortController;
+  promise: Promise<unknown>;
+};
 
-  constructor(options: DockerBrowserClientOptions) {
-    if (!isRecord(options)) throw new TypeError("options must be an object.");
-    if (!isSandboxClient(options.sandboxClient)) {
-      throw new TypeError("sandboxClient must be a DockerSandboxClient.");
-    }
-    assertNonEmptyString(options.image, "image");
-    this.sandboxClient = options.sandboxClient;
-    this.image = options.image;
-  }
+type HandleState = "active" | "stopping" | "stopped" | "destroying" | "destroyed" | "error";
 
-  async pullImage(options: PullDockerBrowserImageOptions = {}): Promise<void> {
-    assertOptionsObject(options);
-    let pullOptions: Parameters<typeof this.sandboxClient.pullImage>[0] = { image: this.image };
-    if (options.abortSignal !== undefined) {
-      pullOptions = { ...pullOptions, abortSignal: options.abortSignal };
-    }
-    await this.sandboxClient.pullImage(pullOptions);
-  }
-
-  async createBrowser(options: CreateDockerBrowserOptions): Promise<DockerBrowser> {
-    validateCreateOptions(options);
-    options.abortSignal?.throwIfAborted();
-    const resources = {
-      ...options.resources,
-      sharedMemoryMb: options.resources?.sharedMemoryMb ?? defaultSharedMemoryMb,
-    };
-    let sandboxOptions: Parameters<typeof this.sandboxClient.createSandbox>[0] = {
-      image: this.image,
-      workdir: "/workspace",
-      workspace: options.workspace,
-      network: { mode: "bridge", ports: [cdpPort, noVncPort] },
-      user: "pwuser",
-      labels: {
-        "anvia.browser.schema": browserSchema,
-      },
-      resources,
-      security: {
-        noNewPrivileges: true,
-        dropCapabilities: ["ALL"],
-        addCapabilities: ["SYS_CHROOT"],
-        seccompProfile: { type: "path", path: seccompProfilePath },
-      },
-    };
-    if (options.id !== undefined) sandboxOptions = { ...sandboxOptions, id: options.id };
-    if (options.runtime !== undefined) {
-      sandboxOptions = { ...sandboxOptions, runtime: options.runtime };
-    }
-    if (options.abortSignal !== undefined) {
-      sandboxOptions = { ...sandboxOptions, abortSignal: options.abortSignal };
-    }
-    const sandbox = await this.sandboxClient.createSandbox(sandboxOptions);
-
-    try {
-      await configureBrowser(sandbox, options);
-      await startBrowserServices(sandbox, options.abortSignal);
-      return new DockerBrowserHandle(sandbox);
-    } catch (error) {
-      await sandbox.destroy().catch(() => undefined);
-      throw new BrowserError("Unable to configure the browser sandbox.", "startup_failed", {
-        cause: error,
-      });
-    }
-  }
-
-  async resumeBrowser(options: ResumeDockerBrowserOptions): Promise<DockerBrowser> {
-    assertOptionsObject(options);
-    assertNonEmptyString(options.id, "id");
-    options.abortSignal?.throwIfAborted();
-    const sandbox = await this.sandboxClient.resumeSandbox(options);
-    try {
-      await assertBrowserImage(sandbox, options.abortSignal);
-      await startBrowserServices(sandbox, options.abortSignal);
-      return new DockerBrowserHandle(sandbox);
-    } catch (error) {
-      await sandbox.stop().catch(() => undefined);
-      throw new BrowserError("Unable to resume browser services.", "startup_failed", {
-        cause: error,
-      });
-    }
-  }
-}
-
-class DockerBrowserHandle implements DockerBrowser {
+export class DockerBrowserHandle implements DockerBrowser {
   readonly id: string;
   readonly sandbox: DockerSandbox;
   readonly desktop: BrowserDesktopEndpoint;
   private readonly control = new BrowserControlState();
   private readonly connections = new Set<PlaywrightBrowserConnectionImpl>();
+  private readonly ownedOperations = new Set<OwnedOperation>();
+  private readonly capabilityStates = new Map<BrowserCapability, BrowserCapabilitySnapshot>(
+    capabilities.map((capability) => [capability, Object.freeze({ capability, state: "unknown" })]),
+  );
+  private readonly capabilityGenerations = new Map<BrowserCapability, number>(
+    capabilities.map((capability) => [capability, 0]),
+  );
+  private handleState: HandleState = "active";
+  private connectionPending = false;
+  private stopPromise: Promise<void> | undefined;
+  private destroyPromise: Promise<void> | undefined;
+  private readonly connectBrowser: typeof connectPlaywrightBrowser;
 
-  constructor(sandbox: DockerSandbox) {
+  constructor(
+    sandbox: DockerSandbox,
+    connectBrowser: typeof connectPlaywrightBrowser = connectPlaywrightBrowser,
+  ) {
     this.sandbox = sandbox;
     this.id = sandbox.id;
+    this.connectBrowser = connectBrowser;
     this.desktop = Object.freeze({
       protocol: "novnc",
       containerPort: noVncPort,
@@ -134,259 +79,420 @@ class DockerBrowserHandle implements DockerBrowser {
   }
 
   get state(): DockerSandboxState {
-    return this.sandbox.state;
+    return this.handleState === "active" ? this.sandbox.state : this.handleState;
   }
 
   inspector(options: DockerSandboxInspectionOptions): DockerSandboxInspector {
     return this.sandbox.inspector(options);
   }
 
-  async waitUntilReady(options: BrowserWaitUntilReadyOptions): Promise<void> {
-    assertOptionsObject(options);
-    assertPositiveSafeInteger(options.timeoutMs, "timeoutMs");
+  readiness(): BrowserReadinessSnapshot {
+    const terminal =
+      this.handleState === "destroyed" || this.handleState === "destroying"
+        ? "destroyed"
+        : this.handleState === "stopped" || this.handleState === "stopping"
+          ? "stopped"
+          : undefined;
+    const entries = Object.fromEntries(
+      capabilities.map((capability) => {
+        const current = this.capabilityStates.get(capability)!;
+        return [
+          capability,
+          terminal === undefined
+            ? current
+            : Object.freeze({ capability, state: terminal } satisfies BrowserCapabilitySnapshot),
+        ];
+      }),
+    ) as Record<BrowserCapability, BrowserCapabilitySnapshot>;
+    const values = Object.values(entries);
+    const state =
+      this.handleState === "error"
+        ? "failed"
+        : (terminal ??
+          (values.some((value) => value.state === "checking")
+            ? "checking"
+            : values.every((value) => value.state === "unknown")
+              ? "unknown"
+              : values.every((value) => value.state === "ready")
+                ? "ready"
+                : values.some((value) => value.state === "failed")
+                  ? values.some((value) => value.state === "ready")
+                    ? "degraded"
+                    : "failed"
+                  : "partial"));
+    return Object.freeze({ state, capabilities: Object.freeze(entries) });
+  }
+
+  async waitForCapabilities(
+    options: BrowserWaitUntilReadyOptions,
+  ): Promise<BrowserReadinessSnapshot> {
+    validateReadinessOptions(options);
     this.assertRunning();
-    const timeout = AbortSignal.timeout(options.timeoutMs);
-    const abortSignal =
-      options.abortSignal === undefined ? timeout : AbortSignal.any([options.abortSignal, timeout]);
-    try {
-      await Promise.all([
-        this.sandbox.runtime.waitForPort({
-          containerPort: cdpPort,
-          timeoutMs: options.timeoutMs,
-          abortSignal,
-        }),
-        this.sandbox.runtime.waitForPort({
-          containerPort: noVncPort,
-          timeoutMs: options.timeoutMs,
-          abortSignal,
-        }),
-      ]);
-      await Promise.all([
-        assertHttpReady(`${endpointFor(this.sandbox, cdpPort)}/json/version`, abortSignal),
-        assertHttpReady(`${endpointFor(this.sandbox, noVncPort)}/vnc.html`, abortSignal),
-      ]);
-    } catch (error) {
-      if (options.abortSignal?.aborted) options.abortSignal.throwIfAborted();
-      throw new BrowserError("Browser did not become ready before the timeout.", "not_ready", {
-        cause: error,
-      });
+    if (options.abortSignal?.aborted) {
+      throw cancellationError(options.abortSignal.reason, "readiness");
     }
+    const requested = options.capabilities ?? capabilities;
+    const ownedController = new AbortController();
+    const timeoutController = new AbortController();
+    const deadline = Date.now() + options.timeoutMs;
+    const timer = setTimeout(
+      () =>
+        timeoutController.abort(
+          new BrowserError("Browser readiness timed out.", "readiness_timeout", {
+            phase: "readiness",
+          }),
+        ),
+      options.timeoutMs,
+    );
+    timer.unref?.();
+    const signals = [ownedController.signal, timeoutController.signal];
+    if (options.abortSignal !== undefined) signals.push(options.abortSignal);
+    const abortSignal = AbortSignal.any(signals);
+    const previous = new Map(
+      requested.map((capability) => [capability, this.capabilityStates.get(capability)!]),
+    );
+    const generations = new Map(
+      requested.map((capability) => {
+        const generation = (this.capabilityGenerations.get(capability) ?? 0) + 1;
+        this.capabilityGenerations.set(capability, generation);
+        return [capability, generation] as const;
+      }),
+    );
+    for (const capability of requested) this.setCapability(capability, "checking");
+
+    const promise = Promise.allSettled(
+      requested.map(async (capability) => {
+        try {
+          await probeBrowserCapability({
+            capability,
+            sandbox: this.sandbox,
+            control: this.control,
+            connectBrowser: this.connectBrowser,
+            abortSignal,
+            deadline,
+          });
+          abortSignal.throwIfAborted();
+          if (this.capabilityGenerations.get(capability) === generations.get(capability)) {
+            this.setCapability(capability, "ready");
+          }
+        } catch (error) {
+          const normalized = normalizeReadinessError(error, capability, {
+            callerAborted: options.abortSignal?.aborted === true,
+            timedOut: timeoutController.signal.aborted,
+          });
+          if (this.capabilityGenerations.get(capability) === generations.get(capability)) {
+            if (options.abortSignal?.aborted) {
+              this.capabilityStates.set(capability, previous.get(capability)!);
+            } else {
+              this.setCapability(capability, "failed", normalized);
+            }
+          }
+          throw normalized;
+        }
+      }),
+    );
+    const owned = { controller: ownedController, promise };
+    this.ownedOperations.add(owned);
+    try {
+      const results = await promise;
+      if (options.abortSignal?.aborted) {
+        throw cancellationError(options.abortSignal.reason, "readiness");
+      }
+      const failures = results.filter(
+        (result): result is PromiseRejectedResult => result.status === "rejected",
+      );
+      this.updateControlAvailability();
+      if (failures.length > 0) throw failures[0]!.reason;
+      return this.readiness();
+    } finally {
+      clearTimeout(timer);
+      this.ownedOperations.delete(owned);
+    }
+  }
+
+  async waitUntilReady(options: BrowserWaitUntilReadyOptions): Promise<void> {
+    await this.waitForCapabilities(options);
   }
 
   async connect(options: BrowserConnectOptions = {}): Promise<PlaywrightBrowserConnection> {
     assertOptionsObject(options);
+    if (options.timeoutMs !== undefined) assertPositiveSafeInteger(options.timeoutMs, "timeoutMs");
     this.assertRunning();
-    try {
-      let connectOptions: Parameters<typeof connectPlaywrightBrowser>[0] = {
-        endpointUrl: endpointFor(this.sandbox, cdpPort),
-        control: this.control,
-      };
-      if (options.abortSignal !== undefined) {
-        connectOptions = { ...connectOptions, abortSignal: options.abortSignal };
+    if (options.abortSignal?.aborted) {
+      throw cancellationError(options.abortSignal.reason, "connect");
+    }
+    if (this.connectionPending || this.connections.size > 0) {
+      throw new BrowserError(
+        "Browser already has an active or pending automation connection.",
+        "agent_action_busy",
+        { phase: "connect" },
+      );
+    }
+    this.connectionPending = true;
+    const controller = new AbortController();
+    const signals = [controller.signal];
+    if (options.abortSignal !== undefined) signals.push(options.abortSignal);
+    const abortSignal = AbortSignal.any(signals);
+    let owned!: OwnedOperation;
+    const promise = (async () => {
+      // Register the operation before endpoint resolution or the connection factory can fail.
+      await Promise.resolve();
+      try {
+        abortSignal.throwIfAborted();
+        const connection = await this.connectBrowser({
+          endpointUrl: endpointFor(this.sandbox, cdpPort),
+          control: this.control,
+          timeoutMs: options.timeoutMs ?? defaultConnectTimeoutMs,
+          abortSignal,
+          scheduling: options.scheduling,
+          onClosed: (closedConnection) => this.connections.delete(closedConnection),
+        });
+        this.connections.add(connection);
+        const disconnectedDuringInitialization = connection.closed;
+        if (
+          disconnectedDuringInitialization ||
+          this.handleState !== "active" ||
+          this.state !== "running"
+        ) {
+          this.connections.delete(connection);
+          let cleanupError: unknown;
+          try {
+            await connection.disconnect();
+          } catch (caught) {
+            cleanupError = caught;
+          }
+          if (
+            disconnectedDuringInitialization &&
+            this.handleState === "active" &&
+            this.state === "running"
+          ) {
+            throw new BrowserError(
+              "Browser disconnected while automation was initializing.",
+              "connection_closed",
+              {
+                ...(cleanupError === undefined ? {} : { cause: cleanupError }),
+                phase: "connect",
+              },
+            );
+          }
+          const lifecycleError = this.lifecycleError(
+            "Browser stopped while the connection was initializing.",
+          );
+          throw cleanupError === undefined
+            ? lifecycleError
+            : new BrowserError(lifecycleError.message, lifecycleError.code, {
+                cause: cleanupError,
+                ...(lifecycleError.phase === undefined ? {} : { phase: lifecycleError.phase }),
+              });
+        }
+        return connection;
+      } catch (error) {
+        if (options.abortSignal?.aborted) {
+          throw cancellationError(options.abortSignal.reason, "connect");
+        }
+        if (controller.signal.aborted) throw controller.signal.reason;
+        if (error instanceof BrowserError) throw error;
+        throw new BrowserError("Unable to connect to Chromium over CDP.", "transport_failure", {
+          cause: error,
+          phase: "connect",
+        });
+      } finally {
+        this.connectionPending = false;
+        this.ownedOperations.delete(owned);
       }
-      const connection = await connectPlaywrightBrowser(connectOptions);
-      this.connections.add(connection);
-      return connection;
-    } catch (error) {
-      if (options.abortSignal?.aborted) options.abortSignal.throwIfAborted();
-      throw new BrowserError("Unable to connect to Chromium over CDP.", "not_ready", {
-        cause: error,
-      });
+    })();
+    owned = { controller, promise };
+    this.ownedOperations.add(owned);
+    return promise;
+  }
+
+  async stop(options: BrowserLifecycleOptions = {}): Promise<void> {
+    assertOptionsObject(options);
+    if (this.handleState === "stopped") return;
+    if (this.handleState === "destroyed" || this.handleState === "destroying") {
+      throw new BrowserError("Browser runtime is destroyed.", "runtime_destroyed");
+    }
+    validateLifecycleOptions(options, "stop-browser");
+    if (this.stopPromise !== undefined) {
+      return waitForSharedLifecycle(this.stopPromise, options, "stop-browser");
+    }
+    this.handleState = "stopping";
+    this.control.setAvailability("disconnected");
+    const promise = this.performStop(options);
+    this.stopPromise = promise;
+    try {
+      await promise;
+    } finally {
+      if (this.stopPromise === promise) this.stopPromise = undefined;
     }
   }
 
-  async stop(options: Readonly<{ abortSignal?: AbortSignal }> = {}): Promise<void> {
+  async destroy(options: BrowserLifecycleOptions = {}): Promise<void> {
     assertOptionsObject(options);
-    await this.disconnectAll();
-    await this.sandbox.stop(options);
-  }
-
-  async destroy(): Promise<void> {
-    this.control.destroy();
-    await this.disconnectAll();
-    await this.sandbox.destroy();
+    if (this.handleState === "destroyed") return;
+    validateLifecycleOptions(options, "destroy-browser");
+    if (this.destroyPromise === undefined) {
+      this.handleState = "destroying";
+      this.control.destroy();
+      const activeStop = this.stopPromise;
+      const promise = (async () => {
+        if (activeStop !== undefined) await activeStop.catch(() => undefined);
+        await this.performDestroy();
+      })();
+      this.destroyPromise = promise;
+      void promise.then(
+        () => {
+          if (this.destroyPromise === promise) this.destroyPromise = undefined;
+        },
+        () => {
+          if (this.destroyPromise === promise) this.destroyPromise = undefined;
+        },
+      );
+    }
+    return waitForSharedLifecycle(this.destroyPromise, options, "destroy-browser");
   }
 
   async [Symbol.asyncDispose](): Promise<void> {
     await this.destroy();
   }
 
+  private async performStop(options: BrowserLifecycleOptions): Promise<void> {
+    const bounded = boundedSignal(options, defaultLifecycleTimeoutMs, "stop-browser");
+    try {
+      await this.abortOwnedOperations(
+        new BrowserError("Browser runtime is stopping.", "connection_closed", {
+          phase: "stop-browser",
+        }),
+      );
+      const disconnectFailures = await this.disconnectAll({ abortSignal: bounded.signal });
+      await this.sandbox.stop({ abortSignal: bounded.signal });
+      if (this.handleState === "stopping") this.handleState = "stopped";
+      bounded.throwIfAborted();
+      if (disconnectFailures.length > 0) {
+        throw new BrowserError(
+          "Browser stopped, but one or more automation workers failed to disconnect.",
+          "transport_failure",
+          {
+            cause: new AggregateError(disconnectFailures, "Automation worker cleanup failed."),
+            phase: "stop-browser",
+            recovery: "restart",
+          },
+        );
+      }
+    } catch (error) {
+      if (this.handleState === "stopping") this.handleState = "error";
+      throw bounded.normalize(error, "Unable to stop browser runtime.", "transport_failure");
+    } finally {
+      bounded.dispose();
+    }
+  }
+
+  private async performDestroy(): Promise<void> {
+    try {
+      await this.abortOwnedOperations(
+        new BrowserError("Browser runtime was destroyed.", "runtime_destroyed", {
+          phase: "destroy-browser",
+        }),
+      );
+      const disconnectFailures = await this.disconnectAll({});
+      await this.sandbox.destroy();
+      this.handleState = "destroyed";
+      if (disconnectFailures.length > 0) {
+        throw new BrowserError(
+          "Browser was destroyed, but one or more automation workers failed to disconnect.",
+          "transport_failure",
+          {
+            cause: new AggregateError(disconnectFailures, "Automation worker cleanup failed."),
+            phase: "destroy-browser",
+            retryable: false,
+            recovery: "none",
+          },
+        );
+      }
+    } catch (error) {
+      if (this.handleState !== "destroyed") this.handleState = "error";
+      if (error instanceof BrowserError) throw error;
+      throw new BrowserError("Unable to destroy browser runtime.", "transport_failure", {
+        cause: error,
+        phase: "destroy-browser",
+        recovery: "retry",
+      });
+    }
+  }
+
   private assertRunning(): void {
-    if (this.state !== "running") {
+    if (this.handleState === "destroyed" || this.handleState === "destroying") {
+      throw new BrowserError("Browser runtime is destroyed.", "runtime_destroyed");
+    }
+    if (this.handleState !== "active" || this.state !== "running") {
       throw new BrowserError(`Browser is not running: ${this.state}`, "invalid_state");
     }
   }
 
-  private async disconnectAll(): Promise<void> {
+  private lifecycleError(message: string): BrowserError {
+    return this.handleState === "destroying" || this.handleState === "destroyed"
+      ? new BrowserError(message, "runtime_destroyed")
+      : new BrowserError(message, "connection_closed", { phase: "connect" });
+  }
+
+  private async abortOwnedOperations(error: BrowserError): Promise<void> {
+    const operations = [...this.ownedOperations];
+    for (const operation of operations) operation.controller.abort(error);
+    await Promise.allSettled(operations.map((operation) => operation.promise));
+  }
+
+  private async disconnectAll(options: BrowserLifecycleOptions): Promise<readonly unknown[]> {
     const connections = [...this.connections];
     this.connections.clear();
     const results = await Promise.allSettled(
-      connections.map((connection) => connection.disconnect()),
+      connections.map((connection) => connection.disconnect(options)),
     );
-    const failures = results
+    return results
       .filter((result): result is PromiseRejectedResult => result.status === "rejected")
       .map((result) => result.reason);
-    if (failures.length > 0) {
-      throw new AggregateError(failures, "Unable to disconnect browser automation clients.");
+  }
+
+  private setCapability(
+    capability: BrowserCapability,
+    state: BrowserCapabilitySnapshot["state"],
+    error?: BrowserError,
+  ): void {
+    this.capabilityStates.set(
+      capability,
+      Object.freeze({
+        capability,
+        state,
+        checkedAt: new Date().toISOString(),
+        ...(error === undefined ? {} : { error }),
+      }),
+    );
+  }
+
+  private updateControlAvailability(): void {
+    if (this.handleState !== "active" || this.state !== "running") {
+      this.control.setAvailability("disconnected");
+      return;
     }
+    const failed = capabilities.some(
+      (capability) => this.capabilityStates.get(capability)?.state === "failed",
+    );
+    this.control.setAvailability(failed ? "degraded" : "available");
   }
 }
 
-async function configureBrowser(
-  sandbox: DockerSandbox,
-  options: CreateDockerBrowserOptions,
-): Promise<void> {
-  let execOptions: Parameters<typeof sandbox.runtime.exec>[0] = {
-    command: "/usr/local/bin/anvia-browser-configure",
-    input: JSON.stringify({
-      password: options.desktop.password,
-      width: options.desktop.viewport.width,
-      height: options.desktop.viewport.height,
-    }),
-  };
-  if (options.abortSignal !== undefined) {
-    execOptions = { ...execOptions, abortSignal: options.abortSignal };
-  }
-  const result = await sandbox.runtime.exec(execOptions);
-  if (result.status !== "exited" || result.exitCode !== 0) {
-    throw new Error("Browser image rejected its runtime configuration.");
-  }
-}
-
-async function assertBrowserImage(
-  sandbox: DockerSandbox,
-  abortSignal?: AbortSignal,
-): Promise<void> {
-  let execOptions: Parameters<typeof sandbox.runtime.exec>[0] = {
-    command: "/usr/local/bin/anvia-browser-version",
-  };
-  if (abortSignal !== undefined) execOptions = { ...execOptions, abortSignal };
-  const result = await sandbox.runtime.exec(execOptions);
-  if (
-    result.status !== "exited" ||
-    result.exitCode !== 0 ||
-    new TextDecoder("utf-8", { fatal: true }).decode(result.stdout).trim() !== browserSchema
-  ) {
-    throw new Error("Sandbox does not contain a compatible Anvia browser image.");
-  }
-}
-
-async function startBrowserServices(
-  sandbox: DockerSandbox,
-  abortSignal?: AbortSignal,
-): Promise<void> {
-  let startOptions: Parameters<typeof sandbox.runtime.startProcess>[0] = {
-    command: "/usr/local/bin/anvia-browser-start",
-  };
-  if (abortSignal !== undefined) startOptions = { ...startOptions, abortSignal };
-  await sandbox.runtime.startProcess(startOptions);
-}
-
-async function assertHttpReady(url: string, abortSignal: AbortSignal): Promise<void> {
-  while (true) {
-    abortSignal.throwIfAborted();
-    try {
-      const response = await fetch(url, { signal: abortSignal, redirect: "error" });
-      if (response.ok) {
-        await response.body?.cancel();
-        return;
-      }
-      await response.body?.cancel();
-    } catch (error) {
-      if (abortSignal.aborted) throw abortSignal.reason ?? error;
-    }
-    await waitForRetry(abortSignal);
-  }
-}
-
-async function waitForRetry(abortSignal: AbortSignal): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(finish, 50);
-    const abort = () => finish(abortSignal.reason ?? new DOMException("Aborted", "AbortError"));
-    abortSignal.addEventListener("abort", abort, { once: true });
-
-    function finish(error?: unknown): void {
-      clearTimeout(timeout);
-      abortSignal.removeEventListener("abort", abort);
-      if (error === undefined) resolve();
-      else reject(error);
-    }
-  });
-}
-
-function endpointFor(sandbox: DockerSandbox, containerPort: number): string {
-  const published = publishedPort(sandbox, containerPort);
-  return `http://${hostForUrl(published.host)}:${published.hostPort}`;
-}
-
-function publishedPort(sandbox: DockerSandbox, containerPort: number): DockerSandboxPublishedPort {
-  const port = sandbox.runtime.publishedPorts.find(
-    (candidate) => candidate.containerPort === containerPort && candidate.protocol === "tcp",
-  );
-  if (port === undefined) {
-    throw new BrowserError(`Browser port is not published: ${containerPort}`, "invalid_state");
-  }
-  return port;
-}
-
-function hostForUrl(host: string): string {
-  return host.includes(":") ? `[${host}]` : host;
-}
-
-function validateCreateOptions(options: CreateDockerBrowserOptions): void {
+function validateReadinessOptions(options: BrowserWaitUntilReadyOptions): void {
   assertOptionsObject(options);
-  if (options.id !== undefined) assertNonEmptyString(options.id, "id");
-  if (!isRecord(options.workspace)) throw new TypeError("workspace must be an object.");
-  if (!isRecord(options.network) || options.network.mode !== "bridge") {
-    throw new TypeError('network must be { mode: "bridge" }.');
+  assertPositiveSafeInteger(options.timeoutMs, "timeoutMs");
+  if (options.capabilities === undefined) return;
+  if (!Array.isArray(options.capabilities) || options.capabilities.length === 0) {
+    throw new TypeError("capabilities must be a non-empty array.");
   }
-  if (!isRecord(options.desktop) || options.desktop.protocol !== "novnc") {
-    throw new TypeError('desktop must use protocol: "novnc".');
+  const unique = new Set<BrowserCapability>();
+  for (const capability of options.capabilities) {
+    if (!capabilities.includes(capability)) {
+      throw new TypeError(`Unsupported browser capability: ${capability}`);
+    }
+    if (unique.has(capability)) throw new TypeError(`Duplicate browser capability: ${capability}`);
+    unique.add(capability);
   }
-  if (!/^[\x20-\x7e]{8}$/.test(options.desktop.password)) {
-    throw new TypeError("desktop.password must contain exactly 8 printable ASCII characters.");
-  }
-  if (!isRecord(options.desktop.viewport)) {
-    throw new TypeError("desktop.viewport must be an object.");
-  }
-  assertIntegerInRange(options.desktop.viewport.width, "desktop.viewport.width", 640, 3840);
-  assertIntegerInRange(options.desktop.viewport.height, "desktop.viewport.height", 480, 2160);
-  if (options.runtime?.maxProcesses !== undefined && options.runtime.maxProcesses < 1) {
-    throw new RangeError("runtime.maxProcesses must allow the browser service process.");
-  }
-}
-
-function assertIntegerInRange(value: number, name: string, min: number, max: number): void {
-  if (!Number.isSafeInteger(value) || value < min || value > max) {
-    throw new RangeError(`${name} must be a safe integer between ${min} and ${max}.`);
-  }
-}
-
-function assertPositiveSafeInteger(value: number, name: string): void {
-  if (!Number.isSafeInteger(value) || value <= 0) {
-    throw new RangeError(`${name} must be a positive safe integer.`);
-  }
-}
-
-function assertNonEmptyString(value: unknown, name: string): asserts value is string {
-  if (typeof value !== "string" || value.length === 0) {
-    throw new TypeError(`${name} must be a non-empty string.`);
-  }
-}
-
-function assertOptionsObject(value: unknown): asserts value is Record<string, unknown> {
-  if (!isRecord(value)) throw new TypeError("options must be an object.");
-}
-
-function isSandboxClient(value: unknown): value is DockerSandboxClient {
-  return (
-    isRecord(value) &&
-    typeof value.pullImage === "function" &&
-    typeof value.createSandbox === "function" &&
-    typeof value.resumeSandbox === "function"
-  );
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/tool-browser/src/errors.ts
+++ b/packages/tool-browser/src/errors.ts
@@ -1,18 +1,78 @@
+import type { BrowserCapability } from "./types";
+
 export type BrowserErrorCode =
+  | "action_timeout"
+  | "agent_action_busy"
+  | "cancelled"
   | "connection_closed"
+  | "connection_timeout"
+  | "human_control_conflict"
   | "human_controlled"
   | "invalid_state"
+  | "lifecycle_timeout"
   | "navigation_blocked"
   | "not_ready"
-  | "startup_failed";
+  | "readiness_timeout"
+  | "runtime_destroyed"
+  | "startup_failed"
+  | "tool_failed"
+  | "transport_failure";
+
+export type BrowserErrorRecovery = "none" | "retry" | "reconnect" | "restart" | "recreate";
+
+export type BrowserErrorOptions = ErrorOptions &
+  Readonly<{
+    retryable?: boolean;
+    recovery?: BrowserErrorRecovery;
+    capability?: BrowserCapability;
+    phase?: string;
+  }>;
+
+const defaults: Record<
+  BrowserErrorCode,
+  Readonly<{ retryable: boolean; recovery: BrowserErrorRecovery }>
+> = {
+  action_timeout: { retryable: true, recovery: "retry" },
+  agent_action_busy: { retryable: true, recovery: "retry" },
+  cancelled: { retryable: true, recovery: "retry" },
+  connection_closed: { retryable: true, recovery: "reconnect" },
+  connection_timeout: { retryable: true, recovery: "reconnect" },
+  human_control_conflict: { retryable: true, recovery: "retry" },
+  human_controlled: { retryable: true, recovery: "retry" },
+  invalid_state: { retryable: false, recovery: "none" },
+  lifecycle_timeout: { retryable: true, recovery: "retry" },
+  navigation_blocked: { retryable: false, recovery: "none" },
+  not_ready: { retryable: true, recovery: "retry" },
+  readiness_timeout: { retryable: true, recovery: "retry" },
+  runtime_destroyed: { retryable: false, recovery: "recreate" },
+  startup_failed: { retryable: true, recovery: "recreate" },
+  tool_failed: { retryable: true, recovery: "retry" },
+  transport_failure: { retryable: true, recovery: "reconnect" },
+};
 
 export class BrowserError extends Error {
+  readonly retryable: boolean;
+  readonly recovery: BrowserErrorRecovery;
+  readonly capability: BrowserCapability | undefined;
+  readonly phase: string | undefined;
+
   constructor(
     message: string,
     readonly code: BrowserErrorCode,
-    options?: ErrorOptions,
+    options: BrowserErrorOptions = {},
   ) {
     super(message, options);
     this.name = "BrowserError";
+    this.retryable = options.retryable ?? defaults[code].retryable;
+    this.recovery = options.recovery ?? defaults[code].recovery;
+    this.capability = options.capability;
+    this.phase = options.phase;
   }
+}
+
+export function cancellationError(reason: unknown, phase: string): BrowserError {
+  return new BrowserError("Browser operation was cancelled by the caller.", "cancelled", {
+    cause: reason,
+    phase,
+  });
 }

--- a/packages/tool-browser/src/index.ts
+++ b/packages/tool-browser/src/index.ts
@@ -1,15 +1,28 @@
-export { DockerBrowserClient } from "./docker-browser";
-export { BrowserError, type BrowserErrorCode } from "./errors";
+export { DockerBrowserClient } from "./docker-browser-client";
+export {
+  BrowserError,
+  type BrowserErrorCode,
+  type BrowserErrorOptions,
+  type BrowserErrorRecovery,
+} from "./errors";
 export { createBrowserTools } from "./tools";
 export type {
   AcquireBrowserHumanControlOptions,
+  BrowserActionOptions,
+  BrowserCapability,
+  BrowserCapabilitySnapshot,
+  BrowserCapabilityState,
   BrowserConnectOptions,
   BrowserControl,
+  BrowserControlAvailability,
   BrowserControlSnapshot,
   BrowserDesktopEndpoint,
   BrowserDesktopOptions,
   BrowserHumanControlLease,
+  BrowserLifecycleOptions,
   BrowserNavigationPolicy,
+  BrowserReadinessSnapshot,
+  BrowserSchedulingOptions,
   BrowserTab,
   BrowserToolLimits,
   BrowserToolName,

--- a/packages/tool-browser/src/lifecycle.ts
+++ b/packages/tool-browser/src/lifecycle.ts
@@ -1,0 +1,127 @@
+import { BrowserError, cancellationError } from "./errors";
+import type { BrowserLifecycleOptions } from "./types";
+
+export const defaultLifecycleTimeoutMs = 120_000;
+const maxTimerMs = 2_147_483_647;
+
+export type BoundedSignal = {
+  signal: AbortSignal;
+  timedOut: () => boolean;
+  throwIfAborted: () => void;
+  normalize: (
+    error: unknown,
+    message: string,
+    code: "startup_failed" | "transport_failure",
+  ) => BrowserError;
+  dispose: () => void;
+};
+
+export function boundedSignal(
+  options: BrowserLifecycleOptions,
+  defaultTimeoutMs: number,
+  phase: string,
+): BoundedSignal {
+  const timeoutMs = options.timeoutMs ?? defaultTimeoutMs;
+  assertPositiveSafeInteger(timeoutMs, "timeoutMs");
+  if (options.abortSignal?.aborted) throw cancellationError(options.abortSignal.reason, phase);
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () =>
+      controller.abort(
+        new BrowserError(`Browser lifecycle operation timed out: ${phase}.`, "lifecycle_timeout", {
+          phase,
+        }),
+      ),
+    timeoutMs,
+  );
+  timer.unref?.();
+  const signal =
+    options.abortSignal === undefined
+      ? controller.signal
+      : AbortSignal.any([options.abortSignal, controller.signal]);
+  return {
+    signal,
+    timedOut: () => controller.signal.aborted,
+    throwIfAborted: () => {
+      if (options.abortSignal?.aborted) {
+        throw cancellationError(options.abortSignal.reason, phase);
+      }
+      if (controller.signal.aborted) throw controller.signal.reason;
+    },
+    normalize: (error, message, code) => {
+      if (options.abortSignal?.aborted) {
+        return error instanceof AggregateError
+          ? new BrowserError("Browser operation was cancelled by the caller.", "cancelled", {
+              cause: error,
+              phase,
+            })
+          : cancellationError(options.abortSignal.reason, phase);
+      }
+      if (controller.signal.aborted) {
+        const reason = controller.signal.reason as BrowserError;
+        return error === reason
+          ? reason
+          : new BrowserError(reason.message, "lifecycle_timeout", { cause: error, phase });
+      }
+      if (error instanceof BrowserError) return error;
+      return new BrowserError(message, code, { cause: error, phase });
+    },
+    dispose: () => clearTimeout(timer),
+  };
+}
+
+export function validateLifecycleOptions(options: BrowserLifecycleOptions, phase: string): void {
+  if (options.timeoutMs !== undefined) assertPositiveSafeInteger(options.timeoutMs, "timeoutMs");
+  if (options.abortSignal?.aborted) {
+    throw cancellationError(options.abortSignal.reason, phase);
+  }
+}
+
+export async function waitForSharedLifecycle(
+  promise: Promise<void>,
+  options: BrowserLifecycleOptions,
+  phase: string,
+): Promise<void> {
+  const bounded = boundedSignal(options, defaultLifecycleTimeoutMs, phase);
+  try {
+    await waitForPromise(promise, bounded.signal);
+    bounded.throwIfAborted();
+  } catch (error) {
+    throw bounded.normalize(error, `Unable to wait for ${phase}.`, "transport_failure");
+  } finally {
+    bounded.dispose();
+  }
+}
+
+export function assertPositiveSafeInteger(value: number, name: string): void {
+  if (!Number.isSafeInteger(value) || value <= 0 || value > maxTimerMs) {
+    throw new RangeError(`${name} must be a positive integer no greater than ${maxTimerMs}.`);
+  }
+}
+
+export function assertOptionsObject(value: unknown): asserts value is Record<string, unknown> {
+  if (!isRecord(value)) throw new TypeError("options must be an object.");
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function waitForPromise<T>(promise: Promise<T>, abortSignal: AbortSignal): Promise<T> {
+  abortSignal.throwIfAborted();
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      abortSignal.removeEventListener("abort", abort);
+      callback();
+    };
+    const abort = () => finish(() => reject(abortSignal.reason));
+    abortSignal.addEventListener("abort", abort, { once: true });
+    void promise.then(
+      (value) => finish(() => resolve(value)),
+      (error) => finish(() => reject(error)),
+    );
+  });
+}

--- a/packages/tool-browser/src/readiness.ts
+++ b/packages/tool-browser/src/readiness.ts
@@ -1,0 +1,189 @@
+import type { DockerSandbox, DockerSandboxPublishedPort } from "@anvia/sandbox";
+import { type connectPlaywrightBrowser } from "./connection";
+import type { BrowserControlState } from "./control";
+import { BrowserError } from "./errors";
+import type { BrowserCapability } from "./types";
+
+export const cdpPort = 9222;
+export const noVncPort = 6080;
+export const browserCapabilities = ["runtime", "browser", "automation", "desktop"] as const;
+
+const automationProbeAttemptTimeoutMs = 5_000;
+
+export async function probeBrowserCapability(options: {
+  capability: BrowserCapability;
+  sandbox: DockerSandbox;
+  control: BrowserControlState;
+  connectBrowser: typeof connectPlaywrightBrowser;
+  abortSignal: AbortSignal;
+  deadline: number;
+}): Promise<void> {
+  const { capability, sandbox, abortSignal, deadline } = options;
+  switch (capability) {
+    case "runtime":
+      if (sandbox.state !== "running") {
+        throw new BrowserError(`Browser is not running: ${sandbox.state}`, "invalid_state");
+      }
+      return;
+    case "browser":
+      await sandbox.runtime.waitForPort({
+        containerPort: cdpPort,
+        timeoutMs: remainingTime(deadline),
+        abortSignal,
+      });
+      await assertCdpHttpReady(`${endpointFor(sandbox, cdpPort)}/json/version`, abortSignal);
+      return;
+    case "desktop":
+      await sandbox.runtime.waitForPort({
+        containerPort: noVncPort,
+        timeoutMs: remainingTime(deadline),
+        abortSignal,
+      });
+      await assertHttpReady(`${endpointFor(sandbox, noVncPort)}/vnc.html`, abortSignal);
+      return;
+    case "automation":
+      await sandbox.runtime.waitForPort({
+        containerPort: cdpPort,
+        timeoutMs: remainingTime(deadline),
+        abortSignal,
+      });
+      await assertCdpHttpReady(`${endpointFor(sandbox, cdpPort)}/json/version`, abortSignal);
+      for (let attempt = 0; ; attempt += 1) {
+        abortSignal.throwIfAborted();
+        try {
+          const connection = await options.connectBrowser({
+            endpointUrl: endpointFor(sandbox, cdpPort),
+            control: options.control,
+            timeoutMs: Math.min(automationProbeAttemptTimeoutMs, remainingTime(deadline)),
+            abortSignal,
+          });
+          try {
+            if (connection.closed) {
+              throw new Error("CDP connection closed during initialization.");
+            }
+          } finally {
+            await connection.disconnect({
+              timeoutMs: remainingTime(deadline),
+              abortSignal,
+            });
+          }
+          abortSignal.throwIfAborted();
+          return;
+        } catch (error) {
+          if (abortSignal.aborted) throw abortSignal.reason ?? error;
+          await waitForRetry(abortSignal, Math.min(500, 50 * 2 ** Math.min(attempt, 3)));
+        }
+      }
+  }
+}
+
+export function endpointFor(sandbox: DockerSandbox, containerPort: number): string {
+  const published = publishedPort(sandbox, containerPort);
+  return `http://${hostForUrl(published.host)}:${published.hostPort}`;
+}
+
+export function normalizeReadinessError(
+  error: unknown,
+  capability: BrowserCapability,
+  state: { callerAborted: boolean; timedOut: boolean },
+): BrowserError {
+  if (state.callerAborted) {
+    return new BrowserError("Browser readiness was cancelled by the caller.", "cancelled", {
+      cause: error,
+      capability,
+      phase: "readiness",
+    });
+  }
+  if (state.timedOut) {
+    return new BrowserError(
+      `Browser ${capability} capability did not become ready before the timeout.`,
+      "readiness_timeout",
+      { cause: error, capability, phase: "readiness" },
+    );
+  }
+  if (
+    error instanceof BrowserError &&
+    (error.code === "connection_closed" || error.code === "runtime_destroyed")
+  ) {
+    return error;
+  }
+  return new BrowserError(`Browser ${capability} capability is not ready.`, "not_ready", {
+    cause: error,
+    capability,
+    phase: "readiness",
+  });
+}
+
+async function assertCdpHttpReady(url: string, abortSignal: AbortSignal): Promise<void> {
+  await assertHttpReady(url, abortSignal, async (response) => {
+    const value: unknown = await response.json();
+    if (
+      !isRecord(value) ||
+      typeof value.webSocketDebuggerUrl !== "string" ||
+      !value.webSocketDebuggerUrl.startsWith("ws")
+    ) {
+      throw new Error("CDP version endpoint did not expose a WebSocket debugger URL.");
+    }
+  });
+}
+
+async function assertHttpReady(
+  url: string,
+  abortSignal: AbortSignal,
+  verify?: (response: Response) => Promise<void>,
+): Promise<void> {
+  while (true) {
+    abortSignal.throwIfAborted();
+    try {
+      const response = await fetch(url, { signal: abortSignal, redirect: "error" });
+      try {
+        if (response.ok) {
+          await verify?.(response);
+          return;
+        }
+      } finally {
+        await response.body?.cancel().catch(() => undefined);
+      }
+    } catch (error) {
+      if (abortSignal.aborted) throw abortSignal.reason ?? error;
+    }
+    await waitForRetry(abortSignal);
+  }
+}
+
+async function waitForRetry(abortSignal: AbortSignal, delayMs = 50): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => finish(), delayMs);
+    timer.unref?.();
+    const abort = () => finish(abortSignal.reason ?? new DOMException("Aborted", "AbortError"));
+    abortSignal.addEventListener("abort", abort, { once: true });
+    function finish(error?: unknown): void {
+      clearTimeout(timer);
+      abortSignal.removeEventListener("abort", abort);
+      if (error === undefined) resolve();
+      else reject(error);
+    }
+  });
+}
+
+function remainingTime(deadline: number): number {
+  return Math.max(1, deadline - Date.now());
+}
+
+function publishedPort(sandbox: DockerSandbox, containerPort: number): DockerSandboxPublishedPort {
+  const port = sandbox.runtime.publishedPorts.find(
+    (candidate) => candidate.containerPort === containerPort && candidate.protocol === "tcp",
+  );
+  if (port === undefined) {
+    throw new BrowserError(`Browser port is not published: ${containerPort}`, "invalid_state");
+  }
+  return port;
+}
+
+function hostForUrl(host: string): string {
+  return host.includes(":") ? `[${host}]` : host;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/tool-browser/src/scheduler.ts
+++ b/packages/tool-browser/src/scheduler.ts
@@ -1,0 +1,241 @@
+import { BrowserError, cancellationError } from "./errors";
+
+type Task<T> = {
+  abortSignal?: AbortSignal;
+  abort?: () => void;
+  controller: AbortController;
+  operation: (abortSignal: AbortSignal) => Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+};
+
+type Resource = {
+  running: boolean;
+  ready: boolean;
+  tasks: Task<unknown>[];
+};
+
+export class ResourceScheduler {
+  private readonly resources = new Map<string, Resource>();
+  private readonly readyResources: string[] = [];
+  private readonly activeTasks = new Set<Task<unknown>>();
+  private readonly serial: boolean;
+  private readonly maxConcurrentResources: number;
+  private readonly maxQueuedActions: number;
+  private activeResources = 0;
+  private queuedActions = 0;
+  private closedError: BrowserError | undefined;
+
+  constructor(options: {
+    mode: "serial" | "per-tab";
+    maxConcurrentResources: number;
+    maxQueuedActions: number;
+  }) {
+    this.serial = options.mode === "serial";
+    this.maxConcurrentResources = options.maxConcurrentResources;
+    this.maxQueuedActions = options.maxQueuedActions;
+  }
+
+  run<T>(
+    resourceKey: string,
+    abortSignal: AbortSignal | undefined,
+    operation: (abortSignal: AbortSignal) => Promise<T>,
+  ): Promise<T> {
+    if (this.closedError !== undefined) return Promise.reject(this.closedError);
+    if (abortSignal?.aborted) {
+      return Promise.reject(abortReason(abortSignal, "agent-action-queue"));
+    }
+    if (this.queuedActions >= this.maxQueuedActions) {
+      return Promise.reject(
+        new BrowserError("Browser action queue capacity was reached.", "agent_action_busy", {
+          phase: "agent-action-queue",
+        }),
+      );
+    }
+
+    const key = this.serial ? "browser" : resourceKey;
+    let resource = this.resources.get(key);
+    if (resource === undefined) {
+      resource = { running: false, ready: false, tasks: [] };
+      this.resources.set(key, resource);
+    }
+
+    return new Promise<T>((resolve, reject) => {
+      const task: Task<T> = {
+        controller: new AbortController(),
+        operation,
+        resolve,
+        reject,
+        ...(abortSignal === undefined ? {} : { abortSignal }),
+      };
+      if (abortSignal !== undefined) {
+        task.abort = () => {
+          const current = this.resources.get(key);
+          const index = current?.tasks.indexOf(task as Task<unknown>) ?? -1;
+          if (index === -1) return;
+          current?.tasks.splice(index, 1);
+          this.queuedActions -= 1;
+          abortSignal.removeEventListener("abort", task.abort!);
+          reject(abortReason(abortSignal, "agent-action-queue"));
+          this.deleteIdleResource(key, current);
+        };
+        abortSignal.addEventListener("abort", task.abort, { once: true });
+      }
+      resource.tasks.push(task as Task<unknown>);
+      this.queuedActions += 1;
+      this.markReady(key, resource);
+      this.pump();
+    });
+  }
+
+  close(error = new BrowserError("Browser connection is closed.", "connection_closed")): void {
+    if (this.closedError !== undefined) return;
+    this.closedError = error;
+    for (const task of this.activeTasks) task.controller.abort(error);
+    for (const [key, resource] of this.resources) {
+      for (const task of resource.tasks.splice(0)) {
+        this.queuedActions -= 1;
+        if (task.abort !== undefined) task.abortSignal?.removeEventListener("abort", task.abort);
+        task.reject(error);
+      }
+      resource.ready = false;
+      if (!resource.running) this.resources.delete(key);
+    }
+    this.readyResources.length = 0;
+  }
+
+  private markReady(key: string, resource: Resource): void {
+    if (resource.running || resource.ready || resource.tasks.length === 0) return;
+    resource.ready = true;
+    this.readyResources.push(key);
+  }
+
+  private pump(): void {
+    while (
+      this.closedError === undefined &&
+      this.activeResources < this.maxConcurrentResources &&
+      this.readyResources.length > 0
+    ) {
+      const key = this.readyResources.shift();
+      if (key === undefined) return;
+      const resource = this.resources.get(key);
+      if (resource === undefined || resource.running || resource.tasks.length === 0) continue;
+      resource.ready = false;
+      const task = resource.tasks.shift();
+      if (task === undefined) continue;
+      this.queuedActions -= 1;
+      if (task.abort !== undefined) task.abortSignal?.removeEventListener("abort", task.abort);
+      resource.running = true;
+      this.activeResources += 1;
+      this.activeTasks.add(task);
+      const effectiveSignal =
+        task.abortSignal === undefined
+          ? task.controller.signal
+          : AbortSignal.any([task.abortSignal, task.controller.signal]);
+      let operation: Promise<unknown>;
+      try {
+        operation = task.operation(effectiveSignal);
+      } catch (error) {
+        operation = Promise.reject(error);
+      }
+      void operation.then(task.resolve, task.reject).finally(() => {
+        this.activeTasks.delete(task);
+        resource.running = false;
+        this.activeResources -= 1;
+        this.markReady(key, resource);
+        this.deleteIdleResource(key, resource);
+        this.pump();
+      });
+    }
+  }
+
+  private deleteIdleResource(key: string, resource: Resource | undefined): void {
+    if (resource !== undefined && !resource.running && resource.tasks.length === 0) {
+      this.resources.delete(key);
+    }
+  }
+}
+
+type MutexWaiter = {
+  resolve: (release: () => void) => void;
+  reject: (error: unknown) => void;
+  abortSignal?: AbortSignal;
+  abort?: () => void;
+};
+
+export class AsyncMutex {
+  private readonly waiters: MutexWaiter[] = [];
+  private locked = false;
+  private closedError: BrowserError | undefined;
+
+  async run<T>(abortSignal: AbortSignal | undefined, operation: () => Promise<T>): Promise<T> {
+    const release = await this.acquire(abortSignal);
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  close(error = new BrowserError("Browser connection is closed.", "connection_closed")): void {
+    if (this.closedError !== undefined) return;
+    this.closedError = error;
+    for (const waiter of this.waiters.splice(0)) {
+      if (waiter.abort !== undefined) {
+        waiter.abortSignal?.removeEventListener("abort", waiter.abort);
+      }
+      waiter.reject(error);
+    }
+  }
+
+  private acquire(abortSignal: AbortSignal | undefined): Promise<() => void> {
+    if (this.closedError !== undefined) return Promise.reject(this.closedError);
+    if (abortSignal?.aborted) {
+      return Promise.reject(abortReason(abortSignal, "browser-resource-lock"));
+    }
+    if (!this.locked) {
+      this.locked = true;
+      return Promise.resolve(this.releaseCallback());
+    }
+    return new Promise((resolve, reject) => {
+      const waiter: MutexWaiter = {
+        resolve,
+        reject,
+        ...(abortSignal === undefined ? {} : { abortSignal }),
+      };
+      if (abortSignal !== undefined) {
+        waiter.abort = () => {
+          const index = this.waiters.indexOf(waiter);
+          if (index === -1) return;
+          this.waiters.splice(index, 1);
+          reject(abortReason(abortSignal, "browser-resource-lock"));
+        };
+        abortSignal.addEventListener("abort", waiter.abort, { once: true });
+      }
+      this.waiters.push(waiter);
+    });
+  }
+
+  private releaseCallback(): () => void {
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      const waiter = this.waiters.shift();
+      if (waiter === undefined) {
+        this.locked = false;
+        return;
+      }
+      if (waiter.abort !== undefined) {
+        waiter.abortSignal?.removeEventListener("abort", waiter.abort);
+      }
+      waiter.resolve(this.releaseCallback());
+    };
+  }
+}
+
+function abortReason(abortSignal: AbortSignal, phase: string): BrowserError {
+  return abortSignal.reason instanceof BrowserError
+    ? abortSignal.reason
+    : cancellationError(abortSignal.reason, phase);
+}

--- a/packages/tool-browser/src/tools.ts
+++ b/packages/tool-browser/src/tools.ts
@@ -1,6 +1,10 @@
 import { type AnyTool, createTool, ToolOutput } from "@anvia/core/tool";
-import type { Locator, Page } from "playwright-core";
 import { z } from "zod";
+import type {
+  AutomationScreenshotResult,
+  AutomationSnapshotResult,
+  AutomationTabResult,
+} from "./automation-protocol";
 import { asConnection } from "./connection";
 import { BrowserError } from "./errors";
 import type { BrowserNavigationPolicy, BrowserToolName, CreateBrowserToolsOptions } from "./types";
@@ -25,14 +29,17 @@ const targetSchema = z.discriminatedUnion("by", [
 
 const noInput = z.object({});
 const tabInput = z.object({ tabId: z.string().uuid() });
+const explicitTab = { tabId: z.string().uuid().optional() };
 const navigateInput = z.object({
+  ...explicitTab,
   url: z.url(),
   waitUntil: z.enum(["commit", "domcontentloaded", "load", "networkidle"]).optional(),
 });
-const clickInput = z.object({ target: targetSchema });
-const typeInput = z.object({ target: targetSchema, text: z.string() });
-const pressKeyInput = z.object({ key: z.string().min(1).max(100) });
-const screenshotInput = z.object({});
+const clickInput = z.object({ ...explicitTab, target: targetSchema });
+const typeInput = z.object({ ...explicitTab, target: targetSchema, text: z.string() });
+const pressKeyInput = z.object({ ...explicitTab, key: z.string().min(1).max(100) });
+const screenshotInput = z.object(explicitTab);
+const snapshotInput = z.object(explicitTab);
 
 const defaultActionTimeoutMs = 10_000;
 const defaultNavigationTimeoutMs = 30_000;
@@ -53,13 +60,13 @@ export function createBrowserTools(options: CreateBrowserToolsOptions): readonly
   const tools = options.tools.map((name) => {
     switch (name) {
       case "browser_list_tabs":
-        return createListTabsTool(connection);
+        return createListTabsTool(connection, limits.actionTimeoutMs);
       case "browser_open_tab":
-        return createOpenTabTool(connection);
+        return createOpenTabTool(connection, limits.actionTimeoutMs);
       case "browser_select_tab":
-        return createSelectTabTool(connection);
+        return createSelectTabTool(connection, limits.actionTimeoutMs);
       case "browser_close_tab":
-        return createCloseTabTool(connection);
+        return createCloseTabTool(connection, limits.actionTimeoutMs);
       case "browser_navigate":
         return createNavigateTool(connection, policy, limits.navigationTimeoutMs);
       case "browser_snapshot":
@@ -69,9 +76,9 @@ export function createBrowserTools(options: CreateBrowserToolsOptions): readonly
       case "browser_type":
         return createTypeTool(connection, limits.actionTimeoutMs);
       case "browser_press_key":
-        return createPressKeyTool(connection);
+        return createPressKeyTool(connection, limits.actionTimeoutMs);
       case "browser_screenshot":
-        return createScreenshotTool(connection);
+        return createScreenshotTool(connection, limits.actionTimeoutMs);
       default:
         return assertNever(name);
     }
@@ -81,50 +88,43 @@ export function createBrowserTools(options: CreateBrowserToolsOptions): readonly
 
 type Connection = ReturnType<typeof asConnection>;
 
-function createListTabsTool(connection: Connection): AnyTool {
+function createListTabsTool(connection: Connection, timeoutMs: number): AnyTool {
   return createTool({
     name: "browser_list_tabs",
     description: "List Chromium tabs and identify the tab selected for subsequent browser tools.",
     inputSchema: noInput,
-    execute: async () => ({ tabs: await connection.listTabs() }),
+    execute: async (_args, context) => ({
+      tabs: await connection.listTabs({ abortSignal: context.abortSignal, timeoutMs }),
+    }),
   });
 }
 
-function createOpenTabTool(connection: Connection): AnyTool {
+function createOpenTabTool(connection: Connection, timeoutMs: number): AnyTool {
   return createTool({
     name: "browser_open_tab",
     description: "Open and select a new blank Chromium tab.",
     inputSchema: noInput,
-    execute: async (_args, context) =>
-      connection.runAction(context.abortSignal, async () => {
-        const page = await connection.openTab();
-        return tabResult(connection, page);
-      }),
+    execute: async (_args, context) => connection.openTab(context.abortSignal, timeoutMs),
   });
 }
 
-function createSelectTabTool(connection: Connection): AnyTool {
+function createSelectTabTool(connection: Connection, timeoutMs: number): AnyTool {
   return createTool({
     name: "browser_select_tab",
     description: "Select an existing Chromium tab by its browser tab ID.",
     inputSchema: tabInput,
     execute: async ({ tabId }, context) =>
-      connection.runAction(context.abortSignal, async () =>
-        tabResult(connection, connection.selectTab(tabId)),
-      ),
+      connection.selectTab(tabId, context.abortSignal, timeoutMs),
   });
 }
 
-function createCloseTabTool(connection: Connection): AnyTool {
+function createCloseTabTool(connection: Connection, timeoutMs: number): AnyTool {
   return createTool({
     name: "browser_close_tab",
     description: "Close an existing Chromium tab by its browser tab ID.",
     inputSchema: tabInput,
     execute: async ({ tabId }, context) =>
-      connection.runAction(context.abortSignal, async () => {
-        await connection.closeTab(tabId);
-        return { closedTabId: tabId, tabs: await connection.tabSummaries() };
-      }),
+      connection.closeTab(tabId, context.abortSignal, timeoutMs),
   });
 }
 
@@ -135,37 +135,48 @@ function createNavigateTool(
 ): AnyTool {
   return createTool({
     name: "browser_navigate",
-    description: "Navigate the selected Chromium tab to an allowed HTTP or HTTPS URL.",
+    description:
+      "Navigate an explicit tab, or the selected tab in serial compatibility mode, to an allowed HTTP or HTTPS URL.",
     inputSchema: navigateInput,
-    execute: async ({ url, waitUntil }, context) =>
-      connection.runAction(context.abortSignal, async () => {
-        assertNavigationAllowed(url, policy);
-        const page = connection.selectedPage();
-        await page.goto(url, {
-          timeout: timeoutMs,
-          waitUntil: waitUntil ?? "load",
-        });
-        assertNavigationAllowed(page.url(), policy);
-        return tabResult(connection, page);
-      }),
+    execute: async ({ tabId, url, waitUntil }, context) => {
+      assertNavigationAllowed(url, policy);
+      const result = await connection.runTabCommand<AutomationTabResult>({
+        tabId,
+        abortSignal: context.abortSignal,
+        timeoutMs,
+        phase: "navigate",
+        command: (targetTabId) => ({
+          method: "navigate",
+          params: {
+            tabId: targetTabId,
+            url,
+            waitUntil: waitUntil ?? "load",
+            timeoutMs,
+          },
+        }),
+      });
+      assertNavigationAllowed(result.url, policy);
+      return result;
+    },
   });
 }
 
 function createSnapshotTool(connection: Connection, timeoutMs: number, maxChars: number): AnyTool {
   return createTool({
     name: "browser_snapshot",
-    description: "Inspect the selected tab using a bounded ARIA accessibility snapshot.",
-    inputSchema: noInput,
-    execute: async (_args, context) =>
-      connection.runAction(context.abortSignal, async () => {
-        const page = connection.selectedPage();
-        const snapshot = await page.locator("body").ariaSnapshot({ timeout: timeoutMs });
-        const truncated = snapshot.length > maxChars;
-        return {
-          ...(await tabResult(connection, page)),
-          snapshot: truncated ? snapshot.slice(0, maxChars) : snapshot,
-          truncated,
-        };
+    description:
+      "Inspect an explicit tab, or the selected tab in serial compatibility mode, using a bounded ARIA accessibility snapshot.",
+    inputSchema: snapshotInput,
+    execute: async ({ tabId }, context) =>
+      connection.runTabCommand<AutomationSnapshotResult>({
+        tabId,
+        abortSignal: context.abortSignal,
+        timeoutMs,
+        phase: "snapshot",
+        command: (targetTabId) => ({
+          method: "snapshot",
+          params: { tabId: targetTabId, timeoutMs, maxChars },
+        }),
       }),
   });
 }
@@ -173,13 +184,18 @@ function createSnapshotTool(connection: Connection, timeoutMs: number, maxChars:
 function createClickTool(connection: Connection, timeoutMs: number): AnyTool {
   return createTool({
     name: "browser_click",
-    description: "Click one strictly matched element in the selected tab.",
+    description: "Click one strictly matched element in an explicit tab or the selected tab.",
     inputSchema: clickInput,
-    execute: async ({ target }, context) =>
-      connection.runAction(context.abortSignal, async () => {
-        const page = connection.selectedPage();
-        await locatorFor(page, target).click({ timeout: timeoutMs });
-        return tabResult(connection, page);
+    execute: async ({ tabId, target }, context) =>
+      connection.runTabCommand<AutomationTabResult>({
+        tabId,
+        abortSignal: context.abortSignal,
+        timeoutMs,
+        phase: "click",
+        command: (targetTabId) => ({
+          method: "click",
+          params: { tabId: targetTabId, target, timeoutMs },
+        }),
       }),
   });
 }
@@ -187,92 +203,70 @@ function createClickTool(connection: Connection, timeoutMs: number): AnyTool {
 function createTypeTool(connection: Connection, timeoutMs: number): AnyTool {
   return createTool({
     name: "browser_type",
-    description: "Replace the value of one strictly matched editable element.",
+    description:
+      "Replace the value of one strictly matched editable element in an explicit or selected tab.",
     inputSchema: typeInput,
-    execute: async ({ target, text }, context) =>
-      connection.runAction(context.abortSignal, async () => {
-        const page = connection.selectedPage();
-        await locatorFor(page, target).fill(text, { timeout: timeoutMs });
-        return tabResult(connection, page);
+    execute: async ({ tabId, target, text }, context) =>
+      connection.runTabCommand<AutomationTabResult>({
+        tabId,
+        abortSignal: context.abortSignal,
+        timeoutMs,
+        phase: "type",
+        command: (targetTabId) => ({
+          method: "type",
+          params: { tabId: targetTabId, target, text, timeoutMs },
+        }),
       }),
   });
 }
 
-function createPressKeyTool(connection: Connection): AnyTool {
+function createPressKeyTool(connection: Connection, timeoutMs: number): AnyTool {
   return createTool({
     name: "browser_press_key",
-    description: "Press an explicit keyboard key or key combination in the selected tab.",
+    description:
+      "Press an explicit keyboard key or key combination in an explicit or selected tab.",
     inputSchema: pressKeyInput,
-    execute: async ({ key }, context) =>
-      connection.runAction(context.abortSignal, async () => {
-        const page = connection.selectedPage();
-        await page.keyboard.press(key);
-        return tabResult(connection, page);
+    execute: async ({ tabId, key }, context) =>
+      connection.runTabCommand<AutomationTabResult>({
+        tabId,
+        abortSignal: context.abortSignal,
+        timeoutMs,
+        phase: "press-key",
+        command: (targetTabId) => ({
+          method: "pressKey",
+          params: { tabId: targetTabId, key },
+        }),
       }),
   });
 }
 
-function createScreenshotTool(connection: Connection): AnyTool {
+function createScreenshotTool(connection: Connection, timeoutMs: number): AnyTool {
   return createTool({
     name: "browser_screenshot",
-    description: "Capture the visible viewport of the selected Chromium tab as PNG.",
+    description: "Capture the visible viewport of an explicit or selected Chromium tab as PNG.",
     inputSchema: screenshotInput,
-    execute: async (_args, context) =>
-      connection.runAction(context.abortSignal, async () => {
-        const page = connection.selectedPage();
-        const png = await page.screenshot({ type: "png", fullPage: false });
-        const metadata = await tabResult(connection, page);
-        return ToolOutput.content([
-          { type: "text", text: JSON.stringify(metadata) },
-          {
-            type: "file",
-            data: { type: "data", data: png.toString("base64") },
-            mediaType: "image/png",
-            filename: "browser-screenshot.png",
-          },
-        ]);
-      }),
+    execute: async ({ tabId }, context) => {
+      const result = await connection.runTabCommand<AutomationScreenshotResult>({
+        tabId,
+        abortSignal: context.abortSignal,
+        timeoutMs,
+        phase: "screenshot",
+        command: (targetTabId) => ({
+          method: "screenshot",
+          params: { tabId: targetTabId, timeoutMs },
+        }),
+      });
+      return ToolOutput.content([
+        { type: "text", text: JSON.stringify(result.metadata) },
+        {
+          type: "file",
+          data: { type: "data", data: result.pngBase64 },
+          mediaType: "image/png",
+          filename: "browser-screenshot.png",
+        },
+      ]);
+    },
   });
-}
-
-async function tabResult(connection: Connection, page: Page) {
-  return {
-    tabId: connection.idFor(page),
-    title: await page.title(),
-    url: page.url(),
-  };
-}
-
-type BrowserTarget = z.infer<typeof targetSchema>;
-
-function locatorFor(page: Page, target: BrowserTarget): Locator {
-  switch (target.by) {
-    case "role": {
-      const options: { name?: string; exact?: boolean } = {};
-      if (target.name !== undefined) options.name = target.name;
-      if (target.exact !== undefined) options.exact = target.exact;
-      return page.getByRole(target.role as never, options);
-    }
-    case "text": {
-      const options: { exact?: boolean } = {};
-      if (target.exact !== undefined) options.exact = target.exact;
-      return page.getByText(target.text, options);
-    }
-    case "label": {
-      const options: { exact?: boolean } = {};
-      if (target.exact !== undefined) options.exact = target.exact;
-      return page.getByLabel(target.label, options);
-    }
-    case "placeholder": {
-      const options: { exact?: boolean } = {};
-      if (target.exact !== undefined) options.exact = target.exact;
-      return page.getByPlaceholder(target.placeholder, options);
-    }
-    case "test-id":
-      return page.getByTestId(target.testId);
-    case "css":
-      return page.locator(target.selector);
-  }
 }
 
 function snapshotNavigationPolicy(policy: BrowserNavigationPolicy): BrowserNavigationPolicy {

--- a/packages/tool-browser/src/types.ts
+++ b/packages/tool-browser/src/types.ts
@@ -8,15 +8,19 @@ import type {
   DockerSandboxState,
   DockerSandboxWorkspace,
 } from "@anvia/sandbox";
+import type { BrowserError } from "./errors";
+
+export type BrowserLifecycleOptions = Readonly<{
+  timeoutMs?: number | undefined;
+  abortSignal?: AbortSignal | undefined;
+}>;
 
 export type DockerBrowserClientOptions = Readonly<{
   sandboxClient: DockerSandboxClient;
   image: string;
 }>;
 
-export type PullDockerBrowserImageOptions = Readonly<{
-  abortSignal?: AbortSignal;
-}>;
+export type PullDockerBrowserImageOptions = BrowserLifecycleOptions;
 
 export type BrowserViewport = Readonly<{
   width: number;
@@ -36,25 +40,77 @@ export type CreateDockerBrowserOptions = Readonly<{
   desktop: BrowserDesktopOptions;
   resources?: DockerSandboxResources;
   runtime?: DockerSandboxRuntimeLimits;
-  abortSignal?: AbortSignal;
+  timeoutMs?: number | undefined;
+  abortSignal?: AbortSignal | undefined;
 }>;
 
 export type ResumeDockerBrowserOptions = Readonly<{
   id: string;
-  abortSignal?: AbortSignal;
+  timeoutMs?: number | undefined;
+  abortSignal?: AbortSignal | undefined;
+}>;
+
+export type BrowserCapability = "runtime" | "browser" | "automation" | "desktop";
+
+export type BrowserCapabilityState =
+  | "unknown"
+  | "checking"
+  | "ready"
+  | "failed"
+  | "stopped"
+  | "destroyed";
+
+export type BrowserCapabilitySnapshot = Readonly<{
+  capability: BrowserCapability;
+  state: BrowserCapabilityState;
+  checkedAt?: string;
+  error?: BrowserError;
+}>;
+
+export type BrowserReadinessSnapshot = Readonly<{
+  state:
+    | "unknown"
+    | "checking"
+    | "partial"
+    | "ready"
+    | "degraded"
+    | "failed"
+    | "stopped"
+    | "destroyed";
+  capabilities: Readonly<Record<BrowserCapability, BrowserCapabilitySnapshot>>;
 }>;
 
 export type BrowserWaitUntilReadyOptions = Readonly<{
   timeoutMs: number;
-  abortSignal?: AbortSignal;
+  abortSignal?: AbortSignal | undefined;
+  capabilities?: readonly [BrowserCapability, ...BrowserCapability[]] | undefined;
 }>;
 
+export type BrowserSchedulingOptions =
+  | Readonly<{
+      mode: "serial";
+      maxQueuedActions?: number;
+    }>
+  | Readonly<{
+      mode: "per-tab";
+      maxConcurrentTabs?: number;
+      maxQueuedActions?: number;
+    }>;
+
 export type BrowserConnectOptions = Readonly<{
-  abortSignal?: AbortSignal;
+  timeoutMs?: number | undefined;
+  abortSignal?: AbortSignal | undefined;
+  scheduling?: BrowserSchedulingOptions | undefined;
 }>;
+
+export type BrowserControlAvailability = "available" | "degraded" | "disconnected" | "destroyed";
 
 export type BrowserControlSnapshot = Readonly<{
   mode: "agent" | "human";
+  state: "agent" | "agent-active" | "human-pending" | "human";
+  availability: BrowserControlAvailability;
+  activeAgentActions: number;
+  humanPending: boolean;
   ownerId?: string;
   expiresAt?: string;
 }>;
@@ -62,7 +118,8 @@ export type BrowserControlSnapshot = Readonly<{
 export type AcquireBrowserHumanControlOptions = Readonly<{
   ownerId: string;
   leaseTimeoutMs: number;
-  abortSignal?: AbortSignal;
+  timeoutMs?: number | undefined;
+  abortSignal?: AbortSignal | undefined;
 }>;
 
 export type RenewBrowserHumanControlOptions = Readonly<{
@@ -92,14 +149,21 @@ export type BrowserDesktopEndpoint = Readonly<{
 
 export interface DockerBrowser extends AsyncDisposable {
   readonly id: string;
+  /** Includes browser-handle lifecycle transitions such as `stopping` and `destroying`. */
   readonly state: DockerSandboxState;
   readonly desktop: BrowserDesktopEndpoint;
   readonly sandbox: DockerSandbox;
   inspector(options: DockerSandboxInspectionOptions): DockerSandboxInspector;
+  readiness(): BrowserReadinessSnapshot;
+  waitForCapabilities(options: BrowserWaitUntilReadyOptions): Promise<BrowserReadinessSnapshot>;
   waitUntilReady(options: BrowserWaitUntilReadyOptions): Promise<void>;
   connect(options?: BrowserConnectOptions): Promise<PlaywrightBrowserConnection>;
-  stop(options?: Readonly<{ abortSignal?: AbortSignal }>): Promise<void>;
-  destroy(): Promise<void>;
+  stop(options?: BrowserLifecycleOptions): Promise<void>;
+  /**
+   * Starts an irreversible terminal transition. A timeout or cancellation bounds this caller's
+   * wait; uncancellable sandbox cleanup remains owned and visible as `destroying` to later callers.
+   */
+  destroy(options?: BrowserLifecycleOptions): Promise<void>;
 }
 
 export type BrowserTab = Readonly<{
@@ -109,10 +173,12 @@ export type BrowserTab = Readonly<{
   selected: boolean;
 }>;
 
+export type BrowserActionOptions = BrowserLifecycleOptions;
+
 export interface PlaywrightBrowserConnection extends AsyncDisposable {
   readonly closed: boolean;
-  listTabs(): Promise<readonly BrowserTab[]>;
-  disconnect(): Promise<void>;
+  listTabs(options?: BrowserActionOptions): Promise<readonly BrowserTab[]>;
+  disconnect(options?: BrowserLifecycleOptions): Promise<void>;
 }
 
 export type BrowserToolName =

--- a/packages/tool-browser/test/concurrency.test.ts
+++ b/packages/tool-browser/test/concurrency.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AutomationCommand } from "../src/automation-protocol";
+import type { AutomationBackend, AutomationCommandOptions } from "../src/automation-client";
+import { PlaywrightBrowserConnectionImpl } from "../src/connection";
+import { BrowserControlState } from "../src/control";
+
+const tabA = "11111111-1111-4111-8111-111111111111";
+const tabB = "22222222-2222-4222-8222-222222222222";
+
+describe("browser resource scheduling", () => {
+  it("overlaps operations on different tabs in per-tab mode", async () => {
+    const { connection, backend } = createConnection("per-tab");
+    const first = action(connection, tabA);
+    const firstCall = await backend.nextCall();
+    const second = action(connection, tabB);
+    const secondCall = await backend.nextCall();
+
+    expect([firstCall.command, secondCall.command]).toEqual([
+      expect.objectContaining({
+        method: "pressKey",
+        params: expect.objectContaining({ tabId: tabA }),
+      }),
+      expect.objectContaining({
+        method: "pressKey",
+        params: expect.objectContaining({ tabId: tabB }),
+      }),
+    ]);
+    firstCall.resolve(result(tabA));
+    secondCall.resolve(result(tabB));
+    await expect(Promise.all([first, second])).resolves.toHaveLength(2);
+  });
+
+  it("keeps same-tab operations ordered and releases the queue after failure", async () => {
+    const { connection, backend } = createConnection("per-tab");
+    const first = action(connection, tabA);
+    const firstCall = await backend.nextCall();
+    const second = action(connection, tabA);
+    await flushMicrotasks();
+    expect(backend.calls).toHaveLength(1);
+
+    firstCall.reject(new Error("injected failure"));
+    await expect(first).rejects.toMatchObject({
+      code: "tool_failed",
+      cause: expect.objectContaining({ message: "injected failure" }),
+    });
+    const secondCall = await backend.nextCall();
+    secondCall.resolve(result(tabA));
+    await expect(second).resolves.toMatchObject({ tabId: tabA });
+  });
+
+  it("preserves global serial behavior in compatibility mode", async () => {
+    const { connection, backend } = createConnection("serial");
+    const first = action(connection, tabA);
+    const firstCall = await backend.nextCall();
+    const second = action(connection, tabB);
+    await flushMicrotasks();
+    expect(backend.calls).toHaveLength(1);
+
+    firstCall.resolve(result(tabA));
+    await first;
+    const secondCall = await backend.nextCall();
+    secondCall.resolve(result(tabB));
+    await second;
+  });
+
+  it("bounds queued work without counting the active operation", async () => {
+    const backend = new ManualBackend();
+    const connection = new PlaywrightBrowserConnectionImpl({
+      backend,
+      control: new BrowserControlState(),
+      scheduling: { mode: "per-tab", maxConcurrentTabs: 1, maxQueuedActions: 1 },
+    });
+    const active = action(connection, tabA);
+    const activeCall = await backend.nextCall();
+    const queued = action(connection, tabB);
+
+    await expect(action(connection, "33333333-3333-4333-8333-333333333333")).rejects.toMatchObject({
+      code: "agent_action_busy",
+    });
+    activeCall.resolve(result(tabA));
+    await active;
+    const queuedCall = await backend.nextCall();
+    queuedCall.resolve(result(tabB));
+    await queued;
+  });
+
+  it("cancels one tab without blocking another tab", async () => {
+    const { connection, backend } = createConnection("per-tab");
+    const controller = new AbortController();
+    const cancelled = action(connection, tabA, controller.signal);
+    await backend.nextCall();
+    const independent = action(connection, tabB);
+    const independentCall = await backend.nextCall();
+
+    controller.abort(new Error("cancel tab A"));
+    independentCall.resolve(result(tabB));
+    await expect(cancelled).rejects.toMatchObject({ code: "cancelled" });
+    await expect(independent).resolves.toMatchObject({ tabId: tabB });
+  });
+
+  it("marks a closing tab before queued work can target it", async () => {
+    const { connection, backend } = createConnection("per-tab");
+    const active = action(connection, tabA);
+    const activeCall = await backend.nextCall();
+    const closing = connection.closeTab(tabA, undefined, 1_000);
+
+    await expect(action(connection, tabA)).rejects.toMatchObject({ code: "invalid_state" });
+    activeCall.resolve(result(tabA));
+    await active;
+    const closeCall = await backend.nextCall();
+    closeCall.resolve({ closedTabId: tabA, tabs: [] });
+    await expect(closing).resolves.toMatchObject({ closedTabId: tabA });
+  });
+
+  it("serializes concurrent tab creation through the browser-context lock", async () => {
+    const { connection, backend } = createConnection("per-tab");
+    const first = connection.openTab(undefined, 1_000);
+    const firstCall = await backend.nextCall();
+    const second = connection.openTab(undefined, 1_000);
+    await flushMicrotasks();
+    expect(backend.calls).toHaveLength(1);
+
+    firstCall.resolve(result(tabA));
+    await first;
+    const secondCall = await backend.nextCall();
+    secondCall.resolve(result(tabB));
+    await expect(second).resolves.toMatchObject({ tabId: tabB });
+  });
+
+  it("does not mark a tab closed when close times out before reaching the backend", async () => {
+    vi.useFakeTimers();
+    try {
+      const { connection, backend } = createConnection("per-tab");
+      const opening = connection.openTab(undefined, 1_000);
+      const openCall = await backend.nextCall();
+      const closing = connection.closeTab(tabA, undefined, 50);
+      const rejected = expect(closing).rejects.toMatchObject({ code: "action_timeout" });
+
+      await vi.advanceTimersByTimeAsync(50);
+      await rejected;
+      const stillUsable = action(connection, tabA);
+      const actionCall = await backend.nextCall();
+      actionCall.resolve(result(tabA));
+      await expect(stillUsable).resolves.toMatchObject({ tabId: tabA });
+
+      openCall.resolve(result(tabB));
+      await opening;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not poison tab tracking when a started close fails", async () => {
+    const { connection, backend } = createConnection("per-tab");
+    const closing = connection.closeTab(tabA, undefined, 1_000);
+    const closeCall = await backend.nextCall();
+    closeCall.reject(new Error("close refused"));
+    await expect(closing).rejects.toMatchObject({ code: "tool_failed" });
+
+    const retry = action(connection, tabA);
+    const retryCall = await backend.nextCall();
+    retryCall.resolve(result(tabA));
+    await expect(retry).resolves.toMatchObject({ tabId: tabA });
+  });
+
+  it("rejects queued and active work predictably during shutdown", async () => {
+    const { connection, backend } = createConnection("serial");
+    const active = action(connection, tabA);
+    await backend.nextCall();
+    const queued = action(connection, tabB);
+
+    await connection.disconnect();
+    await expect(active).rejects.toMatchObject({ code: "connection_closed" });
+    await expect(queued).rejects.toMatchObject({ code: "connection_closed" });
+  });
+
+  it("preserves connection_closed for active work contending on the context lock", async () => {
+    const { connection, backend } = createConnection("per-tab");
+    const opening = connection.openTab(undefined, 1_000);
+    await backend.nextCall();
+    const closing = connection.closeTab(tabA, undefined, 1_000);
+    await flushMicrotasks();
+    expect(backend.calls).toHaveLength(1);
+
+    await connection.disconnect();
+    await expect(opening).rejects.toMatchObject({ code: "connection_closed" });
+    await expect(closing).rejects.toMatchObject({ code: "connection_closed" });
+  });
+
+  it("lets human control wait for active work and rejects new work while pending", async () => {
+    const control = new BrowserControlState();
+    const { connection, backend } = createConnection("per-tab", control);
+    const active = action(connection, tabA);
+    const activeCall = await backend.nextCall();
+    const acquiring = control.acquireHumanControl({
+      ownerId: "viewer",
+      leaseTimeoutMs: 30_000,
+      timeoutMs: 1_000,
+    });
+
+    expect(control.snapshot()).toMatchObject({ state: "human-pending", activeAgentActions: 1 });
+    await expect(action(connection, tabB)).rejects.toMatchObject({
+      code: "human_control_conflict",
+    });
+    activeCall.resolve(result(tabA));
+    await active;
+    const lease = await acquiring;
+    expect(control.snapshot()).toMatchObject({ state: "human", ownerId: "viewer" });
+    lease.release();
+  });
+});
+
+function createConnection(mode: "serial" | "per-tab", control = new BrowserControlState()) {
+  const backend = new ManualBackend();
+  return {
+    backend,
+    connection: new PlaywrightBrowserConnectionImpl({
+      backend,
+      control,
+      scheduling:
+        mode === "serial" ? { mode: "serial" } : { mode: "per-tab", maxConcurrentTabs: 4 },
+    }),
+  };
+}
+
+function action(
+  connection: PlaywrightBrowserConnectionImpl,
+  tabId: string,
+  abortSignal?: AbortSignal,
+) {
+  return connection.runTabCommand<ReturnType<typeof result>>({
+    tabId,
+    abortSignal,
+    timeoutMs: 1_000,
+    phase: "test-action",
+    command: (targetTabId) => ({
+      method: "pressKey",
+      params: { tabId: targetTabId, key: "Enter" },
+    }),
+  });
+}
+
+function result(tabId: string) {
+  return { tabId, title: "Tab", url: "https://example.com" };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+type ManualCall = {
+  command: AutomationCommand;
+  resolve: (value: unknown) => void;
+  reject: (error: unknown) => void;
+};
+
+class ManualBackend implements AutomationBackend {
+  readonly calls: ManualCall[] = [];
+  private readonly callWaiters: Array<(call: ManualCall) => void> = [];
+  private isClosed = false;
+  private observedCalls = 0;
+
+  get closed(): boolean {
+    return this.isClosed;
+  }
+
+  command<T>(command: AutomationCommand, options: AutomationCommandOptions): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const call: ManualCall = { command, resolve: (value) => resolve(value as T), reject };
+      this.calls.push(call);
+      const waiter = this.callWaiters.shift();
+      waiter?.(call);
+      options.abortSignal?.addEventListener("abort", () => reject(options.abortSignal?.reason), {
+        once: true,
+      });
+    });
+  }
+
+  nextCall(): Promise<ManualCall> {
+    const observed = this.calls[this.observedCalls];
+    if (observed !== undefined) {
+      this.observedCalls += 1;
+      return Promise.resolve(observed);
+    }
+    return new Promise((resolve) =>
+      this.callWaiters.push((call) => {
+        this.observedCalls += 1;
+        resolve(call);
+      }),
+    );
+  }
+
+  async disconnect(): Promise<void> {
+    this.isClosed = true;
+  }
+
+  onDisconnected(_listener: () => void): () => void {
+    return () => undefined;
+  }
+}

--- a/packages/tool-browser/test/connection-lifecycle.test.ts
+++ b/packages/tool-browser/test/connection-lifecycle.test.ts
@@ -1,0 +1,372 @@
+import { EventEmitter } from "node:events";
+import { fork, type ChildProcess } from "node:child_process";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AutomationRequest, AutomationResponse } from "../src/automation-protocol";
+import { type AutomationBackend, AutomationWorkerClient } from "../src/automation-client";
+import { PlaywrightBrowserConnectionImpl } from "../src/connection";
+import { BrowserControlState } from "../src/control";
+
+describe("AutomationWorkerClient connection lifecycle", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("establishes and explicitly disconnects a successful connection", async () => {
+    const child = new FakeChild((message) => {
+      if (message.method === "connect") child.respond(success(message.id));
+      if (message.method === "disconnect") child.respond(success(message.id));
+    });
+    const client = await AutomationWorkerClient.connect({
+      endpointUrl: "http://127.0.0.1:9222",
+      timeoutMs: 1_000,
+      workerFactory: () => child.asChildProcess(),
+    });
+
+    expect(client.closed).toBe(false);
+    await client.disconnect();
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(client.closed).toBe(true);
+    expect(child.listenerCount("message")).toBe(0);
+    expect(child.listenerCount("error")).toBe(1);
+    expect(child.listenerCount("exit")).toBe(0);
+  });
+
+  it("owns and terminates an attempt that times out before transport connection", async () => {
+    vi.useFakeTimers();
+    const child = new FakeChild(() => undefined);
+    const connecting = AutomationWorkerClient.connect({
+      endpointUrl: "http://127.0.0.1:9222",
+      timeoutMs: 50,
+      workerFactory: () => child.asChildProcess(),
+    });
+    const rejected = expect(connecting).rejects.toMatchObject({ code: "connection_timeout" });
+
+    await vi.advanceTimersByTimeAsync(50);
+    await rejected;
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("ignores a successful initialization response that arrives after timeout", async () => {
+    vi.useFakeTimers();
+    let connectId = 0;
+    const child = new FakeChild((message) => {
+      if (message.method === "connect") connectId = message.id;
+    });
+    const connecting = AutomationWorkerClient.connect({
+      endpointUrl: "http://127.0.0.1:9222",
+      timeoutMs: 50,
+      workerFactory: () => child.asChildProcess(),
+    });
+    const rejected = expect(connecting).rejects.toMatchObject({ code: "connection_timeout" });
+
+    await vi.advanceTimersByTimeAsync(50);
+    child.respond(success(connectId));
+    await rejected;
+    expect(child.kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("terminates an attempt cancelled during initialization", async () => {
+    const child = new FakeChild(() => undefined);
+    const controller = new AbortController();
+    const connecting = AutomationWorkerClient.connect({
+      endpointUrl: "http://127.0.0.1:9222",
+      timeoutMs: 1_000,
+      abortSignal: controller.signal,
+      workerFactory: () => child.asChildProcess(),
+    });
+    controller.abort(new Error("cancelled by test"));
+
+    await expect(connecting).rejects.toMatchObject({ code: "cancelled" });
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  it("escalates cancellation when an active worker operation cannot acknowledge cleanup", async () => {
+    vi.useFakeTimers();
+    const child = new FakeChild((message) => {
+      if (message.method === "connect") child.respond(success(message.id));
+    });
+    const client = await AutomationWorkerClient.connect({
+      endpointUrl: "http://127.0.0.1:9222",
+      timeoutMs: 1_000,
+      workerFactory: () => child.asChildProcess(),
+    });
+    const controller = new AbortController();
+    const operation = client.command(
+      { method: "listTabs", params: {} },
+      {
+        abortSignal: controller.signal,
+        cancelOperation: true,
+        phase: "list-tabs",
+      },
+    );
+    const rejected = expect(operation).rejects.toMatchObject({ code: "cancelled" });
+    controller.abort(new Error("cancel active command"));
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await rejected;
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  it("settles a cancellation racing with success exactly once and ignores late messages", async () => {
+    let connectId = 0;
+    const child = new FakeChild((message) => {
+      if (message.method === "connect") connectId = message.id;
+    });
+    const controller = new AbortController();
+    const connecting = AutomationWorkerClient.connect({
+      endpointUrl: "http://127.0.0.1:9222",
+      timeoutMs: 1_000,
+      abortSignal: controller.signal,
+      workerFactory: () => child.asChildProcess(),
+    });
+    controller.abort(new Error("winner"));
+    child.respond(success(connectId));
+
+    await expect(connecting).rejects.toMatchObject({ code: "cancelled" });
+    expect(child.kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("contains worker failure during initialization and supports a clean retry", async () => {
+    const failedChild = new FakeChild((message) => {
+      failedChild.respond({
+        kind: "response",
+        id: message.id,
+        ok: false,
+        error: { name: "Error", message: "browser disconnected" },
+      });
+    });
+    await expect(
+      AutomationWorkerClient.connect({
+        endpointUrl: "http://127.0.0.1:9222",
+        timeoutMs: 1_000,
+        workerFactory: () => failedChild.asChildProcess(),
+      }),
+    ).rejects.toMatchObject({ code: "transport_failure", retryable: true });
+
+    const retryChild = new FakeChild((message) => retryChild.respond(success(message.id)));
+    const retry = await AutomationWorkerClient.connect({
+      endpointUrl: "http://127.0.0.1:9222",
+      timeoutMs: 1_000,
+      workerFactory: () => retryChild.asChildProcess(),
+    });
+    await retry.disconnect();
+  });
+
+  it("treats browser disconnection during initialization as a retryable transport failure", async () => {
+    const child = new FakeChild(() => undefined);
+    const connecting = AutomationWorkerClient.connect({
+      endpointUrl: "http://127.0.0.1:9222",
+      timeoutMs: 1_000,
+      workerFactory: () => child.asChildProcess(),
+    });
+    child.crash();
+
+    await expect(connecting).rejects.toMatchObject({
+      code: "transport_failure",
+      retryable: true,
+      recovery: "reconnect",
+    });
+  });
+
+  it("contains a synchronous IPC send failure", async () => {
+    const child = new FakeChild(() => {
+      throw new Error("ipc send failed");
+    });
+
+    await expect(
+      AutomationWorkerClient.connect({
+        endpointUrl: "http://127.0.0.1:9222",
+        timeoutMs: 1_000,
+        workerFactory: () => child.asChildProcess(),
+      }),
+    ).rejects.toMatchObject({ code: "transport_failure" });
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  it("normalizes a worker creation failure before transport creation", async () => {
+    await expect(
+      AutomationWorkerClient.connect({
+        endpointUrl: "http://127.0.0.1:9222",
+        timeoutMs: 1_000,
+        workerFactory: () => {
+          throw new Error("fork failed");
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "transport_failure",
+      cause: expect.objectContaining({ message: "fork failed" }),
+    });
+  });
+
+  it("fails closed when the isolated worker sends a malformed response", async () => {
+    let connectId = 0;
+    const child = new FakeChild((message) => {
+      if (message.method === "connect") connectId = message.id;
+    });
+    const connecting = AutomationWorkerClient.connect({
+      endpointUrl: "http://127.0.0.1:9222",
+      timeoutMs: 1_000,
+      workerFactory: () => child.asChildProcess(),
+    });
+    child.respond({ kind: "response", id: connectId, ok: "yes" });
+
+    await expect(connecting).rejects.toMatchObject({ code: "transport_failure" });
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  it("turns an unexpected post-connect worker crash into a connection event", async () => {
+    const child = new FakeChild((message) => child.respond(success(message.id)));
+    const client = await AutomationWorkerClient.connect({
+      endpointUrl: "http://127.0.0.1:9222",
+      timeoutMs: 1_000,
+      workerFactory: () => child.asChildProcess(),
+    });
+    const disconnected = vi.fn();
+    client.onDisconnected(disconnected);
+
+    child.crash();
+    await Promise.resolve();
+    expect(client.closed).toBe(true);
+    expect(disconnected).toHaveBeenCalledOnce();
+  });
+
+  it("contains a late protocol assertion in a real child process", async () => {
+    const client = await AutomationWorkerClient.connect({
+      endpointUrl: "http://127.0.0.1:9222",
+      timeoutMs: 1_000,
+      workerFactory: () =>
+        fork(new URL("./fixtures/crashing-automation-worker.mjs", import.meta.url), [], {
+          stdio: ["ignore", "ignore", "ignore", "ipc"],
+        }),
+    });
+    const disconnected = new Promise<void>((resolve) => client.onDisconnected(resolve));
+    const operation = client.command(
+      { method: "listTabs", params: {} },
+      { phase: "regression-probe" },
+    );
+
+    await operation;
+    await disconnected;
+    expect(client.closed).toBe(true);
+  });
+
+  it("joins concurrent disconnect calls even when the backend is already marked closed", async () => {
+    let finishDisconnect: (() => void) | undefined;
+    const disconnect = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishDisconnect = resolve;
+        }),
+    );
+    const backend: AutomationBackend = {
+      closed: true,
+      command: vi.fn(),
+      disconnect,
+      onDisconnected: () => () => undefined,
+    };
+    const connection = new PlaywrightBrowserConnectionImpl({
+      backend,
+      control: new BrowserControlState(),
+    });
+
+    const first = connection.disconnect();
+    const second = connection.disconnect();
+    expect(disconnect).toHaveBeenCalledOnce();
+    finishDisconnect?.();
+    await Promise.all([first, second]);
+    await connection.disconnect();
+    expect(disconnect).toHaveBeenCalledOnce();
+  });
+
+  it("honors cancellation for a later caller waiting on an active disconnect", async () => {
+    let finishDisconnect: (() => void) | undefined;
+    const backend: AutomationBackend = {
+      closed: false,
+      command: vi.fn(),
+      disconnect: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            finishDisconnect = resolve;
+          }),
+      ),
+      onDisconnected: () => () => undefined,
+    };
+    const connection = new PlaywrightBrowserConnectionImpl({
+      backend,
+      control: new BrowserControlState(),
+    });
+    const first = connection.disconnect({ timeoutMs: 1_000 });
+    const controller = new AbortController();
+    const second = connection.disconnect({
+      timeoutMs: 1_000,
+      abortSignal: controller.signal,
+    });
+    controller.abort(new Error("stop waiting"));
+
+    await expect(second).rejects.toMatchObject({ code: "cancelled" });
+    finishDisconnect?.();
+    await first;
+    expect(backend.disconnect).toHaveBeenCalledOnce();
+  });
+
+  it("does not close a connection when disconnect is already cancelled", async () => {
+    const backend: AutomationBackend = {
+      closed: false,
+      command: vi.fn(),
+      disconnect: vi.fn(async () => undefined),
+      onDisconnected: () => () => undefined,
+    };
+    const connection = new PlaywrightBrowserConnectionImpl({
+      backend,
+      control: new BrowserControlState(),
+    });
+    const controller = new AbortController();
+    controller.abort(new Error("keep connected"));
+
+    await expect(connection.disconnect({ abortSignal: controller.signal })).rejects.toMatchObject({
+      code: "cancelled",
+    });
+    expect(connection.closed).toBe(false);
+    expect(backend.disconnect).not.toHaveBeenCalled();
+    await connection.disconnect();
+  });
+});
+
+function success(id: number): AutomationResponse {
+  return { kind: "response", id, ok: true, value: undefined };
+}
+
+class FakeChild extends EventEmitter {
+  connected = true;
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  readonly kill = vi.fn((signal: NodeJS.Signals = "SIGTERM") => {
+    if (this.exitCode !== null || this.signalCode !== null) return false;
+    this.connected = false;
+    this.signalCode = signal;
+    queueMicrotask(() => this.emit("exit", null, signal));
+    return true;
+  });
+  readonly send = vi.fn((message: AutomationRequest, callback?: (error: Error | null) => void) => {
+    this.onSend(message);
+    callback?.(null);
+    return true;
+  });
+
+  constructor(private readonly onSend: (message: AutomationRequest) => void) {
+    super();
+  }
+
+  respond(message: unknown): void {
+    queueMicrotask(() => this.emit("message", message));
+  }
+
+  crash(): void {
+    this.connected = false;
+    this.exitCode = 1;
+    this.emit("exit", 1, null);
+  }
+
+  asChildProcess(): ChildProcess {
+    return this as unknown as ChildProcess;
+  }
+}

--- a/packages/tool-browser/test/control.test.ts
+++ b/packages/tool-browser/test/control.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { BrowserControlState } from "../src/control";
 
 describe("BrowserControlState", () => {
+  afterEach(() => vi.useRealTimers());
+
   it("waits for an active agent action before granting human control", async () => {
     const control = new BrowserControlState();
     let finishAction: (() => void) | undefined;
@@ -17,7 +19,7 @@ describe("BrowserControlState", () => {
     });
 
     await expect(control.runAgentAction(async () => undefined)).rejects.toMatchObject({
-      code: "human_controlled",
+      code: "human_control_conflict",
     });
     finishAction?.();
     await action;
@@ -32,13 +34,14 @@ describe("BrowserControlState", () => {
   });
 
   it("expires and renews human control leases", async () => {
+    vi.useFakeTimers();
     const control = new BrowserControlState();
     const lease = await control.acquireHumanControl({ ownerId: "viewer", leaseTimeoutMs: 20 });
     const firstExpiration = lease.expiresAt;
     lease.renew({ leaseTimeoutMs: 100 });
     expect(Date.parse(lease.expiresAt)).toBeGreaterThanOrEqual(Date.parse(firstExpiration));
-    await new Promise((resolve) => setTimeout(resolve, 120));
-    expect(control.snapshot()).toEqual({ mode: "agent" });
+    await vi.advanceTimersByTimeAsync(120);
+    expect(control.snapshot()).toMatchObject({ mode: "agent", state: "agent" });
   });
 
   it("propagates abort while takeover waits for an action", async () => {
@@ -61,5 +64,140 @@ describe("BrowserControlState", () => {
     finishAction?.();
     await action;
     await expect(control.runAgentAction(async () => "available")).resolves.toBe("available");
+  });
+
+  it("times out acquisition and completely clears pending state", async () => {
+    vi.useFakeTimers();
+    const control = new BrowserControlState();
+    let finishAction: (() => void) | undefined;
+    const action = control.runAgentAction(
+      () =>
+        new Promise<void>((resolve) => {
+          finishAction = resolve;
+        }),
+    );
+    const acquiring = control.acquireHumanControl({
+      ownerId: "viewer",
+      leaseTimeoutMs: 30_000,
+      timeoutMs: 50,
+    });
+    const rejected = expect(acquiring).rejects.toMatchObject({
+      code: "human_control_conflict",
+    });
+
+    await vi.advanceTimersByTimeAsync(50);
+    await rejected;
+    expect(control.snapshot()).toMatchObject({ state: "agent-active", humanPending: false });
+    finishAction?.();
+    await action;
+    await expect(control.runAgentAction(async () => "resumed")).resolves.toBe("resumed");
+  });
+
+  it("rejects a second human acquisition while the first is pending", async () => {
+    const control = new BrowserControlState();
+    let finishAction: (() => void) | undefined;
+    const action = control.runAgentAction(
+      () =>
+        new Promise<void>((resolve) => {
+          finishAction = resolve;
+        }),
+    );
+    const controller = new AbortController();
+    const first = control.acquireHumanControl({
+      ownerId: "first",
+      leaseTimeoutMs: 30_000,
+      abortSignal: controller.signal,
+    });
+
+    await expect(
+      control.acquireHumanControl({ ownerId: "second", leaseTimeoutMs: 30_000 }),
+    ).rejects.toMatchObject({ code: "human_control_conflict" });
+    controller.abort(new Error("cancel first acquisition"));
+    await expect(first).rejects.toMatchObject({ code: "cancelled" });
+    finishAction?.();
+    await action;
+  });
+
+  it("rejects simultaneous acquisition and tolerates release racing with destroy", async () => {
+    const control = new BrowserControlState();
+    const lease = await control.acquireHumanControl({
+      ownerId: "first",
+      leaseTimeoutMs: 30_000,
+    });
+    await expect(
+      control.acquireHumanControl({ ownerId: "second", leaseTimeoutMs: 30_000 }),
+    ).rejects.toMatchObject({ code: "human_controlled" });
+
+    control.destroy();
+    expect(() => lease.release()).not.toThrow();
+    expect(control.snapshot()).toMatchObject({ availability: "destroyed" });
+  });
+
+  it("clears pending human state synchronously when destroyed", async () => {
+    const control = new BrowserControlState();
+    let finishAction: (() => void) | undefined;
+    const action = control.runAgentAction(
+      () =>
+        new Promise<void>((resolve) => {
+          finishAction = resolve;
+        }),
+    );
+    const acquiring = control.acquireHumanControl({
+      ownerId: "viewer",
+      leaseTimeoutMs: 30_000,
+    });
+
+    control.destroy();
+    expect(control.snapshot()).toMatchObject({
+      availability: "destroyed",
+      humanPending: false,
+    });
+    await expect(acquiring).rejects.toMatchObject({ code: "runtime_destroyed" });
+    finishAction?.();
+    await action;
+  });
+
+  it("treats destroyed availability as a terminal transition", async () => {
+    const control = new BrowserControlState();
+
+    control.setAvailability("destroyed");
+
+    expect(control.snapshot()).toMatchObject({ availability: "destroyed" });
+    await expect(control.runAgentAction(async () => undefined)).rejects.toMatchObject({
+      code: "runtime_destroyed",
+    });
+    await expect(
+      control.acquireHumanControl({ ownerId: "late", leaseTimeoutMs: 30_000 }),
+    ).rejects.toMatchObject({ code: "runtime_destroyed" });
+  });
+
+  it("clears pending control and blocks new work when the runtime disconnects", async () => {
+    const control = new BrowserControlState();
+    let finishAction: (() => void) | undefined;
+    const action = control.runAgentAction(
+      () =>
+        new Promise<void>((resolve) => {
+          finishAction = resolve;
+        }),
+    );
+    const acquiring = control.acquireHumanControl({
+      ownerId: "viewer",
+      leaseTimeoutMs: 30_000,
+    });
+
+    control.setAvailability("disconnected");
+    await expect(acquiring).rejects.toMatchObject({ code: "connection_closed" });
+    expect(control.snapshot()).toMatchObject({
+      availability: "disconnected",
+      humanPending: false,
+    });
+    await expect(control.runAgentAction(async () => undefined)).rejects.toMatchObject({
+      code: "connection_closed",
+    });
+    await expect(
+      control.acquireHumanControl({ ownerId: "late", leaseTimeoutMs: 30_000 }),
+    ).rejects.toMatchObject({ code: "connection_closed" });
+    finishAction?.();
+    await action;
   });
 });

--- a/packages/tool-browser/test/docker-browser.integration.test.ts
+++ b/packages/tool-browser/test/docker-browser.integration.test.ts
@@ -1,6 +1,6 @@
 import { DockerSandboxClient } from "@anvia/sandbox";
 import { describe, expect, it } from "vitest";
-import { DockerBrowserClient } from "../src/docker-browser";
+import { DockerBrowserClient } from "../src/docker-browser-client";
 import { createBrowserTools } from "../src/tools";
 
 const enabled = process.env.ANVIA_BROWSER_DOCKER_TESTS === "1";
@@ -26,7 +26,15 @@ describe.skipIf(!enabled)("Docker browser integration", () => {
 
     try {
       try {
-        await browser.waitUntilReady({ timeoutMs: 15_000 });
+        const desktop = await browser.waitForCapabilities({
+          capabilities: ["desktop"],
+          timeoutMs: 15_000,
+        });
+        expect(desktop.capabilities.desktop.state).toBe("ready");
+        await browser.waitForCapabilities({
+          capabilities: ["runtime", "browser", "automation"],
+          timeoutMs: 15_000,
+        });
       } catch (error) {
         const processes = await browser.sandbox.runtime.listProcesses();
         for (const process of processes) {
@@ -63,23 +71,31 @@ describe.skipIf(!enabled)("Docker browser integration", () => {
           ].join(""),
         ],
       });
-      await using connection = await browser.connect();
+      await using connection = await browser.connect({
+        timeoutMs: 15_000,
+        scheduling: { mode: "per-tab", maxConcurrentTabs: 4 },
+      });
       const tools = createBrowserTools({
         connection,
-        tools: ["browser_navigate", "browser_snapshot", "browser_screenshot"],
+        tools: ["browser_open_tab", "browser_navigate", "browser_snapshot", "browser_screenshot"],
         navigation: { mode: "origins", origins: ["http://127.0.0.1:8080"] },
       });
+      const openTab = tools.find((tool) => tool.name === "browser_open_tab");
       const navigate = tools.find((tool) => tool.name === "browser_navigate");
       const snapshot = tools.find((tool) => tool.name === "browser_snapshot");
       const screenshot = tools.find((tool) => tool.name === "browser_screenshot");
-      await navigate?.call({ url: "http://127.0.0.1:8080" });
-      await expect(snapshot?.call({})).resolves.toMatchObject({ truncated: false });
-      await expect(screenshot?.call({})).resolves.toMatchObject({
+      const opened = (await openTab?.call({})) as { tabId: string };
+      await navigate?.call({ tabId: opened.tabId, url: "http://127.0.0.1:8080" });
+      await expect(snapshot?.call({ tabId: opened.tabId })).resolves.toMatchObject({
+        tabId: opened.tabId,
+        truncated: false,
+      });
+      await expect(screenshot?.call({ tabId: opened.tabId })).resolves.toMatchObject({
         content: [expect.any(Object), { type: "file", mediaType: "image/png" }],
       });
       await connection.disconnect();
       await browser.waitUntilReady({ timeoutMs: 5_000 });
-      await using resumedConnection = await browser.connect();
+      await using resumedConnection = await browser.connect({ timeoutMs: 5_000 });
       await expect(resumedConnection.listTabs()).resolves.not.toHaveLength(0);
     } finally {
       await browser.destroy();

--- a/packages/tool-browser/test/docker-browser.test.ts
+++ b/packages/tool-browser/test/docker-browser.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
-import { DockerBrowserClient } from "../src/docker-browser";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DockerBrowserClient } from "../src/docker-browser-client";
 
 describe("DockerBrowserClient", () => {
+  afterEach(() => vi.useRealTimers());
+
   it("does no constructor I/O and pulls only when explicitly requested", async () => {
     const sandboxClient = fakeSandboxClient();
     const client = new DockerBrowserClient({
@@ -12,7 +14,9 @@ describe("DockerBrowserClient", () => {
     expect(sandboxClient.createSandbox).not.toHaveBeenCalled();
 
     await client.pullImage();
-    expect(sandboxClient.pullImage).toHaveBeenCalledWith({ image: "browser:test" });
+    expect(sandboxClient.pullImage).toHaveBeenCalledWith(
+      expect.objectContaining({ image: "browser:test", abortSignal: expect.any(AbortSignal) }),
+    );
   });
 
   it("provisions fixed loopback services and configures the password through stdin", async () => {
@@ -52,9 +56,9 @@ describe("DockerBrowserClient", () => {
         input: JSON.stringify({ password: "passw0rd", width: 1440, height: 900 }),
       }),
     );
-    expect(sandboxClient.runtime.startProcess).toHaveBeenCalledWith({
-      command: "/usr/local/bin/anvia-browser-start",
-    });
+    expect(sandboxClient.runtime.startProcess).toHaveBeenCalledWith(
+      expect.objectContaining({ command: "/usr/local/bin/anvia-browser-start" }),
+    );
     expect(browser.desktop).toMatchObject({ protocol: "novnc", containerPort: 6080 });
   });
 
@@ -80,11 +84,33 @@ describe("DockerBrowserClient", () => {
     vi.stubGlobal("fetch", fetch);
 
     try {
-      await browser.waitUntilReady({ timeoutMs: 1_000 });
-      expect(fetch).toHaveBeenCalledTimes(3);
+      await browser.waitUntilReady({ timeoutMs: 1_000, capabilities: ["desktop"] });
+      expect(fetch).toHaveBeenCalledTimes(2);
     } finally {
       vi.unstubAllGlobals();
     }
+  });
+
+  it("reports timeout when an underlying lifecycle call completes late", async () => {
+    vi.useFakeTimers();
+    const sandboxClient = fakeSandboxClient();
+    let finishPull: (() => void) | undefined;
+    sandboxClient.pullImage.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishPull = resolve;
+        }),
+    );
+    const client = new DockerBrowserClient({
+      sandboxClient: sandboxClient.client,
+      image: "browser:test",
+    });
+    const pulling = client.pullImage({ timeoutMs: 50 });
+    const rejected = expect(pulling).rejects.toMatchObject({ code: "lifecycle_timeout" });
+
+    await vi.advanceTimersByTimeAsync(50);
+    finishPull?.();
+    await rejected;
   });
 
   it("rejects VNC values that x11vnc would truncate", async () => {

--- a/packages/tool-browser/test/fixtures/crashing-automation-worker.mjs
+++ b/packages/tool-browser/test/fixtures/crashing-automation-worker.mjs
@@ -1,0 +1,9 @@
+process.on("message", (message) => {
+  if (message?.kind !== "request") return;
+  process.send?.({ kind: "response", id: message.id, ok: true, value: null }, () => {
+    if (message.method === "connect") return;
+    setImmediate(() => {
+      throw new Error("simulated late Playwright protocol assertion");
+    });
+  });
+});

--- a/packages/tool-browser/test/readiness-lifecycle.test.ts
+++ b/packages/tool-browser/test/readiness-lifecycle.test.ts
@@ -1,0 +1,481 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { connectPlaywrightBrowser } from "../src/connection";
+import { DockerBrowserHandle } from "../src/docker-browser";
+
+describe("DockerBrowser capability readiness", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("reports desktop readiness without attempting CDP automation", async () => {
+    const sandbox = fakeSandbox();
+    const connect = vi.fn(async () => {
+      throw new Error("automation must not be probed");
+    }) as unknown as typeof connectPlaywrightBrowser;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("desktop")),
+    );
+    const browser = new DockerBrowserHandle(sandbox as never, connect);
+
+    const snapshot = await browser.waitForCapabilities({
+      timeoutMs: 1_000,
+      capabilities: ["desktop"],
+    });
+    expect(snapshot.capabilities.desktop.state).toBe("ready");
+    expect(snapshot.capabilities.automation.state).toBe("unknown");
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unusable automation session and records the failed capability", async () => {
+    vi.useFakeTimers();
+    const sandbox = fakeSandbox();
+    const disconnect = vi.fn(async () => undefined);
+    const connect = vi.fn(async () => ({
+      closed: true,
+      disconnect,
+    })) as unknown as typeof connectPlaywrightBrowser;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ webSocketDebuggerUrl: "ws://127.0.0.1/devtools" })),
+    );
+    const browser = new DockerBrowserHandle(sandbox as never, connect);
+    const waiting = browser.waitForCapabilities({
+      timeoutMs: 100,
+      capabilities: ["automation"],
+    });
+    const rejected = expect(waiting).rejects.toMatchObject({
+      code: "readiness_timeout",
+      capability: "automation",
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+    await rejected;
+    expect(browser.readiness().capabilities.automation).toMatchObject({
+      state: "failed",
+      error: { capability: "automation" },
+    });
+    expect(disconnect).toHaveBeenCalled();
+  });
+
+  it("keeps a healthy desktop usable when browser protocol discovery fails", async () => {
+    vi.useFakeTimers();
+    const sandbox = fakeSandbox();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) =>
+        String(input).includes("6080")
+          ? new Response("desktop")
+          : Response.json({ Browser: "Chromium" }),
+      ),
+    );
+    const browser = new DockerBrowserHandle(sandbox as never, vi.fn() as never);
+    const waiting = browser.waitForCapabilities({
+      timeoutMs: 100,
+      capabilities: ["browser", "desktop"],
+    });
+    const rejected = expect(waiting).rejects.toMatchObject({ code: "readiness_timeout" });
+
+    await vi.advanceTimersByTimeAsync(100);
+    await rejected;
+    expect(browser.readiness()).toMatchObject({
+      state: "degraded",
+      capabilities: {
+        browser: { state: "failed" },
+        desktop: { state: "ready" },
+      },
+    });
+  });
+
+  it("cancels readiness probes without retaining failed state", async () => {
+    const sandbox = fakeSandbox();
+    let observedSignal: AbortSignal | undefined;
+    let markStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const connect = vi.fn(
+      async (options: Parameters<typeof connectPlaywrightBrowser>[0]) =>
+        new Promise<never>((_resolve, reject) => {
+          observedSignal = options.abortSignal;
+          markStarted?.();
+          options.abortSignal?.addEventListener(
+            "abort",
+            () => reject(options.abortSignal?.reason),
+            {
+              once: true,
+            },
+          );
+        }),
+    ) as unknown as typeof connectPlaywrightBrowser;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ webSocketDebuggerUrl: "ws://127.0.0.1/devtools" })),
+    );
+    const browser = new DockerBrowserHandle(sandbox as never, connect);
+    const controller = new AbortController();
+    const waiting = browser.waitForCapabilities({
+      timeoutMs: 1_000,
+      capabilities: ["automation"],
+      abortSignal: controller.signal,
+    });
+    await started;
+    controller.abort(new Error("cancel probe"));
+
+    await expect(waiting).rejects.toMatchObject({ code: "cancelled" });
+    expect(observedSignal?.aborted).toBe(true);
+    expect(browser.readiness().capabilities.automation.state).toBe("unknown");
+  });
+
+  it("does not start or mutate readiness for an already-cancelled caller", async () => {
+    const connect = vi.fn() as unknown as typeof connectPlaywrightBrowser;
+    const browser = new DockerBrowserHandle(fakeSandbox() as never, connect);
+    const controller = new AbortController();
+    controller.abort(new Error("do not probe"));
+
+    await expect(
+      browser.waitForCapabilities({
+        timeoutMs: 1_000,
+        capabilities: ["automation"],
+        abortSignal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ code: "cancelled" });
+    expect(connect).not.toHaveBeenCalled();
+    expect(browser.readiness().capabilities.automation.state).toBe("unknown");
+  });
+
+  it("prevents an older cancelled probe from overwriting newer readiness", async () => {
+    let rejectFirst: ((reason: unknown) => void) | undefined;
+    let markFirstStarted: (() => void) | undefined;
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve;
+    });
+    const connection = { closed: false, disconnect: vi.fn() };
+    let connectCalls = 0;
+    const connect = vi.fn(async (options: Parameters<typeof connectPlaywrightBrowser>[0]) => {
+      connectCalls += 1;
+      if (connectCalls === 1) {
+        markFirstStarted?.();
+        return new Promise<never>((_resolve, reject) => {
+          rejectFirst = reject;
+          options.abortSignal?.addEventListener(
+            "abort",
+            () => reject(options.abortSignal?.reason),
+            { once: true },
+          );
+        });
+      }
+      return connection;
+    }) as unknown as typeof connectPlaywrightBrowser;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ webSocketDebuggerUrl: "ws://127.0.0.1/devtools" })),
+    );
+    const browser = new DockerBrowserHandle(fakeSandbox() as never, connect);
+    const oldController = new AbortController();
+    const oldProbe = browser.waitForCapabilities({
+      timeoutMs: 1_000,
+      capabilities: ["automation"],
+      abortSignal: oldController.signal,
+    });
+    await firstStarted;
+
+    await browser.waitForCapabilities({ timeoutMs: 1_000, capabilities: ["automation"] });
+    expect(browser.readiness().capabilities.automation.state).toBe("ready");
+
+    oldController.abort(new Error("obsolete probe"));
+    rejectFirst?.(oldController.signal.reason);
+    await expect(oldProbe).rejects.toMatchObject({ code: "cancelled" });
+    expect(browser.readiness().capabilities.automation.state).toBe("ready");
+  });
+
+  it("keeps control availability disconnected when stop aborts a readiness probe", async () => {
+    const sandbox = fakeSandbox();
+    const connect = abortableConnectionFactory();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ webSocketDebuggerUrl: "ws://127.0.0.1/devtools" })),
+    );
+    const browser = new DockerBrowserHandle(sandbox as never, connect.factory);
+    const waiting = browser.waitForCapabilities({
+      timeoutMs: 10_000,
+      capabilities: ["automation"],
+    });
+    await connect.started;
+    const rejected = expect(waiting).rejects.toMatchObject({ code: "connection_closed" });
+
+    await browser.stop();
+    await rejected;
+    expect(browser.desktop.control.snapshot().availability).toBe("disconnected");
+    expect(browser.readiness().state).toBe("stopped");
+  });
+});
+
+describe("DockerBrowser pending connection ownership", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("retries deterministically after repeated connection failures", async () => {
+    const sandbox = fakeSandbox();
+    let attempts = 0;
+    const connection = { closed: false, disconnect: vi.fn(async () => undefined) };
+    const connect = vi.fn(async () => {
+      attempts += 1;
+      if (attempts <= 2) throw new Error(`injected failure ${attempts}`);
+      return connection;
+    }) as unknown as typeof connectPlaywrightBrowser;
+    const browser = new DockerBrowserHandle(sandbox as never, connect);
+
+    await expect(browser.connect()).rejects.toMatchObject({ code: "transport_failure" });
+    await expect(browser.connect()).rejects.toMatchObject({ code: "transport_failure" });
+    await expect(browser.connect()).resolves.toBe(connection);
+    await browser.destroy();
+  });
+
+  it("releases ownership when endpoint resolution fails synchronously", async () => {
+    const sandbox = fakeSandbox();
+    sandbox.runtime.publishedPorts = sandbox.runtime.publishedPorts.filter(
+      ({ containerPort }) => containerPort !== 9222,
+    );
+    const connect = vi.fn() as unknown as typeof connectPlaywrightBrowser;
+    const browser = new DockerBrowserHandle(sandbox as never, connect);
+
+    await expect(browser.connect()).rejects.toMatchObject({ code: "invalid_state" });
+
+    expect(connect).not.toHaveBeenCalled();
+    expect(
+      (browser as unknown as { ownedOperations: ReadonlySet<unknown> }).ownedOperations.size,
+    ).toBe(0);
+    await browser.destroy();
+  });
+
+  it("rejects a second connection while one attempt owns the runtime", async () => {
+    let finishConnect: ((connection: unknown) => void) | undefined;
+    const connection = { closed: false, disconnect: vi.fn(async () => undefined) };
+    const connect = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          finishConnect = resolve;
+        }),
+    ) as unknown as typeof connectPlaywrightBrowser;
+    const browser = new DockerBrowserHandle(fakeSandbox() as never, connect);
+    const first = browser.connect();
+
+    await expect(browser.connect()).rejects.toMatchObject({ code: "agent_action_busy" });
+    finishConnect?.(connection);
+    await expect(first).resolves.toBe(connection);
+    await expect(browser.connect()).rejects.toMatchObject({ code: "agent_action_busy" });
+    await browser.destroy();
+  });
+
+  it("rejects a connection that disconnects at the initialization boundary", async () => {
+    const sandbox = fakeSandbox();
+    const disconnect = vi.fn(async () => undefined);
+    const connect = vi.fn(async () => ({
+      closed: true,
+      disconnect,
+    })) as unknown as typeof connectPlaywrightBrowser;
+    const browser = new DockerBrowserHandle(sandbox as never, connect);
+
+    await expect(browser.connect()).rejects.toMatchObject({ code: "connection_closed" });
+    expect(disconnect).toHaveBeenCalledOnce();
+  });
+
+  it("aborts and joins a pending connection before stop completes", async () => {
+    const sandbox = fakeSandbox();
+    const connect = abortableConnectionFactory();
+    const browser = new DockerBrowserHandle(sandbox as never, connect.factory);
+    const connecting = browser.connect({ timeoutMs: 10_000 });
+    await connect.started;
+
+    await browser.stop();
+    await expect(connecting).rejects.toMatchObject({ code: "connection_closed" });
+    expect(connect.aborted()).toBe(true);
+    expect(sandbox.stop).toHaveBeenCalledOnce();
+  });
+
+  it("aborts and joins a pending connection before destroy completes", async () => {
+    const sandbox = fakeSandbox();
+    const connect = abortableConnectionFactory();
+    const browser = new DockerBrowserHandle(sandbox as never, connect.factory);
+    const connecting = browser.connect({ timeoutMs: 10_000 });
+    await connect.started;
+
+    await browser.destroy();
+    await expect(connecting).rejects.toMatchObject({ code: "runtime_destroyed" });
+    expect(connect.aborted()).toBe(true);
+    expect(sandbox.destroy).toHaveBeenCalledOnce();
+  });
+
+  it("does not enter stopping state for an already-cancelled stop", async () => {
+    const sandbox = fakeSandbox();
+    const browser = new DockerBrowserHandle(sandbox as never);
+    const controller = new AbortController();
+    controller.abort(new Error("do not stop"));
+
+    await expect(browser.stop({ abortSignal: controller.signal })).rejects.toMatchObject({
+      code: "cancelled",
+    });
+    expect(browser.readiness().state).toBe("unknown");
+    expect(sandbox.stop).not.toHaveBeenCalled();
+    await browser.destroy();
+  });
+
+  it("bounds a later caller waiting on an active stop", async () => {
+    vi.useFakeTimers();
+    let finishStop: (() => void) | undefined;
+    const sandbox = fakeSandbox();
+    sandbox.stop.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishStop = resolve;
+        }),
+    );
+    const browser = new DockerBrowserHandle(sandbox as never);
+    const first = browser.stop({ timeoutMs: 1_000 });
+    await vi.advanceTimersByTimeAsync(1);
+    const second = browser.stop({ timeoutMs: 50 });
+    const rejected = expect(second).rejects.toMatchObject({ code: "lifecycle_timeout" });
+
+    await vi.advanceTimersByTimeAsync(50);
+    await rejected;
+    expect(browser.readiness().state).toBe("stopped");
+    finishStop?.();
+    await first;
+  });
+
+  it("bounds destroy while retaining ownership of uncancellable sandbox cleanup", async () => {
+    vi.useFakeTimers();
+    let finishDestroy: (() => void) | undefined;
+    const sandbox = fakeSandbox();
+    sandbox.destroy.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishDestroy = resolve;
+        }),
+    );
+    const browser = new DockerBrowserHandle(sandbox as never);
+    const first = browser.destroy({ timeoutMs: 50 });
+    const rejected = expect(first).rejects.toMatchObject({ code: "lifecycle_timeout" });
+
+    await vi.advanceTimersByTimeAsync(50);
+    await rejected;
+    expect(browser.desktop.control.snapshot().availability).toBe("destroyed");
+    expect(browser.state).toBe("destroying");
+
+    const joined = browser.destroy({ timeoutMs: 1_000 });
+    finishDestroy?.();
+    await joined;
+    expect(browser.state).toBe("destroyed");
+    expect(sandbox.destroy).toHaveBeenCalledOnce();
+  });
+
+  it("bounds a cancelled destroy wait without abandoning sandbox cleanup", async () => {
+    let finishDestroy: (() => void) | undefined;
+    const sandbox = fakeSandbox();
+    sandbox.destroy.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishDestroy = resolve;
+        }),
+    );
+    const browser = new DockerBrowserHandle(sandbox as never);
+    const controller = new AbortController();
+    const first = browser.destroy({ timeoutMs: 10_000, abortSignal: controller.signal });
+
+    controller.abort(new Error("stop waiting"));
+    await expect(first).rejects.toMatchObject({ code: "cancelled" });
+    expect(browser.state).toBe("destroying");
+
+    const joined = browser.destroy({ timeoutMs: 1_000 });
+    finishDestroy?.();
+    await joined;
+    expect(browser.state).toBe("destroyed");
+    expect(sandbox.destroy).toHaveBeenCalledOnce();
+  });
+
+  it("keeps destroy terminal when an earlier stop completes late", async () => {
+    let finishStop: (() => void) | undefined;
+    let finishDestroy: (() => void) | undefined;
+    let markStopStarted: (() => void) | undefined;
+    let markDestroyStarted: (() => void) | undefined;
+    const stopStarted = new Promise<void>((resolve) => {
+      markStopStarted = resolve;
+    });
+    const destroyStarted = new Promise<void>((resolve) => {
+      markDestroyStarted = resolve;
+    });
+    const sandbox = fakeSandbox();
+    sandbox.stop.mockImplementation(() => {
+      markStopStarted?.();
+      return new Promise<void>((resolve) => {
+        finishStop = resolve;
+      });
+    });
+    sandbox.destroy.mockImplementation(() => {
+      markDestroyStarted?.();
+      return new Promise<void>((resolve) => {
+        finishDestroy = resolve;
+      });
+    });
+    const browser = new DockerBrowserHandle(sandbox as never);
+    const stopping = browser.stop({ timeoutMs: 1_000 });
+    await stopStarted;
+    const destroying = browser.destroy({ timeoutMs: 1_000 });
+
+    expect(browser.state).toBe("destroying");
+    finishStop?.();
+    await stopping;
+    expect(browser.state).toBe("destroying");
+
+    await destroyStarted;
+    finishDestroy?.();
+    await destroying;
+    expect(browser.state).toBe("destroyed");
+  });
+});
+
+function abortableConnectionFactory() {
+  let markStarted: (() => void) | undefined;
+  const started = new Promise<void>((resolve) => {
+    markStarted = resolve;
+  });
+  let signal: AbortSignal | undefined;
+  const factory = vi.fn(
+    async (options: Parameters<typeof connectPlaywrightBrowser>[0]) =>
+      new Promise<never>((_resolve, reject) => {
+        signal = options.abortSignal;
+        markStarted?.();
+        options.abortSignal?.addEventListener("abort", () => reject(options.abortSignal?.reason), {
+          once: true,
+        });
+      }),
+  ) as unknown as typeof connectPlaywrightBrowser;
+  return { factory, started, aborted: () => signal?.aborted === true };
+}
+
+function fakeSandbox() {
+  let state = "running";
+  return {
+    id: "browser-test",
+    get state() {
+      return state;
+    },
+    runtime: {
+      publishedPorts: [
+        { containerPort: 9222, host: "127.0.0.1", hostPort: 49100, protocol: "tcp" },
+        { containerPort: 6080, host: "127.0.0.1", hostPort: 49101, protocol: "tcp" },
+      ],
+      waitForPort: vi.fn(),
+    },
+    inspector: vi.fn(),
+    stop: vi.fn(async () => {
+      state = "stopped";
+    }),
+    destroy: vi.fn(async () => {
+      state = "destroyed";
+    }),
+  };
+}

--- a/packages/tool-browser/test/tools.test.ts
+++ b/packages/tool-browser/test/tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { PlaywrightBrowserConnectionImpl } from "../src/connection";
+import { type AutomationBackend, PlaywrightBrowserConnectionImpl } from "../src/connection";
 import { BrowserControlState } from "../src/control";
 import { createBrowserTools } from "../src/tools";
 
@@ -24,7 +24,7 @@ describe("createBrowserTools", () => {
   });
 
   it("blocks non-HTTP navigation before Playwright receives it", async () => {
-    const { connection, page } = fakeConnection();
+    const { connection, command } = fakeConnection();
     const [navigate] = createBrowserTools({
       connection,
       tools: ["browser_navigate"],
@@ -33,11 +33,32 @@ describe("createBrowserTools", () => {
     await expect(navigate?.call({ url: "file:///etc/passwd" })).rejects.toMatchObject({
       code: "navigation_blocked",
     });
-    expect(page.goto).not.toHaveBeenCalled();
+    expect(command).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: "navigate" }),
+      expect.anything(),
+    );
   });
 
-  it("guards top-level navigation caused by any browser interaction", async () => {
-    const { connection, context } = fakeConnection();
+  it("reports navigation policy rejection from redirects as navigation_blocked", async () => {
+    const { connection, command } = fakeConnection();
+    const [navigate] = createBrowserTools({
+      connection,
+      tools: ["browser_navigate"],
+      navigation: { mode: "origins", origins: ["https://example.com"] },
+    });
+    await connection.listTabs();
+    command.mockRejectedValueOnce(new Error("page.goto: net::ERR_BLOCKED_BY_CLIENT"));
+
+    await expect(
+      navigate?.call({
+        tabId: "11111111-1111-4111-8111-111111111111",
+        url: "https://example.com/redirect",
+      }),
+    ).rejects.toMatchObject({ code: "navigation_blocked" });
+  });
+
+  it("installs the navigation policy before browser interaction", async () => {
+    const { connection, command } = fakeConnection();
     const [snapshot] = createBrowserTools({
       connection,
       tools: ["browser_snapshot"],
@@ -45,23 +66,11 @@ describe("createBrowserTools", () => {
     });
     await snapshot?.call({});
 
-    const handler = context.route.mock.calls[0]?.[1] as
-      | ((route: unknown) => Promise<void>)
-      | undefined;
-    expect(handler).toBeTypeOf("function");
-    const frame = { page: () => ({ mainFrame: () => frame }) };
-    const route = {
-      request: () => ({
-        isNavigationRequest: () => true,
-        frame: () => frame,
-        url: () => "http://127.0.0.1/private",
-      }),
-      abort: vi.fn(),
-      continue: vi.fn(),
-    };
-    await handler?.(route);
-    expect(route.abort).toHaveBeenCalledWith("blockedbyclient");
-    expect(route.continue).not.toHaveBeenCalled();
+    expect(command.mock.calls[0]?.[0]).toEqual({
+      method: "setNavigationPolicy",
+      params: { policy: { mode: "origins", origins: ["https://example.com"] } },
+    });
+    expect(command.mock.calls[0]?.[1]).toEqual(expect.anything());
   });
 
   it("returns native structured PNG output", async () => {
@@ -95,43 +104,39 @@ describe("createBrowserTools", () => {
 });
 
 function fakeConnection(control = new BrowserControlState()) {
-  const locator = {
-    ariaSnapshot: vi.fn(async () => "- document"),
-    click: vi.fn(),
-    fill: vi.fn(),
-  };
-  const page = {
-    title: vi.fn(async () => "Example"),
-    url: vi.fn(() => "https://example.com"),
-    isClosed: vi.fn(() => false),
-    locator: vi.fn(() => locator),
-    getByRole: vi.fn(() => locator),
-    getByText: vi.fn(() => locator),
-    getByLabel: vi.fn(() => locator),
-    getByPlaceholder: vi.fn(() => locator),
-    getByTestId: vi.fn(() => locator),
-    screenshot: vi.fn(async () => Buffer.from("png")),
-    goto: vi.fn(),
-    route: vi.fn(),
-    unroute: vi.fn(),
-    mainFrame: vi.fn(() => ({})),
-    keyboard: { press: vi.fn() },
-    close: vi.fn(),
-  };
-  const context = {
-    pages: vi.fn(() => [page]),
-    newPage: vi.fn(async () => page),
-    route: vi.fn(async (_pattern: string, _handler: unknown) => undefined),
-  };
-  const browser = {
-    contexts: vi.fn(() => [context]),
-    once: vi.fn(),
-    isConnected: vi.fn(() => true),
-    close: vi.fn(),
+  const tabId = "11111111-1111-4111-8111-111111111111";
+  const command = vi.fn(async (request: { method: string }, _options?: unknown) => {
+    switch (request.method) {
+      case "listTabs":
+        return [{ id: tabId, title: "Example", url: "https://example.com", selected: true }];
+      case "snapshot":
+        return {
+          tabId,
+          title: "Example",
+          url: "https://example.com",
+          snapshot: "- document",
+          truncated: false,
+        };
+      case "screenshot":
+        return {
+          metadata: { tabId, title: "Example", url: "https://example.com" },
+          pngBase64: Buffer.from("png").toString("base64"),
+        };
+      default:
+        return undefined;
+    }
+  });
+  const backend: AutomationBackend = {
+    closed: false,
+    command: async <T>(
+      request: Parameters<AutomationBackend["command"]>[0],
+      options: Parameters<AutomationBackend["command"]>[1],
+    ) => command(request, options) as Promise<T>,
+    disconnect: vi.fn(),
+    onDisconnected: vi.fn(() => () => undefined),
   };
   return {
-    page,
-    context,
-    connection: new PlaywrightBrowserConnectionImpl(browser as never, control),
+    command,
+    connection: new PlaywrightBrowserConnectionImpl({ backend, control }),
   };
 }


### PR DESCRIPTION
## Summary

- isolate Playwright CDP automation in a supervised child process so late protocol assertions cannot terminate the consumer host
- add bounded lifecycle cancellation, capability-specific readiness, deterministic per-tab scheduling, and race-safe human control
- expose structured recovery metadata, optional stable tab targeting, migration guidance, a patch changeset, and deterministic fault-injection coverage

## Engineering report

### Root causes

The previous runtime connected Playwright in the consumer process, treated readiness as an all-or-nothing CDP gate, serialized all actions through one selected-tab tail, and had no owned cleanup boundary for late completion after timeout. A rejected `connectOverCDP()` call could therefore be followed by a Playwright protocol callback that asserted outside the rejected promise and terminated the host. Connection-local selected state and a global action tail also prevented safe independent-tab concurrency.

### Lifecycle model

Every public lifecycle wait now has a timeout and optional `AbortSignal`. Connect attempts settle once, own their worker until termination, ignore late IPC, and leave no reusable partial state. Stop and destroy transition through explicit active/stopping/stopped/destroying/destroyed/error states, abort and join readiness/connect work, disconnect workers, and retain deterministic retry or cleanup behavior. Concurrent lifecycle callers join the visible shared transition while retaining bounded waits.

Readiness is tracked independently for runtime, Chromium/CDP discovery, usable Playwright automation, and noVNC desktop viewing. Desktop probing never opens Playwright; automation readiness proves context initialization and `Browser.getVersion` on a real CDP session.

### Concurrency and control model

Serial selected-tab scheduling remains the default. Per-tab mode uses FIFO resource queues, a browser-context mutex, bounded admission, and fair one-operation-per-resource turns. Explicit tab operations overlap across tabs and remain ordered within a tab. A browser handle permits one active or pending tool connection so independent workers and navigation policies cannot bypass resource ordering.

Human control is a runtime-wide gate. Pending acquisition waits for active work, rejects work that has not entered the gate, supports timeout/cancellation cleanup, and safely handles renewal, expiration, release, stop, and destroy races.

### Public API and compatibility

New public types cover lifecycle options, scheduling, readiness snapshots, capability state, control availability, and error recovery. Page tools accept optional `tabId`; omitted IDs retain selected-tab behavior. Errors preserve `cause` and expose `code`, `retryable`, `recovery`, `phase`, and optional `capability`.

This uses a patch changeset. Migration guidance remains important because each handle now permits one active or pending automation connection and structural `BrowserControlSnapshot` implementations must provide the new arbitration fields. Existing single-connection consumers and selected-tab tool calls remain source-compatible. `MIGRATION.md` covers concurrent tab targeting, readiness, cancellation, and control snapshots.

### Playwright and Node compatibility

The package and Docker image remain aligned on exact `playwright-core` 1.62.1. Its package engine is Node `>=20`; Anvia retains Node `>=20.12` and recommends supported Node 22, 24, or 26 releases. Validation ran on Node 26.7.0 with pnpm 11.0.4.

Inspection of Playwright 1.62.1 confirms that its progress timeout races and attempts transport cleanup, but a later internal protocol exception is outside the settled API promise. An in-process wrapper cannot guarantee host survival from that failure mode, so the child process is technically necessary. It is a crash boundary, not a tenant security boundary.

## Validation

- `pnpm check`
- `pnpm --filter ./packages/** typecheck` — 35 package workspaces passed
- `pnpm --filter ./packages/** test` — all enabled package suites passed
- `pnpm --filter @anvia/browser typecheck`
- `pnpm --filter @anvia/browser test` — 62 passed, Docker suite skipped by its environment gate
- `pnpm --filter cookbook typecheck`
- Studio consumer suite — 31 files and 214 tests passed through the package-wide run
- `pnpm --filter @anvia/browser pack --dry-run` — verified worker entry, declarations, image, security profile, and migration notes

Coverage includes connection success/failure/timeout/cancellation races, late success and delayed worker crash, disconnect during initialization, retry, stop/destroy during connect, malformed IPC, listener/timer/process cleanup, independent-tab overlap, same-tab ordering, bounded/fair queues, close races, shutdown under lock contention, human-control races, and independent readiness capabilities.

## Docker integration result

The real Docker Chromium/CDP/noVNC test was attempted with the existing browser image. This host fails before Chromium starts because Docker `runc` 1.5.1 built with Go 1.26.5 segfaults in `libpathrs` while applying the existing custom Playwright seccomp profile. A control run with Docker default seccomp succeeds, confirming the blocker is the host runtime/profile application path rather than the browser code. This PR does not weaken or bypass the security profile. The gated integration test remains ready for CI or a corrected Docker host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added capability-specific readiness checks for runtime, browser, automation, and desktop services.
  * Added per-tab scheduling for concurrent browser actions while preserving serial operation mode.
  * Added explicit tab targeting with stable tab IDs.
  * Added bounded timeouts, cancellation, and safer human-control coordination.
  * Added structured browser errors with recovery guidance.

* **Breaking Changes**
  * A connection now permits only one active or pending automation session.
  * Tab-based tools require an explicit `tabId` where applicable.

* **Documentation**
  * Added migration guidance and expanded lifecycle, concurrency, readiness, and recovery documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->