### PR TITLE
chore: remove personal maintainer metadata and attribute license to Anvia

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Indra Zulfi
+Copyright (c) 2026 Anvia
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.2",
   "description": "Install editable Anvia UI components into React applications.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.10",
   "description": "Framework-neutral client protocol, transports, and UI message state for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.9",
   "description": "Core runtime primitives for context-aware Anvia agents.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/embedding-transformers/package.json
+++ b/packages/embedding-transformers/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.9",
   "description": "Transformers.js embedding model adapter for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/graph-memgraph/package.json
+++ b/packages/graph-memgraph/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.11",
   "description": "Schema-first Memgraph GraphRAG integration for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/graph-neo4j/package.json
+++ b/packages/graph-neo4j/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.11",
   "description": "Schema-first Neo4j GraphRAG integration for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.11",
   "description": "Provider-neutral knowledge graph primitives for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.9",
   "description": "Structured logger adapters for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.10",
   "description": "Model Context Protocol client integration for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/memory-drizzle/package.json
+++ b/packages/memory-drizzle/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.9",
   "description": "Drizzle-backed durable session memory store for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/memory-postgres/package.json
+++ b/packages/memory-postgres/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.9",
   "description": "Postgres-backed durable session memory store for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/memory-prisma/package.json
+++ b/packages/memory-prisma/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.9",
   "description": "Prisma-backed durable session memory store for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/memory-sqlite/package.json
+++ b/packages/memory-sqlite/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.9",
   "description": "SQLite-backed durable session memory store for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/observability-langfuse/package.json
+++ b/packages/observability-langfuse/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.9",
   "description": "Langfuse tracing adapter for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/observability-lens/package.json
+++ b/packages/observability-lens/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.10",
   "description": "Native Anvia Lens tracing and evaluation adapter for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/observability-otel/package.json
+++ b/packages/observability-otel/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.10",
   "description": "OpenTelemetry tracing and eval reporting adapter for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/provider-anthropic/package.json
+++ b/packages/provider-anthropic/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.9",
   "description": "Anthropic provider adapter for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/provider-gemini/package.json
+++ b/packages/provider-gemini/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.9",
   "description": "Gemini provider adapter for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/provider-grok/package.json
+++ b/packages/provider-grok/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.9",
   "description": "Grok provider adapter for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/provider-mistral/package.json
+++ b/packages/provider-mistral/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.9",
   "description": "Mistral provider adapter for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/provider-openai/package.json
+++ b/packages/provider-openai/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.9",
   "description": "OpenAI provider adapter for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.11",
   "description": "Composable, headless React UI primitives for Anvia applications.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.11",
   "description": "React hooks for Anvia client streams and runtime primitives.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.10",
   "description": "Server-side client protocol and generic event stream responses for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/tool-browser/package.json
+++ b/packages/tool-browser/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.11",
   "description": "Visible Chromium runtime and semantic browser tools for Anvia agents.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/tool-sandbox/package.json
+++ b/packages/tool-sandbox/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.9",
   "description": "Sandboxed workspace tools for Anvia agents.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/tool-studio/package.json
+++ b/packages/tool-studio/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.14",
   "description": "Studio UI and HTTP runtime for Anvia agents.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/vector-chroma/package.json
+++ b/packages/vector-chroma/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.9",
   "description": "ChromaDB vector store adapter for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/vector-lancedb/package.json
+++ b/packages/vector-lancedb/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.9",
   "description": "LanceDB vector store adapter for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/vector-milvus/package.json
+++ b/packages/vector-milvus/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.10",
   "description": "Milvus vector store adapter for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/vector-pgvector/package.json
+++ b/packages/vector-pgvector/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.9",
   "description": "Postgres pgvector store adapter for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/vector-pinecone/package.json
+++ b/packages/vector-pinecone/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.9",
   "description": "Pinecone vector store adapter for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/vector-qdrant/package.json
+++ b/packages/vector-qdrant/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.10",
   "description": "Qdrant vector store adapter for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/vector-redis/package.json
+++ b/packages/vector-redis/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.9",
   "description": "Redis vector store adapter for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/vector-weaviate/package.json
+++ b/packages/vector-weaviate/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.9",
   "description": "Weaviate vector store adapter for Anvia.",
   "author": "anvia",
-  "maintainer": "Indra Zulfi",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What changed

Housekeeping cleanup, two parts:

1. Removed the non-standard `"maintainer"` field from all 35 `packages/*/package.json` manifests (35 × 1-line deletion).
2. Changed the `LICENSE` copyright holder to **Anvia**.

## Why no changeset

Metadata-only: no runtime, API, build, or published-consumer behavior changes. Per repo convention, changesets target public package behavior changes — versioning 35 packages as patch for manifest hygiene would produce a full-suite npm release with no functional delta. The cleaned manifests land in published tarballs on each package's next versioned release.

## Validation

- Repo-wide grep: 0 remaining `"maintainer"` fields in manifests
- `jq` parse of every workspace `package.json`: all valid
- `pnpm check` (oxfmt + oxlint): clean
- No generated files (`dist/`, `coverage/`) touched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated licensing attribution from Indra Zulfi to Anvia.
  - Removed maintainer metadata from package information across the project.
  - No user-facing functionality or runtime behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->