### PR TITLE
security(milvus): validate metadata filter keys in Boolean expressions

### DIFF
--- a/.changeset/milvus-filter-key-validation.md
+++ b/.changeset/milvus-filter-key-validation.md
@@ -1,0 +1,9 @@
+---
+"@anvia/milvus": patch
+---
+
+Validate metadata filter keys before building Milvus Boolean expressions. Filter keys must be plain
+identifiers (letters, digits, underscores, and dots for nested fields), must not use reserved
+expression keywords as path segments, and numeric filter values must be finite. Searches with
+hostile filter input now fail fast with a descriptive error instead of forwarding attacker-shaped
+strings to Milvus.

--- a/packages/vector-milvus/src/filters.ts
+++ b/packages/vector-milvus/src/filters.ts
@@ -1,5 +1,30 @@
 import type { VectorFilter } from "@anvia/core/vector-store";
 
+const milvusIdentifierPattern = /^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$/;
+
+const milvusExpressionKeywords = new Set([
+  "and",
+  "or",
+  "not",
+  "exists",
+  "in",
+  "like",
+  "is",
+  "null",
+  "true",
+  "false",
+  "json_contains",
+  "json_contains_all",
+  "json_contains_any",
+  "array_contains",
+  "array_contains_all",
+  "array_contains_any",
+  "array_length",
+  "text_match",
+  "phrase_match",
+  "random_sample",
+]);
+
 export function filterToMilvusExpr(filter: VectorFilter | undefined): string | undefined {
   if (filter === undefined) {
     return undefined;
@@ -7,16 +32,19 @@ export function filterToMilvusExpr(filter: VectorFilter | undefined): string | u
 
   switch (filter.type) {
     case "eq": {
+      const key = sanitizeFilterKey(filter.key);
       const val = milvusLiteral(filter.value);
-      return `${filter.key} == ${val}`;
+      return `${key} == ${val}`;
     }
     case "gt": {
+      const key = sanitizeFilterKey(filter.key);
       const val = milvusLiteral(filter.value);
-      return `${filter.key} > ${val}`;
+      return `${key} > ${val}`;
     }
     case "lt": {
+      const key = sanitizeFilterKey(filter.key);
       const val = milvusLiteral(filter.value);
-      return `${filter.key} < ${val}`;
+      return `${key} < ${val}`;
     }
     case "and": {
       const parts = filter.filters
@@ -33,12 +61,35 @@ export function filterToMilvusExpr(filter: VectorFilter | undefined): string | u
   }
 }
 
+function sanitizeFilterKey(key: string): string {
+  if (!milvusIdentifierPattern.test(key)) {
+    throw new Error(
+      `Invalid metadata filter key: "${key}". Filter keys must start with a letter or underscore,` +
+        ` and contain only alphanumeric characters, underscores, and dots for nested fields.`,
+    );
+  }
+  for (const segment of key.split(".")) {
+    if (milvusExpressionKeywords.has(segment.toLowerCase())) {
+      throw new Error(
+        `Invalid metadata filter key: "${key}". The segment "${segment}" is a reserved Milvus ` +
+          `expression keyword.`,
+      );
+    }
+  }
+  return key;
+}
+
 function milvusLiteral(value: string | number | boolean | null): string {
   if (value === null) {
     return "null";
   }
   if (typeof value === "string") {
     return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  }
+  if (typeof value === "number" && !Number.isFinite(value)) {
+    throw new Error(
+      `Invalid metadata filter value: ${value}. Numeric filter values must be finite.`,
+    );
   }
   return String(value);
 }

--- a/packages/vector-milvus/test/milvus-vector-store.test.ts
+++ b/packages/vector-milvus/test/milvus-vector-store.test.ts
@@ -143,9 +143,9 @@ describe("Milvus metadata filter expression validation", () => {
       store.search({
         vector: [1, 0],
         topK: 1,
-        filter: { type: "eq", key: "user.name and true", value: "x" },
+        filter: { type: "eq", key: "user.and.name", value: "x" },
       }),
-    ).rejects.toThrow(/Invalid metadata filter key/);
+    ).rejects.toThrow(/reserved Milvus expression keyword/);
     expect(client.search).not.toHaveBeenCalled();
   });
 

--- a/packages/vector-milvus/test/milvus-vector-store.test.ts
+++ b/packages/vector-milvus/test/milvus-vector-store.test.ts
@@ -114,3 +114,74 @@ describe("MilvusVectorClient", () => {
     ).toEqual([2, 4]);
   });
 });
+
+describe("Milvus metadata filter expression validation", () => {
+  function storeFor(client: MilvusClientLike) {
+    return new MilvusVectorClient({ client }).vectorStore({
+      collectionName: "docs",
+      dimensions: 2,
+    });
+  }
+
+  it("rejects filter keys that inject Boolean expression operators", async () => {
+    const client = fixture();
+    const store = storeFor(client);
+    await expect(
+      store.search({
+        vector: [1, 0],
+        topK: 1,
+        filter: { type: "eq", key: "a == 1 or b != b", value: "x" },
+      }),
+    ).rejects.toThrow(/Invalid metadata filter key/);
+    expect(client.search).not.toHaveBeenCalled();
+  });
+
+  it("rejects nested filter keys that contain expression keywords", async () => {
+    const client = fixture();
+    const store = storeFor(client);
+    await expect(
+      store.search({
+        vector: [1, 0],
+        topK: 1,
+        filter: { type: "eq", key: "user.name and true", value: "x" },
+      }),
+    ).rejects.toThrow(/Invalid metadata filter key/);
+    expect(client.search).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-finite numeric filter values", async () => {
+    const client = fixture();
+    const store = storeFor(client);
+    await expect(
+      store.search({
+        vector: [1, 0],
+        topK: 1,
+        filter: { type: "gt", key: "price", value: Number.NaN },
+      }),
+    ).rejects.toThrow(/Invalid metadata filter value/);
+    expect(client.search).not.toHaveBeenCalled();
+  });
+
+  it("still sends expressions for legitimate keys and values", async () => {
+    const client = fixture();
+    const store = storeFor(client);
+    await expect(
+      store.search({
+        vector: [1, 0],
+        topK: 1,
+        filter: {
+          type: "and",
+          filters: [
+            { type: "eq", key: "category", value: "cat" },
+            { type: "gt", key: "user.rating", value: 4.5 },
+          ],
+        },
+      }),
+    ).resolves.toHaveLength(1);
+    expect(client.search).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter: '(category == "cat") && (user.rating > 4.5)',
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## What this fixes

While working through how the vector adapters turn `VectorFilter` objects into store-specific query
syntax, I noticed that `@anvia/milvus` builds its Boolean expressions by interpolating `filter.key`
directly into the string:

```ts
return `${filter.key} == ${val}`;
```

Values on the right side go through `milvusLiteral()`, which escapes backslashes and double quotes,
but the key side had no validation at all. Because a filter key lands in the expression body, a key
carrying expression syntax changes what Milvus evaluates. A key shaped like `a == 1 or b != b`
escapes the quoted literal entirely and becomes part of the Boolean logic, so a search that was
meant to say "metadata field equals value" can instead evaluate an expression the caller never
intended.

This is the same class of bug that was fixed for LanceDB in #338. The LanceDB side got
`sanitizeColumnName()` plus keyword rejection at the time, and the Milvus adapter (added later in
#102) kept the unguarded interpolation. This PR closes that sibling so the injection class is
handled consistently across the family instead of in one adapter.

## Who can reach this

Filter objects come from the calling application, so the exposure depends on where an app gets its
filters. Apps that build filters from request parameters, or forward LLM-derived filter objects
into `store.search()`, hand attacker-influenced strings to the expression builder. Two things worth
noting for context:

- The built-in `createVectorSearchTool` in `@anvia/core` intentionally exposes only `query` and
  `topK` to the model, so the default agent tool path does not pass model-generated keys through.
- The store API is public, though, and I think the right place for this boundary is inside the
  adapter rather than relying on every caller to sanitize first. That matches where #338 put the
  fix for LanceDB.

Per the security guidance in CONTRIBUTING.md I'm keeping the reproduction minimal here. The
regression tests in this PR double as the smallest useful reproduction, and I'm glad to walk
through details privately if the maintainers prefer.

## What changed

Two validators now run before any expression string is built, so a hostile filter fails fast inside
`@anvia/milvus` and never reaches `client.search()`:

1. `sanitizeFilterKey()` checks that a key is a plain identifier: it must start with a letter or
   underscore, and may contain alphanumeric characters, underscores, and dots for nested segments
   (`user.rating` is fine). Each dot-separated segment is also checked against a list of reserved
   Milvus expression keywords (`and`, `or`, `not`, `in`, `like`, `exists`, the `json_contains`
   family, `array_contains` family, `array_length`, `text_match`, `phrase_match`,
   `random_sample`, and the boolean/null literals). The identifier shape follows the approach
   accepted for LanceDB in #338, with the keyword check modeled on the follow-up hardening in
   `d3609ddc`.
2. `milvusLiteral()` now rejects non-finite numbers. Previously `Number.NaN` serialized to the
   literal text `NaN`, which is not a valid Milvus value and would either error at the server or,
   worse, silently misbehave depending on the expression. Finite numbers keep working exactly as
   before.

Both validators throw a descriptive `Error` naming the offending key or value, so a caller passing
bad input gets a message that points at their filter instead of a cryptic Milvus server error.

## Behavior change and compatibility

This is a tightening, and the changeset marks it as a patch for `@anvia/milvus`:

- Filter keys that are plain identifiers keep working unchanged, including dotted nested keys.
- Keys with operator characters, whitespace, leading digits/symbols, or reserved keywords as
  segments now throw immediately. Any app that was passing such keys was already producing
  expressions that did not mean what the app thought, so I'd be surprised if this breaks a
  legitimate setup, but it is a visible behavior change and easy to relax if maintainers would
  rather start with a narrower denylist.
- Non-finite numeric values (`NaN`, `Infinity`) now throw. This mirrors the #338 precedent, which
  made non-finite numeric filter values throw in LanceDB as well.

## Tests

Four new tests in `packages/vector-milvus/test/milvus-vector-store.test.ts`, written test-first:

- Three regression tests assert that a search with an injected key, a keyword segment, or a
  non-finite numeric value rejects with the new error and that `client.search` is never called.
  All three failed against the previous code (the hostile filter was forwarded to the fake client)
  and pass after the change.
- One positive test locks in the legitimate path: `category == "cat"` combined with
  `user.rating > 4.5` still produces the expected expression through `and` composition, so the
  validation does not over-reach into normal usage.

Full package suite goes from 5 passing to 8 passing with no existing test disturbed.

## Validation

```
pnpm --filter @anvia/milvus test        # 8 passed
pnpm --filter @anvia/milvus typecheck   # pass
pnpm --filter @anvia/milvus build       # pass
pnpm exec oxfmt --check <changed files> # pass
pnpm exec oxlint <changed files>        # 0 warnings, 0 errors
```

A changeset is included (`.changeset/milvus-filter-key-validation.md`, patch bump for
`@anvia/milvus`).

## Scope notes and possible follow-ups

I kept the diff focused on `filters.ts` and its tests. Two adjacent things I deliberately left out
so this stays reviewable, both happy to do as follow-ups if wanted:

- The delete path in `store.ts` builds its filter with `JSON.stringify(document.id)` inside a
  template string. The quoting is correct for the ids it receives and those come from typed
  document objects, but it is the one other place in the package where a string lands inside an
  expression, so parameterizing or directly testing it would be a reasonable hardening pass.
- The keyword list is a reasonable starting set taken from Milvus Boolean expression syntax. If I
  missed a reserved word, extending the set is a one-line change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Metadata filter keys, including nested fields, are now validated before searches are executed.
  * Malformed keys and reserved expression keywords are rejected with clear errors.
  * Non-finite numeric filter values are rejected with descriptive errors.
  * Valid nested metadata filters continue to work as expected while unsafe input is blocked from reaching Milvus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->