### PR TITLE
fix(browser): isolate worker IPC from watch mode

### DIFF
--- a/.changeset/quiet-browsers-watch.md
+++ b/.changeset/quiet-browsers-watch.md
@@ -1,0 +1,5 @@
+---
+"@anvia/browser": patch
+---
+
+Isolate automation-worker IPC from Node watch dependency messages and preserve bounded protocol and readiness failure diagnostics.

--- a/packages/tool-browser/src/automation-client.ts
+++ b/packages/tool-browser/src/automation-client.ts
@@ -1,6 +1,11 @@
 import { fork, type ChildProcess } from "node:child_process";
-import type { AutomationCommand, AutomationRequest, SerializedError } from "./automation-protocol";
-import { isAutomationResponse } from "./automation-protocol";
+import type {
+  AutomationCommand,
+  AutomationMessageSummary,
+  AutomationRequest,
+  SerializedError,
+} from "./automation-protocol";
+import { isAutomationResponse, summarizeAutomationMessage } from "./automation-protocol";
 import { BrowserError, cancellationError } from "./errors";
 import type { BrowserLifecycleOptions } from "./types";
 
@@ -316,7 +321,7 @@ export class AutomationWorkerClient implements AutomationBackend {
 
   private handleMessage(message: unknown): void {
     if (!isAutomationResponse(message)) {
-      throw new TypeError("Invalid browser automation worker response.");
+      throw new InvalidAutomationResponseError(summarizeAutomationMessage(message));
     }
     if (message.kind === "event") {
       if (!this.disconnecting) {
@@ -376,8 +381,10 @@ export class AutomationWorkerClient implements AutomationBackend {
 
   private cleanupChildListeners(): void {
     this.child.off("message", this.onMessage);
+    this.child.off("error", this.onError);
     this.child.off("exit", this.onExit);
     this.child.stderr?.off("data", this.onStderrData);
+    this.child.stderr?.off("error", this.onStderrError);
   }
 
   private rejectSend(phase: string, cause: unknown): void {
@@ -401,8 +408,11 @@ export class AutomationWorkerClient implements AutomationBackend {
   }
 }
 
-function spawnAutomationWorker(): ChildProcess {
-  return fork(automationWorkerUrl(), [], {
+export function spawnAutomationWorker(workerUrl = automationWorkerUrl()): ChildProcess {
+  const env = { ...process.env };
+  delete env.WATCH_REPORT_DEPENDENCIES;
+  return fork(workerUrl, [], {
+    env,
     execArgv: [],
     serialization: "advanced",
     stdio: ["ignore", "ignore", "pipe", "ipc"],
@@ -426,5 +436,11 @@ function deserializeError(value: SerializedError): Error {
 function assertPositiveSafeInteger(value: number, name: string): void {
   if (!Number.isSafeInteger(value) || value <= 0 || value > 2_147_483_647) {
     throw new RangeError(`${name} must be a positive integer no greater than 2147483647.`);
+  }
+}
+
+class InvalidAutomationResponseError extends TypeError {
+  constructor(readonly responseSummary: AutomationMessageSummary) {
+    super("Invalid browser automation worker response.");
   }
 }

--- a/packages/tool-browser/src/automation-protocol.ts
+++ b/packages/tool-browser/src/automation-protocol.ts
@@ -76,6 +76,31 @@ export type AutomationScreenshotResult = Readonly<{
   pngBase64: string;
 }>;
 
+export type AutomationMessageSummary = Readonly<{
+  type: string;
+  ownPropertyNames: readonly string[];
+  ownPropertyCount: number;
+  kind: "response" | "cancelled" | "event" | "other" | undefined;
+  id: number | "non-number" | undefined;
+  ok: boolean | "non-boolean" | undefined;
+  constructorName: "Object" | "null-prototype" | "other" | undefined;
+  hasExpectedPrototype: boolean;
+  hasRequiredFields: boolean;
+}>;
+
+const safeSummaryPropertyNames = new Set([
+  "cmd",
+  "error",
+  "event",
+  "id",
+  "kind",
+  "ok",
+  "value",
+  "watch:import",
+  "watch:require",
+]);
+const maxSummaryPropertyNames = 12;
+
 export function isAutomationResponse(value: unknown): value is AutomationResponse {
   if (!isRecord(value)) return false;
   switch (value.kind) {
@@ -89,6 +114,48 @@ export function isAutomationResponse(value: unknown): value is AutomationRespons
     default:
       return false;
   }
+}
+
+export function summarizeAutomationMessage(value: unknown): AutomationMessageSummary {
+  const isObject = isRecord(value);
+  const prototype = isObject ? Object.getPrototypeOf(value) : undefined;
+  const propertyNames = isObject ? Object.getOwnPropertyNames(value) : [];
+  return Object.freeze({
+    type: value === null ? "null" : Array.isArray(value) ? "array" : typeof value,
+    ownPropertyNames: Object.freeze(
+      propertyNames
+        .slice(0, maxSummaryPropertyNames)
+        .map((name) => (safeSummaryPropertyNames.has(name) ? name : "<other>")),
+    ),
+    ownPropertyCount: propertyNames.length,
+    kind:
+      !isObject || value.kind === undefined
+        ? undefined
+        : value.kind === "response" || value.kind === "cancelled" || value.kind === "event"
+          ? value.kind
+          : "other",
+    id:
+      !isObject || value.id === undefined
+        ? undefined
+        : typeof value.id === "number"
+          ? value.id
+          : "non-number",
+    ok:
+      !isObject || value.ok === undefined
+        ? undefined
+        : typeof value.ok === "boolean"
+          ? value.ok
+          : "non-boolean",
+    constructorName: !isObject
+      ? undefined
+      : prototype === null
+        ? "null-prototype"
+        : prototype === Object.prototype
+          ? "Object"
+          : "other",
+    hasExpectedPrototype: isObject && prototype === Object.prototype,
+    hasRequiredFields: isAutomationResponse(value),
+  });
 }
 
 function isSerializedError(value: unknown): value is SerializedError {

--- a/packages/tool-browser/src/readiness.ts
+++ b/packages/tool-browser/src/readiness.ts
@@ -48,6 +48,7 @@ export async function probeBrowserCapability(options: {
         abortSignal,
       });
       await assertCdpHttpReady(`${endpointFor(sandbox, cdpPort)}/json/version`, abortSignal);
+      let lastProbeFailure: unknown;
       for (let attempt = 0; ; attempt += 1) {
         abortSignal.throwIfAborted();
         try {
@@ -70,8 +71,14 @@ export async function probeBrowserCapability(options: {
           abortSignal.throwIfAborted();
           return;
         } catch (error) {
-          if (abortSignal.aborted) throw abortSignal.reason ?? error;
-          await waitForRetry(abortSignal, Math.min(500, 50 * 2 ** Math.min(attempt, 3)));
+          if (abortSignal.aborted) throw lastProbeFailure ?? error;
+          lastProbeFailure = error;
+          try {
+            await waitForRetry(abortSignal, Math.min(500, 50 * 2 ** Math.min(attempt, 3)));
+          } catch (retryError) {
+            if (abortSignal.aborted) throw lastProbeFailure;
+            throw retryError;
+          }
         }
       }
   }
@@ -95,6 +102,15 @@ export function normalizeReadinessError(
     });
   }
   if (state.timedOut) {
+    if (error instanceof BrowserError && error.code === "transport_failure") {
+      return new BrowserError(error.message, error.code, {
+        cause: error,
+        capability,
+        phase: "readiness",
+        recovery: error.recovery,
+        retryable: error.retryable,
+      });
+    }
     return new BrowserError(
       `Browser ${capability} capability did not become ready before the timeout.`,
       "readiness_timeout",

--- a/packages/tool-browser/src/readiness.ts
+++ b/packages/tool-browser/src/readiness.ts
@@ -41,7 +41,7 @@ export async function probeBrowserCapability(options: {
       });
       await assertHttpReady(`${endpointFor(sandbox, noVncPort)}/vnc.html`, abortSignal);
       return;
-    case "automation":
+    case "automation": {
       await sandbox.runtime.waitForPort({
         containerPort: cdpPort,
         timeoutMs: remainingTime(deadline),
@@ -81,6 +81,7 @@ export async function probeBrowserCapability(options: {
           }
         }
       }
+    }
   }
 }
 

--- a/packages/tool-browser/test/automation-protocol.test.ts
+++ b/packages/tool-browser/test/automation-protocol.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { isAutomationResponse, summarizeAutomationMessage } from "../src/automation-protocol";
+
+describe("automation worker response protocol", () => {
+  it.each([
+    { kind: "response", id: 1, ok: true, value: undefined },
+    {
+      kind: "response",
+      id: 2,
+      ok: false,
+      error: { name: "Error", message: "connection failed" },
+    },
+    { kind: "cancelled", id: 3 },
+    { kind: "event", event: "disconnected" },
+  ])("accepts a valid $kind message", (message) => {
+    expect(isAutomationResponse(message)).toBe(true);
+  });
+
+  it.each([
+    undefined,
+    null,
+    [],
+    { kind: "response", id: 0, ok: true, value: undefined },
+    { kind: "response", id: 1, ok: true },
+    { kind: "response", id: 1, ok: "true", value: undefined },
+    { kind: "response", id: 1, ok: false, error: { message: "missing name" } },
+    { kind: "cancelled", id: -1 },
+    { kind: "event", event: "other" },
+    { "watch:import": ["file:///private/application.ts"] },
+  ])("rejects malformed or non-protocol input", (message) => {
+    expect(isAutomationResponse(message)).toBe(false);
+  });
+
+  it("summarizes rejected input without retaining values or unknown property names", () => {
+    const summary = summarizeAutomationMessage({
+      kind: "not-a-protocol-kind",
+      id: "private-id",
+      ok: "private-status",
+      "private-property-name": "private-value",
+      "watch:import": ["file:///private/application.ts"],
+    });
+
+    expect(summary).toEqual({
+      type: "object",
+      ownPropertyNames: ["kind", "id", "ok", "<other>", "watch:import"],
+      ownPropertyCount: 5,
+      kind: "other",
+      id: "non-number",
+      ok: "non-boolean",
+      constructorName: "Object",
+      hasExpectedPrototype: true,
+      hasRequiredFields: false,
+    });
+    expect(JSON.stringify(summary)).not.toContain("private");
+  });
+});

--- a/packages/tool-browser/test/connection-lifecycle.test.ts
+++ b/packages/tool-browser/test/connection-lifecycle.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
-import { fork, type ChildProcess } from "node:child_process";
+import { fork, spawn, type ChildProcess } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AutomationRequest, AutomationResponse } from "../src/automation-protocol";
 import { type AutomationBackend, AutomationWorkerClient } from "../src/automation-client";
@@ -25,7 +26,7 @@ describe("AutomationWorkerClient connection lifecycle", () => {
     expect(child.kill).toHaveBeenCalledWith("SIGTERM");
     expect(client.closed).toBe(true);
     expect(child.listenerCount("message")).toBe(0);
-    expect(child.listenerCount("error")).toBe(1);
+    expect(child.listenerCount("error")).toBe(0);
     expect(child.listenerCount("exit")).toBe(0);
   });
 
@@ -209,9 +210,97 @@ describe("AutomationWorkerClient connection lifecycle", () => {
     });
     child.respond({ kind: "response", id: connectId, ok: "yes" });
 
-    await expect(connecting).rejects.toMatchObject({ code: "transport_failure" });
+    await expect(connecting).rejects.toMatchObject({
+      code: "transport_failure",
+      cause: {
+        code: "transport_failure",
+        cause: {
+          name: "TypeError",
+          responseSummary: {
+            type: "object",
+            ownPropertyNames: ["kind", "id", "ok"],
+            kind: "response",
+            id: 1,
+            ok: "non-boolean",
+            hasExpectedPrototype: true,
+            hasRequiredFields: false,
+          },
+        },
+      },
+    });
     expect(child.kill).toHaveBeenCalledWith("SIGTERM");
   });
+
+  it("rejects Node watch control messages without retaining dependency payloads", async () => {
+    const child = new FakeChild(() => undefined);
+    const connecting = AutomationWorkerClient.connect({
+      endpointUrl: "http://127.0.0.1:9222",
+      timeoutMs: 1_000,
+      workerFactory: () => child.asChildProcess(),
+    });
+    child.respond({ "watch:import": ["file:///private/application.ts"] });
+
+    let caught: unknown;
+    try {
+      await connecting;
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toMatchObject({
+      code: "transport_failure",
+      cause: {
+        cause: {
+          responseSummary: {
+            ownPropertyNames: ["watch:import"],
+            ownPropertyCount: 1,
+            hasRequiredFields: false,
+          },
+        },
+      },
+    });
+    expect(JSON.stringify(caught)).not.toContain("private");
+    expect(child.listenerCount("message")).toBe(0);
+    expect(child.listenerCount("error")).toBe(0);
+    expect(child.listenerCount("exit")).toBe(0);
+  });
+
+  it("reconnects successfully after a recoverable malformed worker response", async () => {
+    const failedChild = new FakeChild(() => undefined);
+    const failedConnection = AutomationWorkerClient.connect({
+      endpointUrl: "http://127.0.0.1:9222",
+      timeoutMs: 1_000,
+      workerFactory: () => failedChild.asChildProcess(),
+    });
+    failedChild.respond({ kind: "unexpected-worker-message" });
+    await expect(failedConnection).rejects.toMatchObject({
+      code: "transport_failure",
+      retryable: true,
+      recovery: "reconnect",
+    });
+
+    const healthyChild = new FakeChild((message) => healthyChild.respond(success(message.id)));
+    const connection = await AutomationWorkerClient.connect({
+      endpointUrl: "http://127.0.0.1:9222",
+      timeoutMs: 1_000,
+      workerFactory: () => healthyChild.asChildProcess(),
+    });
+    await connection.disconnect();
+
+    expect(failedChild.listenerCount("message")).toBe(0);
+    expect(healthyChild.listenerCount("message")).toBe(0);
+  });
+
+  it("isolates startup handshakes from Node watch IPC and cleans up repeated workers", async () => {
+    const result = await runWatchedAutomationFixture();
+
+    expect(result.stdout).toContain(
+      JSON.stringify({ automationWorkerRegression: true, cleaned: true }),
+    );
+    expect(result.stderr).not.toContain("Invalid browser automation worker response");
+    expect(result.exitCode === 0 || (result.exitCode === null && result.signal === "SIGINT")).toBe(
+      true,
+    );
+  }, 15_000);
 
   it("turns an unexpected post-connect worker crash into a connection event", async () => {
     const child = new FakeChild((message) => child.respond(success(message.id)));
@@ -369,4 +458,62 @@ class FakeChild extends EventEmitter {
   asChildProcess(): ChildProcess {
     return this as unknown as ChildProcess;
   }
+}
+
+async function runWatchedAutomationFixture(): Promise<{
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+}> {
+  const fixture = fileURLToPath(
+    new URL("./fixtures/watched-automation-client.ts", import.meta.url),
+  );
+  const child = spawn(
+    process.execPath,
+    ["--import", "tsx", "--watch", "--watch-preserve-output", fixture],
+    {
+      cwd: process.cwd(),
+      env: { ...process.env, NO_COLOR: "1" },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  let stdout = "";
+  let stderr = "";
+  let completed = false;
+  const marker = '"automationWorkerRegression":true';
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout = `${stdout}${chunk}`.slice(-32_768);
+    if (!completed && stdout.includes(marker)) {
+      completed = true;
+      child.kill("SIGINT");
+    }
+  });
+  child.stderr.on("data", (chunk: string) => {
+    stderr = `${stderr}${chunk}`.slice(-32_768);
+  });
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error("Watched automation regression fixture timed out."));
+    }, 10_000);
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once("exit", (exitCode, signal) => {
+      clearTimeout(timer);
+      if (!completed) {
+        reject(
+          new Error(
+            `Watched automation regression fixture exited before completion: code=${exitCode ?? "null"} signal=${signal ?? "null"}\n${stderr}`,
+          ),
+        );
+        return;
+      }
+      resolve({ stdout, stderr, exitCode, signal });
+    });
+  });
 }

--- a/packages/tool-browser/test/fixtures/automation-worker-matrix.mjs
+++ b/packages/tool-browser/test/fixtures/automation-worker-matrix.mjs
@@ -1,0 +1,87 @@
+import { fork } from "node:child_process";
+
+const workerUrl = new URL("../../dist/automation-worker.js", import.meta.url);
+const cycles = Number(process.env.ANVIA_BROWSER_REPRO_CYCLES ?? "1");
+const lingerMs = Number(process.env.ANVIA_BROWSER_REPRO_LINGER_MS ?? "0");
+
+for (let cycle = 1; cycle <= cycles; cycle += 1) {
+  await runCycle(cycle);
+  if (lingerMs > 0) await new Promise((resolve) => setTimeout(resolve, lingerMs));
+}
+
+async function runCycle(cycle) {
+  const child = fork(workerUrl, [], {
+    execArgv: [],
+    serialization: "advanced",
+    stdio: ["ignore", "ignore", "pipe", "ipc"],
+  });
+  const messages = await new Promise((resolve, reject) => {
+    const received = [];
+    let count = 0;
+    const timer = setTimeout(() => reject(new Error("worker response timeout")), 5_000);
+    child.on("message", (value) => {
+      count += 1;
+      if (received.length < 8) received.push(summarize(value));
+      if (value?.kind !== "response") return;
+      clearTimeout(timer);
+      resolve({ count, firstMessages: received });
+    });
+    child.once("error", reject);
+    child.send({ kind: "request", id: 1, method: "disconnect", params: {} });
+  });
+  process.stdout.write(
+    `${JSON.stringify({
+      cycle,
+      parentHasIpc: process.connected === true,
+      parentSerializationMode: process.env.NODE_CHANNEL_SERIALIZATION_MODE,
+      responses: messages,
+    })}\n`,
+  );
+  child.kill("SIGTERM");
+  await new Promise((resolve) => child.once("exit", resolve));
+}
+
+function summarize(value) {
+  const isObject = value !== null && typeof value === "object";
+  const prototype = isObject ? Object.getPrototypeOf(value) : undefined;
+  const safePropertyNames = new Set([
+    "error",
+    "event",
+    "id",
+    "kind",
+    "ok",
+    "value",
+    "watch:import",
+    "watch:require",
+  ]);
+  return {
+    type: value === null ? "null" : Array.isArray(value) ? "array" : typeof value,
+    ownPropertyNames: isObject
+      ? Object.getOwnPropertyNames(value)
+          .slice(0, 12)
+          .map((name) => (safePropertyNames.has(name) ? name : "<other>"))
+      : [],
+    kind:
+      !isObject || value.kind === undefined
+        ? undefined
+        : value.kind === "response" || value.kind === "cancelled" || value.kind === "event"
+          ? value.kind
+          : "other",
+    id: isObject && typeof value.id === "number" ? value.id : undefined,
+    ok: isObject && typeof value.ok === "boolean" ? value.ok : undefined,
+    constructorName: !isObject
+      ? undefined
+      : prototype === null
+        ? "null-prototype"
+        : prototype === Object.prototype
+          ? "Object"
+          : "other",
+    expectedPrototype: isObject && prototype === Object.prototype,
+    hasRequiredFields:
+      isObject &&
+      value.kind === "response" &&
+      Number.isSafeInteger(value.id) &&
+      typeof value.ok === "boolean" &&
+      (value.ok ? Object.hasOwn(value, "value") : Object.hasOwn(value, "error")),
+  };
+}

--- a/packages/tool-browser/test/fixtures/browser-automation-scenario.mjs
+++ b/packages/tool-browser/test/fixtures/browser-automation-scenario.mjs
@@ -1,0 +1,89 @@
+import { DockerBrowserClient } from "../../dist/index.js";
+
+const endpoint = new URL(requiredEnvironment("ANVIA_BROWSER_REPRO_ENDPOINT"));
+const cycles = Number(process.env.ANVIA_BROWSER_REPRO_CYCLES ?? "3");
+const lingerMs = Number(process.env.ANVIA_BROWSER_REPRO_LINGER_MS ?? "0");
+const probeReadiness = process.env.ANVIA_BROWSER_REPRO_READINESS === "1";
+const sandbox = fakeSandbox(endpoint);
+const browserClient = new DockerBrowserClient({
+  image: "browser-automation-reproduction",
+  sandboxClient: {
+    pullImage: async () => undefined,
+    createSandbox: async () => sandbox,
+    resumeSandbox: async () => sandbox,
+  },
+});
+const browser = await browserClient.resumeBrowser({ id: sandbox.id });
+const keepAlive = setInterval(() => undefined, 60_000);
+
+try {
+  if (probeReadiness) {
+    await browser.waitForCapabilities({
+      capabilities: ["automation"],
+      timeoutMs: 5_000,
+      abortSignal: new AbortController().signal,
+    });
+  }
+  for (let cycle = 1; cycle <= cycles; cycle += 1) {
+    const requestController = new AbortController();
+    const connection = await browser.connect({
+      timeoutMs: 5_000,
+      scheduling: { mode: "per-tab", maxConcurrentTabs: 8, maxQueuedActions: 100 },
+      abortSignal: requestController.signal,
+    });
+    await connection.disconnect();
+    process.stdout.write(`${JSON.stringify({ cycle, connected: true })}\n`);
+    if (lingerMs > 0) await new Promise((resolve) => setTimeout(resolve, lingerMs));
+  }
+} catch (error) {
+  process.stdout.write(`${JSON.stringify({ connected: false, error: summarizeError(error) })}\n`);
+  process.exitCode = 1;
+} finally {
+  clearInterval(keepAlive);
+  await browser.destroy().catch(() => undefined);
+}
+
+function fakeSandbox(endpointUrl) {
+  return {
+    id: "browser-automation-reproduction",
+    state: "running",
+    runtime: {
+      publishedPorts: [
+        {
+          containerPort: 9222,
+          host: endpointUrl.hostname,
+          hostPort: Number(endpointUrl.port),
+          protocol: "tcp",
+        },
+      ],
+      waitForPort: async () => undefined,
+      exec: async () => ({
+        status: "exited",
+        exitCode: 0,
+        stdout: new TextEncoder().encode("1\n"),
+        stderr: new Uint8Array(),
+      }),
+      startProcess: async () => ({ id: "browser-service" }),
+    },
+    inspector: () => ({}),
+    stop: async () => undefined,
+    destroy: async () => undefined,
+  };
+}
+
+function summarizeError(value, depth = 0) {
+  if (!(value instanceof Error) || depth >= 5) return { type: typeof value };
+  return {
+    name: value.name,
+    code: typeof value.code === "string" ? value.code : undefined,
+    phase: typeof value.phase === "string" ? value.phase : undefined,
+    responseSummary: value.responseSummary,
+    cause: summarizeError(value.cause, depth + 1),
+  };
+}
+
+function requiredEnvironment(name) {
+  const value = process.env[name];
+  if (value === undefined) throw new Error(`Missing ${name}.`);
+  return value;
+}

--- a/packages/tool-browser/test/fixtures/successful-automation-worker-dependency.mjs
+++ b/packages/tool-browser/test/fixtures/successful-automation-worker-dependency.mjs
@@ -1,0 +1,1 @@
+export const loaded = true;

--- a/packages/tool-browser/test/fixtures/successful-automation-worker.mjs
+++ b/packages/tool-browser/test/fixtures/successful-automation-worker.mjs
@@ -1,0 +1,11 @@
+import { loaded } from "./successful-automation-worker-dependency.mjs";
+
+if (!loaded) process.exit(1);
+
+process.on("message", (message) => {
+  if (message.kind === "cancel") {
+    process.send?.({ kind: "cancelled", id: message.id });
+    return;
+  }
+  process.send?.({ kind: "response", id: message.id, ok: true, value: undefined });
+});

--- a/packages/tool-browser/test/fixtures/watched-automation-client.ts
+++ b/packages/tool-browser/test/fixtures/watched-automation-client.ts
@@ -1,0 +1,33 @@
+import type { ChildProcess } from "node:child_process";
+import { AutomationWorkerClient, spawnAutomationWorker } from "../../src/automation-client";
+
+const workerUrl = new URL("./successful-automation-worker.mjs", import.meta.url);
+const children: ChildProcess[] = [];
+
+for (let cycle = 0; cycle < 3; cycle += 1) {
+  const controller = new AbortController();
+  const client = await AutomationWorkerClient.connect({
+    endpointUrl: "http://127.0.0.1:9222",
+    timeoutMs: 2_000,
+    abortSignal: controller.signal,
+    workerFactory: () => {
+      const child = spawnAutomationWorker(workerUrl);
+      children.push(child);
+      return child;
+    },
+  });
+  await client.disconnect({ abortSignal: controller.signal });
+}
+
+const cleaned = children.every(
+  (child) =>
+    (child.exitCode !== null || child.signalCode !== null) &&
+    child.listenerCount("message") === 0 &&
+    child.listenerCount("error") === 0 &&
+    child.listenerCount("exit") === 0 &&
+    (child.stderr?.listenerCount("data") ?? 0) === 0 &&
+    (child.stderr?.listenerCount("error") ?? 0) === 0,
+);
+
+process.stdout.write(`${JSON.stringify({ automationWorkerRegression: true, cleaned })}\n`);
+if (!cleaned) process.exitCode = 1;

--- a/packages/tool-browser/test/readiness-lifecycle.test.ts
+++ b/packages/tool-browser/test/readiness-lifecycle.test.ts
@@ -91,14 +91,20 @@ describe("DockerBrowser capability readiness", () => {
 
   it("preserves the final automation transport failure when readiness reaches its deadline", async () => {
     vi.useFakeTimers();
-    const probeFailure = new BrowserError(
+    const firstProbeFailure = new BrowserError(
       "Browser automation worker sent an invalid response.",
       "transport_failure",
       { cause: new TypeError("Invalid browser automation worker response."), phase: "connect" },
     );
-    const connect = vi.fn(async () => {
-      throw probeFailure;
-    }) as unknown as typeof connectPlaywrightBrowser;
+    const finalProbeFailure = new BrowserError(
+      "Browser automation worker sent a final invalid response.",
+      "transport_failure",
+      { phase: "connect" },
+    );
+    const connect = vi
+      .fn()
+      .mockRejectedValueOnce(firstProbeFailure)
+      .mockRejectedValueOnce(finalProbeFailure) as unknown as typeof connectPlaywrightBrowser;
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => Response.json({ webSocketDebuggerUrl: "ws://127.0.0.1/devtools" })),
@@ -112,7 +118,7 @@ describe("DockerBrowser capability readiness", () => {
       code: "transport_failure",
       capability: "automation",
       phase: "readiness",
-      cause: probeFailure,
+      cause: finalProbeFailure,
     });
 
     await vi.advanceTimersByTimeAsync(100);
@@ -120,7 +126,7 @@ describe("DockerBrowser capability readiness", () => {
     expect(connect).toHaveBeenCalledTimes(2);
     expect(browser.readiness().capabilities.automation).toMatchObject({
       state: "failed",
-      error: { code: "transport_failure", cause: probeFailure },
+      error: { code: "transport_failure", cause: finalProbeFailure },
     });
   });
 

--- a/packages/tool-browser/test/readiness-lifecycle.test.ts
+++ b/packages/tool-browser/test/readiness-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { connectPlaywrightBrowser } from "../src/connection";
 import { DockerBrowserHandle } from "../src/docker-browser";
+import { BrowserError } from "../src/errors";
 
 describe("DockerBrowser capability readiness", () => {
   afterEach(() => {
@@ -85,6 +86,41 @@ describe("DockerBrowser capability readiness", () => {
         browser: { state: "failed" },
         desktop: { state: "ready" },
       },
+    });
+  });
+
+  it("preserves the final automation transport failure when readiness reaches its deadline", async () => {
+    vi.useFakeTimers();
+    const probeFailure = new BrowserError(
+      "Browser automation worker sent an invalid response.",
+      "transport_failure",
+      { cause: new TypeError("Invalid browser automation worker response."), phase: "connect" },
+    );
+    const connect = vi.fn(async () => {
+      throw probeFailure;
+    }) as unknown as typeof connectPlaywrightBrowser;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ webSocketDebuggerUrl: "ws://127.0.0.1/devtools" })),
+    );
+    const browser = new DockerBrowserHandle(fakeSandbox() as never, connect);
+    const waiting = browser.waitForCapabilities({
+      timeoutMs: 100,
+      capabilities: ["automation"],
+    });
+    const rejected = expect(waiting).rejects.toMatchObject({
+      code: "transport_failure",
+      capability: "automation",
+      phase: "readiness",
+      cause: probeFailure,
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+    await rejected;
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(browser.readiness().capabilities.automation).toMatchObject({
+      state: "failed",
+      error: { code: "transport_failure", cause: probeFailure },
     });
   });
 


### PR DESCRIPTION
## Summary

- isolate automation-worker IPC from Node watch dependency reports
- preserve bounded structural diagnostics for rejected worker messages
- preserve the final automation transport failure when readiness reaches its deadline
- clean up worker IPC and stderr listeners and cover recoverable reconnects
- add a patch changeset for @anvia/browser

## Root cause

Node watch mode sets WATCH_REPORT_DEPENDENCIES for the watched application. The forked automation worker inherited that variable, so Node loaders emitted watch:import and watch:require dependency reports over the same IPC channel used by the browser automation protocol. The client correctly rejected the first non-protocol message before the actual startup response arrived.

The fix removes that watch-only environment variable from the isolated automation worker. Protocol validation remains strict and advanced IPC serialization remains enabled.

## Verification

- pnpm --filter @anvia/browser test: 86 passed, 1 Docker-gated test skipped
- pnpm --filter @anvia/browser typecheck
- pnpm exec oxlint packages/tool-browser
- pnpm exec oxfmt --check packages/tool-browser .changeset/quiet-browsers-watch.md
- pnpm --filter @anvia/browser build
- built-package matrix on Node 26.7.0: plain Node, long-running cycles, node --watch, node --import tsx --watch, request-scoped AbortSignal, readiness probing, direct connect, and repeated disconnect/reconnect
- reproduced the Node watch dependency messages on Node 24.19.0, confirming the issue is not Node 26-specific
- verified no orphaned automation workers or reproduction Docker containers remained

The standard Docker integration test is environment-gated. The automation matrix was additionally exercised against healthy CDP from a disposable local browser container, which was removed afterward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser automation diagnostics for malformed responses and readiness failures.
  * Prevented automation-worker communication from being affected by unrelated watch-mode messages.
  * Ensured worker connections and event listeners are fully cleaned up after disconnects.
  * Preserved actionable transport error details during readiness timeouts.

* **Tests**
  * Added coverage for malformed messages, reconnection, cleanup, readiness failures, and watched-worker scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->