### PR TITLE
feat(openai,grok): default completionModel api to chat and add gpt-6-astra

### DIFF
--- a/.changeset/openai-chat-default-api.md
+++ b/.changeset/openai-chat-default-api.md
@@ -1,0 +1,6 @@
+---
+"@anvia/openai": patch
+"@anvia/grok": patch
+---
+
+`completionModel()` now defaults to the Chat Completions API. `api` is optional and falls back to `"chat"`; pass `api: "responses"` explicitly to keep using the Responses API. Grok server-side provider tools are only advertised on Responses handles.

--- a/.changeset/openai-gpt-6-astra.md
+++ b/.changeset/openai-gpt-6-astra.md
@@ -1,0 +1,5 @@
+---
+"@anvia/openai": patch
+---
+
+Add `gpt-6-astra` to the known OpenAI completion model list with context limits and reasoning-effort controls.

--- a/packages/provider-grok/README.md
+++ b/packages/provider-grok/README.md
@@ -41,7 +41,8 @@ if (result.type === "response") console.log(result.output);
 
 ## Completion APIs
 
-`GrokClient` targets `https://api.x.ai/v1` by default. Choose the protocol on each model handle:
+`GrokClient` targets `https://api.x.ai/v1` by default. Model handles default to the Chat
+Completions API; opt into Responses with `api: "responses"`:
 
 ```ts
 const client = new GrokClient({
@@ -49,10 +50,10 @@ const client = new GrokClient({
 });
 ```
 
-Use the Chat Completions adapter when a workflow specifically needs that surface:
+The Responses API remains available when a workflow specifically needs that surface:
 
 ```ts
-const chatModel = client.completionModel({ modelId: "grok-4.6", api: "chat" });
+const responsesModel = client.completionModel({ modelId: "grok-4.6", api: "responses" });
 ```
 
 Provider-specific xAI parameters can be passed through completion `providerOptions`.
@@ -72,7 +73,8 @@ const response = await model.completion({
 
 Grok's Responses API can execute web search, X search, code interpreter, collections search, and
 remote MCP tools on xAI's servers. Pass them through the same `.tools(...)` API as local executable
-tools:
+tools. Select Responses explicitly (`api: "responses"`); Chat Completions handles do not advertise
+provider tools:
 
 ```ts
 import { Agent } from "@anvia/core";

--- a/packages/provider-grok/src/grok/client.ts
+++ b/packages/provider-grok/src/grok/client.ts
@@ -54,7 +54,7 @@ export type GrokCompletionModelOptions<
   Controls extends CompletionModelControls = GrokControlsFor<ModelId>,
 > = {
   modelId: ModelId;
-  api: "responses" | "chat";
+  api?: "responses" | "chat" | undefined;
   contextLimits?: ModelContextLimits | undefined;
   controls?: Controls | undefined;
 };

--- a/packages/provider-grok/src/grok/completion.ts
+++ b/packages/provider-grok/src/grok/completion.ts
@@ -23,7 +23,7 @@ export class GrokCompletionModel<
   constructor(
     client: OpenAI,
     readonly modelId: GrokCompletionModelId,
-    api: "responses" | "chat",
+    api?: "responses" | "chat" | undefined,
     readonly contextLimits?: ModelContextLimits,
     readonly controls?: Controls,
   ) {

--- a/packages/provider-grok/test/client.test.ts
+++ b/packages/provider-grok/test/client.test.ts
@@ -21,6 +21,15 @@ describe("GrokClient", () => {
     );
   });
 
+  it("defaults to chat completions when api is omitted", () => {
+    const client = injectedClient(fakeSdk());
+
+    const defaulted = client.completionModel({ modelId: GROK_4_5 });
+    expect(defaulted.capabilities.providerTools).toBeUndefined();
+    const responses = client.completionModel({ modelId: GROK_4_5, api: "responses" });
+    expect(responses.capabilities.providerTools).toBe(true);
+  });
+
   it("types known Grok models while accepting custom model strings", () => {
     const client = injectedClient(fakeSdk());
 

--- a/packages/provider-openai/README.md
+++ b/packages/provider-openai/README.md
@@ -55,7 +55,8 @@ if (result.type === "response") console.log(result.output);
 
 ## OpenAI-Compatible APIs
 
-`baseUrl` changes only the endpoint. Choose the protocol on each model handle explicitly:
+`baseUrl` changes only the endpoint. Model handles default to the Chat Completions API; opt into
+Responses with `api: "responses"` per handle:
 
 ```ts
 import { OpenAIClient } from "@anvia/openai";
@@ -68,7 +69,7 @@ const client = new OpenAIClient({
 const model = client.completionModel({ modelId: "openai/gpt-5.2", api: "chat" });
 ```
 
-The same client can create both `{ api: "responses" }` and `{ api: "chat" }` handles.
+The same client can create both `{ api: "chat" }` (the default) and `{ api: "responses" }` handles.
 Known reasoning models advertise a typed `reasoningEffort` control. For custom OpenAI-compatible
 model IDs, pass an explicit `controls` descriptor to `completionModel()` when the endpoint supports
 the same parameter. Canonical controls map to `reasoning.effort` for Responses and

--- a/packages/provider-openai/src/openai/client.ts
+++ b/packages/provider-openai/src/openai/client.ts
@@ -51,7 +51,7 @@ export type OpenAICompletionModelOptions<
   Controls extends CompletionModelControls = OpenAIControlsFor<ModelId>,
 > = {
   modelId: ModelId;
-  api: "responses" | "chat";
+  api?: "responses" | "chat" | undefined;
   contextLimits?: ModelContextLimits | undefined;
   controls?: Controls | undefined;
 };
@@ -100,9 +100,9 @@ export class OpenAIClient implements ModelListingClient {
       OPENAI_COMPLETION_MODEL_CONTEXT_LIMITS,
       options.contextLimits,
     );
-    return options.api === "chat"
-      ? new OpenAIChatCompletionModel(this.sdk, modelId, contextLimits, controls)
-      : new OpenAIResponsesCompletionModel(this.sdk, modelId, contextLimits, controls);
+    return options.api === "responses"
+      ? new OpenAIResponsesCompletionModel(this.sdk, modelId, contextLimits, controls)
+      : new OpenAIChatCompletionModel(this.sdk, modelId, contextLimits, controls);
   }
 
   embeddingModel(options: OpenAIEmbeddingModelOptions): OpenAIEmbeddingModelHandle {

--- a/packages/provider-openai/src/openai/controls.ts
+++ b/packages/provider-openai/src/openai/controls.ts
@@ -22,7 +22,7 @@ export type OpenAIControlsFor<ModelId extends OpenAICompletionModelId> = ModelId
   ? ReasoningEffortControls<"high">
   : ModelId extends "gpt-5.2-pro" | "gpt-5.4-pro" | "gpt-5.5-pro"
     ? ReasoningEffortControls<"medium" | "high" | "xhigh">
-    : ModelId extends `gpt-5.6${string}`
+    : ModelId extends `gpt-5.6${string}` | `gpt-6${string}`
       ? ReasoningEffortControls<"none" | "low" | "medium" | "high" | "xhigh" | "max">
       : ModelId extends `gpt-5.${2 | 4 | 5}${string}`
         ? ReasoningEffortControls<"none" | "low" | "medium" | "high" | "xhigh">
@@ -66,7 +66,9 @@ export function openAIControlsForModel(modelId: string): OpenAIReasoningControls
   if (modelId === "gpt-5.2-pro" || modelId === "gpt-5.4-pro" || modelId === "gpt-5.5-pro") {
     return PRO_REASONING_CONTROLS;
   }
-  if (modelId.startsWith("gpt-5.6")) return GPT_5_6_REASONING_CONTROLS;
+  if (modelId.startsWith("gpt-5.6") || modelId.startsWith("gpt-6")) {
+    return GPT_5_6_REASONING_CONTROLS;
+  }
   if (modelId.startsWith("gpt-5.2") || modelId.startsWith("gpt-5.4")) {
     return LATE_GPT_5_DEFAULT_NONE_CONTROLS;
   }

--- a/packages/provider-openai/src/openai/controls.ts
+++ b/packages/provider-openai/src/openai/controls.ts
@@ -22,20 +22,26 @@ export type OpenAIControlsFor<ModelId extends OpenAICompletionModelId> = ModelId
   ? ReasoningEffortControls<"high">
   : ModelId extends "gpt-5.2-pro" | "gpt-5.4-pro" | "gpt-5.5-pro"
     ? ReasoningEffortControls<"medium" | "high" | "xhigh">
-    : ModelId extends `gpt-5.6${string}` | `gpt-6${string}`
-      ? ReasoningEffortControls<"none" | "low" | "medium" | "high" | "xhigh" | "max">
-      : ModelId extends `gpt-5.${2 | 4 | 5}${string}`
-        ? ReasoningEffortControls<"none" | "low" | "medium" | "high" | "xhigh">
-        : ModelId extends `gpt-5.3${string}`
-          ? ReasoningEffortControls<"low" | "medium" | "high" | "xhigh">
-          : ModelId extends `gpt-5.1${string}`
-            ? ReasoningEffortControls<"none" | "low" | "medium" | "high">
-            : ModelId extends `gpt-5${string}`
-              ? ReasoningEffortControls<"minimal" | "low" | "medium" | "high">
-              : ModelId extends `o${number}${string}`
-                ? ReasoningEffortControls<"low" | "medium" | "high">
-                : NoCompletionModelControls;
+    : ModelId extends "gpt-6-astra"
+      ? ReasoningEffortControls<"low" | "medium" | "high" | "xhigh" | "max">
+      : ModelId extends `gpt-5.6${string}`
+        ? ReasoningEffortControls<"none" | "low" | "medium" | "high" | "xhigh" | "max">
+        : ModelId extends `gpt-5.${2 | 4 | 5}${string}`
+          ? ReasoningEffortControls<"none" | "low" | "medium" | "high" | "xhigh">
+          : ModelId extends `gpt-5.3${string}`
+            ? ReasoningEffortControls<"low" | "medium" | "high" | "xhigh">
+            : ModelId extends `gpt-5.1${string}`
+              ? ReasoningEffortControls<"none" | "low" | "medium" | "high">
+              : ModelId extends `gpt-5${string}`
+                ? ReasoningEffortControls<"minimal" | "low" | "medium" | "high">
+                : ModelId extends `o${number}${string}`
+                  ? ReasoningEffortControls<"low" | "medium" | "high">
+                  : NoCompletionModelControls;
 
+const GPT_6_ASTRA_REASONING_CONTROLS = reasoningControls(
+  ["low", "medium", "high", "xhigh", "max"] as const,
+  "medium",
+);
 const GPT_5_6_REASONING_CONTROLS = reasoningControls(
   ["none", "low", "medium", "high", "xhigh", "max"] as const,
   "medium",
@@ -66,9 +72,8 @@ export function openAIControlsForModel(modelId: string): OpenAIReasoningControls
   if (modelId === "gpt-5.2-pro" || modelId === "gpt-5.4-pro" || modelId === "gpt-5.5-pro") {
     return PRO_REASONING_CONTROLS;
   }
-  if (modelId.startsWith("gpt-5.6") || modelId.startsWith("gpt-6")) {
-    return GPT_5_6_REASONING_CONTROLS;
-  }
+  if (modelId === "gpt-6-astra") return GPT_6_ASTRA_REASONING_CONTROLS;
+  if (modelId.startsWith("gpt-5.6")) return GPT_5_6_REASONING_CONTROLS;
   if (modelId.startsWith("gpt-5.2") || modelId.startsWith("gpt-5.4")) {
     return LATE_GPT_5_DEFAULT_NONE_CONTROLS;
   }

--- a/packages/provider-openai/src/openai/models.ts
+++ b/packages/provider-openai/src/openai/models.ts
@@ -41,6 +41,7 @@ export type KnownOpenAICompletionModelId =
   | "gpt-5.6-luna"
   | "gpt-5.6-sol"
   | "gpt-5.6-terra"
+  | "gpt-6-astra"
   | "o1"
   | "o1-pro"
   | "o3"
@@ -111,6 +112,7 @@ export const OPENAI_COMPLETION_MODEL_CONTEXT_LIMITS: Readonly<Record<string, Mod
     "gpt-5.6-luna": CONTEXT_1M_128K,
     "gpt-5.6-sol": CONTEXT_1M_128K,
     "gpt-5.6-terra": CONTEXT_1M_128K,
+    "gpt-6-astra": CONTEXT_1M_128K,
     o1: CONTEXT_200K_100K,
     "o1-pro": CONTEXT_200K_100K,
     o3: CONTEXT_200K_100K,

--- a/packages/provider-openai/test/client.test.ts
+++ b/packages/provider-openai/test/client.test.ts
@@ -55,7 +55,7 @@ describe("OpenAIClient", () => {
     >();
     const astraModel = client.completionModel({ modelId: "gpt-6-astra", api: "responses" });
     expectTypeOf(astraModel.controls!.reasoningEffort.options).items.toEqualTypeOf<
-      "none" | "low" | "medium" | "high" | "xhigh" | "max"
+      "low" | "medium" | "high" | "xhigh" | "max"
     >();
     const proReasoningModel = client.completionModel({
       modelId: "gpt-5.4-pro",

--- a/packages/provider-openai/test/client.test.ts
+++ b/packages/provider-openai/test/client.test.ts
@@ -10,6 +10,8 @@ import {
   type OpenAISpeechGenerationModelId,
   type OpenAITranscriptionModelId,
 } from "../src/index";
+import { OpenAIChatCompletionModel } from "../src/openai/chat-completion";
+import { OpenAIResponsesCompletionModel } from "../src/openai/responses";
 
 describe("OpenAIClient", () => {
   it("rejects mixed injected and managed configuration", () => {
@@ -17,6 +19,17 @@ describe("OpenAIClient", () => {
     expectTypeOf(mixed).not.toMatchTypeOf<OpenAIClientOptions>();
     expect(() => new OpenAIClient(mixed as never)).toThrow(
       "OpenAIClient cannot combine client with apiKey",
+    );
+  });
+
+  it("defaults to chat completions when api is omitted", () => {
+    const client = new OpenAIClient({ client: {} as never });
+
+    expect(client.completionModel({ modelId: "custom-model" })).toBeInstanceOf(
+      OpenAIChatCompletionModel,
+    );
+    expect(client.completionModel({ modelId: "custom-model", api: "responses" })).toBeInstanceOf(
+      OpenAIResponsesCompletionModel,
     );
   });
 
@@ -38,6 +51,10 @@ describe("OpenAIClient", () => {
       api: "responses",
     });
     expectTypeOf(latestReasoningModel.controls!.reasoningEffort.options).items.toEqualTypeOf<
+      "none" | "low" | "medium" | "high" | "xhigh" | "max"
+    >();
+    const astraModel = client.completionModel({ modelId: "gpt-6-astra", api: "responses" });
+    expectTypeOf(astraModel.controls!.reasoningEffort.options).items.toEqualTypeOf<
       "none" | "low" | "medium" | "high" | "xhigh" | "max"
     >();
     const proReasoningModel = client.completionModel({

--- a/packages/provider-openai/test/openai-responses.test.ts
+++ b/packages/provider-openai/test/openai-responses.test.ts
@@ -39,6 +39,14 @@ describe("OpenAI Responses mapping", () => {
       },
     );
     expect(
+      client.completionModel({ modelId: "gpt-6-astra", api: "responses" }).controls,
+    ).toMatchObject({
+      reasoningEffort: {
+        options: ["low", "medium", "high", "xhigh", "max"],
+        defaultValue: "medium",
+      },
+    });
+    expect(
       client.completionModel({ modelId: "gpt-5.4-pro", api: "responses" }).controls,
     ).toMatchObject({
       reasoningEffort: {

--- a/packages/provider-openai/test/openai-responses.test.ts
+++ b/packages/provider-openai/test/openai-responses.test.ts
@@ -83,6 +83,7 @@ describe("OpenAI Responses mapping", () => {
       contextLimits: { contextWindow: 42_000, maxOutputTokens: 2_000 },
     });
     const unknown = client.completionModel({ modelId: "unknown", api: "responses" });
+    const astra = client.completionModel({ modelId: "gpt-6-astra", api: "responses" });
 
     expect(builtIn.contextLimits).toMatchObject({
       contextWindow: 1_050_000,
@@ -90,6 +91,10 @@ describe("OpenAI Responses mapping", () => {
     });
     expect(custom.contextLimits).toEqual({ contextWindow: 42_000, maxOutputTokens: 2_000 });
     expect(unknown.contextLimits).toBeUndefined();
+    expect(astra.contextLimits).toMatchObject({
+      contextWindow: 1_050_000,
+      maxOutputTokens: 128_000,
+    });
   });
 
   it("maps incomplete max-output responses to the normalized length reason", () => {


### PR DESCRIPTION
## What changed

- `@anvia/openai` / `@anvia/grok`: `completionModel()` now defaults to the Chat Completions API. `api` is optional (`"chat"` fallback); pass `api: "responses"` explicitly for the Responses API. Previously the field was required and `undefined` fell through to Responses.
- Grok README documents the new default and that server-side provider tools (`providerTools` capability) are only advertised on Responses handles.
- `@anvia/openai`: add `gpt-6-astra` to the known completion model list with `CONTEXT_1M_128K` limits and its documented reasoning-effort controls (`low | medium | high | xhigh | max`, default `medium`) — matched explicitly, not via a `gpt-6*` wildcard. Per the pullfrog review, `none` is not accepted by the model (HTTP 400).
- Tests: default-api assertions for both clients (omitted `api` → chat model / no `providerTools`; `"responses"` → responses model / `providerTools: true`), type-level and runtime effort-options assertions plus a context-limits assertion for `gpt-6-astra`.
- Changesets: `.changeset/openai-chat-default-api.md`, `.changeset/openai-gpt-6-astra.md` (patch for both packages).

Note: the `gpt-6-astra` context limits mirror the newest-generation pattern (`CONTEXT_1M_128K`); adjust `models.ts` if published specs differ.

## Validation

- `pnpm --filter @anvia/openai typecheck` — pass
- `pnpm --filter @anvia/openai test` — 146 passed
- `pnpm --filter @anvia/grok typecheck` — pass (after `@anvia/openai` dist rebuild)
- `pnpm --filter @anvia/grok test` — 42 passed
- `pnpm check` (oxfmt + oxlint) — pass

Skipped: project-wide `pnpm typecheck` / `pnpm test` (other packages do not consume these type changes; all TS callers passed `api` explicitly, so no call-site breakage is possible).

## Generated files

None tracked; `packages/provider-openai/dist` was rebuilt locally only.
