### PR TITLE
fix(browser): use patch changeset

### DIFF
--- a/.changeset/steady-browser-runtime.md
+++ b/.changeset/steady-browser-runtime.md
@@ -1,11 +1,11 @@
 ---
-"@anvia/browser": major
+"@anvia/browser": patch
 ---
 
 Add supervised Playwright process isolation, capability readiness, bounded lifecycle cancellation,
 per-tab concurrent tool scheduling, explicit tab targeting, race-safe human control, and structured
 recovery errors while preserving serial selected-tab compatibility.
 
-This is a major change because a browser handle now permits one active or pending automation connection,
-and structural `BrowserControlSnapshot` implementations must provide the new arbitration and
-availability fields.
+This patch hardens the existing browser runtime while preserving the default serial selected-tab
+workflow. Consumers with structural `BrowserControlSnapshot` test doubles should add the documented
+arbitration and availability fields.


### PR DESCRIPTION
## Summary

- correct the pending @anvia/browser release level from major to patch
- remove the incorrect major-release rationale
- preserve the migration note for structural BrowserControlSnapshot test doubles

## Validation

- pnpm exec changeset status reports @anvia/browser at patch
- no packages are reported at minor or major
- pnpm format:check

This must merge before the generated Version Packages PR #384 is regenerated or merged.