### PR TITLE
Preserve usage metadata across message replay

### DIFF
--- a/.changeset/calm-runs-replay.md
+++ b/.changeset/calm-runs-replay.md
@@ -1,0 +1,9 @@
+---
+"@anvia/client": patch
+"@anvia/react": patch
+---
+
+Hydrate persisted assistant usage, context usage, and sources into replayed UI messages while keeping
+per-generation usage separate from aggregate run usage. Keep latest-context state aligned when a
+new response omits context information. Expose the latest aggregate run usage as
+`useChat().runUsage` and completion usage as `useCompletion().usage`.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -59,7 +59,9 @@ intentionally exposes a safe error shape. Non-JSON outputs require an explicit `
 
 `UIMessage.metadata` remains application-owned and round-trips unchanged. Runtime details such as
 run ID, usage, context usage, status, and trace correlation are stored separately in
-`UIMessage.generation`.
+`UIMessage.generation`. Converting persisted core messages hydrates per-generation usage and context
+usage into that UI field and restores persisted sources as UI message parts while preserving the
+original metadata.
 
 Application-specific stream data is explicit and schema-validated:
 

--- a/packages/client/src/messages.ts
+++ b/packages/client/src/messages.ts
@@ -10,11 +10,12 @@ import type {
   ToolResultPart,
   UserContentPart,
 } from "@anvia/core/completion";
-import { isJsonValue } from "@anvia/core/completion";
+import { getAssistantGenerationMetadata, isJsonValue } from "@anvia/core/completion";
 import type {
   ClientDataMap,
   UIAttachment,
   UIMessage,
+  UIMessageGeneration,
   UIMessagePart,
   UIToolMessagePart,
 } from "./types";
@@ -160,17 +161,31 @@ export function messagesToUIMessages<Metadata extends JsonObject = JsonObject>(
     }
 
     if (message.role === "assistant") {
+      const generationMetadata = getAssistantGenerationMetadata(message);
       const content =
         typeof message.content === "string"
           ? ([{ type: "text", text: message.content }] satisfies AssistantContentPart[])
           : message.content;
       const parts: UIMessagePart[] = content.map(assistantContentToUIMessagePart);
+      for (const source of generationMetadata?.sources ?? []) {
+        parts.push({ id: createId("source"), type: "source", source });
+      }
       let uiMessage: UIMessage<Metadata> = {
         id: createId("msg"),
         role: "assistant",
         parts,
         ...metadataField(message.metadata),
       };
+      if (generationMetadata !== undefined) {
+        const generation: UIMessageGeneration = { usage: generationMetadata.usage };
+        if (generationMetadata.contextUsage !== undefined) {
+          generation.contextUsage = generationMetadata.contextUsage;
+        }
+        uiMessage = {
+          ...uiMessage,
+          generation,
+        };
+      }
       if (message.id !== undefined) uiMessage = { ...uiMessage, modelMessageId: message.id };
       const messageIndex = result.length;
       result.push(uiMessage);

--- a/packages/client/src/reducer.ts
+++ b/packages/client/src/reducer.ts
@@ -224,7 +224,6 @@ export function applyClientStreamEvent<Metadata extends JsonObject, Data extends
         runId: event.runId,
         status: event.status,
       };
-      if (event.usage !== undefined) generation.usage = event.usage;
       if (event.contextUsage !== undefined) generation.contextUsage = event.contextUsage;
       if (event.trace !== undefined) generation.trace = event.trace;
       if (event.memoryCompaction !== undefined) {

--- a/packages/client/test/client.test.ts
+++ b/packages/client/test/client.test.ts
@@ -74,6 +74,95 @@ function CompileToolPartBoundary() {
 void CompileToolPartBoundary;
 
 describe("message boundary", () => {
+  it("hydrates persisted generation usage, context usage, and sources", () => {
+    const usage = {
+      inputTokens: 12,
+      outputTokens: 4,
+      totalTokens: 16,
+      cachedInputTokens: 3,
+      cacheCreationInputTokens: 0,
+    };
+    const contextUsage = {
+      model: { modelId: "test-model", context: { contextWindow: 100 } },
+      usedTokens: 16,
+      remainingTokens: 84,
+      usedPercent: 16,
+      remainingPercent: 84,
+    };
+    const laterUsage = {
+      inputTokens: 20,
+      outputTokens: 5,
+      totalTokens: 25,
+      cachedInputTokens: 4,
+      cacheCreationInputTokens: 1,
+    };
+    const messages: CoreMessage[] = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Hydrated" }],
+        metadata: {
+          anvia: {
+            generation: {
+              provider: "test",
+              modelId: "test-model",
+              usage,
+              contextUsage,
+              sources: [{ type: "url", url: "https://example.test/source" }],
+            },
+          },
+        },
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Hydrated again" }],
+        metadata: {
+          anvia: {
+            generation: {
+              provider: "test",
+              modelId: "test-model",
+              usage: laterUsage,
+            },
+          },
+        },
+      },
+    ];
+
+    const ui = messagesToUIMessages(messages);
+
+    expect(ui[0]?.generation).toEqual({ usage, contextUsage });
+    expect(ui[1]?.generation).toEqual({ usage: laterUsage });
+    expect(ui[0]?.parts).toContainEqual(
+      expect.objectContaining({
+        type: "source",
+        source: { type: "url", url: "https://example.test/source" },
+      }),
+    );
+    expect(uiMessagesToMessages(ui)).toEqual(messages);
+  });
+
+  it("preserves malformed generation metadata without projecting it into UI runtime state", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Legacy" }],
+        metadata: {
+          anvia: {
+            generation: {
+              provider: "test",
+              model: "legacy-model-key",
+              usage: Usage.empty(),
+            },
+          },
+        },
+      },
+    ] satisfies CoreMessage[];
+
+    const ui = messagesToUIMessages(messages);
+
+    expect(ui[0]?.generation).toBeUndefined();
+    expect(uiMessagesToMessages(ui)).toEqual(messages);
+  });
+
   it("round-trips model IDs, metadata, reasoning, attachments, and tool results", () => {
     const messages = [
       {
@@ -1180,24 +1269,43 @@ describe("protocol and transport", () => {
     );
   });
 
-  it("keeps JSON object metadata lossless and stores generated state separately", () => {
+  it("keeps per-generation usage separate from aggregate run usage", () => {
+    const generationUsage = {
+      inputTokens: 3,
+      outputTokens: 2,
+      totalTokens: 5,
+      cachedInputTokens: 0,
+      cacheCreationInputTokens: 0,
+    };
+    const runUsage = {
+      inputTokens: 13,
+      outputTokens: 7,
+      totalTokens: 20,
+      cachedInputTokens: 2,
+      cacheCreationInputTokens: 1,
+    };
     const afterMessage = applyClientStreamEvent(
       [{ id: "assistant_1", role: "assistant", parts: [], metadata: { source: "user" } }],
       {
         type: "message_end",
         runId: "run_1",
         messageId: "assistant_1",
-        usage: Usage.empty(),
+        usage: generationUsage,
       },
     );
     const afterRun = applyClientStreamEvent(afterMessage, {
       type: "run_end",
       runId: "run_1",
       status: "completed",
+      usage: runUsage,
     });
 
     expect(afterRun[0]?.metadata).toEqual({ source: "user" });
-    expect(afterRun[0]?.generation).toMatchObject({ runId: "run_1", status: "completed" });
+    expect(afterRun[0]?.generation).toMatchObject({
+      runId: "run_1",
+      status: "completed",
+      usage: generationUsage,
+    });
   });
 
   it("rejects primitive UI metadata", () => {

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -56,6 +56,8 @@ needs to name them.
 - exposes `ready | submitted | streaming | waiting | error` status;
 - keeps readonly `UIMessage[]` locally and sends core `Message[]` in `ClientStreamRequest`;
 - exposes canonical events through `onEvent` and the returned `events` array;
+- exposes aggregate usage for the latest run through `runUsage`, while each assistant message
+  retains its own provider-generation usage;
 - supports optional resumable streams and unified Agent interaction state.
 
 The default request is:
@@ -96,7 +98,7 @@ server.
 
 `useCompletion({ transport })` is a genuine single-turn controller. Call
 `complete({ prompt })`, or manage `input` and call `submit()`. Each call replaces the previous
-completion, events, and usage; it never exposes or accumulates chat messages.
+completion, events, and `usage`; it never exposes or accumulates chat messages.
 
 `useSmoothStreamText` and `useSmoothStreamItems` only smooth presentation. They do not change
 protocol events or message state.

--- a/packages/react/src/context-usage.ts
+++ b/packages/react/src/context-usage.ts
@@ -4,9 +4,11 @@ import type { ContextUsage } from "@anvia/core/completion";
 export function contextUsageUpdateFromEvent<
   Metadata extends ClientMetadata,
   Data extends ClientDataMap,
->(event: ClientStreamEvent<Metadata, Data>): ContextUsage | undefined {
+>(
+  event: ClientStreamEvent<Metadata, Data>,
+): { contextUsage: ContextUsage | undefined } | undefined {
   return event.type === "message_end" || event.type === "turn_end" || event.type === "run_end"
-    ? event.contextUsage
+    ? { contextUsage: event.contextUsage }
     : undefined;
 }
 
@@ -18,12 +20,14 @@ export function contextUsageFromMessages<
     const message = messages[index];
     if (message?.role !== "assistant") continue;
     if (message.generation?.contextUsage !== undefined) return message.generation.contextUsage;
-    if (!isRecord(message.metadata)) continue;
-    const anvia = message.metadata.anvia;
-    const generation = isRecord(anvia) ? anvia.generation : undefined;
-    if (isRecord(generation) && isContextUsage(generation.contextUsage)) {
-      return generation.contextUsage;
+    if (isRecord(message.metadata)) {
+      const anvia = message.metadata.anvia;
+      const generation = isRecord(anvia) ? anvia.generation : undefined;
+      if (isRecord(generation) && isContextUsage(generation.contextUsage)) {
+        return generation.contextUsage;
+      }
     }
+    return undefined;
   }
   return undefined;
 }

--- a/packages/react/src/run-usage.ts
+++ b/packages/react/src/run-usage.ts
@@ -1,0 +1,9 @@
+import type { ClientDataMap, ClientMetadata, ClientStreamEvent } from "@anvia/client";
+import type { Usage } from "@anvia/core/completion";
+
+export function runUsageUpdateFromEvent<
+  Metadata extends ClientMetadata,
+  Data extends ClientDataMap,
+>(event: ClientStreamEvent<Metadata, Data>): Usage | undefined {
+  return event.type === "run_end" || event.type === "error" ? event.usage : undefined;
+}

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -10,7 +10,7 @@ import type {
   UIMessage,
 } from "@anvia/client";
 import type { AgentInteractionResponse } from "@anvia/core/agent/interactions";
-import type { ContextUsage } from "@anvia/core/completion";
+import type { ContextUsage, Usage } from "@anvia/core/completion";
 
 export type AnyClientTransport = ClientTransport<
   ClientStreamRequest,
@@ -79,6 +79,7 @@ export type SetMessages<Metadata extends ClientMetadata, Data extends ClientData
 export type UseChatResult<Transport extends AnyClientTransport = ClientTransport> = {
   messages: readonly UIMessage<TransportMetadata<Transport>, TransportData<Transport>>[];
   events: readonly ClientStreamEvent<TransportMetadata<Transport>, TransportData<Transport>>[];
+  runUsage?: Usage | undefined;
   contextUsage: ContextUsage | undefined;
   suggestions: readonly ChatSuggestion<TransportMetadata<Transport>>[];
   setMessages: SetMessages<TransportMetadata<Transport>, TransportData<Transport>>;

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -16,9 +16,11 @@ import {
   assertAgentInteractionResponse,
   parseAgentInteractionResponse,
 } from "@anvia/core/agent/interactions";
+import type { Usage } from "@anvia/core/completion";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { contextUsageFromMessages, contextUsageUpdateFromEvent } from "./context-usage";
 import { clearChatResumeState, loadChatResumeState, saveChatResumeState } from "./resume";
+import { runUsageUpdateFromEvent } from "./run-usage";
 import type {
   AnyClientTransport,
   SendMessageInput,
@@ -39,6 +41,7 @@ export function useChat<Transport extends AnyClientTransport = ClientTransport>(
     ...(options.initialMessages ?? []),
   ]);
   const [events, setEvents] = useState<ClientStreamEvent<Metadata, Data>[]>([]);
+  const [runUsage, setRunUsage] = useState<Usage>();
   const [contextUsage, setContextUsage] = useState(() =>
     contextUsageFromMessages(options.initialMessages ?? []),
   );
@@ -128,8 +131,12 @@ export function useChat<Transport extends AnyClientTransport = ClientTransport>(
     (event: ClientStreamEvent<Metadata, Data>): Error | undefined => {
       setEvents((current) => [...current, event]);
       options.onEvent?.(event);
-      const nextContextUsage = contextUsageUpdateFromEvent(event);
-      if (nextContextUsage !== undefined) setContextUsage(nextContextUsage);
+      const contextUsageUpdate = contextUsageUpdateFromEvent(event);
+      if (contextUsageUpdate !== undefined) {
+        setContextUsage(contextUsageUpdate.contextUsage);
+      }
+      const nextRunUsage = runUsageUpdateFromEvent(event);
+      if (nextRunUsage !== undefined) setRunUsage(nextRunUsage);
       if (event.type === "interaction") {
         updateInteraction({ request: event.interaction, runId: event.runId, status: "pending" });
       }
@@ -169,6 +176,7 @@ export function useChat<Transport extends AnyClientTransport = ClientTransport>(
         setStreamId(runOptions.resume.streamId);
       }
       updateMessages(nextMessages);
+      setRunUsage(undefined);
       setContextUsage(contextUsageFromMessages(nextMessages));
       setEvents([]);
       setError(undefined);
@@ -343,6 +351,7 @@ export function useChat<Transport extends AnyClientTransport = ClientTransport>(
     abortRef.current = undefined;
     clearResumeState();
     updateMessages([]);
+    setRunUsage(undefined);
     setContextUsage(undefined);
     setEvents([]);
     interactionsRef.current = [];
@@ -357,6 +366,7 @@ export function useChat<Transport extends AnyClientTransport = ClientTransport>(
   return {
     messages,
     events,
+    runUsage,
     contextUsage,
     suggestions: options.suggestions ?? [],
     setMessages,

--- a/packages/react/src/use-completion.ts
+++ b/packages/react/src/use-completion.ts
@@ -10,9 +10,10 @@ import {
   normalizeClientError,
   type UIMessage,
 } from "@anvia/client";
-import type { ContextUsage } from "@anvia/core/completion";
+import type { ContextUsage, Usage } from "@anvia/core/completion";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { contextUsageUpdateFromEvent } from "./context-usage";
+import { runUsageUpdateFromEvent } from "./run-usage";
 import type { UseChatStatus } from "./types";
 
 export type UseCompletionStatus = UseChatStatus;
@@ -42,6 +43,7 @@ export type UseCompletionResult<
   status: UseCompletionStatus;
   error: Error | undefined;
   events: readonly ClientStreamEvent<Metadata, Data>[];
+  usage?: Usage | undefined;
   contextUsage: ContextUsage | undefined;
 };
 
@@ -52,6 +54,7 @@ export function useCompletion<
   const [input, setInput] = useState(options.initialInput ?? "");
   const [completion, setCompletion] = useState(options.initialCompletion ?? "");
   const [events, setEvents] = useState<ClientStreamEvent<Metadata, Data>[]>([]);
+  const [usage, setUsage] = useState<Usage>();
   const [contextUsage, setContextUsage] = useState<ContextUsage>();
   const [status, setStatus] = useState<UseCompletionStatus>("ready");
   const [error, setError] = useState<Error>();
@@ -78,6 +81,7 @@ export function useCompletion<
       messagesRef.current = [];
       setCompletion("");
       setEvents([]);
+      setUsage(undefined);
       setContextUsage(undefined);
       setError(undefined);
       setStatus("submitted");
@@ -95,8 +99,12 @@ export function useCompletion<
             const event = frame.event;
             setEvents((current) => [...current, event]);
             options.onEvent?.(event);
-            const nextContextUsage = contextUsageUpdateFromEvent(event);
-            if (nextContextUsage !== undefined) setContextUsage(nextContextUsage);
+            const contextUsageUpdate = contextUsageUpdateFromEvent(event);
+            if (contextUsageUpdate !== undefined) {
+              setContextUsage(contextUsageUpdate.contextUsage);
+            }
+            const nextUsage = runUsageUpdateFromEvent(event);
+            if (nextUsage !== undefined) setUsage(nextUsage);
             messagesRef.current = applyClientStreamEvent(messagesRef.current, event);
             setCompletion(assistantText(messagesRef.current));
             if (event.type === "error") {
@@ -142,6 +150,7 @@ export function useCompletion<
     setInput(options.initialInput ?? "");
     setCompletion(options.initialCompletion ?? "");
     setEvents([]);
+    setUsage(undefined);
     setContextUsage(undefined);
     setError(undefined);
     messagesRef.current = [];
@@ -158,6 +167,7 @@ export function useCompletion<
     status,
     error,
     events,
+    usage,
     contextUsage,
   };
 }

--- a/packages/react/test/hooks.test.ts
+++ b/packages/react/test/hooks.test.ts
@@ -8,6 +8,7 @@ import {
   type ClientTransport,
   createDirectClientTransport,
 } from "@anvia/client";
+import type { Message } from "@anvia/core/completion";
 import type { MemoryCompactionMessage } from "@anvia/core/memory";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
@@ -61,6 +62,82 @@ function CompileTransportBoundary() {
 void CompileTransportBoundary;
 
 describe("public boundary", () => {
+  it("hydrates generation usage from memory into replayed UI messages", () => {
+    const usage = {
+      inputTokens: 8,
+      outputTokens: 2,
+      totalTokens: 10,
+      cachedInputTokens: 1,
+      cacheCreationInputTokens: 0,
+    };
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: "Stored" }],
+      metadata: {
+        anvia: {
+          generation: { provider: "test", modelId: "test-model", usage },
+        },
+      },
+    } satisfies Message;
+
+    expect(publicReact.initialMessagesFromMemory([message])[0]?.generation?.usage).toEqual(usage);
+  });
+
+  it("does not reuse an older context usage when the latest stored generation omits it", () => {
+    const contextUsage = {
+      model: { modelId: "known-model", context: { contextWindow: 100 } },
+      usedTokens: 40,
+      remainingTokens: 60,
+      usedPercent: 40,
+      remainingPercent: 60,
+    };
+    const stored = publicReact.initialMessagesFromMemory([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Known" }],
+        metadata: {
+          anvia: {
+            generation: {
+              provider: "test",
+              modelId: "known-model",
+              usage: {
+                inputTokens: 30,
+                outputTokens: 10,
+                totalTokens: 40,
+                cachedInputTokens: 0,
+                cacheCreationInputTokens: 0,
+              },
+              contextUsage,
+            },
+          },
+        },
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Unknown" }],
+        metadata: {
+          anvia: {
+            generation: {
+              provider: "test",
+              modelId: "unknown-model",
+              usage: {
+                inputTokens: 5,
+                outputTokens: 1,
+                totalTokens: 6,
+                cachedInputTokens: 0,
+                cacheCreationInputTokens: 0,
+              },
+            },
+          },
+        },
+      },
+    ]);
+    const transport = createDirectClientTransport({ handler: () => events([]) });
+    const { result } = renderHook(() => useChat({ transport, initialMessages: stored }));
+
+    expect(result.current.contextUsage).toBeUndefined();
+  });
+
   it("does not hide explicit memory compaction messages during hydration", () => {
     const compaction: MemoryCompactionMessage = {
       role: "system",
@@ -88,6 +165,48 @@ describe("public boundary", () => {
 });
 
 describe("useChat", () => {
+  it("clears stale context usage when the latest live generation omits it", async () => {
+    const contextUsage = {
+      model: { modelId: "known-model", context: { contextWindow: 100 } },
+      usedTokens: 40,
+      remainingTokens: 60,
+      usedPercent: 40,
+      remainingPercent: 60,
+    };
+    const transport = createDirectClientTransport({
+      handler: () =>
+        events([
+          { type: "run_start", runId: "run_1", source: "completion" },
+          {
+            type: "message_start",
+            runId: "run_1",
+            messageId: "assistant_2",
+            role: "assistant",
+          },
+          { type: "message_end", runId: "run_1", messageId: "assistant_2" },
+          { type: "run_end", runId: "run_1", status: "completed" },
+        ]),
+    });
+    const { result } = renderHook(() =>
+      useChat({
+        transport,
+        initialMessages: [
+          {
+            id: "assistant_1",
+            role: "assistant",
+            parts: [{ id: "text_1", type: "text", text: "Known" }],
+            generation: { contextUsage },
+          },
+        ],
+      }),
+    );
+    expect(result.current.contextUsage).toEqual(contextUsage);
+
+    await act(async () => result.current.sendMessage({ text: "Switch models" }));
+
+    expect(result.current.contextUsage).toBeUndefined();
+  });
+
   it("exposes memory compaction through events and onEvent without creating a message", async () => {
     const onEvent = vi.fn();
     const transport = createDirectClientTransport({
@@ -134,6 +253,20 @@ describe("useChat", () => {
 
   it("sends core messages and reduces the canonical framed stream", async () => {
     const requests: ClientStreamRequest[] = [];
+    const generationUsage = {
+      inputTokens: 3,
+      outputTokens: 2,
+      totalTokens: 5,
+      cachedInputTokens: 0,
+      cacheCreationInputTokens: 0,
+    };
+    const runUsage = {
+      inputTokens: 13,
+      outputTokens: 7,
+      totalTokens: 20,
+      cachedInputTokens: 2,
+      cacheCreationInputTokens: 1,
+    };
     const transport = createDirectClientTransport({
       handler: ({ request }) => {
         requests.push(request);
@@ -165,7 +298,19 @@ describe("useChat", () => {
             partId: "text_1",
             text: "Hello!",
           },
-          { type: "run_end", runId: "run_1", status: "completed", text: "Hello!" },
+          {
+            type: "message_end",
+            runId: "run_1",
+            messageId: "assistant_1",
+            usage: generationUsage,
+          },
+          {
+            type: "run_end",
+            runId: "run_1",
+            status: "completed",
+            text: "Hello!",
+            usage: runUsage,
+          },
         ]);
       },
     });
@@ -179,8 +324,13 @@ describe("useChat", () => {
     });
     expect("stream" in (requests[0] as unknown as Record<string, unknown>)).toBe(false);
     expect(result.current.text).toBe("Hello!");
+    expect(result.current.messages.at(-1)?.generation?.usage).toEqual(generationUsage);
+    expect(result.current.runUsage).toEqual(runUsage);
     expect(result.current.status).toBe("ready");
-    expect(result.current.events).toHaveLength(6);
+    expect(result.current.events).toHaveLength(7);
+
+    act(() => result.current.reset());
+    expect(result.current.runUsage).toBeUndefined();
   });
 
   it("uses submitted, streaming, and error as distinct states", async () => {
@@ -415,6 +565,13 @@ describe("useChat", () => {
 describe("useCompletion", () => {
   it("runs independent prompt-oriented requests over the client protocol", async () => {
     const requests: ClientCompletionRequest[] = [];
+    const usage = {
+      inputTokens: 5,
+      outputTokens: 1,
+      totalTokens: 6,
+      cachedInputTokens: 0,
+      cacheCreationInputTokens: 0,
+    };
     const transport = createDirectClientTransport<ClientCompletionRequest>({
       handler: ({ request }) => {
         requests.push(request);
@@ -427,7 +584,7 @@ describe("useCompletion", () => {
             partId: "text_1",
             delta: "Done",
           },
-          { type: "run_end", runId: "run_1", status: "completed", text: "Done" },
+          { type: "run_end", runId: "run_1", status: "completed", text: "Done", usage },
         ]);
       },
     });
@@ -437,16 +594,24 @@ describe("useCompletion", () => {
     expect(requests).toEqual([{ prompt: "Write" }]);
     expect(result.current.input).toBe("Write");
     expect(result.current.completion).toBe("Done");
+    expect(result.current.usage).toEqual(usage);
     expect(result.current.status).toBe("ready");
   });
 
   it("keeps error status when the stream reports a protocol error event", async () => {
     const onError = vi.fn();
+    const usage = {
+      inputTokens: 4,
+      outputTokens: 1,
+      totalTokens: 5,
+      cachedInputTokens: 0,
+      cacheCreationInputTokens: 0,
+    };
     const transport = createDirectClientTransport<ClientCompletionRequest>({
       handler: () =>
         events([
           { type: "run_start", runId: "run_1", source: "completion" },
-          { type: "error", runId: "run_1", error: { message: "Safe failure" } },
+          { type: "error", runId: "run_1", error: { message: "Safe failure" }, usage },
           { type: "run_end", runId: "run_1", status: "error" },
         ]),
     });
@@ -456,6 +621,7 @@ describe("useCompletion", () => {
 
     expect(result.current.status).toBe("error");
     expect(result.current.error?.message).toBe("Safe failure");
+    expect(result.current.usage).toEqual(usage);
     expect(onError).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary

- hydrate persisted assistant generation usage, context usage, and sources into replayed UI messages
- keep per-generation message usage separate from aggregate run usage
- expose latest aggregate usage from the React chat and completion hooks
- clear stale context usage when the newest response omits context information
- add a patch-only changeset for @anvia/client and @anvia/react

## Verification

- pnpm check
- pnpm --filter @anvia/core build
- pnpm --filter ./packages/** --filter !@anvia/core build
- pnpm --filter ./packages/** typecheck
- pnpm --filter ./packages/** test
- pnpm changeset status

Docker and external database integration tests remain skipped behind their opt-in environment gates. No visible Studio UI behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added aggregate usage reporting through `useChat().runUsage` and `useCompletion().usage`.
  * Replayed assistant messages now restore generation usage, context usage, and source information.
  * Per-generation usage remains separate from aggregate run usage.

* **Bug Fixes**
  * Context usage now clears correctly when the latest response omits context data.
  * Resetting chat or completion state clears stale usage metrics.

* **Documentation**
  * Updated API documentation for usage and persisted message data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->