### PR TITLE
fix(core): preserve module boundaries for tree shaking

### DIFF
--- a/.changeset/core-module-tree-shaking.md
+++ b/.changeset/core-module-tree-shaking.md
@@ -1,0 +1,5 @@
+---
+"@anvia/core": patch
+---
+
+Preserve source-module boundaries in the ESM build and import Zod's JSON Schema converter directly so bundlers can remove unrelated schema initialization from lightweight consumers such as `createTool`. Public exports, type declarations, and runtime behavior are unchanged.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -110,7 +110,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts src/agent/index.ts src/agent/interactions/index.ts src/internal/agent.ts src/speech-generation/index.ts src/completion/index.ts src/embeddings/index.ts src/evals/index.ts src/image-generation/index.ts src/documents/index.ts src/extractor/index.ts src/guardrails/index.ts src/mcp/index.ts src/memory/index.ts src/model-listing/index.ts src/observability/index.ts src/pipeline/index.ts src/skills/index.ts src/streaming/index.ts src/tool/index.ts src/transcription/index.ts src/vector-store/index.ts --format esm --dts --sourcemap --clean",
+    "build": "tsup",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/core/src/schema/zod-schema.ts
+++ b/packages/core/src/schema/zod-schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { toJSONSchema, type z } from "zod";
 import type { JsonObject } from "../completion/index";
 
 export type ZodSchema<T = unknown> = z.ZodType<T>;
@@ -7,7 +7,7 @@ export function toProviderJsonSchema(
   schema: z.ZodType,
   options: { io?: "input" | "output" } = {},
 ): JsonObject {
-  const jsonSchema = z.toJSONSchema(schema, options) as JsonObject;
+  const jsonSchema = toJSONSchema(schema, options) as JsonObject;
   const { $schema: _schema, ...providerSchema } = jsonSchema;
   return providerSchema;
 }

--- a/packages/core/test/tree-shaking.test.ts
+++ b/packages/core/test/tree-shaking.test.ts
@@ -1,0 +1,85 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { build } from "tsup";
+import { expect, it } from "vitest";
+import config from "../tsup.config";
+
+const execFileAsync = promisify(execFile);
+const packageDir = fileURLToPath(new URL("../", import.meta.url));
+
+it("tree-shakes createTool from root and tool entrypoints without changing execution", async () => {
+  const temporaryDir = await mkdtemp(join(packageDir, ".tree-shaking-"));
+  try {
+    const outDir = join(temporaryDir, "dist");
+    await build({
+      ...config,
+      entry: config.entry.map((entry) => join(packageDir, entry)),
+      outDir,
+      dts: false,
+      config: false,
+      silent: true,
+    });
+
+    for (const [name, entry] of [
+      ["root", "index.js"],
+      ["tool", "tool/index.js"],
+    ] as const) {
+      const consumer = join(temporaryDir, `${name}.ts`);
+      await writeFile(
+        consumer,
+        `export { createTool } from ${JSON.stringify(join(outDir, entry))};`,
+      );
+      const consumerDir = join(temporaryDir, name);
+      await build({
+        entry: [consumer],
+        outDir: consumerDir,
+        format: ["esm"],
+        platform: "node",
+        minify: true,
+        splitting: false,
+        noExternal: [/.*/],
+        config: false,
+        silent: true,
+      });
+      const bundle = join(consumerDir, `${name}.js`);
+      // Include dependencies: this ceiling catches both namespace retention and
+      // unrelated schema initialization leaking across generated module boundaries.
+      expect((await readFile(bundle)).byteLength).toBeLessThan(30_000);
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        [
+          "--input-type=module",
+          "-e",
+          `import { createTool } from ${JSON.stringify(bundle)};
+import { z } from "zod";
+const tool = createTool({
+  name: "double", description: "Double a number",
+  inputSchema: z.object({ value: z.number() }), outputSchema: z.number(),
+  execute: ({ value }) => value * 2,
+});
+if ((await tool.call({ value: 3 })) !== 6) throw new Error("Incorrect result");
+let rejected = false;
+try { await tool.call({ value: "invalid" }); } catch { rejected = true; }
+if (!rejected) throw new Error("Input validation was lost");
+console.log(JSON.stringify(tool.definition()));`,
+        ],
+        { cwd: dirname(consumer) },
+      );
+      expect(JSON.parse(stdout)).toEqual({
+        name: "double",
+        description: "Double a number",
+        parameters: {
+          type: "object",
+          properties: { value: { type: "number" } },
+          required: ["value"],
+          additionalProperties: false,
+        },
+      });
+    }
+  } finally {
+    await rm(temporaryDir, { recursive: true, force: true });
+  }
+}, 30_000);

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,0 +1,36 @@
+import type { Options } from "tsup";
+
+export default {
+  // Keep source module boundaries so unrelated initializers can be tree-shaken.
+  entry: ["src/**/*.ts"],
+  format: ["esm"],
+  splitting: true,
+  dts: {
+    entry: [
+      "src/index.ts",
+      "src/agent/index.ts",
+      "src/agent/interactions/index.ts",
+      "src/internal/agent.ts",
+      "src/speech-generation/index.ts",
+      "src/completion/index.ts",
+      "src/embeddings/index.ts",
+      "src/evals/index.ts",
+      "src/image-generation/index.ts",
+      "src/documents/index.ts",
+      "src/extractor/index.ts",
+      "src/guardrails/index.ts",
+      "src/mcp/index.ts",
+      "src/memory/index.ts",
+      "src/model-listing/index.ts",
+      "src/observability/index.ts",
+      "src/pipeline/index.ts",
+      "src/skills/index.ts",
+      "src/streaming/index.ts",
+      "src/tool/index.ts",
+      "src/transcription/index.ts",
+      "src/vector-store/index.ts",
+    ],
+  },
+  sourcemap: true,
+  clean: true,
+} satisfies Options;


### PR DESCRIPTION
## Summary
- Preserve source-module boundaries in the ESM build while retaining shared chunks and the original 22 declaration entrypoints.
- Import Zod's JSON Schema converter directly from the same package entrypoint.
- Add a consumer-bundle regression test and a patch changeset.
- No intended runtime behavior or public API changes.

## Measurements
Minified Node-target esbuild consumer bundles, dependencies included:
- createTool from root or /tool: 438.93 kB → 21.38 kB (~95% smaller).
- createTool gzip: 89.86 kB → 7.21 kB.
- isJsonValue: unchanged at 948 B.
- Completion and Agent bundles remain essentially unchanged.

Tradeoff: compressed package grows from 345 kB to 381 kB; unpacked contents grow from 1.72 MB to 1.82 MB due to additional module boundaries.

## Verification
- pnpm --filter @anvia/core build
- pnpm --filter @anvia/core typecheck
- pnpm --filter @anvia/core test: 605 tests passed across 37 files.
- Regression test bundles both root and /tool consumers and exercises execution, input validation, and schema generation.
- All 22 public declaration entrypoints are byte-for-byte unchanged; public runtime export names match the baseline.
- Scoped Oxfmt and Oxlint passed; commit formatting hook passed.

Generated dist output was rebuilt for verification, not committed. No UI changes.