### PR TITLE
fix(core): omit stack traces from toReadableStream error events

### DIFF
--- a/.changeset/core-stream-error-stack.md
+++ b/.changeset/core-stream-error-stack.md
@@ -1,0 +1,8 @@
+---
+"@anvia/core": patch
+---
+
+Omit stack traces from `toReadableStream` error events. Error JSON lines emitted
+when the wrapped async iterable throws now carry only the error name and message,
+matching the safe serializers already used by `@anvia/server` and Studio run
+failure responses.

--- a/packages/core/src/streaming/readable-stream.ts
+++ b/packages/core/src/streaming/readable-stream.ts
@@ -37,7 +37,6 @@ function serializeError(error: unknown): unknown {
     return {
       name: error.name,
       message: error.message,
-      stack: error.stack,
     };
   }
 

--- a/packages/core/test/streaming.test.ts
+++ b/packages/core/test/streaming.test.ts
@@ -1973,7 +1973,10 @@ describe("Agent streaming", () => {
       .map((line) => JSON.parse(line));
 
     expect(lines[0]).toEqual({ type: "text_delta", delta: "a" });
-    expect(lines[1]).toMatchObject({ type: "error", error: { message: "boom" } });
+    expect(lines[1]).toEqual({
+      type: "error",
+      error: { name: "Error", message: "boom" },
+    });
   });
 
   it("enforces exact maxTurns boundary on streaming execution", async () => {


### PR DESCRIPTION
## What this fixes

`toReadableStream` is the JSONL helper in `@anvia/core` that turns an async iterable of events into a `ReadableStream`. When the wrapped iterable throws, the helper emits a final JSON line shaped `{ type: "error", error: ... }` so consumers can react to the failure.

That error object currently includes `stack` (from `serializeError` in `packages/core/src/streaming/readable-stream.ts`). Anyone consuming this stream, typically a browser client hitting a server that wrapped agent or completion events, therefore receives the server's internal stack trace: absolute file paths and internal module structure. The error name and message are already there for consumers; the stack adds nothing they should act on and quietly discloses the server's layout.

The server package already handles this correctly. Its own serializer (`packages/server/src/errors.ts`) keeps `name` and `message` and drops the stack, and #405 made the same change for Studio's direct tool-run failure responses. This PR brings the core streaming helper in line with both.

## The test detail worth mentioning

The existing test for this behavior ("emits an error JSON line when readable stream iteration fails") asserted with `toMatchObject({ type: "error", error: { message: "boom" } })`. `toMatchObject` ignores extra keys, so a `stack` slipping into the payload passed silently. I strengthened it to a strict `toEqual` on the full event, which pins the exact shape: name and message, nothing else. That assertion failed before the fix, with the extra `stack` key visible in the diff, and passes after. So it now actually catches this regression instead of only checking that the message is present.

## What changed

- `packages/core/src/streaming/readable-stream.ts`: `serializeError` now returns `{ name, message }` for `Error` instances. Non-Error values pass through untouched, as before.
- `packages/core/test/streaming.test.ts`: strict shape assertion on the error JSON line.
- `.changeset/core-stream-error-stack.md`: patch changeset for `@anvia/core`.

## Compatibility

Error events lose one key: `stack`. Code that read `error.stack` out of these JSON lines will get `undefined`. That is the intended change, but worth stating: anyone relying on stacks client-side should read them server-side instead, where the original error is still intact in-process. The `name` and `message` fields are unchanged, the event envelope (`type: "error"`) is unchanged, and the export surface is unchanged.

## Validation

- Strengthened test run before the fix: fails with the extra `stack` key visible in the assertion diff.
- Same test after the fix: passes.
- `pnpm exec vitest run test/streaming.test.ts test/public-exports.test.ts` in `packages/core`: 74/74 pass, so the public export surface is unaffected.
- `pnpm --filter @anvia/core test`: 35/36 files pass. The single failure is `test/skills.test.ts > executes skill scripts and reports failures`, which fails with `spawn EFTYPE` on Windows. It reproduces on `main` without this change (the test spawns a POSIX-only shebang script; nothing it touches is modified here) and does not appear on Linux CI.
- `pnpm --filter @anvia/core typecheck`: exit 0.

One caveat on local checks: I did not run `pnpm check` on this Windows checkout because the workspace carries CRLF line-ending noise that trips the formatter locally. CI runs it on Linux, and the diff here is three small files.

## Notes

- No dependency changes; `pnpm-lock.yaml` is untouched.
- Scoped to the one helper. No drive-by refactors, no formatting churn.
- No documentation impact beyond the changeset; the behavior matches the serializers the server and Studio packages already use.