### PR TITLE
fix(sandbox): require explicit opt-in for allowlisted shells

### DIFF
--- a/.changeset/sandbox-block-shell-interpreters.md
+++ b/.changeset/sandbox-block-shell-interpreters.md
@@ -8,3 +8,7 @@ Block shell interpreters by default in allow-mode command policies. The sandbox
 uses `mode: "allow"`, preventing agents from bypassing command restrictions via
 shell arguments like `sh -c "arbitrary command"`. Set `allowShellInterpreters:
 true` in the command policy to restore the previous behavior.
+
+The opt-in requires the boolean `true`; non-boolean values are rejected when
+creating tools, including strings such as `"false"`. This applies to both
+`exec_command` and `start_process`.

--- a/.changeset/sandbox-block-shell-interpreters.md
+++ b/.changeset/sandbox-block-shell-interpreters.md
@@ -1,0 +1,10 @@
+---
+"@anvia/sandbox": patch
+---
+
+Block shell interpreters by default in allow-mode command policies. The sandbox
+`exec_command` tool now rejects common shell executables (`sh`, `bash`, `zsh`,
+`ksh`, `dash`, `ash`, `busybox`, `fish`, `csh`, `tcsh`) when the command policy
+uses `mode: "allow"`, preventing agents from bypassing command restrictions via
+shell arguments like `sh -c "arbitrary command"`. Set `allowShellInterpreters:
+true` in the command policy to restore the previous behavior.

--- a/packages/tool-sandbox/README.md
+++ b/packages/tool-sandbox/README.md
@@ -32,6 +32,13 @@ Networking is explicit. Use `{ mode: "none" }` or `{ mode: "bridge", ports: [...
 bind only to `127.0.0.1`. Runtime methods use object arguments, propagate abort signals, and expose
 command and process output as bytes. Tool wrappers decode UTF-8 strictly and return structured values.
 
+With `exec.commands.mode: "allow"`, both `exec_command` and `start_process` reject known shell
+executables by default, including path-qualified names such as `/bin/sh`. To permit an allowlisted
+shell, set `exec.commands.allowShellInterpreters` to the boolean `true`. Omitted or `false` keeps the
+guard enabled; non-boolean values such as `"false"` are rejected when creating tools. This guard
+checks executable names only: allowlisted runtimes such as Node.js or Python can still launch other
+commands, so the command policy does not restrict what those programs can execute.
+
 `resources.sharedMemoryMb` maps to a private Docker `/dev/shm` size. A security configuration may use
 explicit `dropCapabilities` and `addCapabilities` arrays, plus
 `seccompProfile: { type: "path", path }` with an absolute host path. These options are used by

--- a/packages/tool-sandbox/src/tools.ts
+++ b/packages/tool-sandbox/src/tools.ts
@@ -538,6 +538,13 @@ function validateCommandPolicy(policy: DockerSandboxCommandPolicy | undefined): 
   if (policy.mode !== "allow" && policy.mode !== "block") {
     throw toolPolicyError("exec.commands must use mode allow or block.");
   }
+  if (
+    policy.mode === "allow" &&
+    policy.allowShellInterpreters !== undefined &&
+    typeof policy.allowShellInterpreters !== "boolean"
+  ) {
+    throw toolPolicyError("exec.commands.allowShellInterpreters must be a boolean.");
+  }
   if (!Array.isArray(policy.values))
     throw toolPolicyError("exec.commands.values must be an array.");
   const seen = new Set<string>();
@@ -565,19 +572,12 @@ function assertCommandAllowed(
   // Shell interpreters like sh, bash, etc. can execute arbitrary commands
   // through their arguments (e.g., sh -c "rm -rf /")
   // Also block path-qualified shells (e.g., /bin/sh, /usr/bin/bash)
-  if (policy.mode === "allow") {
-    const allowPolicy = policy as Readonly<{
-      mode: "allow";
-      values: readonly string[];
-      allowShellInterpreters?: boolean;
-    }>;
-    if (!allowPolicy.allowShellInterpreters) {
-      const commandBasename = command.split("/").pop() ?? command;
-      if (shellInterpreters.includes(commandBasename as (typeof shellInterpreters)[number])) {
-        throw toolPolicyError(
-          `Command is rejected by sandbox tool policy: ${command} (shell interpreter not allowed)`,
-        );
-      }
+  if (policy.mode === "allow" && policy.allowShellInterpreters !== true) {
+    const commandBasename = command.split("/").pop() ?? command;
+    if (shellInterpreters.includes(commandBasename as (typeof shellInterpreters)[number])) {
+      throw toolPolicyError(
+        `Command is rejected by sandbox tool policy: ${command} (shell interpreter not allowed)`,
+      );
     }
   }
 }

--- a/packages/tool-sandbox/src/tools.ts
+++ b/packages/tool-sandbox/src/tools.ts
@@ -11,6 +11,7 @@ import type {
   DockerSandboxRuntime,
   DockerSandboxToolName,
 } from "./types";
+import { shellInterpreters } from "./types";
 
 const allToolNames = [
   "exec_command",
@@ -505,6 +506,10 @@ function snapshotFactoryOptions(
       : Object.freeze({
           mode: options.exec.commands.mode,
           values: Object.freeze([...options.exec.commands.values]),
+          ...(options.exec.commands.mode === "allow" &&
+          options.exec.commands.allowShellInterpreters !== undefined
+            ? { allowShellInterpreters: options.exec.commands.allowShellInterpreters }
+            : {}),
         });
   let snapshot: CreateDockerSandboxToolsOptions = {
     sandbox: options.sandbox,
@@ -554,6 +559,26 @@ function assertCommandAllowed(
   const included = policy.values.includes(command);
   if ((policy.mode === "allow" && !included) || (policy.mode === "block" && included)) {
     throw toolPolicyError(`Command is rejected by sandbox tool policy: ${command}`);
+  }
+
+  // Block shell interpreters by default to prevent command bypass via args
+  // Shell interpreters like sh, bash, etc. can execute arbitrary commands
+  // through their arguments (e.g., sh -c "rm -rf /")
+  // Also block path-qualified shells (e.g., /bin/sh, /usr/bin/bash)
+  if (policy.mode === "allow") {
+    const allowPolicy = policy as Readonly<{
+      mode: "allow";
+      values: readonly string[];
+      allowShellInterpreters?: boolean;
+    }>;
+    if (!allowPolicy.allowShellInterpreters) {
+      const commandBasename = command.split("/").pop() ?? command;
+      if (shellInterpreters.includes(commandBasename as (typeof shellInterpreters)[number])) {
+        throw toolPolicyError(
+          `Command is rejected by sandbox tool policy: ${command} (shell interpreter not allowed)`,
+        );
+      }
+    }
   }
 }
 

--- a/packages/tool-sandbox/src/types.ts
+++ b/packages/tool-sandbox/src/types.ts
@@ -275,8 +275,25 @@ export type DockerSandboxToolName =
   | "stop_process"
   | "wait_for_port";
 
+/**
+ * List of known shell interpreters that can execute arbitrary commands via args.
+ * These are blocked by default unless explicitly allowed.
+ */
+export const shellInterpreters = [
+  "sh",
+  "bash",
+  "zsh",
+  "ksh",
+  "dash",
+  "ash",
+  "busybox",
+  "fish",
+  "csh",
+  "tcsh",
+] as const;
+
 export type DockerSandboxCommandPolicy =
-  | Readonly<{ mode: "allow"; values: readonly string[] }>
+  | Readonly<{ mode: "allow"; values: readonly string[]; allowShellInterpreters?: boolean }>
   | Readonly<{ mode: "block"; values: readonly string[] }>;
 
 export type DockerSandboxExecToolPolicy = Readonly<{

--- a/packages/tool-sandbox/test/tools.test.ts
+++ b/packages/tool-sandbox/test/tools.test.ts
@@ -74,6 +74,110 @@ describe("createDockerSandboxTools", () => {
     );
   });
 
+  it("blocks shell interpreters by default to prevent command bypass via args", async () => {
+    const [tool] = createDockerSandboxTools({
+      sandbox: createRuntime(),
+      tools: ["exec_command"],
+      exec: {
+        commands: { mode: "allow", values: ["sh", "node"] },
+      },
+    });
+    if (tool === undefined) throw new Error("Expected exec_command tool.");
+
+    // sh is in the allow list, but args with -c can execute arbitrary commands
+    // This should be blocked by default
+    await expect(tool.call({ command: "sh", args: ["-c", "rm -rf /"] })).rejects.toMatchObject({
+      code: "tool_policy",
+    });
+  });
+
+  it("allows shell interpreters when explicitly permitted via allowShellInterpreters", async () => {
+    const sandbox = createRuntime();
+    const [tool] = createDockerSandboxTools({
+      sandbox,
+      tools: ["exec_command"],
+      exec: {
+        commands: { mode: "allow", values: ["sh", "node"], allowShellInterpreters: true },
+      },
+    });
+    if (tool === undefined) throw new Error("Expected exec_command tool.");
+
+    // With allowShellInterpreters: true, sh with args should work
+    await expect(tool.call({ command: "sh", args: ["-c", "echo hello"] })).resolves.toMatchObject({
+      status: "exited",
+    });
+    expect(sandbox.exec).toHaveBeenCalledWith({
+      command: "sh",
+      args: ["-c", "echo hello"],
+    });
+  });
+
+  it("allows shell interpreters in block mode when not in block list", async () => {
+    const sandbox = createRuntime();
+    const [tool] = createDockerSandboxTools({
+      sandbox,
+      tools: ["exec_command"],
+      exec: {
+        commands: { mode: "block", values: ["rm", "curl"] },
+      },
+    });
+    if (tool === undefined) throw new Error("Expected exec_command tool.");
+
+    // In block mode, shell interpreters are allowed if not in the block list
+    await expect(tool.call({ command: "sh", args: ["-c", "echo hello"] })).resolves.toMatchObject({
+      status: "exited",
+    });
+    expect(sandbox.exec).toHaveBeenCalledWith({
+      command: "sh",
+      args: ["-c", "echo hello"],
+    });
+  });
+
+  it("blocks path-qualified shell interpreters by default", async () => {
+    const [tool] = createDockerSandboxTools({
+      sandbox: createRuntime(),
+      tools: ["exec_command"],
+      exec: {
+        commands: { mode: "allow", values: ["/bin/sh", "/usr/bin/bash", "node"] },
+      },
+    });
+    if (tool === undefined) throw new Error("Expected exec_command tool.");
+
+    // Path-qualified shells should also be blocked by the basename check
+    await expect(tool.call({ command: "/bin/sh", args: ["-c", "rm -rf /"] })).rejects.toMatchObject(
+      {
+        code: "tool_policy",
+      },
+    );
+    await expect(
+      tool.call({ command: "/usr/bin/bash", args: ["-c", "rm -rf /"] }),
+    ).rejects.toMatchObject({
+      code: "tool_policy",
+    });
+  });
+
+  it("allows path-qualified shell interpreters when allowShellInterpreters is true", async () => {
+    const sandbox = createRuntime();
+    const [tool] = createDockerSandboxTools({
+      sandbox,
+      tools: ["exec_command"],
+      exec: {
+        commands: { mode: "allow", values: ["/bin/sh"], allowShellInterpreters: true },
+      },
+    });
+    if (tool === undefined) throw new Error("Expected exec_command tool.");
+
+    await expect(
+      tool.call({ command: "/bin/sh", args: ["-c", "echo hello"] }),
+    ).resolves.toMatchObject({
+      status: "exited",
+    });
+    expect(sandbox.exec).toHaveBeenCalledWith({
+      command: "/bin/sh",
+      args: ["-c", "echo hello"],
+    });
+  });
+
   it("delegates text file tools with bounded structured results", async () => {
     const sandbox = createRuntime();
     const tools = toolMap(

--- a/packages/tool-sandbox/test/tools.test.ts
+++ b/packages/tool-sandbox/test/tools.test.ts
@@ -133,6 +133,55 @@ describe("createDockerSandboxTools", () => {
     });
   });
 
+  it.each(["exec_command", "start_process"] as const)(
+    "requires boolean true to allow shells through %s",
+    async (toolName) => {
+      for (const allowShellInterpreters of [undefined, false, true]) {
+        const sandbox = createRuntime();
+        const [tool] = createDockerSandboxTools({
+          sandbox,
+          tools: [toolName],
+          exec: {
+            commands: {
+              mode: "allow",
+              values: ["sh"],
+              ...(allowShellInterpreters === undefined ? {} : { allowShellInterpreters }),
+            },
+          },
+        });
+        if (tool === undefined) throw new Error(`Expected ${toolName} tool.`);
+        const input = { command: "sh", args: ["-c", "echo hello"] };
+        const runtimeMethod = toolName === "exec_command" ? sandbox.exec : sandbox.startProcess;
+
+        if (allowShellInterpreters === true) {
+          await expect(tool.call(input)).resolves.toBeDefined();
+          expect(runtimeMethod).toHaveBeenCalledExactlyOnceWith(input);
+        } else {
+          await expect(tool.call(input)).rejects.toMatchObject({ code: "tool_policy" });
+          expect(runtimeMethod).not.toHaveBeenCalled();
+        }
+      }
+    },
+  );
+
+  it.each(["false", "true", "", 0, 1, null, {}, []].map((value) => ({ value })))(
+    "rejects non-boolean allowShellInterpreters eagerly: $value",
+    ({ value }) => {
+      const sandbox = createRuntime();
+      expect(() =>
+        createDockerSandboxTools({
+          sandbox,
+          tools: ["exec_command", "start_process"],
+          exec: {
+            commands: { mode: "allow", values: ["sh"], allowShellInterpreters: value } as never,
+          },
+        }),
+      ).toThrow("exec.commands.allowShellInterpreters must be a boolean.");
+      expect(sandbox.exec).not.toHaveBeenCalled();
+      expect(sandbox.startProcess).not.toHaveBeenCalled();
+    },
+  );
+
   it("blocks path-qualified shell interpreters by default", async () => {
     const [tool] = createDockerSandboxTools({
       sandbox: createRuntime(),


### PR DESCRIPTION
## Summary

Allow-mode command policies previously accepted an allowlisted shell such as `sh` with arbitrary arguments. This change requires callers to explicitly opt in to known shell executables for both `exec_command` and `start_process` in `@anvia/sandbox`.

- Reject `sh`, `bash`, `zsh`, `ksh`, `dash`, `ash`, `busybox`, `fish`, `csh`, and `tcsh` by default in allow mode, including path-qualified names such as `/bin/sh`.
- Add `allowShellInterpreters` to the allow-mode policy. Only boolean `true` enables allowlisted shells; omitted or `false` keeps the guard enabled. Reject non-boolean values such as `"false"` when creating tools.
- Preserve the option when snapshotting the policy, document the behavior and limitations in the package README, and include a patch changeset for `@anvia/sandbox`.

## Compatibility and scope

Existing allow-mode configurations that intentionally use shells must add `allowShellInterpreters: true`. The shell must still appear in the allowlist. Block-mode policies and execution without a command policy retain their existing behavior.

This is a guard against direct invocation of known shell names. It does not inspect arguments or prevent allowlisted runtimes such as Node.js or Python, command launchers, or unusually named shells from executing other commands. Command policies do not constrain the execution capabilities of allowed programs.

## Validation

- `pnpm --filter @anvia/sandbox test`: 65 passed; six Docker/gVisor integration tests skipped because their opt-in environment flags were not enabled.
- `pnpm --filter @anvia/sandbox typecheck`: passed.
- `pnpm --filter @anvia/sandbox build`: passed.
- `pnpm check`: passed.
- Regression tests reproduced acceptance of eight malformed opt-in values before the fix and pass after it. Tests also cover omitted, false, and true values for both execution tools, path-qualified shells, and block-mode behavior.

No dependencies or lockfile changes. Only ignored build output was regenerated; no generated files are committed. No visible UI changes.
