### PR TITLE
chore: bump all packages to 1.1.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/cli",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Install editable Anvia UI components into React applications.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/client",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "description": "Framework-neutral client protocol, transports, and UI message state for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/core",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "Core runtime primitives for context-aware Anvia agents.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/embedding-transformers/package.json
+++ b/packages/embedding-transformers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/transformers",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "Transformers.js embedding model adapter for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/graph-memgraph/package.json
+++ b/packages/graph-memgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/memgraph",
-  "version": "1.0.12",
+  "version": "1.1.0",
   "description": "Schema-first Memgraph GraphRAG integration for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/graph-neo4j/package.json
+++ b/packages/graph-neo4j/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/neo4j",
-  "version": "1.0.12",
+  "version": "1.1.0",
   "description": "Schema-first Neo4j GraphRAG integration for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/graph",
-  "version": "1.0.12",
+  "version": "1.1.0",
   "description": "Provider-neutral knowledge graph primitives for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/logger",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "Structured logger adapters for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/mcp",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "description": "Model Context Protocol client integration for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/memory-drizzle/package.json
+++ b/packages/memory-drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/memory-drizzle",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "Drizzle-backed durable session memory store for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/memory-postgres/package.json
+++ b/packages/memory-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/memory-postgres",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "Postgres-backed durable session memory store for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/memory-prisma/package.json
+++ b/packages/memory-prisma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/memory-prisma",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "Prisma-backed durable session memory store for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/memory-sqlite/package.json
+++ b/packages/memory-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/memory-sqlite",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "SQLite-backed durable session memory store for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/observability-langfuse/package.json
+++ b/packages/observability-langfuse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/langfuse",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "Langfuse tracing adapter for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/observability-lens/package.json
+++ b/packages/observability-lens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/lens",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "description": "Native Anvia Lens tracing and evaluation adapter for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/observability-otel/package.json
+++ b/packages/observability-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/otel",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "description": "OpenTelemetry tracing and eval reporting adapter for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/provider-anthropic/package.json
+++ b/packages/provider-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/anthropic",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "Anthropic provider adapter for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/provider-gemini/package.json
+++ b/packages/provider-gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/gemini",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "Gemini provider adapter for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/provider-grok/package.json
+++ b/packages/provider-grok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/grok",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "Grok provider adapter for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/provider-mistral/package.json
+++ b/packages/provider-mistral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/mistral",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "Mistral provider adapter for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/provider-openai/package.json
+++ b/packages/provider-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/openai",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "OpenAI provider adapter for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/react-ui",
-  "version": "1.0.12",
+  "version": "1.1.0",
   "description": "Composable, headless React UI primitives for Anvia applications.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/react",
-  "version": "1.0.12",
+  "version": "1.1.0",
   "description": "React hooks for Anvia client streams and runtime primitives.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/server",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "description": "Server-side client protocol and generic event stream responses for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/tool-browser/package.json
+++ b/packages/tool-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/browser",
-  "version": "1.0.12",
+  "version": "1.1.0",
   "description": "Visible Chromium runtime and semantic browser tools for Anvia agents.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/tool-sandbox/package.json
+++ b/packages/tool-sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/sandbox",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "Sandboxed workspace tools for Anvia agents.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/tool-studio/package.json
+++ b/packages/tool-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/studio",
-  "version": "1.0.15",
+  "version": "1.1.0",
   "description": "Studio UI and HTTP runtime for Anvia agents.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/vector-chroma/package.json
+++ b/packages/vector-chroma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/chroma",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "ChromaDB vector store adapter for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/vector-lancedb/package.json
+++ b/packages/vector-lancedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/lancedb",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "LanceDB vector store adapter for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/vector-milvus/package.json
+++ b/packages/vector-milvus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/milvus",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "description": "Milvus vector store adapter for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/vector-pgvector/package.json
+++ b/packages/vector-pgvector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/pgvector",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "Postgres pgvector store adapter for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/vector-pinecone/package.json
+++ b/packages/vector-pinecone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/pinecone",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "Pinecone vector store adapter for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/vector-qdrant/package.json
+++ b/packages/vector-qdrant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/qdrant",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "description": "Qdrant vector store adapter for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/vector-redis/package.json
+++ b/packages/vector-redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/redis",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "Redis vector store adapter for Anvia.",
   "author": "anvia",
   "license": "MIT",

--- a/packages/vector-weaviate/package.json
+++ b/packages/vector-weaviate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvia/weaviate",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "Weaviate vector store adapter for Anvia.",
   "author": "anvia",
   "license": "MIT",


### PR DESCRIPTION
### Summary

Uniformly version all publishable workspace packages to `1.1.0`.

### What Changed

- `packages/*/package.json` (35 files): `version` bumped from `1.0.10`–`1.0.15` to `1.1.0`. Version field only.
- No dependency ranges changed: all internal dependencies use `workspace:*`.
- `pnpm-lock.yaml` is intentionally unchanged (`workspace:*` protocol does not embed versions; `pnpm install` is a no-op sync).
- No changeset added: this is release-engineering alignment, not a behavior change.

### Validation

1. `pnpm install` — clean, lockfile untouched.
2. `npm view @anvia/<pkg>@1.1.0` for all 35 packages — version unclaimed on npm, so the release workflow will publish every package without skips or collisions.
3. Stale-version scan across `scripts/`, `bin/`, `.changeset`, `cookbook`, `tests` — no hardcoded `1.0.1x` references.
4. Pre-commit `check-staged.mjs` formatting hook — passed on all 35 files.

### Skipped

- `pnpm typecheck` / `pnpm test`: version metadata only, no source or dependency-graph changes; workspace suites were green on `main` at `bc374d72`.

### Generated files

None changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the Anvia package suite to version **1.1.0**.
  - This release includes CLI, client, core, provider, storage, vector database, observability, graph, React, server, and tool packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->