### PR TITLE
fix(studio): omit stack traces from tool run error responses

### DIFF
--- a/.changeset/studio-tool-run-error-stack.md
+++ b/.changeset/studio-tool-run-error-stack.md
@@ -1,5 +1,5 @@
 ---
-"@anvia/tool-studio": patch
+"@anvia/studio": patch
 ---
 
 Omit stack traces from tool run error responses. Tool failures reported by

--- a/.changeset/studio-tool-run-error-stack.md
+++ b/.changeset/studio-tool-run-error-stack.md
@@ -1,0 +1,8 @@
+---
+"@anvia/tool-studio": patch
+---
+
+Omit stack traces from tool run error responses. Tool failures reported by
+`POST /agents/:agentId/tools/:toolName/runs` now serialize errors with the same
+safe serializer used by agent and pipeline run failures, keeping the error name
+and message while dropping stack traces.

--- a/packages/tool-studio/src/runtime/tools.ts
+++ b/packages/tool-studio/src/runtime/tools.ts
@@ -5,8 +5,9 @@ import type {
   StudioToolRunRequest,
   StudioToolRunResponse,
 } from "../types";
+import { serializeError } from "./errors";
 import { errorResponse } from "./http";
-import { serializeUnknown, toJsonValue } from "./json";
+import { toJsonValue } from "./json";
 import { agentToolItems, approvalMetadata, mcpServerName } from "./tool-metadata";
 import { isJsonObject, isJsonValue } from "./type-guards";
 
@@ -72,7 +73,7 @@ export function registerToolRoutes(
           agentId,
           toolName,
           status: "error",
-          error: serializeUnknown(error),
+          error: serializeError(error),
           durationMs: ended - started,
           startedAt,
           endedAt: new Date(ended).toISOString(),

--- a/packages/tool-studio/test/runner.test.ts
+++ b/packages/tool-studio/test/runner.test.ts
@@ -1874,6 +1874,36 @@ describe("Anvia studio", () => {
     });
   });
 
+  it("omits stack traces from tool run failures", async () => {
+    const agent = new Agent({
+      id: "support",
+      model: new QueueModel([]),
+      tools: [
+        createRefundTool(() => {
+          throw new Error("refund engine offline");
+        }),
+      ],
+    });
+    const runner = new Studio([agent]);
+
+    const res = await runner.fetch(
+      new Request("http://runner.test/agents/support/tools/issue_refund/runs", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ args: { orderId: "ord_1", amount: 10 } }),
+      }),
+    );
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { status: string; error: Record<string, unknown> };
+    expect(body.status).toBe("error");
+    expect(body.error).toMatchObject({
+      name: expect.any(String),
+      message: expect.stringContaining("refund engine offline"),
+    });
+    expect(body.error).not.toHaveProperty("stack");
+  });
+
   it("exposes only explicitly registered sandbox inspectors", async () => {
     const inspector = {
       id: "workspace_1",


### PR DESCRIPTION
While going through the Studio runtime routes I noticed the tool runner serializes
errors differently from every other run-failure path. This PR brings it in line.

## Context

`POST /agents/:agentId/tools/:toolName/runs` is the endpoint the Studio UI uses to
invoke an agent tool directly and display the result. When the tool call throws, the
route returns a 500 with a JSON body describing the failure. That body was built with
`serializeUnknown`, which keeps the full `stack` property on `Error` instances, so a
failing tool run sent server-side stack traces back over HTTP:

```json
{
  "status": "error",
  "error": {
    "name": "ToolCallError",
    "message": "ToolCallError: refund engine offline",
    "stack": "ToolCallError: refund engine offline\n    at asToolCallError (packages/core/src/internal/agent-runtime/prepared-tool-call.ts:113:7)\n    at Object.call (...)\n    ..."
  }
}
```

That exposes absolute paths, internal module names, and line numbers from whatever
machine is running Studio. The agent-run and pipeline-run routes already used a
serializer that returns only `name` and `message` for the same situation, so the tool
runner was the odd one out. Stacks remain available where they belong: locally stored
trace payloads through the Studio trace observer still contain them for debugging,
and that behavior is untouched.

## What changed

- `packages/tool-studio/src/runtime/tools.ts`: the catch block in the tool-run route
  now uses `serializeError` from `./errors` instead of `serializeUnknown` from
  `./json`. For `Error` instances that returns `{ name, message }`. Thrown values that
  are not `Error` objects still go through the JSON serializer, so that path is
  unchanged.
- `packages/tool-studio/test/runner.test.ts`: added a regression test, "omits stack
  traces from tool run failures". It registers a tool that throws, hits the run
  endpoint, and asserts a 500 response with `status: "error"`, the original error
  message preserved, and no `stack` key on the error object. The test fails against
  the old code because the response carries the stack, and passes with this fix.
- `.changeset/studio-tool-run-error-stack.md`: patch changeset for `@anvia/tool-studio`.

## Validation

```sh
pnpm --filter @anvia/tool-studio typecheck
pnpm --filter @anvia/tool-studio exec vitest run test/runner.test.ts -t "omits stack traces from tool run failures"
pnpm exec oxlint packages/tool-studio/src/runtime/tools.ts packages/tool-studio/test/runner.test.ts
pnpm exec oxfmt --check packages/tool-studio/src/runtime/tools.ts packages/tool-studio/test/runner.test.ts
```

- Typecheck passes.
- The new test passes, and the existing tool-runner tests (direct tool runs, tool
  metadata listing) still pass.
- oxlint reports 0 warnings and 0 errors on the touched files, and both files pass
  the formatter check.
- Full disclosure on the broader test file: on my Windows machine, `test/runner.test.ts`
  has 9 failures, all in the SQLite session-store tests. I verified with `git stash`
  that those fail on `main` without this change too, so they look like local
  `node:sqlite` environment issues rather than anything this PR touches.
- I did not run the full-workspace `pnpm check` locally because a CRLF checkout makes
  the formatter check noisy on Windows; the touched files were checked directly, and
  CI will run the complete check anyway.

## Compatibility and risk

The only observable difference is that `error.stack` disappears from failed tool-run
responses. `name` and `message` are untouched, non-Error throws serialize as before,
and nothing inside this repo reads `stack` from these responses, so the Studio UI is
unaffected. Anyone outside who happened to parse that field would notice it gone,
which is why this ships as a patch with a changeset rather than a silent change.

No public API additions, no dependency changes, no migration steps, and no follow-up
work I'm aware of. Since this is a runtime response change and not a UI render change,
I didn't include screenshots, but I'm happy to capture one of the error state if that
would help review.