### PR TITLE
feat: add containerRuntime option to run sandboxes on gVisor

### DIFF
--- a/.changeset/sandbox-container-runtime.md
+++ b/.changeset/sandbox-container-runtime.md
@@ -1,5 +1,5 @@
 ---
-"@anvia/sandbox": minor
+"@anvia/sandbox": patch
 ---
 
 Add a `containerRuntime` option to `DockerSandboxClient.createSandbox()` for running sandboxes on

--- a/.changeset/sandbox-container-runtime.md
+++ b/.changeset/sandbox-container-runtime.md
@@ -1,0 +1,8 @@
+---
+"@anvia/sandbox": minor
+---
+
+Add a `containerRuntime` option to `DockerSandboxClient.createSandbox()` for running sandboxes on
+alternative Docker runtimes such as gVisor (`runsc`). Creation fails with the new
+`runtime_not_found` error code when the runtime is not registered in the daemon, and sandbox
+inspectors now expose the active `containerRuntime`.

--- a/packages/tool-sandbox/README.md
+++ b/packages/tool-sandbox/README.md
@@ -37,6 +37,15 @@ explicit `dropCapabilities` and `addCapabilities` arrays, plus
 `seccompProfile: { type: "path", path }` with an absolute host path. These options are used by
 `@anvia/browser` to keep Chromium's own process sandbox enabled.
 
+`createSandbox()` accepts `containerRuntime` — the runtime name registered in the Docker daemon (for
+example `runsc` for gVisor). The runtime must already be registered (`runsc install` followed by a
+daemon restart); creation fails with a `runtime_not_found` error otherwise. `resumeSandbox()` keeps
+the container's original runtime. Under gVisor, workspace files persist through
+`stop()`/`resumeSandbox()` because they live on a Docker volume, but changes to the container's
+writable rootfs outside the workspace do not survive a resume, and `security.seccompProfile` is not
+enforced the way it is on the default runtime because the gVisor sentry mediates application
+syscalls itself.
+
 Studio does not discover sandboxes through tool metadata. Register a read-only inspector explicitly:
 
 ```ts

--- a/packages/tool-sandbox/src/docker-sandbox.ts
+++ b/packages/tool-sandbox/src/docker-sandbox.ts
@@ -61,6 +61,7 @@ const labels = {
   workspaceType: `${labelPrefix}workspace.type`,
   workspaceVolume: `${labelPrefix}workspace.volume`,
   networkMode: `${labelPrefix}network.mode`,
+  containerRuntime: `${labelPrefix}container-runtime`,
   commandTimeoutMs: `${labelPrefix}runtime.command-timeout-ms`,
   maxOutputBytes: `${labelPrefix}runtime.max-output-bytes`,
   maxFileBytes: `${labelPrefix}runtime.max-file-bytes`,
@@ -88,6 +89,7 @@ type SandboxConfiguration = {
   id: string;
   containerName: string;
   workdir: string;
+  containerRuntime: string;
   workspace: DockerSandboxWorkspace;
   volumeName: string;
   ownsVolume: boolean;
@@ -121,6 +123,7 @@ export class DockerSandboxClient {
     assertSandboxId(id);
     const containerName = containerNameFor(id);
     const workdir = options.workdir ?? defaultWorkdir;
+    const containerRuntime = options.containerRuntime ?? "default";
     const runtime = resolveRuntimeLimits(options.runtime);
     const workspace = copyWorkspace(options.workspace);
     const network = copyNetwork(options.network);
@@ -137,6 +140,7 @@ export class DockerSandboxClient {
     if (workspace.type === "docker-volume") {
       await this.assertVolumeExists(workspace.name, options.abortSignal);
     }
+    await this.assertRuntimeAvailable(containerRuntime, options.abortSignal);
 
     let containerCreated = false;
     let volumeCreated = false;
@@ -154,6 +158,7 @@ export class DockerSandboxClient {
           containerName,
           image: options.image,
           workdir,
+          containerRuntime,
           workspace,
           volumeName,
           env,
@@ -181,6 +186,7 @@ export class DockerSandboxClient {
         id,
         containerName,
         workdir,
+        containerRuntime,
         workspace,
         volumeName,
         ownsVolume,
@@ -304,6 +310,38 @@ export class DockerSandboxClient {
       result,
     );
   }
+  private async assertRuntimeAvailable(name: string, abortSignal?: AbortSignal): Promise<void> {
+    if (name === "default") return;
+    const result = await runDockerCli(["info", "--format", "{{json .Runtimes}}"], {
+      ...this.cliOptions(abortSignal),
+      maxOutputBytes: defaultMaxOutputBytes,
+    });
+    if (result.exitCode !== 0) {
+      throw new DockerSandboxError(
+        "Unable to inspect Docker runtimes.",
+        "docker_command_failed",
+        result,
+      );
+    }
+    let runtimes: unknown;
+    try {
+      runtimes = JSON.parse(decodeUtf8(result.stdout));
+    } catch (error) {
+      throw new DockerSandboxError(
+        "Docker returned invalid runtime metadata.",
+        "docker_command_failed",
+        undefined,
+        { cause: error },
+      );
+    }
+    if (!isRecord(runtimes) || !(name in runtimes)) {
+      throw new DockerSandboxError(
+        `Docker runtime is not registered in the daemon: ${JSON.stringify(name)}. ` +
+          `Install the runtime (for gVisor: runsc install) and restart the Docker daemon.`,
+        "runtime_not_found",
+      );
+    }
+  }
 
   private cliOptions(abortSignal?: AbortSignal) {
     return { dockerPath: this.dockerPath, signal: abortSignal };
@@ -346,6 +384,7 @@ class DockerSandboxHandle implements DockerSandbox {
       id: this.id,
       provider: "docker",
       workdir: this.configuration.workdir,
+      containerRuntime: this.configuration.containerRuntime,
     };
     if (options.files === true) {
       inspector = {
@@ -920,6 +959,7 @@ function createRunArgs(options: {
   containerName: string;
   image: string;
   workdir: string;
+  containerRuntime: string;
   workspace: DockerSandboxWorkspace;
   volumeName: string;
   env: Record<string, string>;
@@ -937,6 +977,7 @@ function createRunArgs(options: {
     [labels.workspaceType]: options.workspace.type,
     [labels.workspaceVolume]: options.volumeName,
     [labels.networkMode]: options.network.mode,
+    [labels.containerRuntime]: options.containerRuntime,
     [labels.commandTimeoutMs]: `${options.runtime.commandTimeoutMs}`,
     [labels.maxOutputBytes]: `${options.runtime.maxOutputBytes}`,
     [labels.maxFileBytes]: `${options.runtime.maxFileBytes}`,
@@ -952,6 +993,9 @@ function createRunArgs(options: {
     "-w",
     options.workdir,
   ];
+  if (options.containerRuntime !== "default") {
+    args.push("--runtime", options.containerRuntime);
+  }
   for (const [key, value] of Object.entries({ ...options.userLabels, ...runtimeLabels })) {
     args.push("--label", `${key}=${value}`);
   }
@@ -1032,6 +1076,9 @@ function validateCreateOptions(options: CreateDockerSandboxOptions): void {
     if (key.startsWith(labelPrefix)) throw new TypeError(`Docker label is reserved: ${key}`);
   }
   if (options.user !== undefined) assertNonEmptyString(options.user, "user");
+  if (options.containerRuntime !== undefined) {
+    assertNonEmptyString(options.containerRuntime, "containerRuntime");
+  }
   if (options.directories !== undefined && !Array.isArray(options.directories)) {
     throw new TypeError("directories must be an array.");
   }
@@ -1199,6 +1246,9 @@ function snapshotCreateOptions(options: CreateDockerSandboxOptions): CreateDocke
   };
   if (options.id !== undefined) snapshot = { ...snapshot, id: options.id };
   if (options.workdir !== undefined) snapshot = { ...snapshot, workdir: options.workdir };
+  if (options.containerRuntime !== undefined) {
+    snapshot = { ...snapshot, containerRuntime: options.containerRuntime };
+  }
   if (options.files !== undefined) snapshot = { ...snapshot, files: Object.freeze(files) };
   if (options.directories !== undefined) {
     snapshot = { ...snapshot, directories: Object.freeze([...options.directories]) };
@@ -1262,6 +1312,14 @@ function configurationFromInspection(
   const workspaceType = requiredLabel(containerLabels, labels.workspaceType);
   const volumeName = requiredLabel(containerLabels, labels.workspaceVolume);
   const networkMode = requiredLabel(containerLabels, labels.networkMode);
+  const labeledRuntime = containerLabels[labels.containerRuntime];
+  const hostRuntime = inspection.HostConfig?.Runtime;
+  const containerRuntime =
+    labeledRuntime !== undefined && labeledRuntime !== ""
+      ? labeledRuntime
+      : hostRuntime !== undefined && hostRuntime !== ""
+        ? hostRuntime
+        : "default";
   if (networkMode !== "none" && networkMode !== "bridge") invalidInspection("network mode");
   const workspace: DockerSandboxWorkspace =
     workspaceType === "ephemeral"
@@ -1278,6 +1336,7 @@ function configurationFromInspection(
   return {
     id,
     containerName,
+    containerRuntime,
     workdir,
     workspace,
     volumeName,
@@ -1292,6 +1351,7 @@ type DockerContainerInspection = {
   Config: { Labels?: Record<string, string>; WorkingDir?: string };
   HostConfig?: {
     PortBindings?: Record<string, Array<{ HostIp?: string; HostPort?: string }> | null>;
+    Runtime?: string;
   };
   State: { Running?: boolean; Paused?: boolean; Dead?: boolean; Status?: string };
   NetworkSettings?: {

--- a/packages/tool-sandbox/src/errors.ts
+++ b/packages/tool-sandbox/src/errors.ts
@@ -2,6 +2,7 @@ export type DockerSandboxErrorCode =
   | "docker_unavailable"
   | "docker_command_failed"
   | "image_not_found"
+  | "runtime_not_found"
   | "volume_not_found"
   | "sandbox_not_found"
   | "invalid_state"

--- a/packages/tool-sandbox/src/types.ts
+++ b/packages/tool-sandbox/src/types.ts
@@ -47,6 +47,11 @@ export type CreateDockerSandboxOptions = Readonly<{
   workdir?: string;
   workspace: DockerSandboxWorkspace;
   network: DockerSandboxNetwork;
+  /** Docker runtime used to run the container, as registered in the daemon
+   *  (for example "runsc" for gVisor). The runtime must already be registered;
+   *  createSandbox() fails with `runtime_not_found` otherwise. Omitted means
+   *  the daemon default. resumeSandbox() keeps the container's runtime. */
+  containerRuntime?: string;
   files?: Readonly<Record<string, string | Uint8Array>>;
   directories?: readonly string[];
   env?: Readonly<Record<string, string>>;
@@ -236,6 +241,7 @@ export type DockerSandboxInspector = Readonly<{
   id: string;
   provider: "docker";
   workdir: string;
+  containerRuntime: string;
   listFiles?: DockerSandboxRuntime["listFiles"];
   readFile?: DockerSandboxRuntime["readFile"];
   publishedPorts?: readonly DockerSandboxPublishedPort[];

--- a/packages/tool-sandbox/test/docker-sandbox-gvisor.integration.test.ts
+++ b/packages/tool-sandbox/test/docker-sandbox-gvisor.integration.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { DockerSandboxClient } from "../src/docker-sandbox";
+
+const runGvisorTests = process.env.ANVIA_SANDBOX_GVISOR_TESTS === "1";
+const decoder = new TextDecoder("utf-8", { fatal: true });
+
+describe.skipIf(!runGvisorTests)("gVisor sandbox integration", () => {
+  it("creates, operates, resumes, and destroys a runsc sandbox", async () => {
+    const id = `vitest-gvisor-${Date.now()}`;
+    const client = new DockerSandboxClient();
+    await client.pullImage({ image: "debian:bookworm-slim" });
+    let sandbox = await client.createSandbox({
+      id,
+      image: "debian:bookworm-slim",
+      workspace: { type: "ephemeral" },
+      network: { mode: "none" },
+      containerRuntime: "runsc",
+      runtime: { commandTimeoutMs: 10_000, maxOutputBytes: 64_000 },
+    });
+
+    try {
+      expect(sandbox.inspector({ files: true }).containerRuntime).toBe("runsc");
+
+      const result = await sandbox.runtime.exec({
+        command: "sh",
+        args: ["-c", "echo hello-gvisor"],
+      });
+      expect(result.status).toBe("exited");
+      expect(decoder.decode(result.stdout).trim()).toBe("hello-gvisor");
+      // Guards against the --runtime flag silently dropping from createRunArgs:
+      // dmesg prints the gVisor banner only when the container really runs under runsc.
+      const kernel = await sandbox.runtime.exec({ command: "dmesg" });
+      expect(decoder.decode(kernel.stdout)).toContain("Starting gVisor");
+
+      await sandbox.runtime.writeTextFile({ path: "state.txt", text: "kept" });
+      await sandbox.stop();
+      sandbox = await client.resumeSandbox({ id });
+      await expect(sandbox.runtime.readTextFile({ path: "state.txt" })).resolves.toBe("kept");
+      expect(sandbox.inspector({ files: true }).containerRuntime).toBe("runsc");
+    } finally {
+      await sandbox.destroy();
+    }
+    expect(sandbox.state).toBe("destroyed");
+    await expect(client.resumeSandbox({ id })).rejects.toMatchObject({
+      code: "sandbox_not_found",
+    });
+  }, 180_000);
+});

--- a/packages/tool-sandbox/test/docker-sandbox.integration.test.ts
+++ b/packages/tool-sandbox/test/docker-sandbox.integration.test.ts
@@ -140,4 +140,18 @@ describe.skipIf(!runDockerTests)("Docker sandbox integration", () => {
     );
     await expect(sandbox.runtime.listProcesses()).resolves.toEqual([]);
   }, 120_000);
+
+  it("rejects creation when the container runtime is not registered", async () => {
+    const client = new DockerSandboxClient();
+    await client.pullImage({ image: "debian:bookworm-slim" });
+    await expect(
+      client.createSandbox({
+        id: `vitest-runtime-missing-${Date.now()}`,
+        image: "debian:bookworm-slim",
+        workspace: { type: "ephemeral" },
+        network: { mode: "none" },
+        containerRuntime: "anvia-unregistered-runtime",
+      }),
+    ).rejects.toMatchObject({ code: "runtime_not_found" });
+  }, 60_000);
 });

--- a/packages/tool-sandbox/test/docker-sandbox.test.ts
+++ b/packages/tool-sandbox/test/docker-sandbox.test.ts
@@ -95,4 +95,16 @@ describe("DockerSandboxClient validation", () => {
       }),
     ).rejects.toThrow("addCapabilities contains a duplicate");
   });
+
+  it("rejects an empty container runtime before Docker I/O", async () => {
+    const client = new DockerSandboxClient({ dockerPath: "/definitely/missing/docker" });
+    await expect(
+      client.createSandbox({
+        image: "node:22-bookworm",
+        workspace: { type: "ephemeral" },
+        network: { mode: "none" },
+        containerRuntime: "",
+      }),
+    ).rejects.toThrow("containerRuntime");
+  });
 });


### PR DESCRIPTION
## What changed

Adds first-class support for running sandboxes on alternative Docker runtimes such as gVisor (`runsc`):

- `DockerSandboxClient.createSandbox()` accepts `containerRuntime?: string` — the runtime name as registered in the Docker daemon. `createRunArgs` emits `--runtime <name>`; omitted keeps the daemon default.
- New `runtime_not_found` error code: `createSandbox()` pre-flights `docker info` and fails before any volume/container mutation when the runtime is not registered, with a `runsc install` hint.
- The runtime is recorded as the `anvia.sandbox.container-runtime` label. `resumeSandbox()` reconstructs it from the label with a `HostConfig.Runtime` fallback, so sandboxes created before this change keep resuming.
- `DockerSandboxInspector` now exposes `containerRuntime` for Studio/observability.

No changes to `DockerSandboxRuntime`, tools, process manager, port probe, or the `anvia-sandbox` CLI — verified on Docker 29.7.2 + runsc `release-20260831.0` that exec, `docker cp` file transfer, `find -printf` listing, published ports with the `/proc/net/tcp` LISTEN probe, resources (`--memory/--cpus/--pids-limit/--shm-size`), read-only rootfs, `setsid -w` process launcher, and `seccomp`/`cap-add` options all behave identically under runsc.

Documented gVisor caveats in the README: with the containerd snapshotter, the writable rootfs outside the workspace volume does not survive resume (workspace files do), and `security.seccompProfile` is not enforced the same way because the gVisor sentry mediates application syscalls.

## Validation

- `pnpm check` (oxfmt + oxlint) — clean
- `pnpm --filter @anvia/sandbox typecheck` — clean
- `pnpm --filter @anvia/sandbox test` — 50 passed / 6 skipped
- With `ANVIA_SANDBOX_DOCKER_TESTS=1`: `runtime_not_found` negative-path test against live Docker — passed
- With `ANVIA_SANDBOX_GVISOR_TESTS=1`: new end-to-end test against live runsc (create → exec → gVisor kernel banner assertion → write → stop → resume → persistence → destroy) — passed, 51 passed / 5 skipped total

## Skipped

- Full docker-gated suite (`ANVIA_SANDBOX_DOCKER_TESTS=1`, node:22-bookworm pull) — the touched paths are covered by the gated tests above; the suite is runtime-agnostic and unchanged for runc.

## Generated files

None changed.