### PR TITLE
feat(lens): add prompt SDK and explicit prompt attribution

### DIFF
--- a/.changeset/lens-prompt-sdk.md
+++ b/.changeset/lens-prompt-sdk.md
@@ -1,0 +1,7 @@
+---
+"@anvia/lens": minor
+"@anvia/core": minor
+"@anvia/otel": minor
+---
+
+Add first-class Lens prompt retrieval with immutable text/chat snapshots, strict synchronous compilation, bounded caching, fresh reload semantics, and typed errors. Carry explicit prompt identity through Agent generations, pipeline roots, and evaluation runs, including per-generation overrides and safe OpenTelemetry attribution.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -355,6 +355,39 @@ Pass `abortSignal` on a run to cancel the active provider call, tools, and neste
 Run observers receive terminal errors with `status: "cancelled"` for cancellation and
 `status: "failed"` for other failures.
 
+### Prompt attribution
+
+Set `trace.promptRef` on `generate()` or `stream()` to identify the prompt used by a run and
+default its generation attribution. The core `AgentRunPromptRef` contract is
+`{ readonly name: string; readonly version?: number }`; use the registry's resolved numeric version
+when available, not the requested label. This identity does not contain templates or variables.
+
+For runs that change prompts between turns, completion-request middleware is the explicit
+generation override boundary:
+
+```ts
+await agent.generate({
+  prompt: "Summarize the ticket",
+  trace: { promptRef: { name: "support", version: 7 } },
+  middlewares: [
+    {
+      onCompletionRequest: ({ request, turn }) => {
+        if (turn === 0) {
+          return { request, promptRef: { name: "planner", version: 3 } };
+        }
+        return { request, promptRef: null };
+      },
+    },
+  ],
+});
+```
+
+The middleware receives the current `promptRef`. Returning a reference overrides that generation;
+`null` clears it, while omission preserves it. Each turn starts again with the run default, and
+later middleware sees earlier overrides. Set attribution alongside any request changes that select
+another prompt: attribution itself does not change the model input. It is a runtime side channel,
+not a provider request field or global current-prompt setting.
+
 ## Memory
 
 Configure durable conversation memory on the Agent, then run through a session:
@@ -565,6 +598,11 @@ enabled.
 `"throw"` and defaults to `"ignore"`. With `"throw"`, the run rejects with a
 `PipelineObserverDispatchError` containing the failed phase and per-observer failures.
 
+Pipeline run and batch options also accept `trace.promptRef`. This identifies the pipeline root;
+it does not stamp every stage or Agent with that prompt. Select each Agent's relevant prompt with
+`request: ({ input }) => ({ prompt: input, trace: { promptRef } })`, especially when a pipeline uses
+multiple prompts. Trace parent propagation and prompt identity are independent.
+
 ## Documents
 
 Applications own file discovery, file reads, document parsing, source metadata, and per-file error
@@ -692,6 +730,11 @@ console.log(result.results[0]?.scores.exact_match);
 Metrics that implicitly read `case.expected`, `case.context`, or `case.retrievalContext` require
 those fields at compile time. Supplying an explicit metric value or selector removes the matching
 case requirement.
+
+Set `run: { promptRef: { name: "support", version: 7 } }` on `runEvalSuite()` to attribute the
+evaluation run. The reference is preserved in `result.run` and the reporter's run-start, per-metric,
+and run-end contexts. It does not automatically attribute the target Agent or judge generations;
+configure those runs' `trace.promptRef` separately when relevant.
 
 ### Built-in metrics
 

--- a/packages/core/src/agent/run-types.ts
+++ b/packages/core/src/agent/run-types.ts
@@ -21,6 +21,7 @@ import type { GuardrailDecisionRecord, GuardrailPolicyInput } from "../guardrail
 import type { MemoryCompactionInfo, MemoryScope } from "../memory";
 import type {
   AgentGenerationModelInfo,
+  AgentRunPromptRef,
   AgentTraceInfo,
   AgentTraceOptions,
 } from "../observability/types";
@@ -196,6 +197,7 @@ type AgentChildStreamEventBase<Output = string, RawResponse = unknown> =
       turn: number;
       request: CompletionRequest;
       modelInfo: AgentGenerationModelInfo;
+      promptRef?: AgentRunPromptRef | undefined;
     }
   | {
       type: "text_delta";

--- a/packages/core/src/evals/runner.ts
+++ b/packages/core/src/evals/runner.ts
@@ -471,6 +471,7 @@ function resolveRun<Input, Output, Expected>(
   };
   if (options.run?.datasetName !== undefined) run.datasetName = options.run.datasetName;
   if (options.run?.datasetVersion !== undefined) run.datasetVersion = options.run.datasetVersion;
+  if (options.run?.promptRef !== undefined) run.promptRef = options.run.promptRef;
   if (options.run?.metadata !== undefined) run.metadata = options.run.metadata;
   return run;
 }

--- a/packages/core/src/evals/types.ts
+++ b/packages/core/src/evals/types.ts
@@ -1,4 +1,5 @@
 import type { JsonObject, Usage } from "../completion";
+import type { AgentRunPromptRef } from "../observability/types";
 import type { EvalOutcome } from "./outcome";
 
 export type EvalMetadata = JsonObject;
@@ -9,6 +10,7 @@ export type EvalRunOptions = {
   id?: string | undefined;
   datasetName?: string | undefined;
   datasetVersion?: string | undefined;
+  promptRef?: AgentRunPromptRef | undefined;
   metadata?: EvalMetadata | undefined;
 };
 
@@ -17,6 +19,7 @@ export type EvalRunContext = {
   startedAt: string;
   datasetName?: string | undefined;
   datasetVersion?: string | undefined;
+  promptRef?: AgentRunPromptRef | undefined;
   metadata?: EvalMetadata | undefined;
 };
 

--- a/packages/core/src/internal/agent-runtime/agent-run.ts
+++ b/packages/core/src/internal/agent-runtime/agent-run.ts
@@ -183,6 +183,7 @@ export class AgentRun<Output = string, M extends CompletionModel = CompletionMod
   private guardrailDecisions: GuardrailDecisionRecord[] = [];
   private readonly concurrency: number;
   private traceOptions: AgentTraceOptions | undefined;
+  private generationPromptRef: AgentTraceOptions["promptRef"];
   private completionRetryOptions: ResolvedRetryOptions | undefined;
   private readonly requestMiddlewares: AgentMiddleware[];
   private readonly controls: Readonly<Record<string, string>> | undefined;
@@ -792,6 +793,7 @@ export class AgentRun<Output = string, M extends CompletionModel = CompletionMod
           turn: currentTurns,
           request,
           modelInfo: generationStartArgs.modelInfo,
+          promptRef: generationStartArgs.promptRef,
         };
         const bufferResponseEvents =
           this.shouldBufferStreamResponseEvents() || this.agent.outputSchema !== undefined;
@@ -1447,6 +1449,7 @@ export class AgentRun<Output = string, M extends CompletionModel = CompletionMod
     let args: AgentGenerationStartArgs & { modelInfo: AgentGenerationModelInfo } = {
       turn,
       request,
+      promptRef: this.generationPromptRef,
       modelInfo: {
         provider: this.agent.model.provider,
         modelId: this.agent.model.modelId,
@@ -2125,12 +2128,17 @@ export class AgentRun<Output = string, M extends CompletionModel = CompletionMod
     turn: number,
   ): Promise<CompletionRequest> {
     let current = request;
+    this.generationPromptRef = this.traceOptions?.promptRef;
     for (const middleware of this.activeMiddlewares()) {
       const replacement = await middleware.onCompletionRequest?.({
         turn,
         request: current,
         originalRequest: request,
+        promptRef: this.generationPromptRef,
       });
+      if (replacement?.promptRef !== undefined) {
+        this.generationPromptRef = replacement.promptRef ?? undefined;
+      }
       if (replacement?.request !== undefined) {
         current = replacement.request;
         if (current.providerOptions !== undefined) {

--- a/packages/core/src/observability/types.ts
+++ b/packages/core/src/observability/types.ts
@@ -93,6 +93,7 @@ export type AgentGenerationModelInfo = {
 export type AgentGenerationStartArgs = {
   readonly turn: number;
   readonly request: DeepReadonly<CompletionRequest>;
+  readonly promptRef?: DeepReadonly<AgentRunPromptRef> | undefined;
   readonly providerRequest?: DeepReadonly<JsonObject> | undefined;
   readonly modelInfo?: DeepReadonly<AgentGenerationModelInfo> | undefined;
 };

--- a/packages/core/src/pipeline/types.ts
+++ b/packages/core/src/pipeline/types.ts
@@ -101,7 +101,7 @@ export type PipelineRunObserver = {
   onEvent(event: PipelineRunEvent): void | Promise<void>;
 };
 
-export type PipelineTraceOptions = Omit<AgentTraceOptions, "promptRef">;
+export type PipelineTraceOptions = AgentTraceOptions;
 export type PipelineTraceInfo = AgentTraceInfo;
 export type PipelineObserverTraceInfo = AgentObserverTraceInfo;
 export type PipelineObserverErrorPolicy = AgentObserverErrorPolicy;

--- a/packages/core/src/tool/middleware.ts
+++ b/packages/core/src/tool/middleware.ts
@@ -5,16 +5,21 @@ import type {
   ToolResultContentPart,
 } from "../completion";
 import type { MaybePromise } from "../internal/type-utils";
+import type { AgentRunPromptRef } from "../observability/types";
 
 export type CompletionRequestMiddlewareArgs = {
   turn: number;
   request: CompletionRequest;
   originalRequest: CompletionRequest;
+  /** Current generation identity, defaulting to the run's trace.promptRef each turn. */
+  promptRef?: AgentRunPromptRef | undefined;
 };
 
 export type CompletionRequestMiddlewareResult =
   | {
       request: CompletionRequest;
+      /** Override this generation's identity; null explicitly clears the run default. */
+      promptRef?: AgentRunPromptRef | null | undefined;
     }
   | undefined;
 

--- a/packages/core/test/evals.test.ts
+++ b/packages/core/test/evals.test.ts
@@ -69,6 +69,33 @@ class KeywordEmbeddingModel implements EmbeddingModel {
 }
 
 describe("evals", () => {
+  it("preserves resolved prompt identity throughout evaluation reporting", async () => {
+    const promptRef = { name: "support", version: 7 };
+    const observed: unknown[] = [];
+    const result = await runEvalSuite({
+      name: "prompt-eval",
+      run: { promptRef },
+      cases: [{ id: "case", input: "yes", expected: "yes" }],
+      target: (input) => input,
+      metrics: [exactMatch()],
+      reporters: [
+        {
+          onRunStart: ({ run }) => {
+            observed.push(run.promptRef);
+          },
+          report: ({ run }) => {
+            observed.push(run?.promptRef);
+          },
+          onRunEnd: ({ run }) => {
+            observed.push(run.promptRef);
+          },
+        },
+      ],
+    });
+    expect(result.run.promptRef).toEqual(promptRef);
+    expect(observed).toEqual([promptRef, promptRef, promptRef]);
+  });
+
   it("runs deterministic metrics and counts outcomes", async () => {
     const result = await runEvalSuite({
       name: "deterministic",

--- a/packages/core/test/observability.test.ts
+++ b/packages/core/test/observability.test.ts
@@ -177,6 +177,52 @@ const addTool = createTool({
 });
 
 describe("agent observability", () => {
+  it("scopes prompt overrides to one generation and keeps identity out of provider requests", async () => {
+    const observer = new RecordingObserver();
+    const defaultRef = { name: "support", version: 4 };
+    const overrideRef = { name: "planner", version: 9 };
+    const seen: Array<AgentRunPromptRef | undefined> = [];
+    const model = new QueueModel([
+      response([AssistantContent.toolCall("call_1", "add", { x: 1, y: 2 })]),
+      response([AssistantContent.toolCall("call_2", "add", { x: 2, y: 3 })]),
+      response([AssistantContent.text("done")]),
+    ]);
+    const agent = new Agent({
+      id: "multi-prompt",
+      model,
+      tools: [addTool],
+      observability: { observers: { test: observer } },
+    });
+    await agent.generate({
+      prompt: "hello",
+      trace: { promptRef: defaultRef },
+      middlewares: [
+        {
+          onCompletionRequest: ({ request, promptRef }) => {
+            seen.push(promptRef);
+            expect(request).not.toHaveProperty("promptRef");
+            if (seen.length === 1) return { request, promptRef: overrideRef };
+            if (seen.length === 2) return { request, promptRef: null };
+            return undefined;
+          },
+        },
+      ],
+    });
+    expect(seen).toEqual([defaultRef, defaultRef, defaultRef]);
+    const generations = observer.events.filter(
+      (event) =>
+        typeof event === "object" &&
+        event !== null &&
+        "type" in event &&
+        event.type === "generation_start",
+    );
+    expect(generations).toMatchObject([
+      { args: { promptRef: overrideRef } },
+      { args: { promptRef: undefined } },
+      { args: { promptRef: defaultRef } },
+    ]);
+  });
+
   it("records one run and one generation for text-only send", async () => {
     const observer = new RecordingObserver();
     const model = new QueueModel([response([AssistantContent.text("done")])]);
@@ -225,6 +271,7 @@ describe("agent observability", () => {
       expect.objectContaining({
         type: "generation_start",
         args: expect.objectContaining({
+          promptRef: { name: "support.system", version: 3 },
           modelInfo: {
             provider: "test",
             modelId: "test",

--- a/packages/observability-lens/README.md
+++ b/packages/observability-lens/README.md
@@ -1,6 +1,6 @@
 # @anvia/lens
 
-Native Anvia Lens tracing, evaluation reporting, and dataset access for Node.js applications.
+Native Anvia Lens tracing, evaluation reporting, dataset access, and versioned prompts for Node.js applications.
 
 ```sh
 pnpm add @anvia/lens @anvia/core zod
@@ -79,7 +79,7 @@ the root observation as `cancelled` before Lens flushes it.
 
 Set `optional: true` to obtain a disabled client when all Lens connection environment variables
 are absent. `lens.enabled` reports the state. The disabled observer and reporter are safe no-ops;
-dataset access still rejects because it requires a configured connection. Partial configuration is
+dataset and prompt access still reject because they require a configured connection. Partial configuration is
 always an error.
 
 ## Capture and evaluation policy
@@ -151,6 +151,47 @@ omitted. Draft and archived versions are not exposed by the public API.
 Configuration can also come from `ANVIA_LENS_BASE_URL`, `ANVIA_LENS_PUBLIC_KEY`,
 `ANVIA_LENS_SECRET_KEY`, `ANVIA_LENS_SERVICE_NAME`, `ANVIA_LENS_ENVIRONMENT`, and
 `ANVIA_LENS_RELEASE`.
+
+## Versioned prompts
+
+```ts
+const prompts = lens.promptClient({ cacheTtlMs: 60_000, timeoutMs: 5_000 });
+const prompt = await prompts.getPrompt({ name: "support/answer" });
+
+if (prompt.type === "text") {
+  const result = await agent.generate({
+    prompt: prompt.compile({ question: "How do refunds work?" }),
+    trace: { promptRef: prompt.ref },
+  });
+}
+
+const pinned = await prompts.getPrompt({ name: "support/answer", version: 2 });
+const staging = await prompts.getPrompt({ name: "support/answer", label: "staging" });
+```
+
+Omitting the selector resolves `production`, never the newest version. Specify a label **or** a
+positive safe integer version, not both. Committing a version does not deploy it: move the label
+in Lens to deploy or roll back. Runtime credentials retrieve prompts but cannot mutate them.
+
+Resolved snapshots are deeply immutable and expose `ref`, `config`, `labels`, `selector`, and
+`variables`. Compilation is synchronous: `{{question}}` substitutes a named string, surrounding
+whitespace is tolerated, and `\{{question}}` produces literal `{{question}}`. Missing or non-string
+values throw `LensPromptCompilationError`; extra variables are ignored. Substitutions are not
+recursive. Config is returned unchanged, not interpolated. Chat compilation returns a fresh array
+of registry messages with roles and names preserved; these are not cast to Core completion messages.
+
+Each prompt client owns a bounded cache. The default TTL is 60 seconds, including pinned versions;
+expired entries refresh before returning, without stale fallback. Identical concurrent requests
+share retrieval. `cache: "reload"` fetches and replaces a snapshot; `cache: "no-store"` bypasses cache
+reads and writes. `prompts.clearCache()` invalidates cached snapshots. Retrieval accepts an optional
+`signal`; one caller aborting does not cancel other callers sharing retrieval. Failed responses
+are not cached. `LensPromptError` exposes `code` and, for HTTP errors, `status`.
+
+Fetching or compiling never sets a global current prompt. Pass `trace.promptRef` explicitly for
+Agent runs or pipeline roots, and `run: { promptRef: prompt.ref }` to `runEvalSuite` for evaluation
+identity. Pipeline attribution does not stamp unrelated child agents. Per-generation middleware can
+override `promptRef` or clear it with `null`; see Core's middleware documentation. Safe capture retains
+prompt identity without newly capturing template bodies or compilation variables.
 
 ## Development
 

--- a/packages/observability-lens/src/dataset-client.ts
+++ b/packages/observability-lens/src/dataset-client.ts
@@ -1,5 +1,6 @@
 import type { JsonValue } from "@anvia/core/completion";
 import type { ResolvedLensConfig } from "./config.js";
+import { isRecord } from "./type-guards.js";
 import type {
   LensDataset,
   LensDatasetClient,
@@ -229,10 +230,6 @@ function stringArray(value: unknown, response: Response, label: string): string[
     throw invalidResponse(response, `Lens returned invalid ${label}`);
   }
   return value;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function isJsonRecord(value: unknown): value is Record<string, JsonValue> {

--- a/packages/observability-lens/src/index.ts
+++ b/packages/observability-lens/src/index.ts
@@ -1,9 +1,12 @@
 export { resolveLensConfig } from "./config.js";
 export { LensDatasetError } from "./dataset-client.js";
+export { LensPromptCompilationError, LensPromptError } from "./prompt-client.js";
 export { createLensRedactor, DEFAULT_PATTERNS } from "./redaction.js";
 export { LensClient } from "./tracing.js";
 export type {
   LensCaptureMode,
+  LensChatMessage,
+  LensChatPrompt,
   LensClientOptions,
   LensDataset,
   LensDatasetClient,
@@ -14,7 +17,14 @@ export type {
   LensEvalReporterOptions,
   LensObserverOptions,
   LensPipelineObserverOptions,
+  LensPrompt,
+  LensPromptClient,
+  LensPromptClientOptions,
+  LensPromptGetOptions,
+  LensPromptJson,
+  LensPromptRef,
   LensRedactionOptions,
   LensRedactorPattern,
   LensScoreArgs,
+  LensTextPrompt,
 } from "./types.js";

--- a/packages/observability-lens/src/prompt-client.ts
+++ b/packages/observability-lens/src/prompt-client.ts
@@ -119,7 +119,7 @@ export function createLensPromptClient(
       // Expired entries are never a fallback: a failed refresh must surface its error.
       if (cached !== undefined && cached.expires <= Date.now()) stores.cache.delete(key);
       const generation = epoch;
-      const existing = mode === "no-store" ? undefined : stores.pending.get(key);
+      const existing = mode === "default" ? stores.pending.get(key) : undefined;
       const entry =
         existing ??
         createPendingEntry(
@@ -177,10 +177,12 @@ function createPendingEntry(
     selector,
   )
     .then((prompt) => {
-      // A clearCache during flight invalidates the result; no-store never writes.
+      // Only the current request may write: reload supersedes older retrievals,
+      // and clearCache invalidates in-flight results. No-store never writes.
       if (
         mode !== "no-store" &&
         generation === currentEpoch() &&
+        stores.pending.get(key) === entry &&
         !requestSignal.aborted &&
         stores.cacheTtlMs > 0
       ) {

--- a/packages/observability-lens/src/prompt-client.ts
+++ b/packages/observability-lens/src/prompt-client.ts
@@ -1,0 +1,443 @@
+import type { JsonValue } from "@anvia/core/completion";
+import type { ResolvedLensConfig } from "./config.js";
+import { isRecord } from "./type-guards.js";
+import type {
+  LensChatMessage,
+  LensPrompt,
+  LensPromptClient,
+  LensPromptClientOptions,
+  LensPromptGetOptions,
+} from "./types.js";
+
+const DEFAULT_CACHE_TTL_MS = 60_000;
+const DEFAULT_TIMEOUT_MS = 5_000;
+const MAX_CACHE_ENTRIES = 100;
+const DEFAULT_LABEL = "production";
+
+export class LensPromptError extends Error {
+  constructor(
+    message: string,
+    readonly status: number | undefined,
+    readonly code: string,
+  ) {
+    super(message);
+    this.name = "LensPromptError";
+  }
+}
+
+export class LensPromptCompilationError extends LensPromptError {
+  constructor(code: "missing_variable" | "invalid_variable", message: string) {
+    super(message, undefined, code);
+    this.name = "LensPromptCompilationError";
+  }
+}
+
+type PromptSelector = { label: string } | { version: number };
+type PendingEntry = {
+  controller: AbortController;
+  promise: Promise<LensPrompt>;
+  callers: number;
+};
+// Alternating literal text and variable placeholders, parsed exactly once per template.
+type TemplatePart = string | { variable: string };
+
+type PromptStores = {
+  baseUrl: string;
+  authorization: string;
+  timeoutMs: number;
+  cacheTtlMs: number;
+  cache: Map<string, { prompt: LensPrompt; expires: number }>;
+  pending: Map<string, PendingEntry>;
+};
+
+export function createLensPromptClient(
+  tracingConfig: ResolvedLensConfig,
+  options: LensPromptClientOptions = {},
+  lifecycle?: { assertOpen(): void; signal: AbortSignal },
+): LensPromptClient {
+  const baseUrl = (options.baseUrl ?? tracingConfig.baseUrl).replace(/\/+$/, "");
+  const publicKey = options.publicKey ?? tracingConfig.publicKey;
+  const secretKey = options.secretKey ?? tracingConfig.secretKey;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const cacheTtlMs = options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0 || timeoutMs > 2_147_483_647) {
+    throw new TypeError("Anvia Lens prompt timeoutMs must be a positive timer-safe integer");
+  }
+  if (!Number.isFinite(cacheTtlMs) || cacheTtlMs < 0) {
+    throw new TypeError("Anvia Lens prompt cacheTtlMs must be a non-negative number");
+  }
+  const authorization = `Basic ${Buffer.from(`${publicKey}:${secretKey}`).toString("base64")}`;
+  const stores: PromptStores = {
+    baseUrl,
+    authorization,
+    timeoutMs,
+    cacheTtlMs,
+    cache: new Map(),
+    pending: new Map(),
+  };
+  let epoch = 0;
+
+  return {
+    clearCache() {
+      lifecycle?.assertOpen();
+      epoch += 1;
+      stores.cache.clear();
+      stores.pending.clear();
+    },
+    async getPrompt(getOptions: LensPromptGetOptions) {
+      lifecycle?.assertOpen();
+      const { name, label, version, signal } = getOptions;
+      const normalizedName = typeof name === "string" ? name.trim() : "";
+      if (normalizedName.length === 0) throw new TypeError("Anvia Lens prompt name is required");
+      if (label !== undefined && version !== undefined) {
+        throw new TypeError("Anvia Lens prompt requires exactly one of label or version");
+      }
+      if (version !== undefined && (!Number.isSafeInteger(version) || version <= 0)) {
+        throw new TypeError("Anvia Lens prompt version must be a positive safe integer");
+      }
+      if (label !== undefined && (typeof label !== "string" || label.trim().length === 0)) {
+        throw new TypeError("Anvia Lens prompt label is required");
+      }
+      const mode = getOptions.cache ?? "default";
+      if (mode !== "default" && mode !== "reload" && mode !== "no-store") {
+        throw new TypeError("Anvia Lens prompt cache mode is invalid");
+      }
+      if (signal?.aborted) {
+        throw new LensPromptError("Lens prompt request aborted", undefined, "aborted");
+      }
+      const selector: PromptSelector =
+        version === undefined
+          ? { label: (label as string | undefined)?.trim() ?? DEFAULT_LABEL }
+          : { version };
+      const key = JSON.stringify([normalizedName, selector]);
+      const cached = stores.cache.get(key);
+      if (mode === "default" && cached !== undefined && cached.expires > Date.now()) {
+        stores.cache.delete(key);
+        stores.cache.set(key, cached);
+        return cached.prompt;
+      }
+      // Expired entries are never a fallback: a failed refresh must surface its error.
+      if (cached !== undefined && cached.expires <= Date.now()) stores.cache.delete(key);
+      const generation = epoch;
+      const existing = mode === "no-store" ? undefined : stores.pending.get(key);
+      const entry =
+        existing ??
+        createPendingEntry(
+          key,
+          normalizedName,
+          selector,
+          mode,
+          generation,
+          () => epoch,
+          stores,
+          lifecycle?.signal,
+        );
+      if (existing === undefined && mode !== "no-store") stores.pending.set(key, entry);
+      entry.callers += 1;
+      try {
+        return await awaitWithAbort(entry.promise, signal);
+      } finally {
+        entry.callers -= 1;
+        // The shared request only aborts once no caller is waiting on it anymore.
+        if (entry.callers === 0) {
+          if (stores.pending.get(key) === entry) stores.pending.delete(key);
+          entry.controller.abort();
+        }
+      }
+    },
+  };
+}
+
+function createPendingEntry(
+  key: string,
+  name: string,
+  selector: PromptSelector,
+  mode: "default" | "reload" | "no-store",
+  generation: number,
+  currentEpoch: () => number,
+  stores: PromptStores,
+  lifecycleSignal: AbortSignal | undefined,
+): PendingEntry {
+  const controller = new AbortController();
+  const url = new URL(`${stores.baseUrl}/api/public/prompts/${encodeURIComponent(name)}`);
+  if ("label" in selector) url.searchParams.set("label", selector.label);
+  else url.searchParams.set("version", String(selector.version));
+  const requestSignal =
+    lifecycleSignal === undefined
+      ? controller.signal
+      : AbortSignal.any([controller.signal, lifecycleSignal]);
+  let entry!: PendingEntry;
+  // The finally closure only reads `entry` asynchronously, after it is assigned below.
+  const promise = requestPrompt(
+    url,
+    stores.authorization,
+    stores.timeoutMs,
+    requestSignal,
+    name,
+    selector,
+  )
+    .then((prompt) => {
+      // A clearCache during flight invalidates the result; no-store never writes.
+      if (
+        mode !== "no-store" &&
+        generation === currentEpoch() &&
+        !requestSignal.aborted &&
+        stores.cacheTtlMs > 0
+      ) {
+        stores.cache.delete(key);
+        stores.cache.set(key, { prompt, expires: Date.now() + stores.cacheTtlMs });
+        if (stores.cache.size > MAX_CACHE_ENTRIES) {
+          const oldest = stores.cache.keys().next();
+          if (oldest.done !== true) stores.cache.delete(oldest.value);
+        }
+      }
+      return prompt;
+    })
+    .finally(() => {
+      if (stores.pending.get(key) === entry) stores.pending.delete(key);
+    });
+  entry = { controller, promise, callers: 0 };
+  return entry;
+}
+
+async function requestPrompt(
+  url: URL,
+  authorization: string,
+  timeoutMs: number,
+  requestSignal: AbortSignal,
+  name: string,
+  selector: PromptSelector,
+): Promise<LensPrompt> {
+  const timeout = new AbortController();
+  const timer = setTimeout(() => timeout.abort(), timeoutMs);
+  const combined = AbortSignal.any([requestSignal, timeout.signal]);
+  const operation = async (): Promise<LensPrompt> => {
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: "GET",
+        headers: { Accept: "application/json", Authorization: authorization },
+        signal: combined,
+      });
+    } catch {
+      throw new LensPromptError("Unable to reach Anvia Lens", undefined, "network_error");
+    }
+    let value: unknown;
+    try {
+      value = await response.json();
+    } catch {
+      throw new LensPromptError(
+        "Lens returned invalid JSON",
+        response.status,
+        response.ok ? "invalid_response" : "request_failed",
+      );
+    }
+    if (!response.ok) {
+      // Server messages may echo prompt content or credentials; only the code is kept.
+      const code =
+        isRecord(value) && isRecord(value.error) && typeof value.error.code === "string"
+          ? value.error.code
+          : "request_failed";
+      throw new LensPromptError(
+        `Lens prompt request failed (${response.status})`,
+        response.status,
+        code,
+      );
+    }
+    return parsePrompt(value, response.status, name, selector);
+  };
+  try {
+    return await operation();
+  } catch (error) {
+    if (requestSignal.aborted) {
+      throw new LensPromptError("Lens prompt request aborted", undefined, "aborted");
+    }
+    if (timeout.signal.aborted) {
+      throw new LensPromptError("Lens prompt request timed out", undefined, "timeout");
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function awaitWithAbort<T>(promise: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
+  if (signal === undefined) return promise;
+  if (signal.aborted) {
+    return Promise.reject(new LensPromptError("Lens prompt request aborted", undefined, "aborted"));
+  }
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      cleanup();
+      reject(new LensPromptError("Lens prompt request aborted", undefined, "aborted"));
+    };
+    const cleanup = () => signal.removeEventListener("abort", onAbort);
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        cleanup();
+        resolve(value);
+      },
+      (error: unknown) => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}
+
+function parsePrompt(
+  value: unknown,
+  status: number,
+  name: string,
+  selector: PromptSelector,
+): LensPrompt {
+  const invalid = () =>
+    new LensPromptError("Lens returned an invalid prompt", status, "invalid_response");
+  if (
+    !isRecord(value) ||
+    value.name !== name ||
+    typeof value.version !== "number" ||
+    !Number.isSafeInteger(value.version) ||
+    value.version <= 0 ||
+    !isRecord(value.config) ||
+    !isJsonValue(value.config) ||
+    !Array.isArray(value.labels) ||
+    !value.labels.every((label) => typeof label === "string") ||
+    !isRecord(value.selector) ||
+    Object.keys(value.selector).length !== 1
+  ) {
+    throw invalid();
+  }
+  // The response selector and identity must exactly match the normalized request.
+  if ("label" in selector) {
+    if (value.selector.label !== selector.label || !value.labels.includes(selector.label))
+      throw invalid();
+  } else if (value.selector.version !== selector.version || value.version !== selector.version) {
+    throw invalid();
+  }
+  const variables = new Set<string>();
+  const base = {
+    name,
+    version: value.version,
+    ref: Object.freeze({ name, version: value.version }),
+    config: deepFreezeJson(value.config) as { readonly [key: string]: JsonValue },
+    labels: Object.freeze([...(value.labels as string[])]),
+    selector: Object.freeze({ ...selector }) as
+      | { readonly label: string }
+      | { readonly version: number },
+  };
+  if (value.type === "text") {
+    if (typeof value.template !== "string" || value.messages !== null) throw invalid();
+    const parts = parseTemplate(value.template, variables);
+    return Object.freeze({
+      ...base,
+      type: "text" as const,
+      template: value.template,
+      messages: null,
+      variables: Object.freeze([...variables] as string[]),
+      compile: (values: Readonly<Record<string, string>> = {}) => renderTemplate(parts, values),
+    });
+  }
+  if (value.type !== "chat") throw invalid();
+  if (value.template !== null || !Array.isArray(value.messages) || value.messages.length === 0)
+    throw invalid();
+  const messages = value.messages.map((message: unknown): LensChatMessage => {
+    if (
+      !isRecord(message) ||
+      !isChatRole(message.role) ||
+      typeof message.content !== "string" ||
+      (message.name !== undefined && typeof message.name !== "string")
+    ) {
+      throw invalid();
+    }
+    return Object.freeze({
+      role: message.role,
+      content: message.content,
+      ...(message.name === undefined ? {} : { name: message.name }),
+    });
+  });
+  const parts = messages.map((message) => parseTemplate(message.content, variables));
+  return Object.freeze({
+    ...base,
+    type: "chat" as const,
+    template: null,
+    messages: Object.freeze(messages),
+    variables: Object.freeze([...variables] as string[]),
+    compile: (values: Readonly<Record<string, string>> = {}) =>
+      messages.map((message, index) => ({
+        ...message,
+        content: renderTemplate(parts[index] as TemplatePart[], values),
+      })),
+  });
+}
+
+function parseTemplate(template: string, variables: Set<string>): TemplatePart[] {
+  const parts: TemplatePart[] = [];
+  const pattern = /\\?\{\{\s*([a-zA-Z_][a-zA-Z0-9_.-]*)\s*\}\}/g;
+  let offset = 0;
+  for (const match of template.matchAll(pattern)) {
+    parts.push(template.slice(offset, match.index));
+    if (match[0].startsWith("\\")) {
+      // An escaped placeholder renders as its literal text without registering a variable.
+      parts.push(match[0].slice(1));
+    } else {
+      const variable = match[1] as string;
+      variables.add(variable);
+      parts.push({ variable });
+    }
+    offset = (match.index ?? 0) + match[0].length;
+  }
+  parts.push(template.slice(offset));
+  return parts;
+}
+
+function renderTemplate(parts: TemplatePart[], values: Readonly<Record<string, string>>): string {
+  const missing: string[] = [];
+  let rendered = "";
+  for (const part of parts) {
+    if (typeof part === "string") {
+      rendered += part;
+      continue;
+    }
+    if (!Object.hasOwn(values, part.variable)) {
+      missing.push(part.variable);
+      continue;
+    }
+    const value = values[part.variable];
+    if (typeof value !== "string") {
+      throw new LensPromptCompilationError(
+        "invalid_variable",
+        `Anvia Lens prompt variable "${part.variable}" must be a string`,
+      );
+    }
+    // Values are concatenated verbatim: no recursive replacement of placeholders.
+    rendered += value;
+  }
+  if (missing.length > 0) {
+    throw new LensPromptCompilationError(
+      "missing_variable",
+      `Anvia Lens prompt is missing variables: ${missing.join(", ")}`,
+    );
+  }
+  return rendered;
+}
+
+function isChatRole(value: unknown): value is LensChatMessage["role"] {
+  return value === "system" || value === "user" || value === "assistant" || value === "tool";
+}
+
+function isJsonValue(value: unknown): value is JsonValue {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return true;
+  if (typeof value === "number") return Number.isFinite(value);
+  if (Array.isArray(value)) return value.every(isJsonValue);
+  return isRecord(value) && Object.values(value).every(isJsonValue);
+}
+
+function deepFreezeJson(value: JsonValue): JsonValue {
+  if (typeof value === "object" && value !== null) {
+    for (const child of Object.values(value)) deepFreezeJson(child);
+    Object.freeze(value);
+  }
+  return value;
+}

--- a/packages/observability-lens/src/tracing.ts
+++ b/packages/observability-lens/src/tracing.ts
@@ -16,6 +16,7 @@ import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { type ResolvedLensConfig, resolveLensConfig } from "./config.js";
 import { createLensDatasetClient } from "./dataset-client.js";
+import { createLensPromptClient } from "./prompt-client.js";
 import { createLensRedactor } from "./redaction.js";
 import type {
   LensClientOptions,
@@ -26,6 +27,8 @@ import type {
   LensEvalReporterOptions,
   LensObserverOptions,
   LensPipelineObserverOptions,
+  LensPromptClient,
+  LensPromptClientOptions,
   LensScoreArgs,
 } from "./types.js";
 
@@ -44,6 +47,7 @@ export class LensClient {
   private initialization: Promise<LensResources> | undefined;
   private closePromise: Promise<void> | undefined;
   private closed = false;
+  private readonly promptAbort = new AbortController();
 
   constructor(private readonly options: LensClientOptions = {}) {
     if (options.optional === true && !hasLensConnectionEnvironment(options)) {
@@ -150,6 +154,17 @@ export class LensClient {
     };
   }
 
+  promptClient(options: LensPromptClientOptions = {}): LensPromptClient {
+    this.assertOpen();
+    if (this.config === undefined) {
+      throw new Error("LensClient is disabled because no connection is configured.");
+    }
+    return createLensPromptClient(this.config, options, {
+      assertOpen: () => this.assertOpen(),
+      signal: this.promptAbort.signal,
+    });
+  }
+
   async flush(): Promise<void> {
     this.assertOpen();
     const resource =
@@ -204,6 +219,7 @@ export class LensClient {
 
   private async closeResources(): Promise<void> {
     this.closed = true;
+    this.promptAbort.abort();
     const pending =
       this.resource === undefined ? this.initialization : Promise.resolve(this.resource);
     if (pending === undefined) return;

--- a/packages/observability-lens/src/type-guards.ts
+++ b/packages/observability-lens/src/type-guards.ts
@@ -1,0 +1,3 @@
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/observability-lens/src/types.ts
+++ b/packages/observability-lens/src/types.ts
@@ -88,3 +88,65 @@ export type LensDatasetClient = {
     options: LensDatasetGetOptions,
   ): Promise<LensDataset<Input, Expected>>;
 };
+
+export type LensPromptRef = {
+  readonly name: string;
+  readonly version: number;
+};
+
+export type LensPromptJson =
+  | null
+  | string
+  | number
+  | boolean
+  | readonly LensPromptJson[]
+  | { readonly [key: string]: LensPromptJson };
+
+export type LensChatMessage = {
+  readonly role: "system" | "user" | "assistant" | "tool";
+  readonly content: string;
+  readonly name?: string;
+};
+
+type LensPromptSnapshot = LensPromptRef & {
+  readonly ref: LensPromptRef;
+  readonly config: { readonly [key: string]: LensPromptJson };
+  readonly labels: readonly string[];
+  readonly selector: { readonly label: string } | { readonly version: number };
+  readonly variables: readonly string[];
+};
+
+export type LensTextPrompt = LensPromptSnapshot & {
+  readonly type: "text";
+  readonly template: string;
+  readonly messages: null;
+  readonly compile: (variables?: Readonly<Record<string, string>>) => string;
+};
+
+export type LensChatPrompt = LensPromptSnapshot & {
+  readonly type: "chat";
+  readonly template: null;
+  readonly messages: readonly LensChatMessage[];
+  readonly compile: (variables?: Readonly<Record<string, string>>) => LensChatMessage[];
+};
+
+export type LensPrompt = LensTextPrompt | LensChatPrompt;
+
+export type LensPromptClientOptions = {
+  baseUrl?: string | undefined;
+  publicKey?: string | undefined;
+  secretKey?: string | undefined;
+  cacheTtlMs?: number | undefined;
+  timeoutMs?: number | undefined;
+};
+
+export type LensPromptGetOptions = {
+  name: string;
+  cache?: "default" | "reload" | "no-store" | undefined;
+  signal?: AbortSignal | undefined;
+} & ({ label?: string | undefined; version?: never } | { label?: never; version: number });
+
+export type LensPromptClient = {
+  getPrompt(options: LensPromptGetOptions): Promise<LensPrompt>;
+  clearCache(): void;
+};

--- a/packages/observability-lens/test/prompt-client.test.ts
+++ b/packages/observability-lens/test/prompt-client.test.ts
@@ -1,0 +1,515 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  LensClient,
+  LensPromptCompilationError,
+  type LensChatPrompt,
+  type LensTextPrompt,
+} from "../src/index";
+
+let lens: LensClient | undefined;
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  vi.useRealTimers();
+  await lens?.close();
+  lens = undefined;
+});
+
+describe("Lens prompt client", () => {
+  it("fetches a text prompt with the default production label", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      response({
+        name: "support/greeting",
+        version: 3,
+        type: "text",
+        template: "Hello {{ name }}, {{count}} uses \\{{literal}}!",
+        messages: null,
+        config: { count: 3, nested: { deep: true } },
+        labels: ["production", "beta"],
+        selector: { label: "production" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    lens = createClient();
+    const prompt = (await lens
+      .promptClient()
+      .getPrompt({ name: "support/greeting" })) as LensTextPrompt;
+
+    expect(prompt.type).toBe("text");
+    expect(prompt.name).toBe("support/greeting");
+    expect(prompt.version).toBe(3);
+    expect(prompt.ref).toEqual({ name: "support/greeting", version: 3 });
+    expect(prompt.config).toEqual({ count: 3, nested: { deep: true } });
+    expect(prompt.labels).toEqual(["production", "beta"]);
+    expect(prompt.selector).toEqual({ label: "production" });
+    expect(prompt.variables).toEqual(["name", "count"]);
+    expect(prompt.template).toBe("Hello {{ name }}, {{count}} uses \\{{literal}}!");
+    expect(prompt.messages).toBeNull();
+    // Config values are not variables: compilation requires them to be passed explicitly.
+    expect(() => prompt.compile({ name: "Ada" })).toThrow(LensPromptCompilationError);
+    expect(prompt.compile({ name: "Ada", count: "3", extra: "ignored" })).toBe(
+      "Hello Ada, 3 uses {{literal}}!",
+    );
+    const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(url.toString()).toBe(
+      "https://lens.example/api/public/prompts/support%2Fgreeting?label=production",
+    );
+    expect(init.headers).toEqual(
+      expect.objectContaining({
+        Authorization: `Basic ${Buffer.from("pk:sk").toString("base64")}`,
+      }),
+    );
+  });
+
+  it("requests an explicit label and version with the contracted route", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        response(textPrompt({ name: "p", labels: ["beta"], selector: { label: "beta" } })),
+      )
+      .mockResolvedValueOnce(
+        response(textPrompt({ name: "p", version: 2, selector: { version: 2 } })),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    lens = createClient();
+    const client = lens.promptClient();
+
+    await client.getPrompt({ name: "p", label: " beta " });
+    await client.getPrompt({ name: "p", version: 2 });
+    expect((fetchMock.mock.calls[0] as [URL])[0].search).toBe("?label=beta");
+    expect((fetchMock.mock.calls[1] as [URL])[0].search).toBe("?version=2");
+  });
+
+  it("compiles chat prompts into fresh messages preserving names and roles", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(
+        response({
+          name: "chat/assistant",
+          version: 7,
+          type: "chat",
+          template: null,
+          messages: [
+            { role: "system", content: "Be {{tone}}.", name: "policy" },
+            { role: "user", content: "Hi {{name}}" },
+          ],
+          config: { tone: "kind" },
+          labels: ["production"],
+          selector: { label: "production" },
+        }),
+      ),
+    );
+    lens = createClient();
+    const prompt = (await lens
+      .promptClient()
+      .getPrompt({ name: "chat/assistant" })) as LensChatPrompt;
+
+    expect(prompt.type).toBe("chat");
+    expect(prompt.template).toBeNull();
+    expect(prompt.messages).toEqual([
+      { role: "system", content: "Be {{tone}}.", name: "policy" },
+      { role: "user", content: "Hi {{name}}" },
+    ]);
+    expect(prompt.variables).toEqual(["tone", "name"]);
+    const first = prompt.compile({ tone: "kind", name: "Ada" });
+    const second = prompt.compile({ tone: "kind", name: "Ada" });
+    expect(first).toEqual([
+      { role: "system", content: "Be kind.", name: "policy" },
+      { role: "user", content: "Hi Ada" },
+    ]);
+    expect(first).not.toBe(second);
+    expect(first[0]).not.toBe(prompt.messages[0]);
+    first.push({ role: "assistant", content: "mutated" });
+    expect(prompt.messages).toHaveLength(2);
+  });
+
+  it("freezes snapshots deeply for cache safety", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce(response(textPrompt({ name: "frozen" }))));
+    lens = createClient();
+    const prompt = await lens.promptClient().getPrompt({ name: "frozen" });
+
+    expect(Object.isFrozen(prompt)).toBe(true);
+    expect(Object.isFrozen(prompt.ref)).toBe(true);
+    expect(Object.isFrozen(prompt.config)).toBe(true);
+    expect(Object.isFrozen((prompt.config as { nested: object }).nested)).toBe(true);
+    expect(Object.isFrozen(prompt.labels)).toBe(true);
+    expect(Object.isFrozen(prompt.selector)).toBe(true);
+  });
+
+  it("compiles strictly: missing variables typed, non-strings rejected, config not interpolated", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(
+        response(
+          textPrompt({
+            name: "strict",
+            template: "{{a}} {{b}} {{recursive}}",
+            config: { recursive: "{{a}}" },
+          }),
+        ),
+      ),
+    );
+    lens = createClient();
+    const prompt = (await lens.promptClient().getPrompt({ name: "strict" })) as LensTextPrompt;
+
+    expect(() => prompt.compile()).toThrow(LensPromptCompilationError);
+    expect(() => prompt.compile()).toThrow("missing variables: a, b, recursive");
+    let failure: LensPromptCompilationError | undefined;
+    try {
+      prompt.compile({ a: "1", b: "2" });
+    } catch (error) {
+      failure = error as LensPromptCompilationError;
+    }
+    expect(failure?.code).toBe("missing_variable");
+    expect(() => prompt.compile({ a: "1", b: "2", recursive: 42 as never })).toThrow(
+      'variable "recursive" must be a string',
+    );
+    expect(prompt.compile({ a: "1", b: "2", recursive: "{{a}}" })).toBe("1 2 {{a}}");
+  });
+
+  it("renders escaped placeholders literally without registering variables", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          response(textPrompt({ name: "escaped", template: "\\{{name}} {{ name }}" })),
+        ),
+    );
+    lens = createClient();
+    const prompt = (await lens.promptClient().getPrompt({ name: "escaped" })) as LensTextPrompt;
+
+    expect(prompt.variables).toEqual(["name"]);
+    expect(prompt.compile({ name: "Ada" })).toBe("{{name}} Ada");
+    expect(prompt.compile({ name: "Ada" })).toBe("{{name}} Ada");
+  });
+
+  it("validates selector and option inputs", async () => {
+    vi.stubGlobal("fetch", vi.fn());
+    lens = createClient();
+    const client = lens.promptClient();
+
+    await expect(client.getPrompt({ name: "  " })).rejects.toThrow("name is required");
+    await expect(client.getPrompt({ name: "p", label: "a", version: 1 } as never)).rejects.toThrow(
+      "exactly one of label or version",
+    );
+    await expect(client.getPrompt({ name: "p", version: 0 })).rejects.toThrow(
+      "positive safe integer",
+    );
+    await expect(client.getPrompt({ name: "p", version: 1.5 })).rejects.toThrow(
+      "positive safe integer",
+    );
+    await expect(client.getPrompt({ name: "p", label: "" })).rejects.toThrow("label is required");
+    await expect(client.getPrompt({ name: "p", cache: "forever" as never })).rejects.toThrow(
+      "cache mode is invalid",
+    );
+    expect(() => lens?.promptClient({ timeoutMs: 0 })).toThrow("timeoutMs");
+    expect(() => lens?.promptClient({ timeoutMs: 1.5 })).toThrow("timeoutMs");
+    expect(() => lens?.promptClient({ cacheTtlMs: -1 })).toThrow("cacheTtlMs");
+  });
+
+  it("serves cache hits within the TTL and refetches after expiry", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response(textPrompt({ name: "cached", version: 1 })))
+      .mockResolvedValueOnce(response(textPrompt({ name: "cached", version: 2 })));
+    vi.stubGlobal("fetch", fetchMock);
+    lens = createClient();
+    const client = lens.promptClient({ cacheTtlMs: 60_000 });
+
+    const first = await client.getPrompt({ name: "cached" });
+    expect(await client.getPrompt({ name: "cached" })).toBe(first);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(60_001);
+    const second = await client.getPrompt({ name: "cached" });
+    expect(second.version).toBe(2);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("never falls back to expired entries when a refresh fails", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response(textPrompt({ name: "stale" })))
+      .mockResolvedValueOnce(response({ error: { code: "boom", message: "down" } }, 500))
+      .mockResolvedValueOnce(response(textPrompt({ name: "stale", version: 9 })));
+    vi.stubGlobal("fetch", fetchMock);
+    lens = createClient();
+    const client = lens.promptClient({ cacheTtlMs: 1000 });
+
+    await client.getPrompt({ name: "stale" });
+    vi.advanceTimersByTime(1001);
+    await expect(client.getPrompt({ name: "stale" })).rejects.toMatchObject({ code: "boom" });
+    expect((await client.getPrompt({ name: "stale" })).version).toBe(9);
+  });
+
+  it("reload refreshes and no-store bypasses reads and writes", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response(textPrompt({ name: "modes", version: 1 })))
+      .mockResolvedValueOnce(response(textPrompt({ name: "modes", version: 2 })))
+      .mockResolvedValueOnce(response(textPrompt({ name: "modes", version: 3 })));
+    vi.stubGlobal("fetch", fetchMock);
+    lens = createClient();
+    const client = lens.promptClient();
+
+    expect((await client.getPrompt({ name: "modes" })).version).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect((await client.getPrompt({ name: "modes", cache: "reload" })).version).toBe(2);
+    expect((await client.getPrompt({ name: "modes" })).version).toBe(2);
+    expect((await client.getPrompt({ name: "modes", cache: "no-store" })).version).toBe(3);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    // no-store wrote nothing: the reloaded value is still served from cache.
+    expect((await client.getPrompt({ name: "modes" })).version).toBe(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("clearCache forces a refetch and discards in-flight results", async () => {
+    let release: (value: Response) => void = () => {};
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            release = resolve;
+          }),
+      )
+      .mockResolvedValueOnce(response(textPrompt({ name: "reset", version: 5 })));
+    vi.stubGlobal("fetch", fetchMock);
+    lens = createClient();
+    const client = lens.promptClient();
+
+    const inFlight = client.getPrompt({ name: "reset" });
+    client.clearCache();
+    release(response(textPrompt({ name: "reset", version: 2 })));
+    expect((await inFlight).version).toBe(2);
+    expect((await client.getPrompt({ name: "reset" })).version).toBe(5);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("deduplicates concurrent identical requests", async () => {
+    let release: (value: Response) => void = () => {};
+    const fetchMock = vi.fn().mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          release = resolve;
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    lens = createClient();
+    const client = lens.promptClient();
+
+    const first = client.getPrompt({ name: "shared" });
+    const second = client.getPrompt({ name: "shared" });
+    release(response(textPrompt({ name: "shared" })));
+    expect(await first).toBe(await second);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps deduplicated requests alive when only one caller aborts", async () => {
+    let release: (value: Response) => void = () => {};
+    const fetchMock = vi.fn().mockImplementation(
+      (_url: URL, init: RequestInit) =>
+        new Promise<Response>((resolve) => {
+          init.signal?.addEventListener("abort", () =>
+            resolve(response(textPrompt({ name: "racers" }))),
+          );
+          release = resolve;
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    lens = createClient();
+    const client = lens.promptClient();
+    const controller = new AbortController();
+
+    const aborting = client.getPrompt({ name: "racers", signal: controller.signal });
+    const staying = client.getPrompt({ name: "racers" });
+    controller.abort();
+    await expect(aborting).rejects.toMatchObject({ code: "aborted" });
+    const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(init.signal?.aborted).toBe(false);
+    release(response(textPrompt({ name: "racers" })));
+    expect(await staying).toBeTruthy();
+  });
+
+  it("aborts the underlying request when the sole caller aborts and caches nothing", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(
+        (_url: URL, init: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init.signal?.addEventListener("abort", () => reject(new Error("Aborted")));
+          }),
+      )
+      .mockResolvedValueOnce(response(textPrompt({ name: "solo" })));
+    vi.stubGlobal("fetch", fetchMock);
+    lens = createClient();
+    const client = lens.promptClient();
+    const controller = new AbortController();
+
+    const request = client.getPrompt({ name: "solo", signal: controller.signal });
+    controller.abort();
+    await expect(request).rejects.toMatchObject({ code: "aborted" });
+    expect((fetchMock.mock.calls[0] as [URL, RequestInit])[1].signal?.aborted).toBe(true);
+    await client.getPrompt({ name: "solo" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("distinguishes server, network, timeout, and invalid-response failures", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        response({ error: { code: "not_found", message: "internal pk-secret detail" } }, 404),
+      )
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockImplementationOnce(
+        (_url: URL, init: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init.signal?.addEventListener("abort", () => reject(new Error("Aborted")));
+          }),
+      )
+      .mockResolvedValueOnce(new Response("not json", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    lens = createClient();
+    const client = lens.promptClient({ timeoutMs: 5 });
+
+    const cases: Array<[string, Record<string, unknown>]> = [
+      ["not_found", { status: 404, message: "Lens prompt request failed (404)" }],
+      ["network_error", {}],
+      ["timeout", {}],
+      ["invalid_response", {}],
+    ];
+    const messages: string[] = [];
+    for (const [code, extra] of cases) {
+      const error: unknown = await client.getPrompt({ name: "x" }).catch((cause: unknown) => cause);
+      expect(error).toMatchObject({ name: "LensPromptError", code, ...extra });
+      messages.push((error as Error).message);
+    }
+    expect(messages.every((message) => !message.includes("pk-secret"))).toBe(true);
+  });
+
+  it("rejects responses whose identity or shape does not match the request", async () => {
+    const cases = [
+      textPrompt({ name: "other" }),
+      textPrompt({ name: "p", version: 1.5 }),
+      textPrompt({ name: "p", selector: { label: "beta" } }),
+      textPrompt({ name: "p", labels: ["beta"], selector: { label: "production" } }),
+      textPrompt({ name: "p", version: 2, selector: { version: 3 } }),
+      { ...textPrompt({ name: "p" }), selector: { label: "production", version: 1 } },
+      { ...textPrompt({ name: "p" }), config: "nope" },
+      { ...textPrompt({ name: "p" }), labels: "production" },
+      { ...textPrompt({ name: "p" }), messages: [] },
+      { ...textPrompt({ name: "p" }), type: "weird" },
+      { ...textPrompt({ name: "p" }), template: null },
+      { ...chatPrompt({ name: "p" }), messages: [{ role: "bot", content: "hi" }] },
+      { ...chatPrompt({ name: "p" }), messages: [{ role: "user", content: 5 }] },
+      { ...chatPrompt({ name: "p" }), messages: [] },
+      { ...chatPrompt({ name: "p" }), template: "text" },
+    ];
+    for (const value of cases) {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce(response(value)));
+      lens ??= createClient();
+      await expect(lens.promptClient().getPrompt({ name: "p" })).rejects.toMatchObject({
+        code: "invalid_response",
+      });
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("evicts the oldest entry when the cache exceeds its bound", async () => {
+    const fetchMock = vi.fn((url: URL) =>
+      Promise.resolve(
+        response(textPrompt({ name: decodeURIComponent(url.pathname.split("/").pop() ?? "") })),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    lens = createClient();
+    const client = lens.promptClient();
+
+    for (let index = 0; index < 101; index += 1) {
+      await client.getPrompt({ name: `p${index}` });
+    }
+    await client.getPrompt({ name: "p0" });
+    expect(fetchMock).toHaveBeenCalledTimes(102);
+    await client.getPrompt({ name: "p100" });
+    expect(fetchMock).toHaveBeenCalledTimes(102);
+  });
+
+  it("enforces client lifecycle and disabled semantics", async () => {
+    vi.stubEnv("ANVIA_LENS_BASE_URL", "");
+    vi.stubEnv("ANVIA_LENS_PUBLIC_KEY", "");
+    vi.stubEnv("ANVIA_LENS_SECRET_KEY", "");
+    const disabled = new LensClient({ optional: true });
+    expect(() => disabled.promptClient()).toThrow("disabled");
+
+    vi.stubGlobal("fetch", vi.fn());
+    lens = createClient();
+    const client = lens.promptClient();
+    expect(typeof client.getPrompt).toBe("function");
+    expect(typeof client.clearCache).toBe("function");
+    await lens.close();
+    lens = undefined;
+    expect(() => client.clearCache()).toThrow("LensClient is closed.");
+    await expect(client.getPrompt({ name: "p" })).rejects.toThrow("LensClient is closed.");
+
+    const closed = createClient();
+    await closed.close();
+    expect(() => closed.promptClient()).toThrow("LensClient is closed.");
+  });
+});
+
+function createClient(options: { timeoutMs?: number } = {}): LensClient {
+  return new LensClient({
+    baseUrl: "https://lens.example",
+    publicKey: "pk",
+    secretKey: "sk",
+    serviceName: "prompt-test",
+    ...options,
+  });
+}
+
+function textPrompt(
+  overrides: {
+    name?: string;
+    version?: number;
+    template?: string;
+    config?: unknown;
+    labels?: string[];
+    selector?: unknown;
+  } = {},
+): Record<string, unknown> {
+  return {
+    name: "p",
+    version: 1,
+    type: "text",
+    template: "Hello {{name}}",
+    messages: null,
+    config: {},
+    labels: ["production"],
+    selector: { label: "production" },
+    ...overrides,
+  };
+}
+
+function chatPrompt(overrides: { name?: string } = {}): Record<string, unknown> {
+  return {
+    name: "p",
+    version: 1,
+    type: "chat",
+    template: null,
+    messages: [{ role: "user", content: "Hi" }],
+    config: {},
+    labels: ["production"],
+    selector: { label: "production" },
+    ...overrides,
+  };
+}
+
+function response(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/packages/observability-lens/test/prompt-client.test.ts
+++ b/packages/observability-lens/test/prompt-client.test.ts
@@ -266,6 +266,42 @@ describe("Lens prompt client", () => {
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
+  it.each(["default", "reload"] as const)(
+    "reload bypasses an older %s request and prevents late cache overwrites",
+    async (olderMode) => {
+      let releaseOlder: (value: Response) => void = () => {};
+      let releaseReload: (value: Response) => void = () => {};
+      const fetchMock = vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise<Response>((resolve) => {
+              releaseOlder = resolve;
+            }),
+        )
+        .mockImplementationOnce(
+          () =>
+            new Promise<Response>((resolve) => {
+              releaseReload = resolve;
+            }),
+        );
+      vi.stubGlobal("fetch", fetchMock);
+      lens = createClient();
+      const client = lens.promptClient();
+      const older = client.getPrompt({ name: "race", cache: olderMode });
+      const newer = client.getPrompt({ name: "race", cache: "reload" });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      const joined = client.getPrompt({ name: "race" });
+      releaseReload(response(textPrompt({ name: "race", version: 2 })));
+      const refreshed = await newer;
+      expect(await joined).toBe(refreshed);
+      releaseOlder(response(textPrompt({ name: "race", version: 1 })));
+      expect((await older).version).toBe(1);
+      expect(await client.getPrompt({ name: "race" })).toBe(refreshed);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    },
+  );
+
   it("clearCache forces a refetch and discards in-flight results", async () => {
     let release: (value: Response) => void = () => {};
     const fetchMock = vi

--- a/packages/observability-otel/README.md
+++ b/packages/observability-otel/README.md
@@ -90,6 +90,22 @@ Existing `@anvia/otel` integrations retain full capture when the option is omitt
 `captureMaxBytes` to set a per-value limit and `transformInput` / `transformOutput` to redact or
 reshape payloads before export. Runtime observer events are emitted as OpenTelemetry span events.
 
+### Prompt identity
+
+Agent `trace.promptRef: { name, version }` identifies the root and defaults each generation's
+identity. Core completion-request middleware can return `{ request, promptRef: anotherRef }` to
+override one generation or `{ request, promptRef: null }` to leave it unattributed. Omission keeps
+the current identity; the next turn starts from the run default. Generation observer events carry
+their own `promptRef`, so the adapter does not copy the root identity onto unrelated generations.
+
+Pipeline `trace.promptRef` identifies only the pipeline root. Set each Agent stage's
+`request.trace.promptRef` explicitly for multi-prompt pipelines.
+
+Root and generation spans emit `anvia.prompt.name` and numeric `anvia.prompt.version` when supplied.
+These identity attributes remain available in `captureMode: "safe"`; they do not enable capture of
+prompt bodies, variables, or provider request payloads. Prefer the prompt registry's resolved
+numeric version rather than a selector label.
+
 ## Eval reporting
 
 ```ts
@@ -121,6 +137,12 @@ reported by default and can be disabled with `publishInvalid: false`.
 Metric events include required status, score direction, threshold, and evaluator token usage when
 available. Run-finished events publish separate metric and case totals plus aggregate usage and
 optional caller-calculated cost.
+
+Set `run: { promptRef: { name: "support", version: 7 } }` on `runEvalSuite()` for evaluation-run
+attribution. Lifecycle and metric logs emit `anvia.eval.run.prompt.name` and
+`anvia.eval.run.prompt.version`. The version is serialized as a string for ingestion; absent
+versions are omitted. Identity is independent of metadata and payload capture options. This does
+not set prompt identity on the target Agent or judge generations; configure those separately.
 
 ## Runtime scores
 

--- a/packages/observability-otel/src/eval-reporter.ts
+++ b/packages/observability-otel/src/eval-reporter.ts
@@ -265,6 +265,12 @@ function addRunAttributes(
 ): void {
   attributes["anvia.eval.run.id"] = run.id;
   attributes["anvia.eval.run.started_at"] = run.startedAt;
+  if (run.promptRef !== undefined) {
+    attributes["anvia.eval.run.prompt.name"] = run.promptRef.name;
+    if (run.promptRef.version !== undefined) {
+      attributes["anvia.eval.run.prompt.version"] = String(run.promptRef.version);
+    }
+  }
   if (run.datasetName !== undefined) attributes["anvia.eval.run.dataset.name"] = run.datasetName;
   if (run.datasetVersion !== undefined) {
     attributes["anvia.eval.run.dataset.version"] = run.datasetVersion;

--- a/packages/observability-otel/src/helpers.ts
+++ b/packages/observability-otel/src/helpers.ts
@@ -95,6 +95,8 @@ export function generationStartAttributes(
   const params = modelParameters(args.request);
   return compactAttributes({
     "anvia.generation.turn": args.turn,
+    "anvia.prompt.name": args.promptRef?.name,
+    "anvia.prompt.version": args.promptRef?.version,
     "anvia.generation.input": capturedJson(
       {
         instructions: args.request.instructions,

--- a/packages/observability-otel/src/pipeline-tracing.ts
+++ b/packages/observability-otel/src/pipeline-tracing.ts
@@ -159,6 +159,8 @@ function pipelineRunStartAttributes(
     "anvia.trace.session_id": args.trace?.sessionId,
     "anvia.trace.tags": args.trace?.tags === undefined ? undefined : [...args.trace.tags],
     "anvia.trace.version": args.trace?.version,
+    "anvia.prompt.name": args.trace?.promptRef?.name,
+    "anvia.prompt.version": args.trace?.promptRef?.version,
     ...metadataAttributes("anvia.pipeline.metadata", args.pipelineMetadata),
     ...metadataAttributes("anvia.run.metadata", args.runMetadata),
     ...metadataAttributes("anvia.trace.metadata", args.trace?.metadata),

--- a/packages/observability-otel/src/tracing.ts
+++ b/packages/observability-otel/src/tracing.ts
@@ -231,6 +231,16 @@ class OtelToolObserver implements AgentToolObserver {
         turn: childTurn,
         request: child.request as AgentGenerationStartArgs["request"],
       };
+      if (isRecord(child.promptRef) && typeof child.promptRef.name === "string") {
+        generationArgs = {
+          ...generationArgs,
+          promptRef: {
+            name: child.promptRef.name,
+            version:
+              typeof child.promptRef.version === "number" ? child.promptRef.version : undefined,
+          },
+        };
+      }
       if (isRecord(child.modelInfo)) {
         generationArgs = {
           ...generationArgs,

--- a/packages/observability-otel/test/otel.test.ts
+++ b/packages/observability-otel/test/otel.test.ts
@@ -175,6 +175,7 @@ describe("OpenTelemetry eval reporter", () => {
       startedAt: "2026-08-07T00:00:00.000Z",
       datasetName: "support-cases",
       datasetVersion: "v2",
+      promptRef: { name: "support", version: 7 },
       metadata: { commitSha: "abc123" },
     };
 
@@ -200,6 +201,12 @@ describe("OpenTelemetry eval reporter", () => {
       "anvia.eval.run.started",
       "anvia.eval.run.finished",
     ]);
+    for (const [record] of emit.mock.calls) {
+      expect(record.attributes).toMatchObject({
+        "anvia.eval.run.prompt.name": "support",
+        "anvia.eval.run.prompt.version": "7",
+      });
+    }
     expect(emit.mock.calls[1]?.[0]).toMatchObject({
       severityNumber: SeverityNumber.INFO,
       attributes: {
@@ -472,8 +479,12 @@ describe("otel", () => {
       prompt: userMessage("private prompt"),
       history: [userMessage("private history")],
       maxTurns: 1,
+      trace: { promptRef: { name: "support", version: 7 } },
     });
-    const generation = await run?.startGeneration?.(generationStartArgs());
+    const generation = await run?.startGeneration?.({
+      ...generationStartArgs(),
+      promptRef: { name: "planner", version: 11 },
+    });
     await generation?.end({
       turn: 1,
       response: {
@@ -518,6 +529,14 @@ describe("otel", () => {
     expect(tracer.spans[1]?.attributes).not.toHaveProperty("anvia.generation.output");
     expect(tracer.spans[2]?.attributes).not.toHaveProperty("anvia.tool.args");
     expect(tracer.spans[2]?.attributes).not.toHaveProperty("anvia.tool.result");
+    expect(tracer.spans[0]?.attributes).toMatchObject({
+      "anvia.prompt.name": "support",
+      "anvia.prompt.version": 7,
+    });
+    expect(tracer.spans[1]?.attributes).toMatchObject({
+      "anvia.prompt.name": "planner",
+      "anvia.prompt.version": 11,
+    });
   });
 
   it("never exceeds small capture byte limits", async () => {

--- a/packages/observability-otel/test/pipeline-tracing.test.ts
+++ b/packages/observability-otel/test/pipeline-tracing.test.ts
@@ -4,6 +4,30 @@ import { createOtelPipelineObserver } from "../src/index";
 import { FakeTracer } from "./helpers/fake-tracer";
 
 describe("OpenTelemetry Pipeline observer", () => {
+  it("captures pipeline identity in safe mode without stamping child stages", async () => {
+    const tracer = new FakeTracer();
+    const tracing = createOtelPipelineObserver({ tracer: tracer.tracer, captureMode: "safe" });
+    const run = await tracing.startRun({
+      runId: "pipeline-run",
+      pipelineId: "research",
+      input: "private input",
+      trace: { promptRef: { name: "research", version: 8 } },
+    });
+    await run?.startStage?.({
+      runId: "pipeline-run",
+      pipelineId: "research",
+      path: ["child"],
+      node: { id: "child", path: ["child"], kind: "agent", label: "Child" },
+      input: "private input",
+    });
+    expect(tracer.spans[0]?.attributes).toMatchObject({
+      "anvia.prompt.name": "research",
+      "anvia.prompt.version": 8,
+    });
+    expect(tracer.spans[0]?.attributes).not.toHaveProperty("anvia.pipeline.input");
+    expect(tracer.spans[1]?.attributes).not.toHaveProperty("anvia.prompt.name");
+  });
+
   it("maps Pipeline runs and nested stages to parented OpenTelemetry spans", async () => {
     const tracer = new FakeTracer();
     const tracing = createOtelPipelineObserver({


### PR DESCRIPTION
## Summary
- Add `lens.promptClient()` with immutable text/chat prompt snapshots, explicit label or version selection (default: production), strict synchronous compilation, and typed retrieval/compilation errors.
- Add a bounded per-client cache with TTL, reload/no-store modes, invalidation, request deduplication, and independent caller cancellation. No stale fallback or global current prompt.
- Carry explicit prompt identity through Agent generations, pipeline roots, and evaluation runs. Support per-generation middleware override/null opt-out without adding attribution to provider request payloads. Preserve identity under safe capture.
- Document SDK usage and Core/OpenTelemetry attribution contracts.

## Verification
- Core: 606 tests passed.
- OpenTelemetry: 32 tests passed.
- Lens SDK: 34 tests passed, including 18 prompt runtime tests.
- Builds and typechecks passed for Core, OpenTelemetry, and Lens SDK.
- Built SDK exercised against a real Lens API: production/pinned/chat retrieval and compilation, immutable config, cache modes, typed errors, and client close.
- Scoped formatting/lint, staged checks, and git diff whitespace checks passed.

## Integration notes
- Runtime retrieval uses the companion Lens endpoint `/api/public/prompts/:encodedName`; the server implementation is in the separate Lens repository, not this PR.
- Saving a prompt version does not deploy it; omitted selectors resolve production, never newest.
- Existing Core prompt references retain optional versions; resolved Lens prompt references always include a numeric version.
- No publishing or package version changes are included.