### PR TITLE
chore: remove unintended release changeset

### DIFF
--- a/.changeset/lens-prompt-sdk.md
+++ b/.changeset/lens-prompt-sdk.md
@@ -1,7 +1,0 @@
----
-"@anvia/lens": minor
-"@anvia/core": minor
-"@anvia/otel": minor
----
-
-Add first-class Lens prompt retrieval with immutable text/chat snapshots, strict synchronous compilation, bounded caching, fresh reload semantics, and typed errors. Carry explicit prompt identity through Agent generations, pipeline roots, and evaluation runs, including per-generation overrides and safe OpenTelemetry attribution.


### PR DESCRIPTION
Remove only .changeset/lens-prompt-sdk.md as requested. No feature changes, version bumps, or publishing. Prevent the rejected major-version release plan from being regenerated.