### PR TITLE
feat(react-ui): add headless graph explorer primitives

### DIFF
--- a/.changeset/bright-graphs-explore.md
+++ b/.changeset/bright-graphs-explore.md
@@ -1,0 +1,8 @@
+---
+"@anvia/react-ui": patch
+"@anvia/react": patch
+---
+
+Add renderer-agnostic graph explorer state and headless primitives for loading, expanding, searching,
+selecting, refreshing, and rendering bounded `@anvia/graph` exploration results. Keep asynchronous
+controller ownership in React and renderer composition in React UI.

--- a/packages/react-ui/README.md
+++ b/packages/react-ui/README.md
@@ -1,6 +1,6 @@
 # @anvia/react-ui
 
-Composable React UI primitives for Anvia chat and completion experiences.
+Composable, headless React UI primitives for Anvia applications.
 
 ```tsx
 import { createHttpClientTransport } from "@anvia/client";
@@ -93,3 +93,51 @@ For app-owned text state, `StreamMarkdown` is available from `@anvia/react-ui/st
 context-free renderer: pass the already displayed text as `content` and set `live` only for its
 growing tail. Style `[data-state="revealing"]` in the owning application; `@anvia/cli` installs this
 animation with its `markdown`, `message`, `thread`, and `chat` items.
+
+## Graph explorer
+
+`@anvia/react/graph-explorer` owns graph exploration behavior without choosing a layout or rendering
+library. `@anvia/react-ui/graph-explorer` supplies optional headless composition primitives. Provide
+a browser-safe `explore` callback, normally backed by an application HTTP route, then render the
+controller's nodes and relationships with React Flow, Sigma.js, SVG, canvas, or any other renderer:
+
+```tsx
+import type { GraphExplorer } from "@anvia/graph";
+import { useGraphExplorer } from "@anvia/react/graph-explorer";
+import {
+  GraphExplorerNodePrimitive,
+  GraphExplorerPrimitive,
+  GraphExplorerProvider,
+} from "@anvia/react-ui/graph-explorer";
+
+export function KnowledgeGraph({ explore }: { explore: GraphExplorer["explore"] }) {
+  const controller = useGraphExplorer({ explore });
+  return (
+    <GraphExplorerProvider controller={controller}>
+      <GraphExplorerPrimitive.Root>
+        <GraphExplorerPrimitive.Search />
+        <GraphExplorerPrimitive.Viewport>
+          {controller.nodes.map((node) => (
+            <GraphExplorerNodePrimitive.Root key={node.id} nodeId={node.id} asChild>
+              {/* This can instead be an element supplied to a renderer such as React Flow. */}
+              <article>{node.type}</article>
+            </GraphExplorerNodePrimitive.Root>
+          ))}
+        </GraphExplorerPrimitive.Viewport>
+        <GraphExplorerPrimitive.Empty />
+        <GraphExplorerPrimitive.Status />
+      </GraphExplorerPrimitive.Root>
+    </GraphExplorerProvider>
+  );
+}
+```
+
+Call `controller.explore({ mode: "overview" })` to load an initial view. Overview results replace the
+current graph; expansion results merge by opaque node and relationship IDs. Starting a request
+aborts the previous request, while `refresh()` repeats the latest overview with a fresh signal.
+Expansions inherit filters and limits from the latest successful overview unless explicitly
+overridden. `matchedNodeIds` lets renderers dim, hide, or highlight local search results without
+prescribing one visual behavior. Validate data returned by an HTTP route before resolving the
+`explore` callback; the headless controller intentionally trusts its typed boundary. Renderers that
+do not expose React elements for individual nodes can consume the controller directly without the
+node primitives.

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@anvia/react-ui",
   "version": "1.0.10",
-  "description": "Composable React UI primitives for Anvia chat and completion experiences.",
+  "description": "Composable, headless React UI primitives for Anvia applications.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
@@ -36,6 +36,10 @@
       "types": "./dist/completion/index.d.ts",
       "import": "./dist/completion/index.js"
     },
+    "./graph-explorer": {
+      "types": "./dist/graph-explorer/index.d.ts",
+      "import": "./dist/graph-explorer/index.js"
+    },
     "./human-input": {
       "types": "./dist/human-input/index.d.ts",
       "import": "./dist/human-input/index.js"
@@ -66,7 +70,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts src/attachment/index.ts src/chat/index.ts src/completion/index.ts src/human-input/index.ts src/image/index.ts src/message/index.ts src/selection-toolbar/index.ts src/shared.ts src/stream/index.ts src/thread-list/index.ts --format esm --dts --sourcemap --clean --external react --external react-dom",
+    "build": "tsup src/index.ts src/attachment/index.ts src/chat/index.ts src/completion/index.ts src/graph-explorer/index.ts src/human-input/index.ts src/image/index.ts src/message/index.ts src/selection-toolbar/index.ts src/shared.ts src/stream/index.ts src/thread-list/index.ts --format esm --dts --sourcemap --clean --external react --external react-dom",
     "coverage": "vitest run --coverage",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
@@ -89,12 +93,19 @@
   },
   "peerDependencies": {
     "@anvia/client": "workspace:*",
+    "@anvia/graph": "workspace:*",
     "@anvia/react": "workspace:*",
     "react": ">=18",
     "react-dom": ">=18"
   },
+  "peerDependenciesMeta": {
+    "@anvia/graph": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@anvia/client": "workspace:*",
+    "@anvia/graph": "workspace:*",
     "@anvia/react": "workspace:*",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^24.9.1",

--- a/packages/react-ui/src/contexts/graph-explorer.tsx
+++ b/packages/react-ui/src/contexts/graph-explorer.tsx
@@ -1,0 +1,70 @@
+import type { GraphExploreNode, GraphSchemaLike } from "@anvia/graph";
+import type {
+  GraphExplorerController,
+  GraphExplorerExpandNodeOptions,
+  GraphExplorerStatus,
+} from "@anvia/react/graph-explorer";
+import { createContext, createElement, type ReactElement, type ReactNode, useContext } from "react";
+
+export type { GraphExplorerController, GraphExplorerExpandNodeOptions, GraphExplorerStatus };
+
+export type GraphExplorerProviderProps<Schema extends GraphSchemaLike = GraphSchemaLike> = {
+  controller: GraphExplorerController<Schema>;
+  children?: ReactNode;
+};
+
+export type GraphExplorerNodeContextValue = {
+  node: GraphExploreNode;
+  selected: boolean;
+  matched: boolean;
+};
+
+const GraphExplorerContext = createContext<GraphExplorerController | undefined>(undefined);
+const GraphExplorerNodeContext = createContext<GraphExplorerNodeContextValue | undefined>(
+  undefined,
+);
+
+export function GraphExplorerProvider<Schema extends GraphSchemaLike = GraphSchemaLike>({
+  controller,
+  children,
+}: GraphExplorerProviderProps<Schema>): ReactElement {
+  return createElement(
+    GraphExplorerContext.Provider,
+    { value: controller as unknown as GraphExplorerController },
+    children,
+  );
+}
+
+export function InternalGraphExplorerNodeProvider({
+  value,
+  children,
+}: {
+  value: GraphExplorerNodeContextValue;
+  children?: ReactNode;
+}): ReactElement {
+  return createElement(GraphExplorerNodeContext.Provider, { value }, children);
+}
+
+export function useGraphExplorerContext<
+  Schema extends GraphSchemaLike = GraphSchemaLike,
+>(): GraphExplorerController<Schema> {
+  const value = useContext(GraphExplorerContext);
+  if (value === undefined) {
+    throw new Error("Graph explorer primitives must be used inside GraphExplorerProvider.");
+  }
+  return value as unknown as GraphExplorerController<Schema>;
+}
+
+export function useGraphExplorerNode(): GraphExplorerNodeContextValue {
+  const value = useContext(GraphExplorerNodeContext);
+  if (value === undefined) {
+    throw new Error(
+      "Graph explorer node primitives must be used inside GraphExplorerNodePrimitive.Root or GraphExplorerPrimitive.Nodes.",
+    );
+  }
+  return value;
+}
+
+export function useOptionalGraphExplorerNode(): GraphExplorerNodeContextValue | undefined {
+  return useContext(GraphExplorerNodeContext);
+}

--- a/packages/react-ui/src/contexts/index.ts
+++ b/packages/react-ui/src/contexts/index.ts
@@ -4,6 +4,20 @@ export type { ChatController, ChatProviderProps } from "./chat";
 export { ChatProvider, useChatContext, useHumanInput } from "./chat";
 export type { CompletionController, CompletionProviderProps } from "./completion";
 export { CompletionProvider, useCompletionContext } from "./completion";
+export type {
+  GraphExplorerController,
+  GraphExplorerExpandNodeOptions,
+  GraphExplorerNodeContextValue,
+  GraphExplorerProviderProps,
+  GraphExplorerStatus,
+} from "./graph-explorer";
+export {
+  GraphExplorerProvider,
+  InternalGraphExplorerNodeProvider,
+  useGraphExplorerContext,
+  useGraphExplorerNode,
+  useOptionalGraphExplorerNode,
+} from "./graph-explorer";
 export type { CompletionInputContextValue } from "./completion-input";
 export { InternalCompletionInputProvider, useCompletionInput } from "./completion-input";
 export type {

--- a/packages/react-ui/src/graph-explorer/helpers.ts
+++ b/packages/react-ui/src/graph-explorer/helpers.ts
@@ -1,0 +1,10 @@
+import type { GraphExploreNode } from "@anvia/graph";
+
+export function graphExplorerNodeLabel(node: GraphExploreNode): string {
+  for (const key of ["name", "title", "label"] as const) {
+    const value = node.properties[key];
+    if (typeof value === "string" && value.trim().length > 0) return value;
+  }
+  if (node.key !== undefined) return node.key;
+  return `${node.type} ${node.id}`;
+}

--- a/packages/react-ui/src/graph-explorer/index.ts
+++ b/packages/react-ui/src/graph-explorer/index.ts
@@ -1,0 +1,43 @@
+import {
+  GraphExplorerEmpty,
+  GraphExplorerNodes,
+  GraphExplorerRefresh,
+  GraphExplorerRoot,
+  GraphExplorerSearch,
+  GraphExplorerStatus,
+  GraphExplorerViewport,
+  GraphExplorerNodeExpand,
+  GraphExplorerNodeRoot,
+  GraphExplorerNodeTrigger,
+} from "./parts";
+
+export const GraphExplorerPrimitive = {
+  Root: GraphExplorerRoot,
+  Viewport: GraphExplorerViewport,
+  Search: GraphExplorerSearch,
+  Nodes: GraphExplorerNodes,
+  Empty: GraphExplorerEmpty,
+  Status: GraphExplorerStatus,
+  Refresh: GraphExplorerRefresh,
+} as const;
+
+export const GraphExplorerNodePrimitive = {
+  Root: GraphExplorerNodeRoot,
+  Trigger: GraphExplorerNodeTrigger,
+  Expand: GraphExplorerNodeExpand,
+} as const;
+
+export type {
+  GraphExplorerController,
+  GraphExplorerExpandNodeOptions,
+  GraphExplorerNodeContextValue,
+  GraphExplorerProviderProps,
+  GraphExplorerStatus,
+} from "../contexts/graph-explorer";
+export {
+  GraphExplorerProvider,
+  useGraphExplorerContext,
+  useGraphExplorerNode,
+} from "../contexts/graph-explorer";
+export { graphExplorerNodeLabel } from "./helpers";
+export type { GraphExplorerNodeRootProps } from "./parts";

--- a/packages/react-ui/src/graph-explorer/parts.tsx
+++ b/packages/react-ui/src/graph-explorer/parts.tsx
@@ -1,0 +1,278 @@
+import type { GraphExploreNode } from "@anvia/graph";
+import { forwardRef, type ChangeEvent, type MouseEvent, type ReactNode, useCallback } from "react";
+
+import {
+  InternalGraphExplorerNodeProvider,
+  type GraphExplorerController,
+  type GraphExplorerExpandNodeOptions,
+  type GraphExplorerNodeContextValue,
+  useGraphExplorerContext,
+  useGraphExplorerNode,
+  useOptionalGraphExplorerNode,
+} from "../contexts";
+import { type PrimitiveProps, renderPrimitive } from "../primitives";
+import { graphExplorerNodeLabel } from "./helpers";
+
+export const GraphExplorerRoot = forwardRef<HTMLDivElement, PrimitiveProps<"div">>(
+  function GraphExplorerRoot(props, ref) {
+    const explorer = useGraphExplorerContext();
+    const truncated = explorer.truncated.nodes || explorer.truncated.relationships;
+    return renderPrimitive(
+      "div",
+      {
+        ...props,
+        "aria-busy": explorer.status === "loading",
+        "data-role": "graph-explorer",
+        "data-state": explorer.status,
+        "data-truncated": truncated ? "true" : "false",
+      } as PrimitiveProps<"div">,
+      ref,
+    );
+  },
+);
+
+export const GraphExplorerSearch = forwardRef<HTMLInputElement, PrimitiveProps<"input">>(
+  function GraphExplorerSearch({ onChange, ...props }, ref) {
+    const explorer = useGraphExplorerContext();
+    const handleChange = useCallback(
+      (event: ChangeEvent<HTMLInputElement>) => {
+        onChange?.(event);
+        if (!event.defaultPrevented) explorer.setQuery(event.currentTarget.value);
+      },
+      [explorer, onChange],
+    );
+    return renderPrimitive(
+      "input",
+      {
+        ...props,
+        "aria-label": props["aria-label"] ?? "Search graph",
+        "data-state": explorer.query.length === 0 ? "empty" : "populated",
+        onChange: handleChange,
+        type: props.type ?? "search",
+        value: explorer.query,
+      } as PrimitiveProps<"input">,
+      ref,
+    );
+  },
+);
+
+export const GraphExplorerViewport = forwardRef<HTMLDivElement, PrimitiveProps<"div">>(
+  function GraphExplorerViewport(props, ref) {
+    return renderPrimitive(
+      "div",
+      { ...props, "data-role": "graph-explorer-viewport" } as PrimitiveProps<"div">,
+      ref,
+    );
+  },
+);
+
+type GraphExplorerNodesChildren =
+  | ReactNode
+  | ((node: GraphExploreNode, state: GraphExplorerNodeContextValue) => ReactNode);
+
+type GraphExplorerNodesProps = Omit<PrimitiveProps<"div">, "children"> & {
+  children?: GraphExplorerNodesChildren;
+  keepMounted?: boolean;
+};
+
+export const GraphExplorerNodes = forwardRef<HTMLDivElement, GraphExplorerNodesProps>(
+  function GraphExplorerNodes({ children, keepMounted = false, ...props }, ref) {
+    const explorer = useGraphExplorerContext();
+    const empty = explorer.nodes.length === 0;
+    if (empty && !keepMounted) return null;
+    return renderPrimitive(
+      "div",
+      {
+        ...props,
+        children: explorer.nodes.map((node) => {
+          const state: GraphExplorerNodeContextValue = {
+            node,
+            selected: node.id === explorer.selectedNodeId,
+            matched: explorer.matchedNodeIds.has(node.id),
+          };
+          return (
+            <InternalGraphExplorerNodeProvider key={node.id} value={state}>
+              {typeof children === "function"
+                ? children(node, state)
+                : (children ?? (
+                    <GraphExplorerNodeRoot>
+                      <GraphExplorerNodeTrigger />
+                    </GraphExplorerNodeRoot>
+                  ))}
+            </InternalGraphExplorerNodeProvider>
+          );
+        }),
+        "data-state": empty ? "empty" : "populated",
+        role: props.role ?? "list",
+      } as PrimitiveProps<"div">,
+      ref,
+    );
+  },
+);
+
+export const GraphExplorerEmpty = forwardRef<HTMLDivElement, PrimitiveProps<"div">>(
+  function GraphExplorerEmpty(props, ref) {
+    const explorer = useGraphExplorerContext();
+    if (explorer.nodes.length > 0 || explorer.status === "loading") return null;
+    return renderPrimitive(
+      "div",
+      { ...props, children: props.children ?? "No graph nodes." } as PrimitiveProps<"div">,
+      ref,
+    );
+  },
+);
+
+type GraphExplorerStatusChildren = ReactNode | ((explorer: GraphExplorerController) => ReactNode);
+type GraphExplorerStatusProps = Omit<PrimitiveProps<"div">, "children"> & {
+  children?: GraphExplorerStatusChildren;
+};
+
+export const GraphExplorerStatus = forwardRef<HTMLDivElement, GraphExplorerStatusProps>(
+  function GraphExplorerStatus({ children, ...props }, ref) {
+    const explorer = useGraphExplorerContext();
+    const content =
+      typeof children === "function" ? children(explorer) : (children ?? statusText(explorer));
+    return renderPrimitive(
+      "div",
+      {
+        ...props,
+        children: content,
+        "data-state": explorer.status,
+        role: props.role ?? "status",
+      } as PrimitiveProps<"div">,
+      ref,
+    );
+  },
+);
+
+export const GraphExplorerRefresh = forwardRef<HTMLButtonElement, PrimitiveProps<"button">>(
+  function GraphExplorerRefresh({ onClick, ...props }, ref) {
+    const explorer = useGraphExplorerContext();
+    const disabled = props.disabled ?? explorer.status === "loading";
+    const handleClick = useAsyncAction(onClick, disabled, explorer.refresh);
+    return renderPrimitive(
+      "button",
+      {
+        ...props,
+        children: props.children ?? "Refresh graph",
+        disabled,
+        onClick: handleClick,
+        type: props.type ?? "button",
+      } as PrimitiveProps<"button">,
+      ref,
+    );
+  },
+);
+
+export type GraphExplorerNodeRootProps = PrimitiveProps<"div"> & { nodeId?: string };
+
+export const GraphExplorerNodeRoot = forwardRef<HTMLDivElement, GraphExplorerNodeRootProps>(
+  function GraphExplorerNodeRoot({ nodeId, ...props }, ref) {
+    const explorer = useGraphExplorerContext();
+    const inherited = useOptionalGraphExplorerNode();
+    const node = nodeId === undefined ? inherited?.node : explorer.nodeById.get(nodeId);
+    if (node === undefined) {
+      throw new Error(
+        nodeId === undefined
+          ? "GraphExplorerNodePrimitive.Root requires a nodeId outside GraphExplorerPrimitive.Nodes."
+          : `Graph explorer node ${nodeId} is not loaded.`,
+      );
+    }
+    const state: GraphExplorerNodeContextValue = {
+      node,
+      selected: node.id === explorer.selectedNodeId,
+      matched: explorer.matchedNodeIds.has(node.id),
+    };
+    return (
+      <InternalGraphExplorerNodeProvider value={state}>
+        {renderPrimitive(
+          "div",
+          {
+            ...props,
+            "data-match": state.matched ? "matched" : "unmatched",
+            "data-node-id": state.node.id,
+            "data-node-type": state.node.type,
+            "data-state": state.selected ? "selected" : "unselected",
+            role: props.role ?? (inherited === undefined ? undefined : "listitem"),
+          } as PrimitiveProps<"div">,
+          ref,
+        )}
+      </InternalGraphExplorerNodeProvider>
+    );
+  },
+);
+
+export const GraphExplorerNodeTrigger = forwardRef<HTMLButtonElement, PrimitiveProps<"button">>(
+  function GraphExplorerNodeTrigger({ onClick, ...props }, ref) {
+    const explorer = useGraphExplorerContext();
+    const state = useGraphExplorerNode();
+    const handleClick = useCallback(
+      (event: MouseEvent<HTMLButtonElement>) => {
+        onClick?.(event);
+        if (!event.defaultPrevented && !props.disabled) explorer.selectNode(state.node.id);
+      },
+      [explorer, onClick, props.disabled, state.node.id],
+    );
+    return renderPrimitive(
+      "button",
+      {
+        ...props,
+        children: props.children ?? graphExplorerNodeLabel(state.node),
+        onClick: handleClick,
+        type: props.type ?? "button",
+        "aria-pressed": state.selected,
+      } as PrimitiveProps<"button">,
+      ref,
+    );
+  },
+);
+
+type GraphExplorerNodeExpandOptions = Omit<GraphExplorerExpandNodeOptions, "abortSignal">;
+type GraphExplorerNodeExpandProps = PrimitiveProps<"button"> & {
+  options?: GraphExplorerNodeExpandOptions;
+};
+
+export const GraphExplorerNodeExpand = forwardRef<HTMLButtonElement, GraphExplorerNodeExpandProps>(
+  function GraphExplorerNodeExpand({ onClick, options, ...props }, ref) {
+    const explorer = useGraphExplorerContext();
+    const state = useGraphExplorerNode();
+    const disabled = props.disabled ?? explorer.status === "loading";
+    const expand = useCallback(
+      () => explorer.expandNode(state.node.id, options),
+      [explorer, options, state.node.id],
+    );
+    const handleClick = useAsyncAction(onClick, disabled, expand);
+    return renderPrimitive(
+      "button",
+      {
+        ...props,
+        children: props.children ?? "Expand",
+        disabled,
+        onClick: handleClick,
+        type: props.type ?? "button",
+      } as PrimitiveProps<"button">,
+      ref,
+    );
+  },
+);
+
+function useAsyncAction(
+  onClick: ((event: MouseEvent<HTMLButtonElement>) => void) | undefined,
+  disabled: boolean,
+  action: () => Promise<unknown>,
+) {
+  return useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      onClick?.(event);
+      if (event.defaultPrevented || disabled) return;
+      void action().catch(() => undefined);
+    },
+    [action, disabled, onClick],
+  );
+}
+
+function statusText(explorer: GraphExplorerController): ReactNode {
+  if (explorer.status === "loading") return "Loading graph.";
+  if (explorer.status === "error") return "Graph exploration failed.";
+  return `${explorer.nodes.length} nodes, ${explorer.relationships.length} relationships.`;
+}

--- a/packages/react-ui/test/exports.test.ts
+++ b/packages/react-ui/test/exports.test.ts
@@ -15,6 +15,13 @@ import type {
   ThreadListController,
   ThreadListRecord,
 } from "../src";
+import {
+  GraphExplorerNodePrimitive,
+  GraphExplorerPrimitive,
+  type GraphExplorerController,
+  GraphExplorerProvider,
+  useGraphExplorerContext,
+} from "../src/graph-explorer";
 import { AttachmentPrimitive } from "../src/attachment";
 import type { ComposerSubmitMessage as ChatComposerSubmitMessage } from "../src/chat";
 import { ChatProvider, ComposerPrimitive, ThreadPrimitive } from "../src/chat";
@@ -44,6 +51,11 @@ describe("public entrypoints", () => {
     expect(MessagePrimitive.Entity).toBeTypeOf("object");
     expect(HumanInputPrimitive.Approvals).toBeTypeOf("object");
     expect(CompletionPrimitive.Root).toBeTypeOf("object");
+    expect(GraphExplorerPrimitive.Root).toBeTypeOf("object");
+    expect(GraphExplorerPrimitive.Viewport).toBeTypeOf("object");
+    expect(GraphExplorerNodePrimitive.Root).toBeTypeOf("object");
+    expect(GraphExplorerProvider).toBeTypeOf("function");
+    expect(useGraphExplorerContext).toBeTypeOf("function");
     expect(ImagePrimitive.Root).toBeTypeOf("object");
     expect(SelectionToolbarPrimitive.Root).toBeTypeOf("object");
     expect(ThreadListPrimitive.Root).toBeTypeOf("object");
@@ -90,6 +102,11 @@ describe("public entrypoints", () => {
       rect: DOMRect;
     }>();
     expectTypeOf<ThreadListRecord>().toMatchTypeOf<{ id: string; title?: string }>();
+    expectTypeOf<GraphExplorerController>().toMatchTypeOf<{
+      nodes: readonly { id: string }[];
+      query: string;
+      selectNode(nodeId: string | undefined): void;
+    }>();
     expectTypeOf<ThreadListController>().toMatchTypeOf<{
       threads: ThreadListRecord[];
       createThread(): Promise<void> | void;

--- a/packages/react-ui/test/graph-explorer.test.tsx
+++ b/packages/react-ui/test/graph-explorer.test.tsx
@@ -1,0 +1,245 @@
+import type { GraphExploreNode, GraphExploreResult } from "@anvia/graph";
+import type { GraphExplorerController } from "@anvia/react/graph-explorer";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  GraphExplorerNodePrimitive as GraphNode,
+  GraphExplorerPrimitive as GraphExplorer,
+  GraphExplorerProvider,
+  graphExplorerNodeLabel,
+} from "../src/graph-explorer";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("Graph explorer primitives", () => {
+  it("requires a graph explorer provider", () => {
+    expect(() => render(<GraphExplorer.Root />)).toThrow(
+      "Graph explorer primitives must be used inside GraphExplorerProvider.",
+    );
+  });
+
+  it("projects controller state and delegates user actions", () => {
+    const controller = createController();
+    render(
+      <GraphExplorerProvider controller={controller}>
+        <GraphExplorer.Root data-testid="explorer">
+          <GraphExplorer.Search />
+          <GraphExplorer.Viewport data-testid="viewport" />
+          <GraphExplorer.Status />
+          <GraphExplorer.Refresh />
+          <GraphExplorer.Nodes>
+            {(node) => (
+              <GraphNode.Root data-testid={`node-${node.id}`}>
+                <GraphNode.Trigger />
+                <GraphNode.Expand options={{ direction: "both", maxDepth: 2 }} />
+              </GraphNode.Root>
+            )}
+          </GraphExplorer.Nodes>
+          <GraphExplorer.Empty />
+        </GraphExplorer.Root>
+      </GraphExplorerProvider>,
+    );
+
+    const explorer = screen.getByTestId("explorer");
+    const person = screen.getByTestId("node-person_1");
+    expect(explorer.getAttribute("data-state")).toBe("ready");
+    expect(explorer.getAttribute("data-truncated")).toBe("true");
+    expect(explorer.getAttribute("aria-busy")).toBe("false");
+    expect(screen.getByTestId("viewport").getAttribute("data-role")).toBe(
+      "graph-explorer-viewport",
+    );
+    expect(screen.getByText("2 nodes, 1 relationships.")).toBeTruthy();
+    expect(screen.getByRole("list").children).toHaveLength(2);
+    expect(person.getAttribute("role")).toBe("listitem");
+    expect(person.getAttribute("data-state")).toBe("selected");
+    expect(person.getAttribute("data-match")).toBe("matched");
+    expect(person.getAttribute("data-node-type")).toBe("Person");
+    expect(screen.queryByText("No graph nodes.")).toBeNull();
+
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search graph" }), {
+      target: { value: "ada" },
+    });
+    fireEvent.click(within(person).getByRole("button", { name: "Ada" }));
+    fireEvent.click(within(person).getByRole("button", { name: "Expand" }));
+    fireEvent.click(screen.getByRole("button", { name: "Refresh graph" }));
+
+    expect(controller.setQuery).toHaveBeenCalledWith("ada");
+    expect(controller.selectNode).toHaveBeenCalledWith("person_1");
+    expect(controller.expandNode).toHaveBeenCalledWith("person_1", {
+      direction: "both",
+      maxDepth: 2,
+    });
+    expect(controller.refresh).toHaveBeenCalledOnce();
+  });
+
+  it("composes a loaded node directly into an application renderer", () => {
+    const controller = createController({ selectedNodeId: undefined });
+    render(
+      <GraphExplorerProvider controller={controller}>
+        <GraphNode.Root nodeId="product_1" asChild>
+          <article data-testid="canvas-node">
+            <GraphNode.Trigger>Open product</GraphNode.Trigger>
+          </article>
+        </GraphNode.Root>
+      </GraphExplorerProvider>,
+    );
+
+    const node = screen.getByTestId("canvas-node");
+    expect(node.tagName).toBe("ARTICLE");
+    expect(node.getAttribute("role")).toBeNull();
+    expect(node.getAttribute("data-node-id")).toBe("product_1");
+    expect(node.getAttribute("data-match")).toBe("unmatched");
+    fireEvent.click(screen.getByRole("button", { name: "Open product" }));
+    expect(controller.selectNode).toHaveBeenCalledWith("product_1");
+  });
+
+  it("reports invalid node primitive composition", () => {
+    const controller = createController();
+    expect(() =>
+      render(
+        <GraphExplorerProvider controller={controller}>
+          <GraphNode.Root />
+        </GraphExplorerProvider>,
+      ),
+    ).toThrow(
+      "GraphExplorerNodePrimitive.Root requires a nodeId outside GraphExplorerPrimitive.Nodes.",
+    );
+    expect(() =>
+      render(
+        <GraphExplorerProvider controller={controller}>
+          <GraphNode.Root nodeId="missing" />
+        </GraphExplorerProvider>,
+      ),
+    ).toThrow("Graph explorer node missing is not loaded.");
+    expect(() =>
+      render(
+        <GraphExplorerProvider controller={controller}>
+          <GraphNode.Trigger />
+        </GraphExplorerProvider>,
+      ),
+    ).toThrow(
+      "Graph explorer node primitives must be used inside GraphExplorerNodePrimitive.Root or GraphExplorerPrimitive.Nodes.",
+    );
+  });
+
+  it("handles empty, loading, and error presentation states", () => {
+    const empty = createController({
+      nodes: [],
+      nodeById: new Map(),
+      relationships: [],
+      matchedNodeIds: new Set(),
+      status: "error",
+      error: new Error("offline"),
+      truncated: { nodes: false, relationships: false },
+    });
+    const { rerender } = render(
+      <GraphExplorerProvider controller={empty}>
+        <GraphExplorer.Root data-testid="empty-root">
+          <GraphExplorer.Nodes keepMounted />
+          <GraphExplorer.Empty>Nothing loaded.</GraphExplorer.Empty>
+          <GraphExplorer.Status />
+          <GraphExplorer.Refresh />
+        </GraphExplorer.Root>
+      </GraphExplorerProvider>,
+    );
+
+    expect(screen.getByRole("list").getAttribute("data-state")).toBe("empty");
+    expect(screen.getByText("Nothing loaded.")).toBeTruthy();
+    expect(screen.getByText("Graph exploration failed.")).toBeTruthy();
+
+    const loading = createController({
+      nodes: [],
+      nodeById: new Map(),
+      relationships: [],
+      matchedNodeIds: new Set(),
+      status: "loading",
+      truncated: { nodes: false, relationships: false },
+    });
+    rerender(
+      <GraphExplorerProvider controller={loading}>
+        <GraphExplorer.Root data-testid="loading-root">
+          <GraphExplorer.Empty />
+          <GraphExplorer.Status />
+          <GraphExplorer.Refresh />
+        </GraphExplorer.Root>
+      </GraphExplorerProvider>,
+    );
+
+    expect(screen.getByTestId("loading-root").getAttribute("aria-busy")).toBe("true");
+    expect(screen.queryByText("No graph nodes.")).toBeNull();
+    expect(screen.getByText("Loading graph.")).toBeTruthy();
+    expect(
+      (screen.getByRole("button", { name: "Refresh graph" }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+  });
+
+  it("labels nodes from display properties, keys, and opaque identities", () => {
+    expect(graphExplorerNodeLabel({ ...nodes[0]!, properties: { title: "Countess" } })).toBe(
+      "Countess",
+    );
+    expect(graphExplorerNodeLabel({ ...nodes[0]!, properties: { label: "Pioneer" } })).toBe(
+      "Pioneer",
+    );
+    expect(
+      graphExplorerNodeLabel({ ...nodes[0]!, key: "Person:Ada", properties: { name: " " } }),
+    ).toBe("Person:Ada");
+    expect(graphExplorerNodeLabel({ ...nodes[0]!, properties: {} })).toBe("Person person_1");
+  });
+});
+
+const nodes: readonly GraphExploreNode[] = [
+  {
+    id: "person_1",
+    type: "Person",
+    identity: { name: "Ada" },
+    properties: { name: "Ada", role: "Engineer" },
+  },
+  {
+    id: "product_1",
+    type: "Product",
+    identity: { slug: "anvia" },
+    properties: { name: "Anvia Graph" },
+  },
+];
+
+function createController(
+  overrides: Partial<GraphExplorerController> = {},
+): GraphExplorerController {
+  const result: GraphExploreResult = {
+    nodes: [...nodes],
+    relationships: [
+      {
+        id: "uses_1",
+        type: "USES",
+        from: "person_1",
+        to: "product_1",
+        properties: {},
+      },
+    ],
+    truncated: { nodes: true, relationships: false },
+  };
+  const base: GraphExplorerController = {
+    nodes: result.nodes,
+    nodeById: new Map(result.nodes.map((node) => [node.id, node])),
+    relationships: result.relationships,
+    truncated: result.truncated,
+    selectedNodeId: "person_1",
+    selectedNode: result.nodes[0],
+    query: "",
+    matchedNodeIds: new Set(["person_1"]),
+    status: "ready",
+    error: undefined,
+    explore: vi.fn(async () => undefined),
+    expandNode: vi.fn(async () => undefined),
+    refresh: vi.fn(async () => undefined),
+    selectNode: vi.fn(),
+    setQuery: vi.fn(),
+    stop: vi.fn(),
+    reset: vi.fn(),
+  };
+  return { ...base, ...overrides };
+}

--- a/packages/react-ui/tsconfig.json
+++ b/packages/react-ui/tsconfig.json
@@ -9,7 +9,9 @@
       "@anvia/client": ["../client/src/index.ts"],
       "@anvia/core": ["../core/src/index.ts"],
       "@anvia/core/*": ["../core/src/*/index.ts"],
-      "@anvia/react": ["../react/src/index.ts"]
+      "@anvia/graph": ["../graph/src/index.ts"],
+      "@anvia/react": ["../react/src/index.ts"],
+      "@anvia/react/*": ["../react/src/*/index.ts"]
     }
   },
   "include": ["src", "test", "vitest.config.ts"]

--- a/packages/react-ui/vitest.config.ts
+++ b/packages/react-ui/vitest.config.ts
@@ -18,6 +18,9 @@ export default defineConfig({
       "@anvia/core/memory": fileURLToPath(new URL("../core/src/memory/index.ts", import.meta.url)),
       "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
       "@anvia/react": fileURLToPath(new URL("../react/src/index.ts", import.meta.url)),
+      "@anvia/react/graph-explorer": fileURLToPath(
+        new URL("../react/src/graph-explorer/index.ts", import.meta.url),
+      ),
     },
   },
   test: {

--- a/packages/react-ui/vitest.config.ts
+++ b/packages/react-ui/vitest.config.ts
@@ -17,10 +17,10 @@ export default defineConfig({
       ),
       "@anvia/core/memory": fileURLToPath(new URL("../core/src/memory/index.ts", import.meta.url)),
       "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
-      "@anvia/react": fileURLToPath(new URL("../react/src/index.ts", import.meta.url)),
       "@anvia/react/graph-explorer": fileURLToPath(
         new URL("../react/src/graph-explorer/index.ts", import.meta.url),
       ),
+      "@anvia/react": fileURLToPath(new URL("../react/src/index.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@anvia/react",
   "version": "1.0.10",
-  "description": "React hooks for the explicit Anvia client stream protocol.",
+  "description": "React hooks for Anvia client streams and runtime primitives.",
   "author": "anvia",
   "maintainer": "Indra Zulfi",
   "license": "MIT",
@@ -23,10 +23,14 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./graph-explorer": {
+      "types": "./dist/graph-explorer/index.d.ts",
+      "import": "./dist/graph-explorer/index.js"
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts --sourcemap --clean --external react",
+    "build": "tsup src/index.ts src/graph-explorer/index.ts --format esm --dts --sourcemap --clean --external react",
     "coverage": "vitest run --coverage",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
@@ -34,11 +38,18 @@
   "peerDependencies": {
     "@anvia/client": "workspace:*",
     "@anvia/core": "workspace:*",
+    "@anvia/graph": "workspace:*",
     "react": ">=18"
+  },
+  "peerDependenciesMeta": {
+    "@anvia/graph": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@anvia/client": "workspace:*",
     "@anvia/core": "workspace:*",
+    "@anvia/graph": "workspace:*",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^24.9.1",
     "@types/react": "^19.2.14",

--- a/packages/react/src/graph-explorer/index.ts
+++ b/packages/react/src/graph-explorer/index.ts
@@ -1,0 +1,9 @@
+export {
+  graphExplorerNodeMatches,
+  mergeGraphExploreResults,
+  useGraphExplorer,
+  type GraphExplorerController,
+  type GraphExplorerExpandNodeOptions,
+  type GraphExplorerStatus,
+  type UseGraphExplorerOptions,
+} from "./use-graph-explorer";

--- a/packages/react/src/graph-explorer/use-graph-explorer.ts
+++ b/packages/react/src/graph-explorer/use-graph-explorer.ts
@@ -1,0 +1,281 @@
+import type {
+  GraphExploreExpandOptions,
+  GraphExploreNode,
+  GraphExploreOptions,
+  GraphExploreRelationship,
+  GraphExploreResult,
+  GraphExplorer,
+  GraphSchemaLike,
+} from "@anvia/graph";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+const emptyResult: GraphExploreResult = {
+  nodes: [],
+  relationships: [],
+  truncated: { nodes: false, relationships: false },
+};
+
+export type GraphExplorerStatus = "idle" | "loading" | "ready" | "error";
+
+export type GraphExplorerExpandNodeOptions<Schema extends GraphSchemaLike = GraphSchemaLike> = Omit<
+  GraphExploreExpandOptions<Schema>,
+  "mode" | "nodeIds"
+>;
+
+export type GraphExplorerController<Schema extends GraphSchemaLike = GraphSchemaLike> = {
+  nodes: readonly GraphExploreNode[];
+  nodeById: ReadonlyMap<string, GraphExploreNode>;
+  relationships: readonly GraphExploreRelationship[];
+  truncated: GraphExploreResult["truncated"];
+  selectedNodeId: string | undefined;
+  selectedNode: GraphExploreNode | undefined;
+  query: string;
+  matchedNodeIds: ReadonlySet<string>;
+  status: GraphExplorerStatus;
+  error: unknown | undefined;
+  explore(options: GraphExploreOptions<Schema>): Promise<GraphExploreResult | undefined>;
+  expandNode(
+    nodeId: string,
+    options?: GraphExplorerExpandNodeOptions<Schema>,
+  ): Promise<GraphExploreResult | undefined>;
+  refresh(): Promise<GraphExploreResult | undefined>;
+  selectNode(nodeId: string | undefined): void;
+  setQuery(query: string): void;
+  stop(): void;
+  reset(): void;
+};
+
+export type UseGraphExplorerOptions<Schema extends GraphSchemaLike = GraphSchemaLike> = {
+  explore: GraphExplorer<Schema>["explore"];
+  initialResult?: GraphExploreResult;
+  initialQuery?: string;
+  searchText?: (node: GraphExploreNode) => string;
+};
+
+type ExpansionDefaults<Schema extends GraphSchemaLike> = Pick<
+  GraphExplorerExpandNodeOptions<Schema>,
+  "nodeTypes" | "relationships" | "includeProvenance" | "maxNodes" | "maxRelationships"
+>;
+
+export function useGraphExplorer<Schema extends GraphSchemaLike = GraphSchemaLike>(
+  options: UseGraphExplorerOptions<Schema>,
+): GraphExplorerController<Schema> {
+  const { explore: load, searchText } = options;
+  const [result, setResult] = useState(options.initialResult ?? emptyResult);
+  const [selectedNodeId, setSelectedNodeId] = useState<string>();
+  const [query, setQuery] = useState(options.initialQuery ?? "");
+  const [status, setStatus] = useState<GraphExplorerStatus>(
+    options.initialResult === undefined ? "idle" : "ready",
+  );
+  const [error, setError] = useState<unknown>();
+  const abortRef = useRef<AbortController | undefined>(undefined);
+  const requestIdRef = useRef(0);
+  const overviewRef = useRef<GraphExploreOptions<Schema>>({ mode: "overview" });
+  const expansionDefaultsRef = useRef<ExpansionDefaults<Schema>>({});
+
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const explore = useCallback(
+    async (request: GraphExploreOptions<Schema>): Promise<GraphExploreResult | undefined> => {
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+      const requestId = ++requestIdRef.current;
+      const externalSignal = request.abortSignal;
+      const abortFromExternal = () => {
+        controller.abort();
+        if (requestId === requestIdRef.current) {
+          abortRef.current = undefined;
+          setStatus("ready");
+        }
+      };
+      if (externalSignal?.aborted === true) {
+        abortFromExternal();
+        setError(undefined);
+        return undefined;
+      }
+      externalSignal?.addEventListener("abort", abortFromExternal, { once: true });
+
+      const nextRequest = {
+        ...request,
+        abortSignal: controller.signal,
+      } as GraphExploreOptions<Schema>;
+      if (request.mode === "overview") overviewRef.current = withoutAbortSignal(request);
+      setStatus("loading");
+      setError(undefined);
+
+      try {
+        const next = await load(nextRequest);
+        if (controller.signal.aborted || requestId !== requestIdRef.current) return undefined;
+        setResult((current) =>
+          request.mode === "expand" ? mergeGraphExploreResults(current, next) : next,
+        );
+        if (request.mode === "overview") {
+          expansionDefaultsRef.current = expansionDefaults(request);
+          setSelectedNodeId((current) =>
+            next.nodes.some((node) => node.id === current) ? current : undefined,
+          );
+        }
+        setStatus("ready");
+        return next;
+      } catch (caught) {
+        if (controller.signal.aborted || requestId !== requestIdRef.current) return undefined;
+        setError(caught);
+        setStatus("error");
+        throw caught;
+      } finally {
+        externalSignal?.removeEventListener("abort", abortFromExternal);
+        if (abortRef.current === controller) abortRef.current = undefined;
+      }
+    },
+    [load],
+  );
+
+  const expandNode = useCallback(
+    (nodeId: string, expandOptions: GraphExplorerExpandNodeOptions<Schema> = {}) => {
+      if (nodeId.length === 0) throw new TypeError("Graph explorer node id must be non-empty.");
+      return explore({
+        ...expansionDefaultsRef.current,
+        ...expandOptions,
+        mode: "expand",
+        nodeIds: [nodeId],
+      });
+    },
+    [explore],
+  );
+  const refresh = useCallback(() => explore(overviewRef.current), [explore]);
+  const stop = useCallback(() => {
+    requestIdRef.current += 1;
+    abortRef.current?.abort();
+    abortRef.current = undefined;
+    setError(undefined);
+    setStatus("ready");
+  }, []);
+  const reset = useCallback(() => {
+    requestIdRef.current += 1;
+    abortRef.current?.abort();
+    abortRef.current = undefined;
+    overviewRef.current = { mode: "overview" };
+    expansionDefaultsRef.current = {};
+    setResult(emptyResult);
+    setSelectedNodeId(undefined);
+    setQuery("");
+    setError(undefined);
+    setStatus("idle");
+  }, []);
+  const nodeById = useMemo(
+    () => new Map(result.nodes.map((node) => [node.id, node])),
+    [result.nodes],
+  );
+  const selectedNode = selectedNodeId === undefined ? undefined : nodeById.get(selectedNodeId);
+  const matchedNodeIds = useMemo(
+    () =>
+      new Set(
+        result.nodes
+          .filter((node) => graphExplorerNodeMatches(node, query, searchText))
+          .map((node) => node.id),
+      ),
+    [query, result.nodes, searchText],
+  );
+
+  return useMemo(
+    () => ({
+      nodes: result.nodes,
+      nodeById,
+      relationships: result.relationships,
+      truncated: result.truncated,
+      selectedNodeId,
+      selectedNode,
+      query,
+      matchedNodeIds,
+      status,
+      error,
+      explore,
+      expandNode,
+      refresh,
+      selectNode: setSelectedNodeId,
+      setQuery,
+      stop,
+      reset,
+    }),
+    [
+      error,
+      expandNode,
+      explore,
+      matchedNodeIds,
+      nodeById,
+      query,
+      refresh,
+      reset,
+      result,
+      selectedNode,
+      selectedNodeId,
+      status,
+      stop,
+    ],
+  );
+}
+
+export function mergeGraphExploreResults(
+  current: GraphExploreResult,
+  next: GraphExploreResult,
+): GraphExploreResult {
+  const nodes = new Map(current.nodes.map((node) => [node.id, node]));
+  const relationships = new Map(
+    current.relationships.map((relationship) => [relationship.id, relationship]),
+  );
+  for (const node of next.nodes) nodes.set(node.id, node);
+  for (const relationship of next.relationships) relationships.set(relationship.id, relationship);
+  return {
+    nodes: [...nodes.values()],
+    relationships: [...relationships.values()],
+    truncated: {
+      nodes: current.truncated.nodes || next.truncated.nodes,
+      relationships: current.truncated.relationships || next.truncated.relationships,
+    },
+  };
+}
+
+export function graphExplorerNodeMatches(
+  node: GraphExploreNode,
+  query: string,
+  searchText?: ((node: GraphExploreNode) => string) | undefined,
+): boolean {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  if (normalizedQuery.length === 0) return true;
+  if (searchText !== undefined) {
+    return searchText(node).toLocaleLowerCase().includes(normalizedQuery);
+  }
+  return defaultGraphExplorerNodeSearchValues(node).some((value) =>
+    String(value ?? "")
+      .toLocaleLowerCase()
+      .includes(normalizedQuery),
+  );
+}
+
+function defaultGraphExplorerNodeSearchValues(node: GraphExploreNode): unknown[] {
+  const properties = Object.entries(node.properties).flatMap(([key, value]) => [
+    key,
+    Array.isArray(value) ? value.join(" ") : String(value),
+  ]);
+  return [node.type, node.key, ...Object.values(node.identity), ...properties];
+}
+
+function withoutAbortSignal<Schema extends GraphSchemaLike>(
+  options: GraphExploreOptions<Schema>,
+): GraphExploreOptions<Schema> {
+  const { abortSignal: _abortSignal, ...request } = options;
+  return request as GraphExploreOptions<Schema>;
+}
+
+function expansionDefaults<Schema extends GraphSchemaLike>(
+  options: Extract<GraphExploreOptions<Schema>, { mode: "overview" }>,
+): ExpansionDefaults<Schema> {
+  return {
+    nodeTypes: options.nodeTypes,
+    relationships: options.relationships,
+    includeProvenance: options.includeProvenance,
+    maxNodes: options.maxNodes,
+    maxRelationships: options.maxRelationships,
+  };
+}

--- a/packages/react/test/graph-explorer.test.ts
+++ b/packages/react/test/graph-explorer.test.ts
@@ -1,0 +1,274 @@
+// @vitest-environment happy-dom
+import type { GraphExploreOptions, GraphExploreResult, GraphSchemaLike } from "@anvia/graph";
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
+
+import * as publicGraphExplorer from "../src/graph-explorer";
+import { type GraphExplorerExpandNodeOptions, useGraphExplorer } from "../src/graph-explorer";
+
+describe("useGraphExplorer", () => {
+  it("replaces overviews, merges expansions, and indexes selection and search", async () => {
+    const load = vi.fn(async (request: GraphExploreOptions<GraphSchemaLike>) =>
+      request.mode === "overview" ? overviewResult : expansionResult,
+    );
+    const { result } = renderHook(() => useGraphExplorer({ explore: load }));
+
+    await act(async () => {
+      await result.current.explore({
+        mode: "overview",
+        nodeTypes: ["Person", "Product"],
+        relationships: ["USES"],
+        includeProvenance: true,
+        maxNodes: 40,
+        maxRelationships: 80,
+      });
+    });
+    act(() => {
+      result.current.selectNode("person_1");
+      result.current.setQuery("graph");
+    });
+
+    expect(result.current.status).toBe("ready");
+    expect(result.current.selectedNode?.id).toBe("person_1");
+    expect(result.current.nodeById.get("product_1")?.type).toBe("Product");
+    expect([...result.current.matchedNodeIds]).toEqual(["product_1"]);
+
+    await act(async () => {
+      await result.current.expandNode("person_1", { direction: "both", maxDepth: 1 });
+    });
+
+    expect(load.mock.calls[1]?.[0]).toMatchObject({
+      mode: "expand",
+      nodeIds: ["person_1"],
+      nodeTypes: ["Person", "Product"],
+      relationships: ["USES"],
+      includeProvenance: true,
+      maxNodes: 40,
+      maxRelationships: 80,
+      direction: "both",
+      maxDepth: 1,
+    });
+    expect(result.current.nodes.map((node) => node.id)).toEqual([
+      "person_1",
+      "product_1",
+      "database_1",
+    ]);
+    expect(result.current.nodeById.get("person_1")?.properties.name).toBe("Ada Updated");
+    expect(result.current.relationships).toHaveLength(2);
+    expect(result.current.truncated.nodes).toBe(true);
+    expect(() => result.current.expandNode("")).toThrow(
+      "Graph explorer node id must be non-empty.",
+    );
+  });
+
+  it("retries the latest overview while expanding with the last successful filters", async () => {
+    const offline = new Error("offline");
+    const load = vi
+      .fn<(options: GraphExploreOptions<GraphSchemaLike>) => Promise<GraphExploreResult>>()
+      .mockResolvedValueOnce(overviewResult)
+      .mockRejectedValueOnce(offline)
+      .mockResolvedValueOnce(expansionResult);
+    const { result } = renderHook(() => useGraphExplorer({ explore: load }));
+
+    await act(async () => {
+      await result.current.explore({ mode: "overview", nodeTypes: ["Person"] });
+    });
+    let caught: unknown;
+    await act(async () => {
+      caught = await result.current
+        .explore({ mode: "overview", nodeTypes: ["Product"] })
+        .catch((error: unknown) => error);
+    });
+
+    expect(caught).toBe(offline);
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toBe(offline);
+    expect(result.current.nodes).toEqual(overviewResult.nodes);
+
+    await act(async () => {
+      await result.current.expandNode("person_1");
+    });
+    expect(load.mock.calls[2]?.[0]).toMatchObject({
+      mode: "expand",
+      nodeIds: ["person_1"],
+      nodeTypes: ["Person"],
+    });
+
+    act(() => result.current.stop());
+    expect(result.current.status).toBe("ready");
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it("refreshes with a fresh signal and ignores superseded results", async () => {
+    const first = deferred<GraphExploreResult>();
+    const second = deferred<GraphExploreResult>();
+    const load = vi
+      .fn<(options: GraphExploreOptions<GraphSchemaLike>) => Promise<GraphExploreResult>>()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const { result } = renderHook(() => useGraphExplorer({ explore: load }));
+    let firstRun!: Promise<GraphExploreResult | undefined>;
+    let secondRun!: Promise<GraphExploreResult | undefined>;
+
+    act(() => {
+      firstRun = result.current.explore({ mode: "overview", nodeTypes: ["Person"] });
+    });
+    act(() => {
+      secondRun = result.current.refresh();
+    });
+
+    expect(load.mock.calls[0]?.[0].abortSignal?.aborted).toBe(true);
+    expect(load.mock.calls[0]?.[0].abortSignal).not.toBe(load.mock.calls[1]?.[0].abortSignal);
+    await act(async () => {
+      first.resolve(overviewResult);
+      await firstRun;
+    });
+    expect(result.current.nodes).toEqual([]);
+    await act(async () => {
+      second.resolve(otherOverviewResult);
+      await secondRun;
+    });
+    expect(result.current.nodes).toEqual(otherOverviewResult.nodes);
+  });
+
+  it("returns to ready immediately when an external signal aborts", async () => {
+    const pending = deferred<GraphExploreResult>();
+    const load = vi.fn((_request: GraphExploreOptions<GraphSchemaLike>) => pending.promise);
+    const { result } = renderHook(() => useGraphExplorer({ explore: load }));
+    const external = new AbortController();
+    let run!: Promise<GraphExploreResult | undefined>;
+
+    act(() => {
+      run = result.current.explore({ mode: "overview", abortSignal: external.signal });
+    });
+    expect(result.current.status).toBe("loading");
+    act(() => external.abort());
+    expect(result.current.status).toBe("ready");
+
+    await act(async () => {
+      pending.resolve(overviewResult);
+      await run;
+    });
+    expect(result.current.nodes).toEqual([]);
+
+    const alreadyAborted = new AbortController();
+    alreadyAborted.abort();
+    let abortedResult: GraphExploreResult | undefined;
+    await act(async () => {
+      abortedResult = await result.current.explore({
+        mode: "overview",
+        abortSignal: alreadyAborted.signal,
+      });
+    });
+    expect(abortedResult).toBeUndefined();
+    expect(load).toHaveBeenCalledOnce();
+  });
+
+  it("supports initial state, custom search, reset, and the public subpath", () => {
+    const load = vi.fn(async () => overviewResult);
+    const { result } = renderHook(() =>
+      useGraphExplorer({
+        explore: load,
+        initialResult: overviewResult,
+        initialQuery: "engineer",
+        searchText: (node) => String(node.properties.role ?? ""),
+      }),
+    );
+
+    expect(result.current.status).toBe("ready");
+    expect([...result.current.matchedNodeIds]).toEqual(["person_1"]);
+    expect(publicGraphExplorer.useGraphExplorer).toBe(useGraphExplorer);
+
+    act(() => result.current.reset());
+    expect(result.current.status).toBe("idle");
+    expect(result.current.query).toBe("");
+    expect(result.current.nodes).toEqual([]);
+  });
+
+  it("preserves schema-specific exploration options", () => {
+    type Schema = GraphSchemaLike<{
+      nodes: { Person: never };
+      relationships: { KNOWS: never };
+    }>;
+    const load = vi.fn(async (_options: GraphExploreOptions<Schema>) => overviewResult);
+    const { result } = renderHook(() => useGraphExplorer<Schema>({ explore: load }));
+
+    expectTypeOf(result.current.explore).parameter(0).toEqualTypeOf<GraphExploreOptions<Schema>>();
+    expectTypeOf<Parameters<typeof result.current.expandNode>[1]>().toEqualTypeOf<
+      GraphExplorerExpandNodeOptions<Schema> | undefined
+    >();
+  });
+});
+
+const overviewResult: GraphExploreResult = {
+  nodes: [
+    {
+      id: "person_1",
+      type: "Person",
+      identity: { name: "Ada" },
+      properties: { name: "Ada", role: "Engineer" },
+    },
+    {
+      id: "product_1",
+      type: "Product",
+      identity: { slug: "anvia" },
+      properties: { name: "Anvia Graph" },
+    },
+  ],
+  relationships: [
+    {
+      id: "uses_1",
+      type: "USES",
+      from: "person_1",
+      to: "product_1",
+      properties: {},
+    },
+  ],
+  truncated: { nodes: false, relationships: false },
+};
+
+const expansionResult: GraphExploreResult = {
+  nodes: [
+    {
+      ...overviewResult.nodes[0]!,
+      properties: { name: "Ada Updated", role: "Engineer" },
+    },
+    {
+      id: "database_1",
+      type: "Database",
+      identity: { name: "Graph Database" },
+      properties: { name: "Graph Database" },
+    },
+  ],
+  relationships: [
+    {
+      id: "knows_1",
+      type: "KNOWS",
+      from: "person_1",
+      to: "database_1",
+      properties: {},
+    },
+  ],
+  truncated: { nodes: true, relationships: false },
+};
+
+const otherOverviewResult: GraphExploreResult = {
+  nodes: [
+    {
+      id: "person_2",
+      type: "Person",
+      identity: { name: "Grace" },
+      properties: { name: "Grace" },
+    },
+  ],
+  relationships: [],
+  truncated: { nodes: false, relationships: false },
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -7,7 +7,8 @@
     "paths": {
       "@anvia/client": ["../client/src/index.ts"],
       "@anvia/core": ["../core/src/index.ts"],
-      "@anvia/core/*": ["../core/src/*/index.ts"]
+      "@anvia/core/*": ["../core/src/*/index.ts"],
+      "@anvia/graph": ["../graph/src/index.ts"]
     }
   },
   "include": ["src", "test", "vitest.config.ts"]

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       ),
       "@anvia/core/memory": fileURLToPath(new URL("../core/src/memory/index.ts", import.meta.url)),
       "@anvia/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
+      "@anvia/graph": fileURLToPath(new URL("../graph/src/index.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/tool-studio/src/ui/app/modules/graphs/graph-flow.tsx
+++ b/packages/tool-studio/src/ui/app/modules/graphs/graph-flow.tsx
@@ -1,5 +1,6 @@
 import { Handle, MarkerType, type Node, type NodeProps, Position } from "@xyflow/react";
 import type { GraphExploreNode, GraphExploreRelationship, GraphExploreResult } from "@anvia/graph";
+import { graphExplorerNodeLabel, GraphExplorerNodePrimitive } from "@anvia/react-ui/graph-explorer";
 
 export type ExplorerNodeData = {
   label: string;
@@ -13,9 +14,8 @@ export const explorerNodeTypes = {
   graphEntity: GraphEntityNode,
 };
 
-export function toExplorerFlow(result: GraphExploreResult, query: string) {
-  const normalizedQuery = query.trim().toLocaleLowerCase();
-  const visibleNodes = result.nodes.filter((node) => graphNodeMatches(node, normalizedQuery));
+export function toExplorerFlow(result: GraphExploreResult, matchedNodeIds: ReadonlySet<string>) {
+  const visibleNodes = result.nodes.filter((node) => matchedNodeIds.has(node.id));
   const visibleIds = new Set(visibleNodes.map((node) => node.id));
   const nodes = positionNodes(visibleNodes);
   const edges = result.relationships
@@ -24,43 +24,36 @@ export function toExplorerFlow(result: GraphExploreResult, query: string) {
   return { nodes, edges };
 }
 
-export function graphNodeLabel(node: GraphExploreNode): string {
-  for (const key of ["name", "title", "label"] as const) {
-    const value = node.properties[key];
-    if (typeof value === "string" && value.trim().length > 0) return value;
-  }
-  if (node.key !== undefined) return node.key;
-  return `${node.type} ${node.id}`;
-}
-
 function GraphEntityNode(props: NodeProps<ExplorerFlowNode>) {
   return (
-    <article
-      className={[
-        "relative w-[180px] rounded-xl border bg-card px-3 py-2.5 text-left shadow-sm transition",
-        props.selected ? "border-foreground shadow-md" : "border-border/80",
-      ].join(" ")}
-    >
-      <Handle
-        type="target"
-        position={Position.Top}
-        className="!size-1.5 !border-0 !bg-muted-foreground/50"
-      />
-      <div className="flex min-w-0 items-center gap-2.5">
-        <span className={["size-2.5 shrink-0 rounded-full", props.data.color].join(" ")} />
-        <div className="min-w-0">
-          <div className="truncate text-sm font-semibold text-foreground">{props.data.label}</div>
-          <div className="mt-0.5 truncate text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-            {props.data.type}
+    <GraphExplorerNodePrimitive.Root nodeId={props.id} asChild>
+      <article
+        className={[
+          "relative w-[180px] rounded-xl border bg-card px-3 py-2.5 text-left shadow-sm transition",
+          props.selected ? "border-foreground shadow-md" : "border-border/80",
+        ].join(" ")}
+      >
+        <Handle
+          type="target"
+          position={Position.Top}
+          className="!size-1.5 !border-0 !bg-muted-foreground/50"
+        />
+        <div className="flex min-w-0 items-center gap-2.5">
+          <span className={["size-2.5 shrink-0 rounded-full", props.data.color].join(" ")} />
+          <div className="min-w-0">
+            <div className="truncate text-sm font-semibold text-foreground">{props.data.label}</div>
+            <div className="mt-0.5 truncate text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+              {props.data.type}
+            </div>
           </div>
         </div>
-      </div>
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        className="!size-1.5 !border-0 !bg-muted-foreground/50"
-      />
-    </article>
+        <Handle
+          type="source"
+          position={Position.Bottom}
+          className="!size-1.5 !border-0 !bg-muted-foreground/50"
+        />
+      </article>
+    </GraphExplorerNodePrimitive.Root>
   );
 }
 
@@ -76,7 +69,7 @@ function positionNodes(nodes: readonly GraphExploreNode[]): ExplorerFlowNode[] {
         y: Math.sin(angle) * radius,
       },
       data: {
-        label: graphNodeLabel(node),
+        label: graphExplorerNodeLabel(node),
         type: node.type,
         color: nodeTypeColor(node.type),
       },
@@ -95,24 +88,6 @@ function relationshipEdge(relationship: GraphExploreRelationship) {
     labelStyle: { fontSize: 10, fontWeight: 600 },
     style: { strokeWidth: 1.5 },
   };
-}
-
-function graphNodeMatches(node: GraphExploreNode, query: string): boolean {
-  if (query.length === 0) return true;
-  const searchable = [node.type, node.key, ...Object.values(node.identity), ...propertyText(node)];
-  return searchable.some((value) =>
-    String(value ?? "")
-      .toLocaleLowerCase()
-      .includes(query),
-  );
-}
-
-function propertyText(node: GraphExploreNode): string[] {
-  const text: string[] = [];
-  for (const [key, value] of Object.entries(node.properties)) {
-    text.push(key, Array.isArray(value) ? value.join(" ") : String(value));
-  }
-  return text;
 }
 
 function nodeTypeColor(type: string): string {

--- a/packages/tool-studio/src/ui/app/modules/graphs/graphs-page.tsx
+++ b/packages/tool-studio/src/ui/app/modules/graphs/graphs-page.tsx
@@ -1,9 +1,16 @@
 import { Background, BackgroundVariant, Controls, ReactFlow } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { ArrowClockwise, MagnifyingGlass, Plus } from "@phosphor-icons/react";
-import type { GraphExploreNode, GraphExploreResult } from "@anvia/graph";
+import type {
+  GraphExploreNode,
+  GraphExploreOptions,
+  GraphExploreResult,
+  GraphSchemaLike,
+} from "@anvia/graph";
+import { useGraphExplorer } from "@anvia/react/graph-explorer";
+import { graphExplorerNodeLabel, GraphExplorerProvider } from "@anvia/react-ui/graph-explorer";
 import { type CSSProperties, useCallback, useEffect, useMemo, useState } from "react";
-import type { StudioConfig, StudioGraphExploreRequest } from "../../../../types";
+import type { StudioConfig } from "../../../../types";
 import { Button } from "../../components/ui/button";
 import { Input } from "../../components/ui/input";
 import {
@@ -22,13 +29,7 @@ import {
 import { errorMessage } from "../shared/format";
 import { JsonSyntax } from "../shared/renderers";
 import { requestJson } from "../shared/request";
-import { explorerNodeTypes, graphNodeLabel, toExplorerFlow } from "./graph-flow";
-
-const emptyResult: GraphExploreResult = {
-  nodes: [],
-  relationships: [],
-  truncated: { nodes: false, relationships: false },
-};
+import { explorerNodeTypes, toExplorerFlow } from "./graph-flow";
 
 export function GraphsPage(props: {
   graphs: StudioConfig["graphs"];
@@ -41,48 +42,54 @@ export function GraphsPage(props: {
   const [selectedGraphId, setSelectedGraphId] = useState(props.graphs[0]?.id ?? "");
   const [selectedNodeTypes, setSelectedNodeTypes] = useState<string[]>([]);
   const [selectedRelationships, setSelectedRelationships] = useState<string[]>([]);
-  const [result, setResult] = useState<GraphExploreResult>(emptyResult);
-  const [selectedNodeId, setSelectedNodeId] = useState<string>();
-  const [query, setQuery] = useState("");
-  const [loading, setLoading] = useState(false);
   const graph = props.graphs.find((item) => item.id === selectedGraphId) ?? props.graphs[0];
-  const selectedNode = result.nodes.find((node) => node.id === selectedNodeId);
-  const flow = useMemo(() => toExplorerFlow(result, query), [result, query]);
-
-  const explore = useCallback(
-    async (request: StudioGraphExploreRequest, merge: boolean, signal?: AbortSignal) => {
-      if (graph === undefined) return;
-      setLoading(true);
+  const loadGraph = useCallback(
+    async (request: GraphExploreOptions<GraphSchemaLike>) => {
+      if (graph === undefined) throw new Error("Graph explorer unavailable");
+      const { abortSignal, ...body } = request;
       onStatus("Loading graph");
       try {
         const next = await requestJson<GraphExploreResult>(
           `/graphs/${encodeURIComponent(graph.id)}/explore`,
           "Graph explorer",
-          signal,
+          abortSignal,
           "no-store",
           {
             method: "POST",
             headers: { "content-type": "application/json" },
-            body: JSON.stringify(request),
+            body: JSON.stringify(body),
           },
         );
-        setResult((current) => (merge ? mergeResults(current, next) : next));
-        setSelectedNodeId((current) => {
-          if (merge && current !== undefined) return current;
-          return next.nodes[0]?.id;
-        });
-        onStatus("Connected");
+        if (abortSignal?.aborted !== true) onStatus("Connected");
+        return next;
       } catch (loadError) {
-        if (signal?.aborted === true) return;
-        const message = errorMessage(loadError);
-        onError(message);
-        onStatus("Graph error");
-      } finally {
-        if (signal?.aborted !== true) setLoading(false);
+        if (abortSignal?.aborted !== true) {
+          onError(errorMessage(loadError));
+          onStatus("Graph error");
+        }
+        throw loadError;
       }
     },
     [graph, onError, onStatus],
   );
+  const explorer = useGraphExplorer({ explore: loadGraph });
+  const result = useMemo<GraphExploreResult>(
+    () => ({
+      nodes: explorer.nodes,
+      relationships: explorer.relationships,
+      truncated: explorer.truncated,
+    }),
+    [explorer.nodes, explorer.relationships, explorer.truncated],
+  );
+  const flow = useMemo(
+    () => toExplorerFlow(result, explorer.matchedNodeIds),
+    [explorer.matchedNodeIds, result],
+  );
+  const loading = explorer.status === "loading";
+  const selectedNode = explorer.selectedNode;
+  const explore = explorer.explore;
+  const resetExplorer = explorer.reset;
+  const selectNode = explorer.selectNode;
 
   useEffect(() => {
     if (graph === undefined) return;
@@ -91,12 +98,13 @@ export function GraphsPage(props: {
     setSelectedGraphId(graph.id);
     setSelectedNodeTypes(nodeTypes);
     setSelectedRelationships(relationships);
-    setResult(emptyResult);
-    setSelectedNodeId(undefined);
-    const controller = new AbortController();
-    void explore({ mode: "overview", nodeTypes, relationships }, false, controller.signal);
-    return () => controller.abort();
-  }, [explore, graph]);
+    resetExplorer();
+    void explore({ mode: "overview", nodeTypes, relationships })
+      .then((next) => {
+        if (next !== undefined) selectNode(next.nodes[0]?.id);
+      })
+      .catch(() => undefined);
+  }, [explore, graph, resetExplorer, selectNode]);
 
   if (!props.enabled || props.graphs.length === 0) {
     return (
@@ -114,116 +122,116 @@ export function GraphsPage(props: {
   }
 
   function reloadOverview() {
-    void explore(
-      {
-        mode: "overview",
-        nodeTypes: selectedNodeTypes,
-        relationships: selectedRelationships,
-      },
-      false,
-    );
+    void explore({
+      mode: "overview",
+      nodeTypes: selectedNodeTypes,
+      relationships: selectedRelationships,
+    })
+      .then((next) => {
+        if (next !== undefined) selectNode(next.nodes[0]?.id);
+      })
+      .catch(() => undefined);
   }
 
   function expandSelected() {
     if (selectedNode === undefined) return;
-    void explore(
-      {
-        mode: "expand",
-        nodeIds: [selectedNode.id],
+    void explorer
+      .expandNode(selectedNode.id, {
         nodeTypes: selectedNodeTypes,
         relationships: selectedRelationships,
         direction: "both",
         maxDepth: 1,
-      },
-      true,
-    );
+      })
+      .catch(() => undefined);
   }
 
   return (
-    <StudioPageShell aria-label="Graphs">
-      <div className="grid min-h-0 min-w-0 pb-6 pr-6">
-        <StudioSurface className="grid grid-cols-[minmax(0,2fr)_340px] max-lg:grid-cols-1">
-          <div className="relative min-h-0 min-w-0 overflow-hidden border-r border-border/80 bg-card/25 max-lg:min-h-96 max-lg:border-b max-lg:border-r-0">
-            <div className="absolute left-4 top-4 z-10 flex max-w-[calc(100%-2rem)] items-center gap-2 rounded-xl border border-border/80 bg-background/90 p-2 shadow-sm backdrop-blur">
-              <div className="relative min-w-0 flex-1">
-                <MagnifyingGlass className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-                <Input
-                  aria-label="Search loaded nodes"
-                  className="w-64 pl-8"
-                  placeholder="Search loaded nodes"
-                  value={query}
-                  onChange={(event) => setQuery(event.currentTarget.value)}
-                />
+    <GraphExplorerProvider controller={explorer}>
+      <StudioPageShell aria-label="Graphs">
+        <div className="grid min-h-0 min-w-0 pb-6 pr-6">
+          <StudioSurface className="grid grid-cols-[minmax(0,2fr)_340px] max-lg:grid-cols-1">
+            <div className="relative min-h-0 min-w-0 overflow-hidden border-r border-border/80 bg-card/25 max-lg:min-h-96 max-lg:border-b max-lg:border-r-0">
+              <div className="absolute left-4 top-4 z-10 flex max-w-[calc(100%-2rem)] items-center gap-2 rounded-xl border border-border/80 bg-background/90 p-2 shadow-sm backdrop-blur">
+                <div className="relative min-w-0 flex-1">
+                  <MagnifyingGlass className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    aria-label="Search loaded nodes"
+                    className="w-64 pl-8"
+                    placeholder="Search loaded nodes"
+                    value={explorer.query}
+                    onChange={(event) => explorer.setQuery(event.currentTarget.value)}
+                  />
+                </div>
+                <StudioStatusBadge>{flow.nodes.length} nodes</StudioStatusBadge>
+                <StudioStatusBadge>{flow.edges.length} relations</StudioStatusBadge>
               </div>
-              <StudioStatusBadge>{flow.nodes.length} nodes</StudioStatusBadge>
-              <StudioStatusBadge>{flow.edges.length} relations</StudioStatusBadge>
+              {loading && result.nodes.length === 0 ? (
+                <div className="grid h-full min-h-96 place-items-center text-sm text-muted-foreground">
+                  Loading graph…
+                </div>
+              ) : null}
+              {!loading && result.nodes.length === 0 ? (
+                <StudioEmptyState
+                  className="h-full border-0"
+                  title="No nodes found"
+                  text="Try another graph or broaden the selected node and relationship types."
+                />
+              ) : null}
+              {result.nodes.length > 0 ? (
+                <ReactFlow
+                  key={`${graph?.id}:${result.nodes.length}:${result.relationships.length}`}
+                  nodes={flow.nodes}
+                  edges={flow.edges}
+                  className="graph-explorer-flow"
+                  colorMode={props.theme}
+                  nodeTypes={explorerNodeTypes}
+                  fitView
+                  fitViewOptions={{ padding: 0.2, maxZoom: 1 }}
+                  minZoom={0.2}
+                  maxZoom={1.7}
+                  proOptions={{ hideAttribution: true }}
+                  defaultEdgeOptions={{ focusable: true }}
+                  style={
+                    {
+                      "--xy-edge-stroke": "var(--muted-foreground)",
+                      "--xy-edge-stroke-width": "1.4",
+                      "--xy-edge-stroke-selected": "var(--foreground)",
+                    } as CSSProperties
+                  }
+                  onNodeClick={(_, node) => explorer.selectNode(node.id)}
+                >
+                  <Background
+                    variant={BackgroundVariant.Dots}
+                    gap={16}
+                    size={1.5}
+                    color="var(--muted-foreground)"
+                    className="opacity-30"
+                  />
+                  <Controls showInteractive={false} />
+                </ReactFlow>
+              ) : null}
             </div>
-            {loading && result.nodes.length === 0 ? (
-              <div className="grid h-full min-h-96 place-items-center text-sm text-muted-foreground">
-                Loading graph…
-              </div>
-            ) : null}
-            {!loading && result.nodes.length === 0 ? (
-              <StudioEmptyState
-                className="h-full border-0"
-                title="No nodes found"
-                text="Try another graph or broaden the selected node and relationship types."
-              />
-            ) : null}
-            {result.nodes.length > 0 ? (
-              <ReactFlow
-                key={`${graph?.id}:${result.nodes.length}:${result.relationships.length}`}
-                nodes={flow.nodes}
-                edges={flow.edges}
-                className="graph-explorer-flow"
-                colorMode={props.theme}
-                nodeTypes={explorerNodeTypes}
-                fitView
-                fitViewOptions={{ padding: 0.2, maxZoom: 1 }}
-                minZoom={0.2}
-                maxZoom={1.7}
-                proOptions={{ hideAttribution: true }}
-                defaultEdgeOptions={{ focusable: true }}
-                style={
-                  {
-                    "--xy-edge-stroke": "var(--muted-foreground)",
-                    "--xy-edge-stroke-width": "1.4",
-                    "--xy-edge-stroke-selected": "var(--foreground)",
-                  } as CSSProperties
-                }
-                onNodeClick={(_, node) => setSelectedNodeId(node.id)}
-              >
-                <Background
-                  variant={BackgroundVariant.Dots}
-                  gap={16}
-                  size={1.5}
-                  color="var(--muted-foreground)"
-                  className="opacity-30"
-                />
-                <Controls showInteractive={false} />
-              </ReactFlow>
-            ) : null}
-          </div>
-          <GraphInspector
-            graph={graph}
-            graphs={props.graphs}
-            loading={loading}
-            result={result}
-            selectedGraphId={selectedGraphId}
-            selectedNode={selectedNode}
-            selectedNodeTypes={selectedNodeTypes}
-            selectedRelationships={selectedRelationships}
-            onExpand={expandSelected}
-            onReload={reloadOverview}
-            onSelectGraph={setSelectedGraphId}
-            onToggleNodeType={(type) => setSelectedNodeTypes((types) => toggled(types, type))}
-            onToggleRelationship={(type) =>
-              setSelectedRelationships((types) => toggled(types, type))
-            }
-          />
-        </StudioSurface>
-      </div>
-    </StudioPageShell>
+            <GraphInspector
+              graph={graph}
+              graphs={props.graphs}
+              loading={loading}
+              result={result}
+              selectedGraphId={selectedGraphId}
+              selectedNode={selectedNode}
+              selectedNodeTypes={selectedNodeTypes}
+              selectedRelationships={selectedRelationships}
+              onExpand={expandSelected}
+              onReload={reloadOverview}
+              onSelectGraph={setSelectedGraphId}
+              onToggleNodeType={(type) => setSelectedNodeTypes((types) => toggled(types, type))}
+              onToggleRelationship={(type) =>
+                setSelectedRelationships((types) => toggled(types, type))
+              }
+            />
+          </StudioSurface>
+        </div>
+      </StudioPageShell>
+    </GraphExplorerProvider>
   );
 }
 
@@ -363,7 +371,9 @@ function NodeInspector(props: { node: GraphExploreNode }) {
   return (
     <section>
       <StudioStatusBadge>{props.node.type}</StudioStatusBadge>
-      <h2 className="mt-2 break-words text-base font-semibold">{graphNodeLabel(props.node)}</h2>
+      <h2 className="mt-2 break-words text-base font-semibold">
+        {graphExplorerNodeLabel(props.node)}
+      </h2>
       <p className="mt-1 break-all text-xs text-muted-foreground">ID {props.node.id}</p>
       <pre className="mt-4 overflow-x-auto rounded-xl border border-border/80 bg-card p-3 text-xs leading-5">
         <code>
@@ -377,21 +387,4 @@ function NodeInspector(props: { node: GraphExploreNode }) {
 function toggled(values: string[], value: string): string[] {
   if (values.includes(value)) return values.filter((item) => item !== value);
   return [...values, value];
-}
-
-function mergeResults(current: GraphExploreResult, next: GraphExploreResult): GraphExploreResult {
-  const nodes = new Map(current.nodes.map((node) => [node.id, node]));
-  const relationships = new Map(
-    current.relationships.map((relationship) => [relationship.id, relationship]),
-  );
-  for (const node of next.nodes) nodes.set(node.id, node);
-  for (const relationship of next.relationships) relationships.set(relationship.id, relationship);
-  return {
-    nodes: [...nodes.values()],
-    relationships: [...relationships.values()],
-    truncated: {
-      nodes: current.truncated.nodes || next.truncated.nodes,
-      relationships: current.truncated.relationships || next.truncated.relationships,
-    },
-  };
 }

--- a/packages/tool-studio/test/graph-flow.test.ts
+++ b/packages/tool-studio/test/graph-flow.test.ts
@@ -1,6 +1,6 @@
 import type { GraphExploreResult } from "@anvia/graph";
 import { describe, expect, it } from "vitest";
-import { graphNodeLabel, toExplorerFlow } from "../src/ui/app/modules/graphs/graph-flow";
+import { toExplorerFlow } from "../src/ui/app/modules/graphs/graph-flow";
 
 const graph: GraphExploreResult = {
   nodes: [
@@ -24,16 +24,16 @@ const graph: GraphExploreResult = {
 
 describe("graph explorer flow", () => {
   it("creates deterministic nodes, relationship arrows, and useful labels", () => {
-    const flow = toExplorerFlow(graph, "");
+    const flow = toExplorerFlow(graph, new Set(["one", "two"]));
     expect(flow.nodes.map((node) => node.id)).toEqual(["one", "two"]);
+    expect(flow.nodes[0]?.data.label).toBe("Ada");
     expect(flow.edges).toEqual([
       expect.objectContaining({ id: "works", source: "one", target: "two", label: "WORKS_AT" }),
     ]);
-    expect(graphNodeLabel(graph.nodes[0]!)).toBe("Ada");
   });
 
-  it("searches properties and removes relationships with hidden endpoints", () => {
-    const flow = toExplorerFlow(graph, "engineer");
+  it("removes relationships with hidden endpoints", () => {
+    const flow = toExplorerFlow(graph, new Set(["one"]));
     expect(flow.nodes.map((node) => node.id)).toEqual(["one"]);
     expect(flow.edges).toEqual([]);
   });

--- a/packages/tool-studio/vitest.config.ts
+++ b/packages/tool-studio/vitest.config.ts
@@ -15,10 +15,10 @@ export default defineConfig({
       "@anvia/react-ui/graph-explorer": fileURLToPath(
         new URL("../react-ui/src/graph-explorer/index.ts", import.meta.url),
       ),
-      "@anvia/react": fileURLToPath(new URL("../react/src/index.ts", import.meta.url)),
       "@anvia/react/graph-explorer": fileURLToPath(
         new URL("../react/src/graph-explorer/index.ts", import.meta.url),
       ),
+      "@anvia/react": fileURLToPath(new URL("../react/src/index.ts", import.meta.url)),
       "@anvia/core/agent/interactions": fileURLToPath(
         new URL("../core/src/agent/interactions/index.ts", import.meta.url),
       ),

--- a/packages/tool-studio/vitest.config.ts
+++ b/packages/tool-studio/vitest.config.ts
@@ -12,7 +12,13 @@ export default defineConfig({
       "@anvia/react-ui/stream": fileURLToPath(
         new URL("../react-ui/src/stream/index.ts", import.meta.url),
       ),
+      "@anvia/react-ui/graph-explorer": fileURLToPath(
+        new URL("../react-ui/src/graph-explorer/index.ts", import.meta.url),
+      ),
       "@anvia/react": fileURLToPath(new URL("../react/src/index.ts", import.meta.url)),
+      "@anvia/react/graph-explorer": fileURLToPath(
+        new URL("../react/src/graph-explorer/index.ts", import.meta.url),
+      ),
       "@anvia/core/agent/interactions": fileURLToPath(
         new URL("../core/src/agent/interactions/index.ts", import.meta.url),
       ),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -694,6 +694,9 @@ importers:
       '@anvia/core':
         specifier: workspace:*
         version: link:../core
+      '@anvia/graph':
+        specifier: workspace:*
+        version: link:../graph
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -779,6 +782,9 @@ importers:
       '@anvia/client':
         specifier: workspace:*
         version: link:../client
+      '@anvia/graph':
+        specifier: workspace:*
+        version: link:../graph
       '@anvia/react':
         specifier: workspace:*
         version: link:../react


### PR DESCRIPTION
## Summary

- add a schema-aware headless graph explorer controller in @anvia/react
- add renderer-agnostic graph explorer composition primitives in @anvia/react-ui
- migrate the Studio React Flow graph view to consume the controller and node primitives
- document the rendering boundary and add patch changesets for both public packages

## Validation

- pnpm check
- pnpm --filter @anvia/react typecheck
- pnpm --filter @anvia/react test (38 tests)
- pnpm --filter @anvia/react-ui typecheck
- pnpm --filter @anvia/react-ui test (114 tests)
- pnpm --filter @anvia/studio typecheck
- pnpm --filter @anvia/studio test (214 tests)
- pnpm --filter @anvia/studio build

The graph explorer code meets the configured per-package branch targets (React: 91.11%; React UI: 84.7%). The package-wide coverage commands still exit nonzero because existing unrelated code leaves global branch coverage below the configured thresholds (React: 78.35% / 85%; React UI: 76.24% / 80%).

## Visual verification

No screenshot was captured because the Studio graph node markup and styling are unchanged; the integration adds headless provider and asChild behavior only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added graph exploration capabilities with loading, searching, selecting, expanding, refreshing, and resetting.
  - Added headless, customizable graph explorer UI primitives and context hooks.
  - Added node matching and labeling helpers.
  - Integrated graph exploration into the graph workspace.

- **Documentation**
  - Added graph explorer usage guidance and examples.

- **Tests**
  - Added coverage for graph exploration workflows, states, actions, filtering, and rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->