### PR TITLE
fix(mcp): allow protocol version fallback

### DIFF
--- a/.changeset/quiet-mcp-negotiation.md
+++ b/.changeset/quiet-mcp-negotiation.md
@@ -1,0 +1,7 @@
+---
+"@anvia/mcp": patch
+---
+
+Allow MCP clients to configure protocol version negotiation so they can connect to 2025-era servers
+using automatic fallback or the legacy initialization handshake. Preserve the strict `2026-07-28`
+pin as the default.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -32,6 +32,8 @@ import { McpClient, McpClientGroup } from "@anvia/mcp";
 
 const filesystem = new McpClient({
   name: "filesystem",
+  // Probe for the modern protocol and fall back for 2025-era servers.
+  versionNegotiation: { mode: "auto" },
   transport: {
     type: "stdio",
     command: "npx",
@@ -61,9 +63,10 @@ try {
 Construction performs no I/O. `connect()` discovers every tool page once and returns a frozen
 registration snapshot. Reconnect and rebuild the Agent to adopt changed remote tools.
 
-`@anvia/mcp` requires the modern MCP `2026-07-28` protocol. Connections fail clearly when a server
-does not support that revision; the package never attempts or falls back to the legacy MCP
-handshake.
+By default, `@anvia/mcp` requires the modern MCP `2026-07-28` protocol. Connections fail clearly
+when a server does not support that revision. Set `versionNegotiation` to `{ mode: "auto" }` to probe
+for the modern protocol and fall back to the legacy handshake, or `{ mode: "legacy" }` when connecting
+to a known 2025-era server.
 
 Built-in Streamable HTTP connections enforce Anvia URL safety by default and do not accept a custom
 `fetch`. Static request headers are explicit transport configuration; arbitrary Fetch `RequestInit`

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -94,7 +94,7 @@ export class McpClient {
   }
 
   async #initialize(abortSignal: AbortSignal): Promise<McpServer> {
-    const client = createSdkClient();
+    const client = createSdkClient(this.#options.versionNegotiation);
     const resource: ClientResource = { client };
     this.#resource = resource;
 
@@ -270,13 +270,15 @@ function assertUniqueToolNames(tools: readonly { name: string }[], serverName: s
   }
 }
 
-function createSdkClient(): Client {
+function createSdkClient(
+  versionNegotiation: NonNullable<McpClientOptions["versionNegotiation"]> | undefined,
+): Client {
   const implementation = {
     name: "@anvia/mcp",
     version: getMcpClientVersion(),
   };
   return new Client(implementation, {
-    versionNegotiation: { mode: { pin: modernMcpProtocolVersion } },
+    versionNegotiation: versionNegotiation ?? { mode: { pin: modernMcpProtocolVersion } },
   });
 }
 

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -4,6 +4,7 @@ import type {
   OAuthClientProvider,
   StreamableHTTPReconnectionOptions,
   Transport,
+  VersionNegotiationOptions,
 } from "@modelcontextprotocol/client";
 
 export type { McpServer, McpServerInfo, McpTool } from "@anvia/core/mcp";
@@ -45,6 +46,11 @@ export type McpClientTransport =
 export type McpClientOptions = {
   readonly name: string;
   readonly transport: McpClientTransport;
+  /**
+   * MCP protocol version negotiation. Defaults to pinning the modern `2026-07-28` revision without
+   * fallback. Use `mode: "auto"` to allow fallback or `mode: "legacy"` for 2025-era servers.
+   */
+  readonly versionNegotiation?: VersionNegotiationOptions | undefined;
   readonly tools?: {
     readonly prefix?: string | undefined;
   };

--- a/packages/mcp/test/client.test.ts
+++ b/packages/mcp/test/client.test.ts
@@ -162,7 +162,7 @@ describe("McpClient", () => {
     });
   });
 
-  it("requires the latest modern MCP protocol", async () => {
+  it("pins the latest modern MCP protocol by default", async () => {
     const client = new McpClient({
       name: "modern",
       transport: { type: "stdio", command: "node", args: ["server.js"] },
@@ -172,6 +172,26 @@ describe("McpClient", () => {
 
     expect(sdk.clients[0]?.options).toEqual({
       versionNegotiation: { mode: { pin: "2026-07-28" } },
+    });
+  });
+
+  it("passes configured MCP protocol version negotiation to the SDK", async () => {
+    const client = new McpClient({
+      name: "compatible",
+      transport: { type: "stdio", command: "node", args: ["server.js"] },
+      versionNegotiation: {
+        mode: "auto",
+        probe: { timeoutMs: 2_000, maxRetries: 1 },
+      },
+    });
+
+    await client.connect();
+
+    expect(sdk.clients[0]?.options).toEqual({
+      versionNegotiation: {
+        mode: "auto",
+        probe: { timeoutMs: 2_000, maxRetries: 1 },
+      },
     });
   });
 

--- a/packages/mcp/test/modern-protocol.test.ts
+++ b/packages/mcp/test/modern-protocol.test.ts
@@ -39,6 +39,20 @@ class ProtocolTransport implements Transport {
       return;
     }
 
+    if (message.method === "initialize") {
+      const response: JSONRPCMessage = {
+        jsonrpc: "2.0",
+        id: message.id,
+        result: {
+          protocolVersion: "2025-11-25",
+          capabilities: { tools: {} },
+          serverInfo: { name: "legacy", version: "1.0.0" },
+        },
+      };
+      queueMicrotask(() => this.onmessage?.(response));
+      return;
+    }
+
     if (message.method === "tools/list") {
       const response: JSONRPCMessage = {
         jsonrpc: "2.0",
@@ -83,12 +97,34 @@ describe("modern MCP protocol", () => {
 
     expect(requestMethods(transport)).toEqual(["server/discover"]);
   });
+
+  it("connects to a 2025-era server when automatic fallback is configured", async () => {
+    const transport = new ProtocolTransport(false);
+    const client = customClient(transport, { mode: "auto" });
+
+    await expect(client.connect()).resolves.toMatchObject({
+      name: "modern",
+      serverInfo: { name: "legacy", version: "1.0.0" },
+    });
+
+    expect(requestMethods(transport)).toEqual([
+      "server/discover",
+      "initialize",
+      "notifications/initialized",
+      "tools/list",
+    ]);
+    await client.close();
+  });
 });
 
-function customClient(transport: Transport): McpClient {
+function customClient(
+  transport: Transport,
+  versionNegotiation?: { mode: "auto" } | undefined,
+): McpClient {
   return new McpClient({
     name: "modern",
     transport: { type: "custom", create: () => transport },
+    versionNegotiation,
   });
 }
 


### PR DESCRIPTION
## Summary

- expose MCP SDK version negotiation through McpClientOptions
- preserve the strict 2026-07-28 pin as the default
- support automatic fallback or explicit legacy initialization for 2025-era servers
- document the compatibility option and add a patch changeset

## Verification

- pnpm format
- pnpm check
- pnpm --filter @anvia/mcp typecheck
- pnpm --filter @anvia/mcp test (65 tests)
- pnpm --filter @anvia/mcp build
- pnpm changeset status

## Regression coverage

The protocol test now exercises a server that rejects modern discovery, negotiates 2025-11-25 through initialize, sends notifications/initialized, and completes tool discovery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable protocol version negotiation for MCP clients.
  - Automatic mode can fall back to the legacy handshake for 2025-era servers.
  - Legacy mode is available for direct compatibility with older servers.
  - The modern `2026-07-28` protocol remains the default behavior.

- **Documentation**
  - Updated client usage guidance to explain negotiation modes and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->