### PR TITLE
feat(core): add sibling messaging and recursive agent spawning

### DIFF
--- a/.changeset/nested-teams-communicate.md
+++ b/.changeset/nested-teams-communicate.md
@@ -1,0 +1,8 @@
+---
+"@anvia/core": minor
+---
+
+Add opt-in sibling communication and per-definition recursive spawning to AgentTeam.
+Share depth, concurrency, instance, and turn limits across the tree, route outcomes to
+immediate parents, and cascade cancellation and parent failure to descendants.
+Expose parent IDs and depth in member listings and summaries.

--- a/cookbook/07_multi_agent/04-agent-team.ts
+++ b/cookbook/07_multi_agent/04-agent-team.ts
@@ -14,6 +14,8 @@ const specialist = new Agent({
   instructions: [
     "Focus on the specialty and task assigned in your prompt.",
     "If an essential fact is missing, send_message to parent and wait_for_agent.",
+    "Use list_agents to find sibling specialists and exchange relevant findings directly.",
+    "For a complex subproblem, spawn a specialist; spawn a reviewer to check your findings.",
     "Keep findings concise and label assumptions.",
   ].join("\n"),
 });
@@ -31,11 +33,13 @@ const team = new AgentTeam({
   instructions: [
     "Spawn two specialist instances: one for reliability and one for operational complexity.",
     "Send each the relevant user facts. Answer their clarification questions through send_message.",
-    "Wait for both findings, then spawn a reviewer with the combined findings.",
+    "Specialists may delegate subproblems and request reviews; wait for their findings.",
     "Use the review to produce a concise recommendation.",
   ].join("\n"),
   members: [specialist, reviewer],
-  limits: { maxConcurrentAgents: 3, maxAgentInstances: 5, maxTotalTurns: 30 },
+  communication: { siblings: true },
+  spawning: [{ from: specialist, to: [specialist, reviewer] }],
+  limits: { maxDepth: 3, maxConcurrentAgents: 3, maxAgentInstances: 8, maxTotalTurns: 50 },
 });
 
 const stream = team.stream({
@@ -49,7 +53,15 @@ const stream = team.stream({
 
 for await (const event of stream.events) {
   if (event.type === "agent_started") {
-    console.log("started", event.member.agentId, event.instanceId);
+    console.log(
+      "started",
+      event.member.agentId,
+      event.instanceId,
+      "depth",
+      event.member.depth,
+      "parent",
+      event.member.parentInstanceId,
+    );
   } else if (event.type === "message_delivered") {
     console.log("message", event.message.fromInstanceId, "->", event.message.toInstanceId);
   }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -109,6 +109,7 @@ const team = new AgentTeam({
   ].join("\n"),
   members: [researcher, reviewer],
   limits: {
+    maxDepth: 3,
     maxConcurrentAgents: 4,
     maxAgentInstances: 12,
     maxTotalTurns: 100,
@@ -128,21 +129,47 @@ abort signal, interaction resolver, and team limits apply to the whole execution
 
 The runtime adds these model-callable tools:
 
-| Tool                | Available to  | Input                         |
-| ------------------- | ------------- | ----------------------------- |
-| `spawn_<member.id>` | Coordinator   | `{ prompt, name? }`           |
-| `send_message`      | All instances | `{ to, content, replyTo? }`   |
-| `wait_for_agent`    | All instances | `{ instanceId?, timeoutMs? }` |
-| `list_agents`       | All instances | `{}`                          |
-| `cancel_agent`      | Coordinator   | `{ instanceId, reason? }`     |
+| Tool                | Available to                      | Input                         |
+| ------------------- | --------------------------------- | ----------------------------- |
+| `spawn_<member.id>` | Coordinator and permitted parents | `{ prompt, name? }`           |
+| `send_message`      | All instances                     | `{ to, content, replyTo? }`   |
+| `wait_for_agent`    | All instances                     | `{ instanceId?, timeoutMs? }` |
+| `list_agents`       | All instances                     | `{}`                          |
+| `cancel_agent`      | Instances with spawn permissions  | `{ instanceId, reason? }`     |
 
 Spawning returns an `instanceId` immediately. A definition's `agentId` stays the same across its
 instances; each assignment or resumed interaction has a distinct `runId`. Member IDs must contain
 1–58 letters, digits, underscores, or hyphens so generated tool names are valid. Configured tools
 must not use reserved coordination names.
 
-Routing is between a parent and its children. A member can use `to: "parent"`; the coordinator
-addresses children by instance ID. Sibling messaging and recursive spawning are not supported.
+Routing is between a parent and its children by default. A member can use `to: "parent"`;
+parents address children by instance ID. Enable sibling communication and recursive spawning
+with explicit permissions:
+
+```ts
+const team = new AgentTeam({
+  id: "research-team",
+  model,
+  members: [researcher, reviewer],
+  communication: { siblings: true },
+  spawning: [{ from: researcher, to: [researcher, reviewer] }],
+  limits: { maxDepth: 3, maxConcurrentAgents: 4, maxAgentInstances: 12, maxTotalTurns: 100 },
+});
+```
+
+`members` is the definition catalog available to the coordinator. A spawn rule allows every
+instance of `from` to create only the definitions in `to`, using their generated spawn tools.
+Use the same Agent objects registered in `members`; duplicate rules or targets are rejected.
+Rules and communication options are snapshotted at construction. Without rules, only the
+coordinator can spawn. A self-reference enables recursion; each child has its own conversation
+and its definition's tools, without inheriting the parent's tools.
+
+With `communication.siblings: true`, instances sharing the same parent instance can discover,
+message, and wait for one another. Cousins and other branches remain inaccessible. `list_agents`
+includes self, parent, direct children, and enabled siblings, with `parentInstanceId` and `depth`.
+Sibling access does not grant cancellation or approval authority. Only a parent can cancel its
+direct child; cancellation also stops that child's entire subtree, including idle descendants.
+
 `send_message` returns a queued receipt, not a reply. Messages arrive at safe turn/tool boundaries,
 are explicitly attributed to their sender, and cannot satisfy a tool approval. Sending to an idle
 member starts a follow-up run with its retained conversation. Failed or cancelled members cannot
@@ -150,16 +177,19 @@ receive follow-ups. Each inbox accepts at most 128 pending inputs.
 
 `wait_for_agent` wakes on a relevant message, outcome, cancellation, or timeout (default 30 seconds,
 maximum 5 minutes). Waiting agents and agents awaiting application input release their concurrency
-slot. The coordinator also waits automatically before finalizing while members are active, and
-receives their outcomes as attributed messages. A member failure is reported to the coordinator;
-a coordinator error or team cancellation rejects the execution. Guardrail blocking remains a
-`blocked` outcome.
+slot. Every parent waits automatically for its own children before finalizing and receives their
+outcomes as attributed messages. A member failure is reported to its immediate parent; failure or
+blocking cancels its descendants. A coordinator error or team cancellation rejects the execution.
+Guardrail blocking remains a `blocked` outcome. The final `members` array includes all descendants,
+with `parentInstanceId` and `depth` to reconstruct the tree.
 
-The limits above are the defaults. Concurrent and total instance limits include the coordinator.
+The limits in the first example are the defaults. `maxDepth` is a positive integer; the coordinator
+is depth 0 and direct children are depth 1. Concurrent and total instance limits include the coordinator.
 The instance limit counts all instances created during this execution, including completed or
 cancelled ones. The turn budget covers all instances and follow-ups; provider retries remain
 governed by normal retry settings. Reaching the turn budget fails the team. Reaching the instance
-limit rejects the spawn tool call so the coordinator can use existing members. Tools within one
+or depth limit rejects the spawn tool call so the parent can use existing members. All budgets are
+shared across the whole tree; spawning does not reset them. Tools within one
 instance execute sequentially; different instances can execute concurrently.
 
 ### Team streaming and steering

--- a/packages/core/src/agent/team/agent-team.ts
+++ b/packages/core/src/agent/team/agent-team.ts
@@ -3,6 +3,7 @@ import type { CompletionModel } from "../../completion";
 import { assertPositiveSafeInteger } from "../../internal/agent-runtime/run-validation";
 import { TeamRun } from "../../internal/team-runtime/run";
 import { TeamStream } from "../../internal/team-runtime/stream";
+import { TeamPolicy } from "../../internal/team-runtime/policy";
 import type {
   AgentTeamLimits,
   AgentTeamMember,
@@ -21,6 +22,7 @@ export class AgentTeam<
   readonly members: readonly AgentTeamMember[];
   readonly limits: Readonly<Required<AgentTeamLimits>>;
   private readonly coordinator: Agent<Output, M, ContextDocument>;
+  private readonly policy: TeamPolicy;
 
   constructor(options: AgentTeamOptions<Output, M, ContextDocument>) {
     this.coordinator = new Agent(options);
@@ -51,7 +53,9 @@ export class AgentTeam<
       }
     }
     this.members = Object.freeze([...options.members]);
+    this.policy = new TeamPolicy(this.members, options.communication, options.spawning);
     this.limits = Object.freeze({
+      maxDepth: assertPositiveSafeInteger(options.limits?.maxDepth ?? 3, "maxDepth"),
       maxConcurrentAgents: assertPositiveSafeInteger(
         options.limits?.maxConcurrentAgents ?? 4,
         "maxConcurrentAgents",
@@ -101,7 +105,7 @@ export class AgentTeam<
         // The scheduler runs heterogeneous definitions. Public inputs are checked against M above.
         new TeamRun(
           this.coordinator,
-          this.members,
+          this.policy,
           this.limits,
           { ...options } as AgentTeamRunOptions<unknown>,
           streaming,

--- a/packages/core/src/agent/team/index.ts
+++ b/packages/core/src/agent/team/index.ts
@@ -11,5 +11,6 @@ export type {
   AgentTeamOptions,
   AgentTeamOutcome,
   AgentTeamRunOptions,
+  AgentTeamSpawnRule,
   AgentTeamStream,
 } from "./types";

--- a/packages/core/src/agent/team/types.ts
+++ b/packages/core/src/agent/team/types.ts
@@ -15,10 +15,18 @@ import type { CompletionModel, CompletionModelControlsOf, Message, Usage } from 
 /** An Agent definition; individual members may have different output schemas. */
 export type AgentTeamMember = Agent<unknown>;
 
+/** Allow instances of one registered definition to spawn the listed definitions. */
+export type AgentTeamSpawnRule = {
+  from: AgentTeamMember;
+  to: readonly AgentTeamMember[];
+};
+
 type RawResponseOf<Model> =
   Model extends CompletionModel<infer RawResponse> ? RawResponse : unknown;
 
 export type AgentTeamLimits = {
+  /** Maximum instance depth, with the coordinator at 0. Defaults to 3. */
+  maxDepth?: number;
   maxConcurrentAgents?: number;
   maxAgentInstances?: number;
   maxTotalTurns?: number;
@@ -32,6 +40,10 @@ export type AgentTeamOptions<
   ContextDocument = unknown,
 > = AgentOptions<Output, M, ContextDocument> & {
   members: readonly AgentTeamMember[];
+  /** Allow messaging and waiting between instances with the same parent. Defaults to false. */
+  communication?: { siblings?: boolean };
+  /** Additional spawn permissions for members. The coordinator can spawn every member. */
+  spawning?: readonly AgentTeamSpawnRule[];
   limits?: AgentTeamLimits;
 };
 
@@ -70,6 +82,7 @@ export type AgentTeamMemberSummary = Readonly<{
   agentId: string;
   name: string;
   parentInstanceId?: string;
+  depth: number;
   status: AgentTeamMemberStatus;
   usage: Usage;
   outcome?: AgentResponse<unknown> | AgentBlockedOutcome;

--- a/packages/core/src/internal/team-runtime/member.ts
+++ b/packages/core/src/internal/team-runtime/member.ts
@@ -20,6 +20,8 @@ export type TeamInput = {
 export type TeamMember = {
   instanceId: string;
   parentInstanceId?: string;
+  depth: number;
+  definition: Agent<unknown>;
   name: string;
   agent: Agent<unknown>;
   status: AgentTeamMemberStatus;
@@ -42,6 +44,7 @@ export function memberSummary(member: TeamMember): AgentTeamMemberSummary {
     instanceId: member.instanceId,
     agentId: member.agent.id,
     name: member.name,
+    depth: member.depth,
     status: member.status,
     usage: lifecycleSnapshot(member.usage),
     ...(member.parentInstanceId === undefined ? {} : { parentInstanceId: member.parentInstanceId }),

--- a/packages/core/src/internal/team-runtime/policy.ts
+++ b/packages/core/src/internal/team-runtime/policy.ts
@@ -1,0 +1,57 @@
+import type { AgentTeamMember, AgentTeamOptions } from "../../agent/team/types";
+import type { TeamMember } from "./member";
+
+/** Validated definition permissions, shared by every instance in a run. */
+export class TeamPolicy {
+  private readonly siblings: boolean;
+  private readonly spawning = new Map<AgentTeamMember, readonly AgentTeamMember[]>();
+
+  constructor(
+    private readonly catalog: readonly AgentTeamMember[],
+    communication: AgentTeamOptions["communication"],
+    spawning: AgentTeamOptions["spawning"],
+  ) {
+    if (
+      communication !== undefined &&
+      (communication === null ||
+        typeof communication !== "object" ||
+        Array.isArray(communication) ||
+        (communication.siblings !== undefined && typeof communication.siblings !== "boolean"))
+    )
+      throw new TypeError("AgentTeam communication.siblings must be a boolean.");
+    this.siblings = communication?.siblings ?? false;
+    if (spawning !== undefined && !Array.isArray(spawning))
+      throw new TypeError("AgentTeam spawning must be an array.");
+    for (const rule of spawning ?? []) {
+      if (rule === null || typeof rule !== "object" || !catalog.includes(rule.from))
+        throw new TypeError("Spawn rule from must reference a registered Agent instance.");
+      if (this.spawning.has(rule.from))
+        throw new TypeError(`Duplicate spawn rule for "${rule.from.id}".`);
+      if (
+        !Array.isArray(rule.to) ||
+        [...rule.to].some((target: AgentTeamMember) => !catalog.includes(target))
+      )
+        throw new TypeError("Spawn rule to must contain registered Agent instances.");
+      if (new Set(rule.to).size !== rule.to.length)
+        throw new TypeError(`Duplicate spawn target for "${rule.from.id}".`);
+      this.spawning.set(rule.from, Object.freeze([...rule.to]));
+    }
+  }
+
+  spawnTargets(member: TeamMember): readonly AgentTeamMember[] {
+    return member.parentInstanceId === undefined
+      ? this.catalog
+      : (this.spawning.get(member.definition) ?? []);
+  }
+
+  canAccess(caller: TeamMember, target: TeamMember): boolean {
+    return (
+      caller === target ||
+      target.instanceId === caller.parentInstanceId ||
+      target.parentInstanceId === caller.instanceId ||
+      (this.siblings &&
+        caller.parentInstanceId !== undefined &&
+        target.parentInstanceId === caller.parentInstanceId)
+    );
+  }
+}

--- a/packages/core/src/internal/team-runtime/run.ts
+++ b/packages/core/src/internal/team-runtime/run.ts
@@ -659,6 +659,8 @@ export class TeamRun<Output = unknown> {
 
   private stopDescendants(parent: TeamMember, reason: string): void {
     // Instances are inserted after their parents; this also reaches idle descendants without recursion.
+    // The subtree root is already terminal, and each descendant's parent is stopped first.
+    // Only the subtree root reports cancellation to a surviving parent; descendant reports are suppressed.
     const stopped = new Set([parent.instanceId]);
     for (const member of this.instances.values()) {
       if (member.parentInstanceId !== undefined && stopped.has(member.parentInstanceId)) {

--- a/packages/core/src/internal/team-runtime/run.ts
+++ b/packages/core/src/internal/team-runtime/run.ts
@@ -35,6 +35,7 @@ import {
   type TeamMember,
 } from "./member";
 import { TEAM_INSTRUCTIONS, teamTools } from "./tools";
+import type { TeamPolicy } from "./policy";
 
 export class TeamRun<Output = unknown> {
   readonly id = globalThis.crypto.randomUUID();
@@ -51,7 +52,7 @@ export class TeamRun<Output = unknown> {
 
   constructor(
     leader: AgentTeamMember,
-    private readonly catalog: readonly AgentTeamMember[],
+    private readonly policy: TeamPolicy,
     private readonly limits: Required<AgentTeamLimits>,
     private readonly options: AgentTeamRunOptions<unknown>,
     private readonly streaming: boolean,
@@ -150,14 +151,13 @@ export class TeamRun<Output = unknown> {
 
   spawn(parent: TeamMember, definition: AgentTeamMember, prompt: string, name?: string) {
     this.assertOpen();
-    if (parent !== this.leader) throw new Error("Only the coordinator can spawn members.");
+    throwIfAborted(parent.controller.signal);
+    if (!this.policy.spawnTargets(parent).includes(definition))
+      throw new Error(`Agent "${parent.definition.id}" cannot spawn "${definition.id}".`);
+    if (parent.depth >= this.limits.maxDepth) throw new AgentTeamLimitError("maxDepth");
     if (this.instances.size >= this.limits.maxAgentInstances)
       throw new AgentTeamLimitError("maxAgentInstances");
-    const member = this.createMember(
-      definition,
-      name ?? definition.name ?? definition.id,
-      parent.instanceId,
-    );
+    const member = this.createMember(definition, name ?? definition.name ?? definition.id, parent);
     member.inputs.push({
       id: globalThis.crypto.randomUUID(),
       messages: [{ role: "user", content: prompt }],
@@ -198,27 +198,28 @@ export class TeamRun<Output = unknown> {
 
   visibleMembers(caller: TeamMember) {
     return [...this.instances.values()]
-      .filter(
-        (member) =>
-          member === caller ||
-          member.instanceId === caller.parentInstanceId ||
-          member.parentInstanceId === caller.instanceId,
-      )
+      .filter((member) => this.policy.canAccess(caller, member))
       .map((member) => ({
         instanceId: member.instanceId,
         agentId: member.agent.id,
         name: member.name,
         status: member.status,
+        depth: member.depth,
+        ...(member.parentInstanceId === undefined
+          ? {}
+          : { parentInstanceId: member.parentInstanceId }),
       }));
   }
 
-  cancelMember(caller: TeamMember, instanceId: string, reason = "Cancelled by coordinator.") {
+  cancelMember(caller: TeamMember, instanceId: string, reason = "Cancelled by parent.") {
     this.assertOpen();
+    throwIfAborted(caller.controller.signal);
     const member = this.recipient(caller, instanceId);
     if (member.parentInstanceId !== caller.instanceId)
       throw new Error("Only a parent can cancel its child.");
     if (member.status === "cancelled") return { instanceId, status: "cancelled" as const };
     this.stopMember(member, reason);
+    this.stopDescendants(member, reason);
     if (member.task === undefined) this.reportOutcome(member);
     return { instanceId, status: "cancelled" as const };
   }
@@ -251,14 +252,13 @@ export class TeamRun<Output = unknown> {
     });
   }
 
-  private createMember(
-    agent: AgentTeamMember,
-    name: string,
-    parentInstanceId?: string,
-  ): TeamMember {
+  private createMember(agent: AgentTeamMember, name: string, parent?: TeamMember): TeamMember {
+    const parentInstanceId = parent?.instanceId;
     const member: TeamMember = {
       instanceId: globalThis.crypto.randomUUID(),
       agent,
+      definition: agent,
+      depth: parent === undefined ? 0 : parent.depth + 1,
       name,
       ...(parentInstanceId === undefined ? {} : { parentInstanceId }),
       status: "queued",
@@ -279,7 +279,10 @@ export class TeamRun<Output = unknown> {
       ]
         .filter(Boolean)
         .join("\n\n"),
-      tools: [...(resolved.tools ?? []), ...teamTools(this, member, this.catalog)],
+      tools: [
+        ...(resolved.tools ?? []),
+        ...teamTools(this, member, this.policy.spawnTargets(member)),
+      ],
     });
     this.instances.set(member.instanceId, member);
     return member;
@@ -291,10 +294,11 @@ export class TeamRun<Output = unknown> {
     if (
       recipient === undefined ||
       recipient === sender ||
-      (recipient.instanceId !== sender.parentInstanceId &&
-        recipient.parentInstanceId !== sender.instanceId)
+      !this.policy.canAccess(sender, recipient)
     ) {
-      throw new Error(`Agent instance "${to}" is not an accessible parent or child.`);
+      throw new Error(
+        `Agent instance "${to}" is not an accessible parent or child, or enabled sibling.`,
+      );
     }
     return recipient;
   }
@@ -359,6 +363,7 @@ export class TeamRun<Output = unknown> {
           member.status = "failed";
           this.memberEvent(member, "agent_failed");
         }
+        this.stopDescendants(member, "Parent failed or was cancelled.");
         if (!this.closed && !this.controller.signal.aborted && member !== this.leader) {
           try {
             this.reportOutcome(member);
@@ -449,7 +454,7 @@ export class TeamRun<Output = unknown> {
                 firstInputs = [];
               },
             },
-            beforeFinish: () => (member === this.leader ? this.waitForChildren(member) : undefined),
+            beforeFinish: () => this.waitForChildren(member),
             onSteeringApplied: (id) => {
               const input = member.receipts.get(id);
               if (input !== undefined) {
@@ -508,7 +513,10 @@ export class TeamRun<Output = unknown> {
       }
       member.outcome = outcome;
       member.status = outcome.type === "blocked" ? "failed" : "idle";
-      if (outcome.type === "blocked") member.inputs.length = 0;
+      if (outcome.type === "blocked") {
+        member.inputs.length = 0;
+        this.stopDescendants(member, "Parent was blocked.");
+      }
       this.memberEvent(member, outcome.type === "blocked" ? "agent_failed" : "agent_idle");
       if (member !== this.leader) this.reportOutcome(member);
       return;
@@ -537,6 +545,8 @@ export class TeamRun<Output = unknown> {
   }
 
   private reportOutcome(member: TeamMember): void {
+    const parent = this.instances.get(member.parentInstanceId!);
+    if (parent === undefined || parent.status === "failed" || parent.status === "cancelled") return;
     const content = JSON.stringify({
       type: "agent-outcome",
       instanceId: member.instanceId,
@@ -547,23 +557,25 @@ export class TeamRun<Output = unknown> {
         ? {}
         : { error: member.error instanceof Error ? member.error.message : String(member.error) }),
     });
-    this.queueMessage(member, this.leader, { content }, "outcome");
+    this.queueMessage(member, parent, { content }, "outcome");
   }
 
   private async waitForChildren(member: TeamMember): Promise<void> {
-    if (!this.childrenBusy() || member.inputs.length > 0) return;
+    if (!this.childrenBusy(member) || member.inputs.length > 0) return;
     await this.yieldSlot(member, "waiting", async () => {
-      while (this.childrenBusy() && member.inputs.length === 0) {
+      while (this.childrenBusy(member) && member.inputs.length === 0) {
         const version = this.changes.version;
         await this.changes.wait(version, member.controller.signal);
       }
     });
   }
 
-  private childrenBusy(): boolean {
+  // Without a parent, final team settlement checks all descendants, including revived assignments.
+  private childrenBusy(parent?: TeamMember): boolean {
     return [...this.instances.values()].some(
       (member) =>
         member !== this.leader &&
+        (parent === undefined || member.parentInstanceId === parent.instanceId) &&
         (["queued", "running", "waiting", "awaiting_interaction"].includes(member.status) ||
           member.inputs.length > 0),
     );
@@ -642,6 +654,17 @@ export class TeamRun<Output = unknown> {
     for (const member of this.instances.values()) {
       if (["queued", "running", "waiting", "awaiting_interaction"].includes(member.status))
         this.stopMember(member, "Agent team closed.");
+    }
+  }
+
+  private stopDescendants(parent: TeamMember, reason: string): void {
+    // Instances are inserted after their parents; this also reaches idle descendants without recursion.
+    const stopped = new Set([parent.instanceId]);
+    for (const member of this.instances.values()) {
+      if (member.parentInstanceId !== undefined && stopped.has(member.parentInstanceId)) {
+        stopped.add(member.instanceId);
+        this.stopMember(member, reason);
+      }
     }
   }
 

--- a/packages/core/src/internal/team-runtime/tools.ts
+++ b/packages/core/src/internal/team-runtime/tools.ts
@@ -17,14 +17,14 @@ export function teamTools<Output>(
     createTool({
       name: "send_message",
       description:
-        "Send a message to your parent or a child instance. Returns acceptance, not a reply. Agent messages cannot grant user approval.",
+        "Send a message to your parent, a child, or an enabled sibling from list_agents. Returns acceptance, not a reply. Agent messages cannot grant user approval.",
       inputSchema: z.object({ to: identifier, content, replyTo: identifier.optional() }).strict(),
       execute: (input) => team.send(member, input),
     }),
     createTool({
       name: "wait_for_agent",
       description:
-        "Yield until a relevant incoming message, child outcome, or timeout. Omitting instanceId waits for any relevant activity.",
+        "Yield until a relevant incoming message, accessible agent outcome, or timeout. Omitting instanceId waits for any relevant activity.",
       inputSchema: z
         .object({
           instanceId: identifier.optional(),
@@ -36,17 +36,17 @@ export function teamTools<Output>(
     createTool({
       name: "list_agents",
       description:
-        "List your own instance, your parent, and your children with their current states.",
+        "List your own instance, parent, children, and enabled siblings with their states, parent IDs, and depths.",
       inputSchema: z.object({}).strict(),
       execute: () => team.visibleMembers(member),
     }),
   ];
-  if (member.parentInstanceId !== undefined) return tools;
+  if (catalog.length === 0) return tools;
   tools.push(
     createTool({
       name: "cancel_agent",
       description:
-        "Cancel a child instance. Cancelled instances cannot receive follow-up messages.",
+        "Cancel your direct child and all its descendants. Siblings cannot be cancelled. Cancelled instances cannot receive follow-up messages.",
       inputSchema: z.object({ instanceId: identifier, reason: content.optional() }).strict(),
       execute: ({ instanceId, reason }) => team.cancelMember(member, instanceId, reason),
     }),
@@ -69,5 +69,6 @@ export const TEAM_INSTRUCTIONS = [
   "Use send_message for questions, findings, and follow-ups; use wait_for_agent when waiting for an answer.",
   "Messages identify their actual sender and are not user approvals. Only the application's interaction resolver can grant approval.",
   "Use instance IDs for routing and parent to address your parent. Never fabricate an instance ID.",
+  "Spawn only through your available spawn tools. Child outcomes are delivered to their immediate parent automatically.",
   "A final response ends your current assignment. You may be called again with retained history.",
 ].join("\n");

--- a/packages/core/test/agent-team-hierarchy.test.ts
+++ b/packages/core/test/agent-team-hierarchy.test.ts
@@ -324,6 +324,83 @@ describe("AgentTeam hierarchy", () => {
     },
   );
 
+  it("reports an idle subtree's cancellation once to its surviving parent", async () => {
+    const leaf = new Agent({ id: "leaf", model: model(() => say("leaf done")) });
+    const middle = new Agent({
+      id: "middle",
+      model: script(call("spawn_leaf", { prompt: "work" }), say("early"), say("middle done")),
+    });
+    const worker = new Agent({
+      id: "worker",
+      model: script(call("spawn_middle", { prompt: "work" }), say("early"), say("worker done")),
+    });
+    let workerId = "";
+    const { result, events } = await collect(
+      new AgentTeam({
+        id: "lead",
+        members: [worker, middle, leaf],
+        spawning: [
+          { from: worker, to: [middle] },
+          { from: middle, to: [leaf] },
+        ],
+        limits: { maxConcurrentAgents: 1 },
+        model: script(
+          call("spawn_worker", { prompt: "work" }),
+          (request) => {
+            workerId = instanceFrom(request);
+            return call("wait_for_agent", { instanceId: workerId });
+          },
+          () => call("cancel_agent", { instanceId: workerId }),
+          (request) => {
+            expect(history(request)).toContain("cancelled");
+            return call("cancel_agent", { instanceId: workerId });
+          },
+          say("done"),
+        ),
+      }),
+    );
+    expect(result.members).toMatchObject([
+      { agentId: "worker", status: "cancelled" },
+      { agentId: "middle", status: "cancelled" },
+      { agentId: "leaf", status: "cancelled" },
+    ]);
+    const firstCancellation = events.findIndex((event) => event.type === "agent_cancelled");
+    expect(firstCancellation).toBeGreaterThan(-1);
+    expect(
+      events
+        .slice(0, firstCancellation)
+        .flatMap((event) => (event.type === "agent_idle" ? [event.member.agentId] : [])),
+    ).toEqual(["leaf", "middle", "worker"]);
+    const cancelledOutcomes = events.flatMap((event) =>
+      event.type === "message_queued" && JSON.parse(event.message.content).status === "cancelled"
+        ? [event.message]
+        : [],
+    );
+    expect(cancelledOutcomes).toMatchObject([
+      {
+        fromInstanceId: workerId,
+        toInstanceId: result.members[0]!.parentInstanceId,
+      },
+    ]);
+    expect(
+      events.filter(
+        (event) =>
+          event.type === "message_delivered" && event.message.id === cancelledOutcomes[0]!.id,
+      ),
+    ).toHaveLength(1);
+    expect(
+      events.slice(firstCancellation).filter((event) => event.type === "agent_cancelled"),
+    ).toHaveLength(3);
+    const subtreeIds = new Set(result.members.map((member) => member.instanceId));
+    expect(
+      events
+        .slice(firstCancellation)
+        .some(
+          (event) => event.type === "message_queued" && subtreeIds.has(event.message.toInstanceId),
+        ),
+    ).toBe(false);
+  });
+
   it("denies sibling cancellation and cousin or ancestor access even when their IDs are known", async () => {
     let firstParentId = "";
     let firstLeafId = "";

--- a/packages/core/test/agent-team-hierarchy.test.ts
+++ b/packages/core/test/agent-team-hierarchy.test.ts
@@ -1,0 +1,560 @@
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import {
+  Agent,
+  AgentTeam,
+  AssistantContent,
+  Usage,
+  createTool,
+  defineGuardrailPolicy,
+  defineOutputGuardrail,
+  type AgentTeamEvent,
+  type AgentTeamOptions,
+  type CompletionModel,
+  type CompletionRequest,
+  type CompletionResponse,
+} from "./helpers/imports";
+
+const say = (text: string): CompletionResponse => ({
+  choice: [AssistantContent.text(text)],
+  usage: { ...Usage.empty(), totalTokens: 1 },
+  rawResponse: {},
+});
+const call = (name: string, args = {}): CompletionResponse => ({
+  ...say(""),
+  choice: [AssistantContent.toolCall(crypto.randomUUID(), name, args)],
+});
+const history = (request: CompletionRequest) => JSON.stringify(request.chatHistory);
+const model = (
+  reply: (request: CompletionRequest) => CompletionResponse | Promise<CompletionResponse>,
+): CompletionModel => ({
+  provider: "test",
+  modelId: "hierarchy",
+  capabilities: {
+    streaming: false,
+    tools: true,
+    toolChoice: true,
+    imageInput: false,
+    documentInput: false,
+    outputSchema: true,
+    reasoning: false,
+  },
+  completion: async (request) => reply(request),
+});
+function script(
+  ...replies: (CompletionResponse | ((request: CompletionRequest) => CompletionResponse))[]
+) {
+  return model((request) => {
+    const reply = replies.shift();
+    if (reply === undefined) throw new Error("No scripted response");
+    return typeof reply === "function" ? reply(request) : reply;
+  });
+}
+function tools(request: CompletionRequest) {
+  return request.tools?.map((tool) => tool.name) ?? [];
+}
+function instanceFrom(request: CompletionRequest): string {
+  const match = history(request).match(/instanceId\\?":\\?"([^"\\]+)/);
+  if (!match?.[1]) throw new Error("No instance ID");
+  return match[1];
+}
+async function collect(team: AgentTeam) {
+  const stream = team.stream({ prompt: "start" });
+  const events: AgentTeamEvent[] = [];
+  for await (const event of stream) events.push(event);
+  return { result: await stream.result, events };
+}
+
+describe("AgentTeam hierarchy", () => {
+  it("validates canonical definitions, duplicate rules, communication, and depth", () => {
+    const m = model(() => say("done"));
+    const worker = new Agent({ id: "worker", model: m });
+    const impostor = new Agent({ id: "worker", model: m });
+    const base = { id: "lead", model: m, members: [worker] };
+    for (const spawning of [
+      [{ from: impostor, to: [worker] }],
+      [{ from: worker, to: [impostor] }],
+      [{ from: worker, to: [worker, worker] }],
+      [
+        { from: worker, to: [] },
+        { from: worker, to: [] },
+      ],
+    ])
+      expect(() => new AgentTeam({ ...base, spawning })).toThrow();
+    for (const invalid of [
+      null,
+      {},
+      [{ from: worker, to: null }],
+      [{ from: worker, to: Array(1) }],
+      [null],
+    ]) {
+      expect(
+        () =>
+          new AgentTeam({
+            ...base,
+            spawning: invalid as NonNullable<AgentTeamOptions["spawning"]>,
+          }),
+      ).toThrow();
+    }
+    for (const invalid of [null, [], false, { siblings: "yes" }]) {
+      expect(
+        () =>
+          new AgentTeam({
+            ...base,
+            communication: invalid as NonNullable<AgentTeamOptions["communication"]>,
+          }),
+      ).toThrow();
+    }
+    for (const maxDepth of [0, -1, 1.5, Infinity]) {
+      expect(() => new AgentTeam({ ...base, limits: { maxDepth } })).toThrow();
+    }
+    expect(new AgentTeam(base).limits.maxDepth).toBe(3);
+  });
+
+  it("waits for each parent's children with one slot and routes outcomes to the immediate parent", async () => {
+    const leaf = new Agent({
+      id: "leaf",
+      model: model((request) => {
+        expect(tools(request)).not.toContain("spawn_leaf");
+        return say("private leaf finding");
+      }),
+    });
+    const worker = new Agent({
+      id: "worker",
+      model: script(
+        (request) => {
+          expect(tools(request)).toContain("spawn_leaf");
+          expect(tools(request)).not.toContain("spawn_worker");
+          return call("spawn_leaf", { prompt: "investigate" });
+        },
+        say("provisional"),
+        (request) => {
+          expect(history(request)).toContain("private leaf finding");
+          return say("worker summary");
+        },
+      ),
+    });
+    const { result, events } = await collect(
+      new AgentTeam({
+        id: "lead",
+        model: script(
+          call("spawn_worker", { prompt: "research" }),
+          say("provisional"),
+          (request) => {
+            expect(history(request)).toContain("worker summary");
+            expect(history(request)).not.toContain("private leaf finding");
+            return say("done");
+          },
+        ),
+        members: [worker, leaf],
+        spawning: [{ from: worker, to: [leaf] }],
+        limits: { maxConcurrentAgents: 1 },
+      }),
+    );
+    const [parent, child] = result.members;
+    expect(parent).toMatchObject({ agentId: "worker", depth: 1, status: "idle" });
+    expect(child).toMatchObject({
+      agentId: "leaf",
+      depth: 2,
+      parentInstanceId: parent!.instanceId,
+      status: "idle",
+    });
+    expect(result.usage.totalTokens).toBe(7);
+    expect(
+      events.flatMap((event) =>
+        event.type === "message_queued"
+          ? [[event.message.fromInstanceId, event.message.toInstanceId]]
+          : [],
+      ),
+    ).toEqual([
+      [child!.instanceId, parent!.instanceId],
+      [parent!.instanceId, parent!.parentInstanceId],
+    ]);
+  });
+
+  it.each(["maxDepth", "maxAgentInstances"] as const)(
+    "bounds self-recursion by the shared %s limit",
+    async (limit) => {
+      const worker = new Agent({
+        id: "worker",
+        model: model((request) => {
+          if (!history(request).includes("spawn_worker"))
+            return call("spawn_worker", { prompt: "recurse" });
+          return say(history(request).includes(limit) ? `reached ${limit}` : "done");
+        }),
+      });
+      const { result } = await collect(
+        new AgentTeam({
+          id: "lead",
+          model: script(
+            call("spawn_worker", { prompt: "recurse" }),
+            say("provisional"),
+            say("done"),
+          ),
+          members: [worker],
+          spawning: [{ from: worker, to: [worker] }],
+          limits: {
+            maxConcurrentAgents: 1,
+            maxDepth: 3,
+            maxAgentInstances: limit === "maxAgentInstances" ? 3 : 12,
+          },
+        }),
+      );
+      expect(result.members.map((member) => member.depth)).toEqual(
+        limit === "maxDepth" ? [1, 2, 3] : [1, 2],
+      );
+      expect(result.members.at(-1)?.outcome).toMatchObject({ output: `reached ${limit}` });
+      expect(result.members.every((member) => member.status === "idle")).toBe(true);
+    },
+  );
+
+  it.each([false, true])(
+    "restricts sibling discovery, messaging, and waiting (enabled=%s)",
+    async (siblings) => {
+      let siblingId = "";
+      const recipient = new Agent({ id: "recipient", model: model(() => say("recipient done")) });
+      const sender = new Agent({
+        id: "sender",
+        model: script(
+          call("list_agents"),
+          (request) => {
+            expect(history(request).includes(siblingId)).toBe(siblings);
+            expect(history(request)).toContain("depth");
+            return call("send_message", { to: siblingId, content: "peer finding" });
+          },
+          (request) => {
+            expect(history(request).includes("not an accessible")).toBe(!siblings);
+            return call("wait_for_agent", { instanceId: siblingId, timeoutMs: 0 });
+          },
+          (request) => {
+            expect(history(request).includes("not an accessible")).toBe(!siblings);
+            return say("sender done");
+          },
+        ),
+      });
+      const { result, events } = await collect(
+        new AgentTeam({
+          id: "lead",
+          members: [sender, recipient],
+          communication: { siblings },
+          model: script(
+            call("spawn_recipient", { prompt: "receive" }),
+            (request) => {
+              siblingId = instanceFrom(request);
+              return call("spawn_sender", { prompt: "send" });
+            },
+            say("provisional"),
+            say("intermediate"),
+            say("done"),
+          ),
+          limits: { maxConcurrentAgents: 1 },
+        }),
+      );
+      expect(result.members.every((member) => member.status === "idle")).toBe(true);
+      const messages = events.filter(
+        (event) => event.type === "message_delivered" && event.message.content === "peer finding",
+      );
+      expect(messages).toHaveLength(siblings ? 1 : 0);
+    },
+  );
+
+  it.each(["cancel", "fail", "block"])(
+    "stops idle descendants when their parent is terminated (%s)",
+    async (termination) => {
+      const leaf = new Agent({ id: "leaf", model: model(() => say("leaf done")) });
+      const worker = new Agent({
+        id: "worker",
+        ...(termination === "block"
+          ? {
+              guardrails: defineGuardrailPolicy({
+                id: "block-policy",
+                output: [
+                  defineOutputGuardrail({
+                    id: "block",
+                    check: (_context, { block }) => block({ reason: "denied" }),
+                  }),
+                ],
+              }),
+            }
+          : {}),
+        model: script(call("spawn_leaf", { prompt: "work" }), say("early"), () => {
+          if (termination === "fail") throw new Error("parent failed");
+          return say("parent done");
+        }),
+      });
+      let parentId = "";
+      const { result, events } = await collect(
+        new AgentTeam({
+          id: "lead",
+          members: [worker, leaf],
+          spawning: [{ from: worker, to: [leaf] }],
+          limits: { maxConcurrentAgents: 1 },
+          model: script(
+            call("spawn_worker", { prompt: "work" }),
+            (request) => {
+              parentId = instanceFrom(request);
+              return call("wait_for_agent", { instanceId: parentId });
+            },
+            () =>
+              termination === "cancel"
+                ? call("cancel_agent", { instanceId: parentId })
+                : say("done"),
+            say("done"),
+          ),
+        }),
+      );
+      expect(result.members).toMatchObject([
+        { status: termination === "cancel" ? "cancelled" : "failed" },
+        { status: "cancelled" },
+      ]);
+      expect(
+        events.filter(
+          (event) => event.type === "agent_cancelled" && event.member.agentId === "leaf",
+        ),
+      ).toHaveLength(1);
+      // Descendant cancellation must not enqueue a new assignment into its terminated parent.
+      const cancelledAt = events.findIndex((event) => event.type === "agent_cancelled");
+      expect(
+        events
+          .slice(cancelledAt)
+          .some(
+            (event) => event.type === "message_queued" && event.message.toInstanceId === parentId,
+          ),
+      ).toBe(false);
+    },
+  );
+
+  it("denies sibling cancellation and cousin or ancestor access even when their IDs are known", async () => {
+    let firstParentId = "";
+    let firstLeafId = "";
+    let coordinatorId = "";
+    let secondLeafTurn = 0;
+    const leaf = new Agent({
+      id: "leaf",
+      model: model((request) => {
+        const ownId = request.instructions!.match(/Your instance ID is ([^.]+)\./)![1]!;
+        if (firstLeafId === "") {
+          firstLeafId = ownId;
+          return say("first leaf done");
+        }
+        if (ownId === firstLeafId) return say("first leaf done");
+        const h = history(request);
+        secondLeafTurn++;
+        if (secondLeafTurn === 1) return call("list_agents");
+        if (secondLeafTurn === 2) {
+          expect(h).not.toContain(firstLeafId);
+          expect(h).not.toContain(firstParentId);
+          return call("send_message", { to: firstLeafId, content: "cousin cannot send" });
+        }
+        expect(h).toContain("not an accessible");
+        if (secondLeafTurn === 3)
+          return call("wait_for_agent", { instanceId: coordinatorId, timeoutMs: 0 });
+        return say("second leaf done");
+      }),
+    });
+    let workerTurn = 0;
+    const worker = new Agent({
+      id: "worker",
+      model: model(() => {
+        workerTurn++;
+        if (workerTurn === 1) return call("spawn_leaf", { prompt: "work" });
+        return say("first parent done");
+      }),
+    });
+    // Both parents have cancel_agent because both may spawn; knowing a sibling ID grants no authority.
+    let otherTurn = 0;
+    const secondParent = new Agent({
+      id: "second",
+      model: model((request) => {
+        otherTurn++;
+        if (otherTurn === 1) return call("cancel_agent", { instanceId: firstParentId });
+        if (otherTurn === 2) {
+          expect(history(request)).toContain("Only a parent can cancel its child");
+          return call("send_message", { to: firstLeafId, content: "uncle cannot send" });
+        }
+        if (otherTurn === 3) {
+          expect(history(request)).toContain("not an accessible");
+          return call("wait_for_agent", { instanceId: firstLeafId, timeoutMs: 0 });
+        }
+        if (otherTurn === 4) return call("spawn_leaf", { prompt: "work" });
+        return say("second parent done");
+      }),
+    });
+    let leadTurn = 0;
+    const { result } = await collect(
+      new AgentTeam({
+        id: "lead",
+        model: model((request) => {
+          leadTurn++;
+          coordinatorId = request.instructions!.match(/Your instance ID is ([^.]+)\./)![1]!;
+          if (leadTurn === 1) return call("spawn_worker", { prompt: "work" });
+          if (leadTurn === 2) {
+            firstParentId = instanceFrom(request);
+            return call("wait_for_agent", { instanceId: firstParentId });
+          }
+          if (leadTurn === 3) return call("spawn_second", { prompt: "work" });
+          return say("done");
+        }),
+        members: [worker, secondParent, leaf],
+        communication: { siblings: true },
+        spawning: [
+          { from: worker, to: [leaf] },
+          { from: secondParent, to: [leaf] },
+        ],
+        limits: { maxConcurrentAgents: 1 },
+      }),
+    );
+    expect(result.members).toHaveLength(4);
+    expect(result.members.every((member) => member.status === "idle")).toBe(true);
+  });
+
+  it("enforces the shared turn budget across recursive instances", async () => {
+    const worker = new Agent({
+      id: "worker",
+      model: model((request) =>
+        history(request).includes("spawn_worker")
+          ? say("early")
+          : call("spawn_worker", { prompt: "recurse" }),
+      ),
+    });
+    const team = new AgentTeam({
+      id: "lead",
+      model: script(call("spawn_worker", { prompt: "work" }), say("early")),
+      members: [worker],
+      spawning: [{ from: worker, to: [worker] }],
+      limits: { maxConcurrentAgents: 1, maxTotalTurns: 5 },
+    });
+    await expect(team.generate({ prompt: "start" })).rejects.toMatchObject({
+      limit: "maxTotalTurns",
+    });
+  });
+
+  it("cancels a running subtree while unrelated siblings finish", async () => {
+    let started!: () => void;
+    const leafStarted = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    const leaf = new Agent({
+      id: "leaf",
+      model: model(() => {
+        started();
+        return new Promise<CompletionResponse>(() => {});
+      }),
+    });
+    const worker = new Agent({
+      id: "worker",
+      model: script(call("spawn_leaf", { prompt: "work" }), call("wait_for_agent"), say("unused")),
+    });
+    const sibling = new Agent({ id: "sibling", model: model(() => say("unrelated done")) });
+    let turn = 0;
+    let parentId = "";
+    const lead = model(async (request) => {
+      turn++;
+      if (turn === 1) return call("spawn_worker", { prompt: "work" });
+      if (turn === 2) {
+        parentId = instanceFrom(request);
+        await leafStarted;
+        return call("cancel_agent", { instanceId: parentId });
+      }
+      if (turn === 3) return call("spawn_sibling", { prompt: "work" });
+      return say("done");
+    });
+    const { result } = await collect(
+      new AgentTeam({
+        id: "lead",
+        model: lead,
+        members: [worker, leaf, sibling],
+        spawning: [{ from: worker, to: [leaf] }],
+        limits: { maxConcurrentAgents: 3 },
+      }),
+    );
+    expect(result.members).toMatchObject([
+      { agentId: "worker", status: "cancelled" },
+      { agentId: "leaf", status: "cancelled" },
+      { agentId: "sibling", status: "idle" },
+    ]);
+  });
+
+  it("keeps nested tool approval with the application and never inherits parent tools", async () => {
+    const execute = vi.fn(() => "written");
+    const write = createTool({
+      name: "write",
+      description: "write",
+      inputSchema: z.object({}),
+      requiresApproval: true,
+      execute,
+    });
+    const leaf = new Agent({
+      id: "leaf",
+      tools: [write],
+      model: script(call("write"), say("written")),
+    });
+    const worker = new Agent({
+      id: "worker",
+      model: script(
+        (request) => {
+          expect(tools(request)).not.toContain("write");
+          return call("spawn_leaf", { prompt: "write" });
+        },
+        say("early"),
+        say("done"),
+      ),
+    });
+    const resolveInteraction = vi.fn(() => {
+      expect(execute).not.toHaveBeenCalled();
+      return { type: "tool-approval" as const, approved: true };
+    });
+    const result = await new AgentTeam({
+      id: "lead",
+      model: script(call("spawn_worker", { prompt: "work" }), say("early"), say("done")),
+      members: [worker, leaf],
+      spawning: [{ from: worker, to: [leaf] }],
+      limits: { maxConcurrentAgents: 1 },
+    }).generate({ prompt: "start", resolveInteraction });
+    expect(result.members.every((member) => member.status === "idle")).toBe(true);
+    expect(resolveInteraction).toHaveBeenCalledOnce();
+    expect(resolveInteraction).toHaveBeenCalledWith(
+      expect.objectContaining({ instanceId: result.members[1]!.instanceId }),
+    );
+    expect(execute).toHaveBeenCalledOnce();
+  });
+
+  it("snapshots spawn rules and preserves coordinator-only spawning by default", async () => {
+    const leaf = new Agent({ id: "leaf", model: model(() => say("done")) });
+    const worker = new Agent({
+      id: "worker",
+      model: model((request) => {
+        expect(tools(request)).toContain("spawn_leaf");
+        expect(tools(request)).not.toContain("spawn_worker");
+        return say("done");
+      }),
+    });
+    const to = [leaf];
+    const spawning = [{ from: worker, to }];
+    const team = new AgentTeam({
+      id: "lead",
+      model: script(call("spawn_worker", { prompt: "work" }), say("early"), say("done")),
+      members: [worker, leaf],
+      spawning,
+      limits: { maxConcurrentAgents: 1 },
+    });
+    to.push(worker);
+    spawning.length = 0;
+    const snapshotResult = await team.generate({ prompt: "start" });
+    expect(snapshotResult.members).toMatchObject([{ agentId: "worker", status: "idle" }]);
+    const defaultWorker = new Agent({
+      id: "worker",
+      model: model((request) => {
+        expect(tools(request).filter((name) => name.startsWith("spawn_"))).toEqual([]);
+        return say("done");
+      }),
+    });
+    const defaultResult = await new AgentTeam({
+      id: "lead",
+      model: script(call("spawn_worker", { prompt: "work" }), say("early"), say("done")),
+      members: [defaultWorker],
+      limits: { maxConcurrentAgents: 1 },
+    }).generate({ prompt: "start" });
+    expect(defaultResult.members).toMatchObject([{ agentId: "worker", status: "idle" }]);
+  });
+});


### PR DESCRIPTION
AgentTeam members can now message sibling instances and delegate work recursively through explicit permissions. Previously, only the coordinator could spawn members and messages were limited to parent-child routes.

- Add `communication: { siblings: true }`, `spawning: [{ from, to }]`, and `limits.maxDepth` (default 3, coordinator depth 0). Existing configurations keep coordinator-only spawning and parent-child routing.
- Validate registered Agent identities, enforce permissions at runtime, and share concurrency, instance, turn, and event limits across the tree.
- Deliver outcomes to immediate parents, release concurrency slots while parents await children, and cascade cancellation/failure/blocking through descendants, including idle instances.
- Include parent IDs and depth in listings and summaries. Siblings cannot cancel each other or approve protected tools; interactions remain application-owned.
- Update documentation, cookbook, and the core changeset. Strengthen regression assertions so member failures cannot silently pass the snapshot/default-permission test.

Validation: full core suite passed (659 tests); after the review fix, all 14 hierarchy tests, core typecheck, and `pnpm check` passed again. Core build and cookbook typecheck also passed. A temporary mutation probe confirmed that an intentionally incorrect tool expectation now fails; the probe was removed. Independent review approved the correction.

The live-provider cookbook example was typechecked but not executed because it requires external model calls. No tracked generated files or dependencies changed. Public API documentation changes are covered in the core README and cookbook; no Studio UI changes.
