### PR TITLE
Expand Bun runtime compat suite and harden packed-artifact checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,10 @@ jobs:
         run: pnpm --filter './packages/**' test
 
   bun-compatibility:
-    name: Bun compatibility
+    name: Bun compatibility (${{ matrix.bun-version }})
+    strategy:
+      matrix:
+        bun-version: ["1.3.14", "1.x"]
     runs-on: ubuntu-latest
 
     steps:
@@ -86,10 +89,13 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version: ${{ matrix.bun-version }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Test built packages with Bun
         run: pnpm --filter bun-runtime-compat test:bun
+
+      - name: Typecheck Bun compatibility workspace
+        run: pnpm --filter bun-runtime-compat typecheck

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1206,21 +1206,39 @@ importers:
 
   tests/compat/bun-runtime:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.123.0
+        version: 0.123.0(zod@4.5.4)
+      '@anvia/anthropic':
+        specifier: workspace:*
+        version: link:../../../packages/provider-anthropic
       '@anvia/client':
         specifier: workspace:*
         version: link:../../../packages/client
       '@anvia/core':
         specifier: workspace:*
         version: link:../../../packages/core
+      '@anvia/gemini':
+        specifier: workspace:*
+        version: link:../../../packages/provider-gemini
       '@anvia/mcp':
         specifier: workspace:*
         version: link:../../../packages/mcp
+      '@anvia/mistral':
+        specifier: workspace:*
+        version: link:../../../packages/provider-mistral
       '@anvia/openai':
         specifier: workspace:*
         version: link:../../../packages/provider-openai
       '@anvia/server':
         specifier: workspace:*
         version: link:../../../packages/server
+      '@google/genai':
+        specifier: ^2.21.0
+        version: 2.21.0(@modelcontextprotocol/sdk@1.29.0(zod@4.5.4))
+      '@mistralai/mistralai':
+        specifier: ^2.6.4
+        version: 2.6.4(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))
     devDependencies:
       '@types/bun':
         specifier: 1.3.14
@@ -1277,15 +1295,6 @@ importers:
         version: 5.9.3
 
 packages:
-
-  '@anthropic-ai/sdk@0.120.0':
-    resolution: {integrity: sha512-ZlvmNFT/iIF6JD13rxbbMWD8nvGR0RaUp6yMQnoc+4Af0YjVVe/bIdW1XSQQsoxXAtg1NaT6Vak0LKFlJ4d37Q==}
-    hasBin: true
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
-    peerDependenciesMeta:
-      zod:
-        optional: true
 
   '@anthropic-ai/sdk@0.123.0':
     resolution: {integrity: sha512-Y9oX9mPNGZClHQOFqrWRk43Srcu/UHuPq3rfxxOq7JgW0gi+lJA2MAOK4Ul3k/+AUrwRWFJvd0tK3oC0Pw25dw==}
@@ -7142,13 +7151,6 @@ packages:
 
 snapshots:
 
-  '@anthropic-ai/sdk@0.120.0(zod@4.5.4)':
-    dependencies:
-      json-schema-to-ts: 3.1.1
-      standardwebhooks: 1.0.0
-    optionalDependencies:
-      zod: 4.5.4
-
   '@anthropic-ai/sdk@0.123.0(zod@4.5.4)':
     dependencies:
       json-schema-to-ts: 3.1.1
@@ -7158,7 +7160,7 @@ snapshots:
 
   '@anthropic-ai/vertex-sdk@0.19.6(zod@4.5.4)':
     dependencies:
-      '@anthropic-ai/sdk': 0.120.0(zod@4.5.4)
+      '@anthropic-ai/sdk': 0.123.0(zod@4.5.4)
       google-auth-library: 10.6.2
     transitivePeerDependencies:
       - supports-color

--- a/tests/compat/bun-runtime/package.json
+++ b/tests/compat/bun-runtime/package.json
@@ -4,16 +4,22 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "pretest:bun": "pnpm --filter @anvia/core build && pnpm --filter @anvia/client build && pnpm --filter @anvia/server build && pnpm --filter @anvia/openai build && pnpm --filter @anvia/mcp build",
+    "pretest:bun": "pnpm --filter @anvia/core build && pnpm --filter @anvia/client build && pnpm --filter @anvia/server build && pnpm --filter @anvia/openai build && pnpm --filter @anvia/anthropic build && pnpm --filter @anvia/gemini build && pnpm --filter @anvia/mistral build && pnpm --filter @anvia/mcp build",
     "test:bun": "bun test ./test && node ./scripts/test-packed-artifacts.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.123.0",
+    "@anvia/anthropic": "workspace:*",
     "@anvia/client": "workspace:*",
     "@anvia/core": "workspace:*",
+    "@anvia/gemini": "workspace:*",
     "@anvia/mcp": "workspace:*",
+    "@anvia/mistral": "workspace:*",
     "@anvia/openai": "workspace:*",
-    "@anvia/server": "workspace:*"
+    "@anvia/server": "workspace:*",
+    "@google/genai": "^2.21.0",
+    "@mistralai/mistralai": "^2.6.4"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",

--- a/tests/compat/bun-runtime/scripts/test-packed-artifacts.mjs
+++ b/tests/compat/bun-runtime/scripts/test-packed-artifacts.mjs
@@ -1,3 +1,4 @@
+import { createRequire } from "node:module";
 import { spawn } from "node:child_process";
 import { mkdtemp, mkdir, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -6,6 +7,8 @@ import { fileURLToPath } from "node:url";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const repositoryRoot = resolve(scriptDirectory, "../../../..");
+const require = createRequire(import.meta.url);
+const tscEntrypoint = require.resolve("typescript/bin/tsc");
 const temporaryRoot = await mkdtemp(join(tmpdir(), "anvia-bun-packed-"));
 const packsDirectory = join(temporaryRoot, "packs");
 const consumerDirectory = join(temporaryRoot, "consumer");
@@ -57,6 +60,15 @@ try {
   await writeFile(join(consumerDirectory, "smoke.mjs"), smokeTestSource());
 
   await run("bun", ["install", "--ignore-scripts"], { cwd: consumerDirectory });
+  await writeFile(
+    join(consumerDirectory, "tsconfig.json"),
+    `${JSON.stringify(consumerTsconfig(), undefined, 2)}\n`,
+  );
+  await writeFile(join(consumerDirectory, "consumer.ts"), consumerSource());
+  await run(process.execPath, [tscEntrypoint, "-p", join(consumerDirectory, "tsconfig.json")], {
+    cwd: consumerDirectory,
+  });
+  console.log("Packed TypeScript consumer compiles against installed declarations.");
   await run("bun", ["run", "./smoke.mjs"], { cwd: consumerDirectory });
 } finally {
   await rm(temporaryRoot, { force: true, recursive: true });
@@ -98,13 +110,18 @@ function run(command, args, options) {
 function smokeTestSource() {
   return `
 import assert from "node:assert/strict";
-import { createHttpClientTransport } from "@anvia/client";
+import { createHttpClientTransport, parseClientStreamRequest } from "@anvia/client";
 import { Agent } from "@anvia/core";
 import { chunkText } from "@anvia/core/documents";
 import { toReadableStream } from "@anvia/core/streaming";
 import { McpClient } from "@anvia/mcp";
 import { OpenAIClient } from "@anvia/openai";
-import { createClientStreamResponse } from "@anvia/server";
+import {
+  createClientStreamResponse,
+  createMemoryResumableStreamStore,
+  createResumableStream,
+  resumeClientStreamResponse,
+} from "@anvia/server";
 
 assert.equal(typeof Agent, "function");
 assert.equal(typeof createHttpClientTransport, "function");
@@ -146,6 +163,146 @@ assert.deepEqual(
   ["stream_start", "stream_event", "stream_event", "stream_end"],
 );
 
+const packedServer = Bun.serve({
+  hostname: "127.0.0.1",
+  port: 0,
+  async fetch() {
+    return createClientStreamResponse({
+      events: (async function* () {
+        yield { type: "run_start", runId: "packed-live", source: "completion" };
+        yield { type: "run_end", runId: "packed-live", status: "completed" };
+      })(),
+      streamId: "packed-http",
+    });
+  },
+});
+const packedHttpTransport = createHttpClientTransport({
+  endpoint: new URL("/", packedServer.url),
+});
+const packedHttpFrames = [];
+for await (const frame of packedHttpTransport.send({
+  request: { type: "messages", messages: [] },
+})) {
+  packedHttpFrames.push(frame);
+}
+packedServer.stop(true);
+assert.deepEqual(
+  packedHttpFrames.map((frame) => frame.type),
+  ["stream_start", "stream_event", "stream_event", "stream_end"],
+);
+assert.deepEqual(packedHttpFrames[2].event, {
+  type: "run_end",
+  runId: "packed-live",
+  status: "completed",
+});
+
+const packedStore = createMemoryResumableStreamStore();
+const packedProducer = (async function* () {
+  yield { kind: "one" };
+  yield { kind: "two" };
+})();
+const packedReplay = [];
+for await (const envelope of createResumableStream({
+  id: "packed-resumable",
+  store: packedStore,
+  events: packedProducer,
+})) {
+  packedReplay.push(envelope);
+}
+assert.deepEqual(
+  packedReplay.map((envelope) => envelope.type),
+  ["stream_start", "stream_event", "stream_event", "stream_end"],
+);
+assert.equal(packedReplay[3].status, "completed");
+
+let releasePackedProducer;
+const packedResumeStore = createMemoryResumableStreamStore();
+const packedResumeServer = Bun.serve({
+  hostname: "127.0.0.1",
+  port: 0,
+  async fetch(request) {
+    const body = parseClientStreamRequest(await request.json());
+    if (body.resume !== undefined) {
+      return resumeClientStreamResponse({
+        streamId: body.resume.streamId,
+        after: body.resume.after,
+        store: packedResumeStore,
+      });
+    }
+    return createClientStreamResponse({
+      events: gatedProducer(),
+      resumable: { streamId: "packed-resume", store: packedResumeStore },
+    });
+  },
+});
+function gatedProducer() {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield { type: "run_start", runId: "packed-resume", source: "completion" };
+      await new Promise((resolve) => {
+        releasePackedProducer = resolve;
+      });
+      yield { type: "run_end", runId: "packed-resume", status: "completed" };
+    },
+  };
+}
+const firstIterator = createHttpClientTransport({
+  endpoint: new URL("/resume", packedResumeServer.url),
+})
+  .send({ request: { type: "messages", messages: [] } })
+  [Symbol.asyncIterator]();
+const firstStart = await firstIterator.next();
+const firstEvent = await firstIterator.next();
+assert.equal(firstStart.value.type, "stream_start");
+assert.equal(firstEvent.value.event.type, "run_start");
+assert.equal(firstEvent.value.eventId, 1);
+// Sever the first consumer while the producer is parked on its gate; packed
+// server drain must keep producing into the store without a reader attached.
+await firstIterator.return?.();
+const resumeTransport = createHttpClientTransport({
+  endpoint: new URL("/resume", packedResumeServer.url),
+});
+const resumePromise = (async () => {
+  const frames = [];
+  for await (const frame of resumeTransport.send({
+    request: {
+      type: "messages",
+      messages: [],
+      resume: { streamId: "packed-resume", after: 1 },
+    },
+  })) {
+    frames.push(frame);
+  }
+  return frames;
+})();
+releasePackedProducer?.();
+const resumedFrames = await bounded(resumePromise, "packed resumable reconnect");
+packedResumeServer.stop(true);
+assert.deepEqual(
+  resumedFrames.map((frame) => frame.type),
+  ["stream_start", "stream_event", "stream_end"],
+);
+assert.equal(resumedFrames[0].streamId, "packed-resume");
+assert.equal(resumedFrames[0].resumable, true);
+assert.equal(resumedFrames[1].eventId, 2);
+assert.deepEqual(resumedFrames[1].event, {
+  type: "run_end",
+  runId: "packed-resume",
+  status: "completed",
+});
+assert.equal(resumedFrames[2].streamId, "packed-resume");
+assert.equal(resumedFrames[2].eventId, 2);
+assert.equal(resumedFrames[2].status, "completed");
+
+function bounded(promise, label) {
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => {
+      setTimeout(() => reject(new Error("Timed out waiting for " + label)), 10_000);
+    }),
+  ]);
+}
+
 const model = new OpenAIClient({
   client: {
     chat: {
@@ -172,5 +329,91 @@ assert.equal(result.output, "packed packages work");
 assert.equal(result.usage.totalTokens, 4);
 
 console.log("Packed Core, Client, Server, OpenAI, and MCP artifacts work under Bun.");
+`;
+}
+
+function consumerTsconfig() {
+  return {
+    compilerOptions: {
+      target: "ES2022",
+      lib: ["ES2022", "DOM"],
+      module: "ESNext",
+      moduleResolution: "bundler",
+      strict: true,
+      noEmit: true,
+      skipLibCheck: true,
+      types: [],
+    },
+    include: ["consumer.ts"],
+  };
+}
+
+// Type-only consumer: every entrypoint is referenced by name so its installed
+// declaration file must resolve, and the calls mirror the runtime smoke so the
+// signatures have to accept the same usage a real consumer would write.
+function consumerSource() {
+  return `
+import { Agent } from "@anvia/core";
+import { createHttpClientTransport, parseClientStreamRequest } from "@anvia/client";
+import { readJsonlStream } from "@anvia/client/transport";
+import { chunkText } from "@anvia/core/documents";
+import { toReadableStream } from "@anvia/core/streaming";
+import { McpClient } from "@anvia/mcp";
+import { OpenAIClient } from "@anvia/openai";
+import {
+  createClientStreamResponse,
+  createMemoryResumableStreamStore,
+  createResumableStream,
+  resumeClientStreamResponse,
+} from "@anvia/server";
+
+const agentCtor: typeof Agent = Agent;
+const transportFactory: typeof createHttpClientTransport = createHttpClientTransport;
+const jsonlReader: typeof readJsonlStream = readJsonlStream;
+const requestParser: typeof parseClientStreamRequest = parseClientStreamRequest;
+const chunker: typeof chunkText = chunkText;
+const streamAdapter: typeof toReadableStream = toReadableStream;
+const mcpClientCtor: typeof McpClient = McpClient;
+const openaiClientCtor: typeof OpenAIClient = OpenAIClient;
+const clientStreamResponse: typeof createClientStreamResponse = createClientStreamResponse;
+const memoryStoreFactory: typeof createMemoryResumableStreamStore = createMemoryResumableStreamStore;
+const resumableFactory: typeof createResumableStream = createResumableStream;
+const resumeResponse: typeof resumeClientStreamResponse = resumeClientStreamResponse;
+
+const mcpClient = new McpClient({
+  name: "packed-typed",
+  transport: {
+    type: "custom",
+    create() {
+      throw new Error("Not connected during the type-only consumer check");
+    },
+  },
+});
+const mcpName: string = mcpClient.name;
+
+const stream = toReadableStream(
+  (async function* () {
+    yield { type: "text_delta", delta: "typed consumer" };
+  })(),
+);
+const store = createMemoryResumableStreamStore();
+
+console.log(
+  agentCtor.name.length,
+  transportFactory.name.length,
+  requestParser.name.length,
+  jsonlReader.name.length,
+  chunker.name.length,
+  streamAdapter.name.length,
+  mcpClientCtor.name.length,
+  openaiClientCtor.name.length,
+  clientStreamResponse.name.length,
+  resumeResponse.name.length,
+  memoryStoreFactory.name.length,
+  resumableFactory.name.length,
+  mcpName.length,
+  stream !== undefined,
+  store !== undefined,
+);
 `;
 }

--- a/tests/compat/bun-runtime/test/anthropic.test.ts
+++ b/tests/compat/bun-runtime/test/anthropic.test.ts
@@ -1,0 +1,231 @@
+import { afterAll, beforeEach, describe, expect, it } from "bun:test";
+import { generateCompletion, streamCompletion } from "@anvia/core/completion";
+import { AnthropicClient } from "@anvia/anthropic";
+import { BadRequestError } from "@anthropic-ai/sdk";
+
+type RecordedRequest = {
+  method: string;
+  pathname: string;
+  body?: unknown;
+  contentType?: string | undefined;
+};
+
+type MessagesFixtureBody = { model?: string; stream?: boolean };
+
+const requests: RecordedRequest[] = [];
+let resolveSlowRequest: (() => void) | undefined;
+let slowRequestStarted = Promise.resolve();
+
+resetSlowRequest();
+
+const server = Bun.serve({
+  hostname: "127.0.0.1",
+  port: 0,
+  async fetch(request) {
+    const url = new URL(request.url);
+    const contentType = request.headers.get("content-type") ?? undefined;
+    const recorded: RecordedRequest = {
+      method: request.method,
+      pathname: url.pathname,
+      contentType,
+    };
+
+    if (contentType?.startsWith("application/json")) {
+      recorded.body = await request.json();
+    }
+    requests.push(recorded);
+    const body = (recorded.body ?? {}) as MessagesFixtureBody;
+
+    if (url.pathname === "/v1/messages") {
+      if (body.model === "slow-model") {
+        resolveSlowRequest?.();
+        return new Response(new ReadableStream(), {
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      if (body.model === "error-model") {
+        return Response.json(
+          {
+            type: "error",
+            error: {
+              type: "invalid_request_error",
+              message: "Bun fixture rejected this request",
+            },
+          },
+          { status: 400 },
+        );
+      }
+
+      if (body.stream === true) {
+        return eventStream([
+          {
+            type: "message_start",
+            message: { id: "msg_bun", role: "assistant", usage: { input_tokens: 3 } },
+          },
+          { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+          {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "text_delta", text: "Hello from " },
+          },
+          {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "text_delta", text: "Anthropic on Bun" },
+          },
+          { type: "content_block_stop", index: 0 },
+          {
+            type: "message_delta",
+            delta: { stop_reason: "end_turn", stop_sequence: null },
+            usage: { output_tokens: 6 },
+          },
+          { type: "message_stop" },
+        ]);
+      }
+
+      return Response.json({
+        id: "msg_bun",
+        type: "message",
+        role: "assistant",
+        model: "claude-haiku-4-5",
+        content: [{ type: "text", text: "Hello from Anthropic on Bun" }],
+        stop_reason: "end_turn",
+        stop_sequence: null,
+        usage: { input_tokens: 2, output_tokens: 5 },
+      });
+    }
+
+    return new Response("Not found", { status: 404 });
+  },
+});
+
+const client = new AnthropicClient({
+  apiKey: "bun-compat-test-key",
+  baseUrl: new URL(server.url).origin,
+});
+
+beforeEach(() => {
+  requests.length = 0;
+  resetSlowRequest();
+});
+
+afterAll(() => {
+  server.stop(true);
+});
+
+describe("@anvia/anthropic under Bun", () => {
+  it("uses Bun fetch for Messages completions", async () => {
+    const model = client.completionModel({ modelId: "claude-haiku-4-5" });
+
+    const completion = await generateCompletion({ model, prompt: "hello" });
+
+    expect(completion.text).toBe("Hello from Anthropic on Bun");
+    expect(completion.usage).toMatchObject({ inputTokens: 2, outputTokens: 5, totalTokens: 7 });
+    expect(requests).toEqual([
+      expect.objectContaining({
+        method: "POST",
+        pathname: "/v1/messages",
+        body: {
+          model: "claude-haiku-4-5",
+          max_tokens: 1024,
+          messages: [{ role: "user", content: "hello" }],
+        },
+      }),
+    ]);
+  });
+
+  it("parses chunked Messages SSE streams", async () => {
+    const model = client.completionModel({ modelId: "claude-haiku-4-5" });
+
+    const events = await collect(streamCompletion({ model, prompt: "hello" }));
+
+    expect(events).toEqual([
+      { type: "message_id", id: "msg_bun" },
+      { type: "text_delta", delta: "Hello from " },
+      { type: "text_delta", delta: "Anthropic on Bun" },
+      expect.objectContaining({
+        type: "final",
+        result: expect.objectContaining({
+          text: "Hello from Anthropic on Bun",
+          usage: expect.objectContaining({ inputTokens: 3, outputTokens: 6, totalTokens: 9 }),
+        }),
+      }),
+    ]);
+    expect(requests[0]).toMatchObject({
+      method: "POST",
+      pathname: "/v1/messages",
+      body: expect.objectContaining({ model: "claude-haiku-4-5", stream: true }),
+    });
+  });
+
+  it("propagates AbortSignal cancellation through Bun fetch", async () => {
+    const model = client.completionModel({ modelId: "slow-model" });
+    const controller = new AbortController();
+    const completion = generateCompletion({
+      model,
+      prompt: "wait",
+      abortSignal: controller.signal,
+    });
+    await slowRequestStarted;
+
+    controller.abort("caller stopped");
+
+    await expect(completion).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("surfaces vendor SDK errors for HTTP failures", async () => {
+    const model = client.completionModel({ modelId: "error-model" });
+
+    const error = await generateCompletion({ model, prompt: "hello" }).catch(
+      (thrown: unknown) => thrown,
+    );
+
+    expect(error).toBeInstanceOf(BadRequestError);
+    expect(error).toMatchObject({
+      status: 400,
+      message: expect.stringContaining("Bun fixture rejected this request"),
+    });
+    expect(requests[0]).toMatchObject({
+      method: "POST",
+      pathname: "/v1/messages",
+      body: expect.objectContaining({ model: "error-model" }),
+    });
+  });
+});
+
+function eventStream(events: readonly ({ type: string } & Record<string, unknown>)[]): Response {
+  const payload = events
+    .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+    .join("");
+  return fragmentedStream(payload);
+}
+
+function fragmentedStream(payload: string, pieceSize = 13): Response {
+  const bytes = new TextEncoder().encode(payload);
+  let offset = 0;
+  return new Response(
+    new ReadableStream({
+      pull(controller) {
+        if (offset >= bytes.length) {
+          controller.close();
+          return;
+        }
+        const end = Math.min(offset + pieceSize, bytes.length);
+        controller.enqueue(bytes.slice(offset, end));
+        offset = end;
+      },
+    }),
+    { headers: { "content-type": "text/event-stream" } },
+  );
+}
+
+function resetSlowRequest(): void {
+  ({ promise: slowRequestStarted, resolve: resolveSlowRequest } = Promise.withResolvers<void>());
+}
+
+async function collect<T>(events: AsyncIterable<T>): Promise<T[]> {
+  const values: T[] = [];
+  for await (const event of events) values.push(event);
+  return values;
+}

--- a/tests/compat/bun-runtime/test/core.test.ts
+++ b/tests/compat/bun-runtime/test/core.test.ts
@@ -74,7 +74,136 @@ describe("@anvia/core under Bun", () => {
       ),
     ).resolves.toEqual({ type: "text", value: "stdout:\nruntime:bun\n" });
   });
+  it("emits an error frame when the event iterator throws", async () => {
+    const events = (async function* () {
+      yield { type: "text_delta", delta: "one" };
+      throw new Error("iterator failed");
+    })();
+
+    const body = await new Response(toReadableStream(events)).text();
+    const lines = body.split("\n").filter((line) => line.length > 0);
+
+    expect(lines).toHaveLength(2);
+    const firstLine = lines[0];
+    const errorLine = lines[1];
+    if (firstLine === undefined || errorLine === undefined) {
+      throw new Error("Expected an event line and an error line");
+    }
+    expect(JSON.parse(firstLine)).toEqual({ type: "text_delta", delta: "one" });
+    expect(JSON.parse(errorLine)).toMatchObject({
+      type: "error",
+      error: { name: "Error", message: "iterator failed" },
+    });
+  });
+
+  it("propagates consumer cancellation to the event iterator", async () => {
+    let finalized = false;
+    const events = (async function* () {
+      try {
+        let index = 0;
+        while (true) {
+          yield { type: "text_delta", delta: `tick-${index}` };
+          index += 1;
+        }
+      } finally {
+        finalized = true;
+      }
+    })();
+
+    const reader = toReadableStream(events).getReader();
+    expect((await reader.read()).done).toBe(false);
+    await reader.cancel();
+
+    expect(finalized).toBe(true);
+  });
+
+  it("rejects when a skill script exceeds its timeout under Bun", async () => {
+    const directory = await createSkillDirectory(
+      "bun-timeout",
+      "slow.sh",
+      "#!/bin/sh\nwhile true; do :; done\n",
+    );
+    const skillSet = await loadSkills(skill.local(directory));
+    const agent = new Agent({
+      id: "bun-timeout",
+      model: createCompletionModel(),
+      tools: skillSet.tools,
+    });
+
+    await expect(
+      agent.callTool(
+        "run_skill_script",
+        JSON.stringify({
+          skillName: "bun-timeout",
+          scriptPath: "slow.sh",
+          timeoutMs: 100,
+        }),
+      ),
+    ).rejects.toThrow("Skill script timed out after 100ms");
+  });
+
+  it("reports non-zero skill script exits with captured stderr", async () => {
+    const directory = await createSkillDirectory(
+      "bun-fail",
+      "fail.sh",
+      '#!/bin/sh\necho "starting"\necho "broken" >&2\nexit 3\n',
+    );
+    const skillSet = await loadSkills(skill.local(directory));
+    const agent = new Agent({
+      id: "bun-fail",
+      model: createCompletionModel(),
+      tools: skillSet.tools,
+    });
+
+    await expect(
+      agent.callTool(
+        "run_skill_script",
+        JSON.stringify({ skillName: "bun-fail", scriptPath: "fail.sh" }),
+      ),
+    ).rejects.toThrow("Skill script exited with code 3: stdout:\nstarting\n\n\nstderr:\nbroken\n");
+  });
+
+  it("truncates oversized skill script output", async () => {
+    const directory = await createSkillDirectory(
+      "bun-truncate",
+      "flood.sh",
+      "#!/bin/sh\nawk 'BEGIN { for (i = 0; i < 25000; i++) printf \"-\" }'\n",
+    );
+    const skillSet = await loadSkills(skill.local(directory));
+    const agent = new Agent({
+      id: "bun-truncate",
+      model: createCompletionModel(),
+      tools: skillSet.tools,
+    });
+
+    await expect(
+      agent.callTool(
+        "run_skill_script",
+        JSON.stringify({ skillName: "bun-truncate", scriptPath: "flood.sh" }),
+      ),
+    ).resolves.toEqual({ type: "text", value: `stdout:\n${"-".repeat(20_000)}\n[truncated]` });
+  });
 });
+
+async function createSkillDirectory(
+  name: string,
+  scriptName: string,
+  script: string,
+): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "anvia-bun-core-"));
+  tempDirectories.push(root);
+  const directory = join(root, name);
+  const scriptsDirectory = join(directory, "scripts");
+  await mkdir(scriptsDirectory, { recursive: true });
+  await writeFile(
+    join(directory, "SKILL.md"),
+    `---\nname: ${name}\ndescription: Bun compatibility fixture.\n---\nRun the fixture.\n`,
+  );
+  const scriptPath = join(scriptsDirectory, scriptName);
+  await writeFile(scriptPath, script);
+  await chmod(scriptPath, 0o755);
+  return directory;
+}
 
 function createCompletionModel() {
   return {

--- a/tests/compat/bun-runtime/test/fixtures/mcp-stdio-env-server.mjs
+++ b/tests/compat/bun-runtime/test/fixtures/mcp-stdio-env-server.mjs
@@ -1,0 +1,62 @@
+let buffer = "";
+
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  while (true) {
+    const newline = buffer.indexOf("\n");
+    if (newline === -1) return;
+    const line = buffer.slice(0, newline);
+    buffer = buffer.slice(newline + 1);
+    if (line.trim() === "") continue;
+    respond(JSON.parse(line));
+  }
+});
+
+function respond(message) {
+  process.stdout.write(
+    `${JSON.stringify({ jsonrpc: "2.0", id: message.id, result: resultFor(message) })}\n`,
+  );
+}
+
+function resultFor(message) {
+  if (message.method === "server/discover") {
+    return {
+      supportedVersions: ["2026-07-28"],
+      capabilities: { tools: {} },
+      instructions: `token:${process.env.FIXTURE_TOKEN ?? "missing"}`,
+      _meta: {
+        "io.modelcontextprotocol/serverInfo": {
+          name: "bun-stdio-env-fixture",
+          version: "1.0.0",
+        },
+      },
+    };
+  }
+  if (message.method === "tools/list") {
+    return {
+      resultType: "complete",
+      ttlMs: 0,
+      cacheScope: "public",
+      tools: [
+        {
+          name: "echo",
+          inputSchema: {
+            type: "object",
+            properties: { text: { type: "string" } },
+            required: ["text"],
+          },
+        },
+      ],
+    };
+  }
+  if (message.method === "tools/call") {
+    return {
+      resultType: "complete",
+      ttlMs: 0,
+      cacheScope: "private",
+      content: [{ type: "text", text: `echo:${String(message.params?.arguments?.text ?? "")}` }],
+    };
+  }
+  return {};
+}

--- a/tests/compat/bun-runtime/test/fixtures/mcp-stdio-slow-server.mjs
+++ b/tests/compat/bun-runtime/test/fixtures/mcp-stdio-slow-server.mjs
@@ -1,0 +1,81 @@
+import { writeFileSync } from "node:fs";
+
+let buffer = "";
+
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  while (true) {
+    const newline = buffer.indexOf("\n");
+    if (newline === -1) return;
+    const line = buffer.slice(0, newline);
+    buffer = buffer.slice(newline + 1);
+    if (line.trim() === "") continue;
+    respond(JSON.parse(line));
+  }
+});
+
+process.on("SIGTERM", () => {
+  const exitMarkerPath = process.env.MCP_SLOW_EXIT;
+  if (exitMarkerPath) writeFileSync(exitMarkerPath, "");
+  process.exit(143);
+});
+
+function respond(message) {
+  if (message.method === "tools/call") {
+    const receiptPath = process.env.MCP_SLOW_RECEIPT;
+    if (receiptPath) writeFileSync(receiptPath, JSON.stringify({ pid: process.pid }));
+    setTimeout(() => {
+      process.stdout.write(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: message.id,
+          result: {
+            resultType: "complete",
+            ttlMs: 0,
+            cacheScope: "private",
+            content: [{ type: "text", text: "slow-echo" }],
+          },
+        })}\n`,
+      );
+    }, 10_000);
+    return;
+  }
+
+  process.stdout.write(
+    `${JSON.stringify({ jsonrpc: "2.0", id: message.id, result: resultFor(message) })}\n`,
+  );
+}
+
+function resultFor(message) {
+  if (message.method === "server/discover") {
+    return {
+      supportedVersions: ["2026-07-28"],
+      capabilities: { tools: {} },
+      _meta: {
+        "io.modelcontextprotocol/serverInfo": {
+          name: "bun-stdio-slow-fixture",
+          version: "1.0.0",
+        },
+      },
+    };
+  }
+  if (message.method === "tools/list") {
+    return {
+      resultType: "complete",
+      ttlMs: 0,
+      cacheScope: "public",
+      tools: [
+        {
+          name: "echo",
+          inputSchema: {
+            type: "object",
+            properties: { text: { type: "string" } },
+            required: ["text"],
+          },
+        },
+      ],
+    };
+  }
+  return {};
+}

--- a/tests/compat/bun-runtime/test/gemini.test.ts
+++ b/tests/compat/bun-runtime/test/gemini.test.ts
@@ -1,0 +1,222 @@
+import { afterAll, beforeEach, describe, expect, it } from "bun:test";
+import { generateCompletion, streamCompletion } from "@anvia/core/completion";
+import { GeminiClient } from "@anvia/gemini";
+import { GoogleGenAI } from "@google/genai";
+
+type RecordedRequest = {
+  method: string;
+  pathname: string;
+  body?: unknown;
+  contentType?: string | undefined;
+};
+
+const requests: RecordedRequest[] = [];
+let resolveSlowRequest: (() => void) | undefined;
+let slowRequestStarted = Promise.resolve();
+
+resetSlowRequest();
+
+const server = Bun.serve({
+  hostname: "127.0.0.1",
+  port: 0,
+  async fetch(request) {
+    const url = new URL(request.url);
+    const contentType = request.headers.get("content-type") ?? undefined;
+    const recorded: RecordedRequest = {
+      method: request.method,
+      pathname: url.pathname,
+      contentType,
+    };
+
+    if (contentType?.startsWith("application/json")) {
+      recorded.body = await request.json();
+    }
+    requests.push(recorded);
+
+    if (url.pathname === "/v1beta/models/gemini-2.5-flash:generateContent") {
+      return Response.json(generateContentPayload());
+    }
+
+    if (url.pathname === "/v1beta/models/gemini-2.5-flash:streamGenerateContent") {
+      // Real Gemini streams end with a finishReason-only terminal chunk; the
+      // terminal chunk must not restate content that diverges from the deltas.
+      return eventStream([
+        {
+          candidates: [{ content: { parts: [{ text: "Hello from " }], role: "model" }, index: 0 }],
+        },
+        {
+          candidates: [
+            { content: { parts: [{ text: "Gemini on Bun" }], role: "model" }, index: 0 },
+          ],
+        },
+        {
+          candidates: [{ finishReason: "STOP", index: 0 }],
+          usageMetadata: { promptTokenCount: 2, candidatesTokenCount: 5, totalTokenCount: 7 },
+          modelVersion: "gemini-2.5-flash",
+          responseId: "bun-gemini",
+        },
+      ]);
+    }
+
+    if (url.pathname === "/v1beta/models/slow-model:generateContent") {
+      resolveSlowRequest?.();
+      return new Response(new ReadableStream(), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    if (url.pathname === "/v1beta/models/error-model:generateContent") {
+      return Response.json(
+        {
+          error: {
+            code: 400,
+            message: "Bun fixture rejected this request",
+            status: "INVALID_ARGUMENT",
+          },
+        },
+        { status: 400 },
+      );
+    }
+
+    return new Response("Not found", { status: 404 });
+  },
+});
+
+const client = new GeminiClient({
+  client: new GoogleGenAI({
+    apiKey: "bun-compat-test-key",
+    httpOptions: { baseUrl: new URL(server.url).origin },
+  }),
+});
+
+beforeEach(() => {
+  requests.length = 0;
+  resetSlowRequest();
+});
+
+afterAll(() => {
+  server.stop(true);
+});
+
+describe("@anvia/gemini under Bun", () => {
+  it("uses Bun fetch for generateContent completions", async () => {
+    const model = client.completionModel({ modelId: "gemini-2.5-flash" });
+
+    const completion = await generateCompletion({ model, prompt: "hello" });
+
+    expect(completion.text).toBe("Hello from Gemini on Bun");
+    expect(completion.usage).toMatchObject({ inputTokens: 2, outputTokens: 5, totalTokens: 7 });
+    expect(requests).toEqual([
+      expect.objectContaining({
+        method: "POST",
+        pathname: "/v1beta/models/gemini-2.5-flash:generateContent",
+        body: expect.objectContaining({
+          contents: [{ role: "user", parts: [{ text: "hello" }] }],
+        }),
+      }),
+    ]);
+  });
+
+  it("parses chunked streamGenerateContent SSE streams", async () => {
+    const model = client.completionModel({ modelId: "gemini-2.5-flash" });
+
+    const events = await collect(streamCompletion({ model, prompt: "hello" }));
+
+    expect(events).toEqual([
+      { type: "text_delta", delta: "Hello from " },
+      { type: "text_delta", delta: "Gemini on Bun" },
+      { type: "message_id", id: "bun-gemini" },
+      expect.objectContaining({
+        type: "final",
+        result: expect.objectContaining({
+          text: "Hello from Gemini on Bun",
+          usage: expect.objectContaining({ inputTokens: 2, outputTokens: 5, totalTokens: 7 }),
+        }),
+      }),
+    ]);
+    expect(requests[0]).toMatchObject({
+      method: "POST",
+      pathname: "/v1beta/models/gemini-2.5-flash:streamGenerateContent",
+    });
+  });
+
+  it("propagates AbortSignal cancellation through Bun fetch", async () => {
+    const model = client.completionModel({ modelId: "slow-model" });
+    const controller = new AbortController();
+    const completion = generateCompletion({
+      model,
+      prompt: "wait",
+      abortSignal: controller.signal,
+    });
+    await slowRequestStarted;
+
+    controller.abort("caller stopped");
+
+    await expect(completion).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("surfaces vendor SDK errors for HTTP failures", async () => {
+    const model = client.completionModel({ modelId: "error-model" });
+
+    const completion = generateCompletion({ model, prompt: "hello" });
+
+    await expect(completion).rejects.toMatchObject({
+      name: "ApiError",
+      status: 400,
+      message: expect.stringContaining("Bun fixture rejected this request"),
+    });
+    expect(requests[0]).toMatchObject({
+      method: "POST",
+      pathname: "/v1beta/models/error-model:generateContent",
+    });
+  });
+});
+
+function generateContentPayload() {
+  return {
+    candidates: [
+      {
+        content: { parts: [{ text: "Hello from Gemini on Bun" }], role: "model" },
+        finishReason: "STOP",
+        index: 0,
+      },
+    ],
+    usageMetadata: { promptTokenCount: 2, candidatesTokenCount: 5, totalTokenCount: 7 },
+    modelVersion: "gemini-2.5-flash",
+    responseId: "bun-gemini",
+  };
+}
+
+function eventStream(events: readonly unknown[]): Response {
+  const payload = events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("");
+  return fragmentedStream(payload);
+}
+
+function fragmentedStream(payload: string, pieceSize = 13): Response {
+  const bytes = new TextEncoder().encode(payload);
+  let offset = 0;
+  return new Response(
+    new ReadableStream({
+      pull(controller) {
+        if (offset >= bytes.length) {
+          controller.close();
+          return;
+        }
+        const end = Math.min(offset + pieceSize, bytes.length);
+        controller.enqueue(bytes.slice(offset, end));
+        offset = end;
+      },
+    }),
+    { headers: { "content-type": "text/event-stream" } },
+  );
+}
+
+function resetSlowRequest(): void {
+  ({ promise: slowRequestStarted, resolve: resolveSlowRequest } = Promise.withResolvers<void>());
+}
+
+async function collect<T>(events: AsyncIterable<T>): Promise<T[]> {
+  const values: T[] = [];
+  for await (const event of events) values.push(event);
+  return values;
+}

--- a/tests/compat/bun-runtime/test/mcp.test.ts
+++ b/tests/compat/bun-runtime/test/mcp.test.ts
@@ -1,4 +1,7 @@
 import { afterAll, describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { normalizeToolResultOutput } from "@anvia/core/tool";
 import { McpClient } from "@anvia/mcp";
@@ -141,7 +144,133 @@ describe("@anvia/mcp under Bun", () => {
     expect(requests).toHaveLength(0);
     await client.close();
   });
+
+  it("passes stdio environment variables through to the MCP subprocess", async () => {
+    const fixturePath = fileURLToPath(
+      new URL("./fixtures/mcp-stdio-env-server.mjs", import.meta.url),
+    );
+    const client = new McpClient({
+      name: "bun-stdio-env",
+      transport: {
+        type: "stdio",
+        command: process.execPath,
+        args: [fixturePath],
+        env: { FIXTURE_TOKEN: "bun-env-ok" },
+      },
+    });
+
+    try {
+      const registration = await client.connect();
+      expect(registration.instructions).toBe("token:bun-env-ok");
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("closes cleanly while a stdio tool call is in flight", async () => {
+    const fixturePath = fileURLToPath(
+      new URL("./fixtures/mcp-stdio-slow-server.mjs", import.meta.url),
+    );
+    const workDir = mkdtempSync(join(tmpdir(), "anvia-mcp-slow-"));
+    const receiptPath = join(workDir, "receipt.json");
+    const exitMarkerPath = join(workDir, "exited");
+    const client = new McpClient({
+      name: "bun-stdio-slow",
+      transport: {
+        type: "stdio",
+        command: process.execPath,
+        args: [fixturePath],
+        env: { MCP_SLOW_RECEIPT: receiptPath, MCP_SLOW_EXIT: exitMarkerPath },
+      },
+    });
+
+    try {
+      const registration = await client.connect();
+      const tool = registration.tools[0];
+      if (tool === undefined) throw new Error("Expected the slow MCP fixture tool");
+
+      const pending = Promise.resolve(tool.call({ text: "slow" }));
+
+      // The receipt proves the fixture received the call and is parked in its
+      // delayed reply, so close() below really races an in-flight request.
+      await waitForReceipt(receiptPath);
+      const { pid } = JSON.parse(readFileSync(receiptPath, "utf8")) as { pid: number };
+
+      // Either close outcome is SDK-defined while a call is in flight; the
+      // contract is that close settles instead of hanging.
+      const closed = within(
+        client.close().then(
+          () => "resolved" as const,
+          () => "rejected" as const,
+        ),
+      );
+      await expect(
+        within(
+          pending.then(
+            () => "settled",
+            () => "settled",
+          ),
+        ),
+      ).resolves.toBe("settled");
+      expect(["resolved", "rejected"]).toContain(await closed);
+
+      // The child must not outlive the client: closing the transport has to
+      // terminate the fixture (SIGTERM marker or dead pid), never leak it
+      // until the fixture's own 10s reply timer fires.
+      const exitEvidence = await waitForExit(pid, exitMarkerPath);
+      expect(["signaled", "dead"]).toContain(exitEvidence);
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  }, 12_000);
 });
+
+// Watchdog, not a delay: the awaited signal is the close/settle event itself.
+// The timer only bounds a leaked-subprocess hang that has no deterministic signal.
+async function within<T>(promise: Promise<T>, timeoutMs = 3_000): Promise<T> {
+  let timeout: Timer | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error("Timed out waiting for close")), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}
+
+// Polls for the fixture's receipt file: proof the subprocess received the tool
+// call. The awaited signal is the file; the deadline only bounds a broken fixture.
+async function waitForReceipt(path: string, timeoutMs = 3_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(path)) return;
+    await Bun.sleep(10);
+  }
+  throw new Error("Fixture never acknowledged the tool call");
+}
+
+// Waits for fixture termination after close(): either the SIGTERM marker it
+// writes on signal receipt or a dead pid. The deadline bounds a leaked child.
+async function waitForExit(
+  pid: number,
+  exitMarkerPath: string,
+  timeoutMs = 8_000,
+): Promise<"signaled" | "dead"> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(exitMarkerPath)) return "signaled";
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return "dead";
+    }
+    await Bun.sleep(20);
+  }
+  throw new Error(`Fixture subprocess (pid ${pid}) outlived client close`);
+}
 
 function resultFor(message: RpcRequest): Record<string, unknown> {
   if (message.method === "server/discover") {

--- a/tests/compat/bun-runtime/test/mistral.test.ts
+++ b/tests/compat/bun-runtime/test/mistral.test.ts
@@ -1,0 +1,246 @@
+import { afterAll, beforeEach, describe, expect, it } from "bun:test";
+import { generateCompletion, streamCompletion } from "@anvia/core/completion";
+import { MistralClient } from "@anvia/mistral";
+
+type RecordedRequest = {
+  method: string;
+  pathname: string;
+  body?: unknown;
+  contentType?: string | undefined;
+};
+
+type ChatCompletionsFixtureBody = { model?: string; stream?: boolean };
+
+const requests: RecordedRequest[] = [];
+let resolveSlowRequest: (() => void) | undefined;
+let slowRequestStarted = Promise.resolve();
+
+resetSlowRequest();
+
+const server = Bun.serve({
+  hostname: "127.0.0.1",
+  port: 0,
+  async fetch(request) {
+    const url = new URL(request.url);
+    const contentType = request.headers.get("content-type") ?? undefined;
+    const recorded: RecordedRequest = {
+      method: request.method,
+      pathname: url.pathname,
+      contentType,
+    };
+
+    if (contentType?.startsWith("application/json")) {
+      recorded.body = await request.json();
+    }
+    requests.push(recorded);
+    const body = (recorded.body ?? {}) as ChatCompletionsFixtureBody;
+
+    if (url.pathname === "/v1/chat/completions") {
+      if (body.model === "slow-model") {
+        resolveSlowRequest?.();
+        return new Response(new ReadableStream(), {
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      if (body.model === "error-model") {
+        return Response.json(
+          {
+            message: "Bun fixture rejected this request",
+            type: "invalid_request_error",
+            param: null,
+            code: null,
+          },
+          { status: 400 },
+        );
+      }
+
+      if (body.stream === true) {
+        return eventStream([
+          {
+            id: "bun-mistral",
+            object: "chat.completion.chunk",
+            created: 1_700_000_000,
+            model: "mistral-small-latest",
+            choices: [
+              {
+                index: 0,
+                delta: { role: "assistant", content: "Hello from " },
+                finish_reason: null,
+              },
+            ],
+          },
+          {
+            id: "bun-mistral",
+            object: "chat.completion.chunk",
+            created: 1_700_000_000,
+            model: "mistral-small-latest",
+            choices: [
+              {
+                index: 0,
+                delta: { role: "assistant", content: "Mistral on Bun" },
+                finish_reason: null,
+              },
+            ],
+          },
+          {
+            id: "bun-mistral",
+            object: "chat.completion.chunk",
+            created: 1_700_000_000,
+            model: "mistral-small-latest",
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+            usage: { prompt_tokens: 2, completion_tokens: 5, total_tokens: 7 },
+          },
+        ]);
+      }
+
+      return Response.json({
+        id: "bun-mistral",
+        object: "chat.completion",
+        created: 1_700_000_000,
+        model: "mistral-small-latest",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "Hello from Mistral on Bun" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 2, completion_tokens: 5, total_tokens: 7 },
+      });
+    }
+
+    return new Response("Not found", { status: 404 });
+  },
+});
+
+const client = new MistralClient({
+  apiKey: "bun-compat-test-key",
+  baseUrl: new URL(server.url).origin,
+});
+
+beforeEach(() => {
+  requests.length = 0;
+  resetSlowRequest();
+});
+
+afterAll(() => {
+  server.stop(true);
+});
+
+describe("@anvia/mistral under Bun", () => {
+  it("uses Bun fetch for chat completions", async () => {
+    const model = client.completionModel({ modelId: "mistral-small-latest" });
+
+    const completion = await generateCompletion({ model, prompt: "hello" });
+
+    expect(completion.text).toBe("Hello from Mistral on Bun");
+    expect(completion.usage).toMatchObject({ inputTokens: 2, outputTokens: 5, totalTokens: 7 });
+    expect(requests).toEqual([
+      expect.objectContaining({
+        method: "POST",
+        pathname: "/v1/chat/completions",
+        body: {
+          model: "mistral-small-latest",
+          stream: false,
+          messages: [{ role: "user", content: "hello" }],
+        },
+      }),
+    ]);
+  });
+
+  it("parses chunked chat SSE streams", async () => {
+    const model = client.completionModel({ modelId: "mistral-small-latest" });
+
+    const events = await collect(streamCompletion({ model, prompt: "hello" }));
+
+    expect(events).toEqual([
+      { type: "text_delta", delta: "Hello from " },
+      { type: "message_id", id: "bun-mistral" },
+      { type: "text_delta", delta: "Mistral on Bun" },
+      { type: "message_id", id: "bun-mistral" },
+      { type: "message_id", id: "bun-mistral" },
+      expect.objectContaining({
+        type: "final",
+        result: expect.objectContaining({
+          text: "Hello from Mistral on Bun",
+          usage: expect.objectContaining({ inputTokens: 2, outputTokens: 5, totalTokens: 7 }),
+        }),
+      }),
+    ]);
+    expect(requests[0]).toMatchObject({
+      method: "POST",
+      pathname: "/v1/chat/completions",
+      body: expect.objectContaining({ model: "mistral-small-latest", stream: true }),
+    });
+  });
+
+  it("propagates AbortSignal cancellation through Bun fetch", async () => {
+    const model = client.completionModel({ modelId: "slow-model" });
+    const controller = new AbortController();
+    const completion = generateCompletion({
+      model,
+      prompt: "wait",
+      abortSignal: controller.signal,
+    });
+    await slowRequestStarted;
+
+    controller.abort("caller stopped");
+
+    await expect(completion).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("surfaces vendor SDK errors for HTTP failures", async () => {
+    const model = client.completionModel({ modelId: "error-model" });
+
+    const completion = generateCompletion({ model, prompt: "hello" });
+
+    await expect(completion).rejects.toMatchObject({
+      name: "SDKError",
+      statusCode: 400,
+      message: expect.stringContaining("Bun fixture rejected this request"),
+    });
+    expect(requests[0]).toMatchObject({
+      method: "POST",
+      pathname: "/v1/chat/completions",
+      body: expect.objectContaining({ model: "error-model" }),
+    });
+  });
+});
+
+function eventStream(events: readonly unknown[]): Response {
+  const frames = [
+    ...events.map((event) => `data: ${JSON.stringify(event)}\n\n`),
+    "data: [DONE]\n\n",
+  ];
+  return fragmentedStream(frames.join(""));
+}
+
+function fragmentedStream(payload: string, pieceSize = 13): Response {
+  const bytes = new TextEncoder().encode(payload);
+  let offset = 0;
+  return new Response(
+    new ReadableStream({
+      pull(controller) {
+        if (offset >= bytes.length) {
+          controller.close();
+          return;
+        }
+        const end = Math.min(offset + pieceSize, bytes.length);
+        controller.enqueue(bytes.slice(offset, end));
+        offset = end;
+      },
+    }),
+    { headers: { "content-type": "text/event-stream" } },
+  );
+}
+
+function resetSlowRequest(): void {
+  ({ promise: slowRequestStarted, resolve: resolveSlowRequest } = Promise.withResolvers<void>());
+}
+
+async function collect<T>(events: AsyncIterable<T>): Promise<T[]> {
+  const values: T[] = [];
+  for await (const event of events) values.push(event);
+  return values;
+}

--- a/tests/compat/bun-runtime/test/server.test.ts
+++ b/tests/compat/bun-runtime/test/server.test.ts
@@ -1,9 +1,15 @@
 import { afterAll, describe, expect, it } from "bun:test";
 import type { ClientStream, ClientStreamEvent, ClientStreamRequest } from "@anvia/client";
 import { createHttpClientTransport, parseClientStreamRequest } from "@anvia/client";
-import { fetchEventStream } from "@anvia/client/transport";
+import {
+  EventStreamHttpError,
+  fetchEventStream,
+  readJsonlStream,
+  readSseStream,
+} from "@anvia/client/transport";
 import {
   type ClientResumableEvent,
+  type ResumableStreamEnvelope,
   createClientStreamResponse,
   createEventStreamResponse,
   createMemoryResumableStreamStore,
@@ -19,6 +25,8 @@ const requests: Array<{
 }> = [];
 const resumableStore = createMemoryResumableStreamStore<ClientResumableEvent>();
 let observeCancellation: (() => void) | undefined;
+const eventStore = createMemoryResumableStreamStore<GenericEvent>();
+let releaseLiveProducer: (() => void) | undefined;
 
 const server = Bun.serve({
   hostname: "127.0.0.1",
@@ -28,6 +36,17 @@ const server = Bun.serve({
     if (url.pathname === "/cancel") {
       return createEventStreamResponse({
         events: cancellableEvents(() => observeCancellation?.()),
+      });
+    }
+
+    if (url.pathname === "/http-error") {
+      return new Response("upstream unavailable", { status: 503 });
+    }
+
+    if (url.pathname === "/resumable-error") {
+      return createEventStreamResponse({
+        events: failingEvents(),
+        resumable: { id: "bun-error-stream", store: eventStore },
       });
     }
 
@@ -52,6 +71,20 @@ const server = Bun.serve({
           { type: "run_end", runId: "resume-run", status: "completed" },
         ]),
         resumable: { streamId: "bun-resumable", store: resumableStore },
+      });
+    }
+
+    if (url.pathname === "/resumable-live") {
+      if (body.resume !== undefined) {
+        return resumeClientStreamResponse({
+          streamId: body.resume.streamId,
+          after: body.resume.after,
+          store: resumableStore,
+        });
+      }
+      return createClientStreamResponse({
+        events: liveEvents(),
+        resumable: { streamId: "bun-live", store: resumableStore },
       });
     }
 
@@ -167,7 +200,164 @@ describe("@anvia/client and @anvia/server under Bun", () => {
       observeCancellation = undefined;
     }
   });
+
+  it("decodes JSONL records split at every byte boundary", async () => {
+    const text = '{"index":0,"text":"café"}\r\n{"index":1,"text":"naïve"}\r\n{"index":2}';
+
+    const events = await collect(readJsonlStream<Record<string, unknown>>(byteStream(text)));
+
+    expect(events).toEqual([{ index: 0, text: "café" }, { index: 1, text: "naïve" }, { index: 2 }]);
+  });
+
+  it("decodes SSE comments, multi-line data, and an unterminated final record", async () => {
+    const text = [
+      ": heartbeat",
+      'data: {"index":0}',
+      "",
+      'data: {"items":["a",',
+      'data: "b"]}',
+      "",
+      'data: {"index":2}',
+    ].join("\r\n");
+
+    const events = await collect(readSseStream<Record<string, unknown>>(byteStream(text)));
+
+    expect(events).toEqual([{ index: 0 }, { items: ["a", "b"] }, { index: 2 }]);
+  });
+
+  it("surfaces EventStreamHttpError with status and body for non-OK responses", async () => {
+    const failure = fetchEventStream<GenericEvent>({
+      input: new URL("/http-error", server.url),
+    })[Symbol.asyncIterator]();
+
+    await expect(failure.next()).rejects.toBeInstanceOf(EventStreamHttpError);
+    await failure.return?.();
+
+    const probe = fetchEventStream<GenericEvent>({ input: new URL("/http-error", server.url) });
+    const error = await probe[Symbol.asyncIterator]()
+      .next()
+      .catch((caught: unknown) => caught as EventStreamHttpError);
+    expect(error).toBeInstanceOf(EventStreamHttpError);
+    expect((error as EventStreamHttpError).response.status).toBe(503);
+    expect((error as EventStreamHttpError).body).toBe("upstream unavailable");
+  });
+
+  it("reports a missing resumable stream with an empty replay", async () => {
+    const transport = createHttpClientTransport({
+      endpoint: new URL("/resumable", server.url),
+    });
+    const frames = await collect(
+      transport.send({
+        request: { type: "messages", messages: [], resume: { streamId: "bun-missing", after: 0 } },
+      }),
+    );
+
+    expect(frames.map((frame) => frame.type)).toEqual(["stream_start", "stream_end"]);
+    expect(frames[0]).toMatchObject({ streamId: "bun-missing", resumable: true });
+    expect(frames[1]).toMatchObject({ streamId: "bun-missing", eventId: 0, status: "missing" });
+  });
+
+  it("appends an error event and closes the resumable stream when the producer throws", async () => {
+    const events = await collect(
+      fetchEventStream<ResumableStreamEnvelope<GenericEvent>>({
+        input: new URL("/resumable-error", server.url),
+      }),
+    );
+
+    expect(events.map((event) => event.type)).toEqual([
+      "stream_start",
+      "stream_event",
+      "stream_event",
+      "stream_end",
+    ]);
+    expect(events[2]).toMatchObject({
+      eventId: 2,
+      event: { type: "error", error: { name: "Error", message: "producer failed" } },
+    });
+    expect(events[3]).toMatchObject({ streamId: "bun-error-stream", eventId: 2, status: "error" });
+  });
+
+  it("replays into a live resumable stream after a mid-stream disconnect", async () => {
+    const first = createHttpClientTransport({ endpoint: new URL("/resumable-live", server.url) });
+    const firstIterator = first
+      .send({ request: { type: "messages", messages: [] } })
+      [Symbol.asyncIterator]();
+
+    try {
+      await firstIterator.next();
+      await firstIterator.next();
+      await firstIterator.return?.();
+
+      const resumed = createHttpClientTransport({
+        endpoint: new URL("/resumable-live", server.url),
+      });
+      const resumedPromise = collect(
+        resumed.send({
+          request: { type: "messages", messages: [], resume: { streamId: "bun-live", after: 1 } },
+        }),
+      );
+      releaseLiveProducer?.();
+
+      const frames = await resumedPromise;
+      expect(frames.map((frame) => frame.type)).toEqual([
+        "stream_start",
+        "stream_event",
+        "stream_end",
+      ]);
+      expect(frames[1]).toMatchObject({
+        eventId: 2,
+        event: { type: "run_end", runId: "live-run", status: "completed" },
+      });
+      expect(frames[2]).toMatchObject({ streamId: "bun-live", eventId: 2, status: "completed" });
+    } finally {
+      releaseLiveProducer?.();
+      await firstIterator.return?.();
+      releaseLiveProducer = undefined;
+    }
+  });
 });
+
+function byteStream(text: string): ReadableStream<Uint8Array> {
+  const bytes = new TextEncoder().encode(text);
+  let offset = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (offset >= bytes.length) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(bytes.subarray(offset, offset + 1));
+      offset += 1;
+    },
+  });
+}
+
+function failingEvents(): AsyncIterable<GenericEvent> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield { kind: "first" };
+      throw new Error("producer failed");
+    },
+  };
+}
+
+function liveEvents(): ClientStream {
+  return {
+    async *[Symbol.asyncIterator]() {
+      const start: ClientStreamEvent = {
+        type: "run_start",
+        runId: "live-run",
+        source: "completion",
+      };
+      const end: ClientStreamEvent = { type: "run_end", runId: "live-run", status: "completed" };
+      yield start;
+      await new Promise<void>((resolve) => {
+        releaseLiveProducer = resolve;
+      });
+      yield end;
+    },
+  };
+}
 
 function clientEvents(events: readonly ClientStreamEvent[]): ClientStream {
   return values(events);


### PR DESCRIPTION
## Summary

Expands `tests/compat/bun-runtime/` from 18 to 43 tests and deepens the packed-artifact verification. Test/CI only; no product behavior changes and no changeset (private verification workspace).

### Workspace suite (43 tests, 7 files)
- **core**: error frame emission on iterator throw, consumer-cancellation cleanup, skill script timeout, non-zero exit stderr capture, 20k-char output truncation.
- **server**: one-byte-chunk JSONL/SSE decoding (multibyte, CRLF, comments, multi-line `data:`, unterminated final record), `EventStreamHttpError` status/body preservation, resumable `missing` / producer-`error` / live-replay-after-disconnect states.
- **mcp**: stdio env passthrough; in-flight close now uses a fixture receipt handshake (deterministic in-flight proof), asserts close settles, pending call settles, and the subprocess actually terminates (no leak).
- **providers**: new Anthropic, Gemini, Mistral suites (completion, chunked SSE streaming, abort propagation, HTTP 400 mapping) exercising the real vendor SDKs against local `Bun.serve` fixtures — no credentials or external calls.

### Packed artifacts
- New **TypeScript consumer compile**: strict `tsc --noEmit` against the installed tarballs verifies export maps and declaration files for all subpath entrypoints.
- New **resumable reconnect smoke**: sever a consumer mid-stream (gated producer, no sleeps), reconnect with an `after` cursor through packed Client/Server, assert replay + live tail + `stream_end`.
- Retains the original five-package fresh-install runtime smoke.

### CI
- Bun job matrix `["1.3.14", "1.x"]` with per-version job names.
- Adds `pnpm --filter bun-runtime-compat typecheck` after `test:bun`.

## Validation

- `pnpm --filter bun-runtime-compat test:bun` — 43 pass / 0 fail, 100 expect calls; packed compile + reconnect smoke pass (exit 0).
- Packed script additionally verified under **Bun 1.4.2** (both legs of the CI matrix exercised locally).
- `pnpm --filter bun-runtime-compat typecheck` — clean.
- `pnpm lint` (oxlint) — clean; compat files pass `oxfmt --check`.
- `actionlint` on `.github/workflows/ci.yml` — passed.

## Notes for reviewers

- The MCP in-flight close test is bounded settlement + observed child exit; the fixture replies after 10s so any leak would fail the test, not hang it.
- The Gemini fixture uses a content-free terminal chunk, matching core stream-consistency validation; this mirrors observed real API behavior.
- Known follow-up (out of scope): skill runner kills only the direct child, so grandchildren holding inherited pipes can delay `close` under Bun.