### PR TITLE
ci: add Pullfrog agent workflow with OpenAI-compatible BYOK

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -1,0 +1,36 @@
+name: Pullfrog
+run-name: ${{ inputs.name || github.workflow }}
+on:
+  workflow_dispatch:
+    inputs:
+      prompt:
+        type: string
+        description: Agent prompt
+      name:
+        type: string
+        description: Run name
+
+permissions:
+  contents: read
+
+jobs:
+  pullfrog:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Run agent
+        uses: pullfrog/pullfrog@v0
+        with:
+          prompt: ${{ inputs.prompt }}
+        env:
+          OPENAI_COMPATIBLE_BASE_URL: https://gateway.devscale.id/v1
+          OPENAI_COMPATIBLE_API_KEY: ${{ secrets.OPENAI_COMPATIBLE_API_KEY }}
+          OPENAI_COMPATIBLE_MODEL: gpt-5.6-sol
+          OPENAI_COMPATIBLE_CONTEXT: "1050000"
+          OPENAI_COMPATIBLE_MAX_OUTPUT: "131072"


### PR DESCRIPTION
### Summary

Replaces CodeRabbit (uninstalled) with [Pullfrog](https://docs.pullfrog.com) running on a BYOK OpenAI-compatible gateway.

### What Changed

- Adds `.github/workflows/pullfrog.yml` using the `pullfrog/pullfrog@v0` action (manual-setup variant from the [getting-started docs](https://docs.pullfrog.com/getting-started)).
- Credentials live in GitHub Actions secrets; only the key is sensitive:
  - `OPENAI_COMPATIBLE_BASE_URL`: `https://gateway.devscale.id/v1` (plain config)
  - `OPENAI_COMPATIBLE_API_KEY`: repo secret (already set, not in this diff)
  - `OPENAI_COMPATIBLE_MODEL`: `gpt-5.6-sol`
  - `OPENAI_COMPATIBLE_CONTEXT`: `1050000` (per gateway model catalog)
  - `OPENAI_COMPATIBLE_MAX_OUTPUT`: `131072`

### Verification

- Gateway probes (2026-09-04): `/v1/models` lists `gpt-5.6-sol` with 1,050,000 context; a live chat-completions request accepted large `max_tokens` without a cap error; a tools probe confirmed the model returns `tool_calls` (the gateway catalog conservatively lists `function_calling: false`, but the endpoint implements it — required for agent runs).
- `checkout@v5` matches the existing workflow convention in this repo.

### Remaining console steps (outside this diff)

1. Install the Pullfrog GitHub App on `anvia-hq` and select this repo.
2. In the model dropdown pick **Custom › OpenAI-compatible**.
3. Enable PR review automation in the console to replace CodeRabbit reviews.

### Skipped

- No code changes; CI suites unaffected.