### PR TITLE
fix: move zod to peerDependencies in core, graph, and neo4j

### DIFF
--- a/.changeset/zod-peer-dependency.md
+++ b/.changeset/zod-peer-dependency.md
@@ -1,0 +1,7 @@
+---
+"@anvia/core": patch
+"@anvia/graph": patch
+"@anvia/neo4j": patch
+---
+
+Move `zod` from `dependencies` to `peerDependencies` (`^4.4.0`). These packages expose zod types in their public API, so declaring zod as a regular dependency forced consumers to install a second, incompatible copy whenever their own zod version differed. Typechecks against such projects failed with `TS2769` (`ZodSchema`/`def.checks` incompatibility between the two copies) and type instantiation could become slow enough to crash `tsc` on large codebases. With zod as a peer dependency, consumers compile and run against a single shared copy. Local development and tests now resolve zod through `devDependencies` (`^4.5.4`); zod 4.4.x is verified to satisfy the floor.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -115,13 +115,16 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "yaml": "^2.9.0",
-    "zod": "^4.5.4"
+    "yaml": "^2.9.0"
+  },
+  "peerDependencies": {
+    "zod": "^4.4.0"
   },
   "devDependencies": {
     "@types/node": "^24.9.1",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
-    "vitest": "^4.0.8"
+    "vitest": "^4.0.8",
+    "zod": "^4.5.4"
   }
 }

--- a/packages/graph-neo4j/package.json
+++ b/packages/graph-neo4j/package.json
@@ -31,17 +31,18 @@
   },
   "dependencies": {
     "@anvia/graph": "workspace:*",
-    "neo4j-driver": "^6.2.0",
-    "zod": "^4.5.4"
+    "neo4j-driver": "^6.2.0"
   },
   "devDependencies": {
     "@anvia/core": "workspace:*",
     "@types/node": "^24.9.1",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
-    "vitest": "^4.0.8"
+    "vitest": "^4.0.8",
+    "zod": "^4.5.4"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:*",
+    "zod": "^4.4.0"
   }
 }

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -33,17 +33,16 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
-  "dependencies": {
-    "zod": "^4.5.4"
-  },
   "devDependencies": {
     "@anvia/core": "workspace:*",
     "@types/node": "^24.9.1",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
-    "vitest": "^4.0.8"
+    "vitest": "^4.0.8",
+    "zod": "^4.5.4"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:*",
+    "zod": "^4.4.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,9 +218,6 @@ importers:
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
-      zod:
-        specifier: ^4.5.4
-        version: 4.5.4
     devDependencies:
       '@types/node':
         specifier: ^24.9.1
@@ -234,6 +231,9 @@ importers:
       vitest:
         specifier: ^4.0.8
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@8.2.2(@types/node@24.12.2)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.12)(yaml@2.9.0))
+      zod:
+        specifier: ^4.5.4
+        version: 4.5.4
 
   packages/embedding-transformers:
     dependencies:
@@ -258,10 +258,6 @@ importers:
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@8.2.2(@types/node@24.12.2)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/graph:
-    dependencies:
-      zod:
-        specifier: ^4.5.4
-        version: 4.5.4
     devDependencies:
       '@anvia/core':
         specifier: workspace:*
@@ -278,6 +274,9 @@ importers:
       vitest:
         specifier: ^4.0.8
         version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(happy-dom@20.9.0)(vite@8.2.2(@types/node@24.12.2)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.12)(yaml@2.9.0))
+      zod:
+        specifier: ^4.5.4
+        version: 4.5.4
 
   packages/graph-memgraph:
     dependencies:
@@ -315,9 +314,6 @@ importers:
       neo4j-driver:
         specifier: ^6.2.0
         version: 6.2.0
-      zod:
-        specifier: ^4.5.4
-        version: 4.5.4
     devDependencies:
       '@anvia/core':
         specifier: workspace:*
@@ -334,6 +330,9 @@ importers:
       vitest:
         specifier: ^4.0.8
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@8.2.2(@types/node@24.12.2)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.12)(yaml@2.9.0))
+      zod:
+        specifier: ^4.5.4
+        version: 4.5.4
 
   packages/logger:
     dependencies:


### PR DESCRIPTION
## What changed

`@anvia/core`, `@anvia/graph`, and `@anvia/neo4j` expose zod types in their public API (`ZodSchema` in `CreateToolOptions`/`AgentOptions`, graph schema types), but declared `zod: ^4.5.4` as a regular **dependency**. A consumer installing its own zod version (e.g. 4.4.3) ended up with two incompatible copies and typechecks failed:

```
error TS2769: No overload matches this call.
  Type 'ZodObject<{ label: ZodString; }, $strip>' is not assignable to type 'ZodSchema'
    The types of 'def.checks' are incompatible between these types.
      $ZodCheck<never> (zod@4.4.3) is not assignable to $ZodCheck<never> (zod@4.5.4)
        ... `_zod.version.minor`: Type '5' is not assignable to type '4'
```

zod 4.5.x version-brands its types, so the two copies are structurally incompatible — no tsconfig setting avoids it. On large consumer projects the duplicated recursive generics also inflated `tsc` runs severely (20× wall time in our repro).

**Fix:** zod moves to `peerDependencies: "^4.4.0"` in the three packages, with `zod: "^4.5.4"` added to `devDependencies` so local development and tests still resolve a copy.

**Scope decisions:**
- `tool-browser` / `tool-sandbox` keep zod as a regular dependency — their public API (`readonly AnyTool[]` + plain option types) contains no zod types; usage is runtime-internal only.
- `graph-memgraph` / `tool-studio` already declare zod only as a devDependency — unchanged.
- Peer floor `^4.4.0` verified empirically: `core` (604 tests), `graph` (9), `neo4j` (35) all pass typecheck + tests against zod 4.4.3.

## Validation

- `pnpm install --no-frozen-lockfile` — lockfile updated, no peer-resolution warnings
- `pnpm --filter @anvia/core --filter @anvia/graph --filter @anvia/neo4j typecheck` — all pass
- `pnpm --filter @anvia/core --filter @anvia/graph --filter @anvia/neo4j test` — 604 + 9 + 35 passed (1 neo4j integration test skipped, gated by env)
- `pnpm check` — pass
- End-to-end consumer repro: packing this branch's `@anvia/core` and installing it alongside zod 4.4.3 now yields a **single zod copy** and the previously failing `tsc --noEmit --strict --exactOptionalPropertyTypes` passes in ~2s (was 5× TS2769 + 3× TS2589 in ~40s)

## Skipped / notes

- Full-workspace `pnpm typecheck`/`pnpm test` not run; scoped to the three changed packages (no other package's declarations changed)
- No generated files changed (`dist/` rebuilt locally for verification only)
- Changeset included: patch bump for the three packages; `onlyUpdatePeerDependentsWhenOutOfRange: true` means existing workspace dependents (zod ^4.5.4 satisfies ^4.4.0) are not force-bumped