### PR TITLE
feat(studio): expose live AgentTeam runs and interactions

### DIFF
--- a/.changeset/studio-team-runtime.md
+++ b/.changeset/studio-team-runtime.md
@@ -1,0 +1,9 @@
+---
+"@anvia/studio": minor
+"@anvia/core": minor
+---
+
+Register AgentTeam targets in Studio and expose attributed JSONL team runs, coordinator
+steering, cancellation, and application-only interaction responses scoped to each active run.
+Cancel disconnected runs and clean up pending interactions on completion or shutdown.
+Emit AgentTeam agent_queued events when instances are spawned, before they acquire a concurrency slot.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -210,7 +210,8 @@ const outcome = await stream.result;
 ```
 
 `events` is an attributed union of agent events, member state changes, queued/delivered messages,
-interactions, and the terminal team outcome. `textStream` yields coordinator text only, including
+interactions, and the terminal team outcome. New members emit `agent_queued` before acquiring a
+concurrency slot. `textStream` yields coordinator text only, including
 provisional turns before its final answer. `text` resolves to the final text. Choose one event or text
 consumer; final promises can be read alongside it. Reading only a final promise consumes the run
 without buffering unused events. Non-streaming models also work and emit complete response text

--- a/packages/core/src/agent/team/types.ts
+++ b/packages/core/src/agent/team/types.ts
@@ -110,7 +110,13 @@ type TeamEventIdentity = { teamRunId: string; instanceId: string; runId?: string
 
 export type AgentTeamEvent<Output = string> =
   | (TeamEventIdentity & {
-      type: "agent_started" | "agent_waiting" | "agent_idle" | "agent_failed" | "agent_cancelled";
+      type:
+        | "agent_queued"
+        | "agent_started"
+        | "agent_waiting"
+        | "agent_idle"
+        | "agent_failed"
+        | "agent_cancelled";
       member: AgentTeamMemberSummary;
     })
   | (TeamEventIdentity & {

--- a/packages/core/src/internal/team-runtime/run.ts
+++ b/packages/core/src/internal/team-runtime/run.ts
@@ -163,6 +163,7 @@ export class TeamRun<Output = unknown> {
       messages: [{ role: "user", content: prompt }],
       submitted: false,
     });
+    this.memberEvent(member, "agent_queued");
     this.launch(member);
     return { instanceId: member.instanceId, status: "queued" as const };
   }
@@ -612,7 +613,13 @@ export class TeamRun<Output = unknown> {
 
   private memberEvent(
     member: TeamMember,
-    type: "agent_started" | "agent_waiting" | "agent_idle" | "agent_failed" | "agent_cancelled",
+    type:
+      | "agent_queued"
+      | "agent_started"
+      | "agent_waiting"
+      | "agent_idle"
+      | "agent_failed"
+      | "agent_cancelled",
   ) {
     this.emit({ type, ...this.identity(member), member: memberSummary(member) });
   }

--- a/packages/core/test/agent-team-hierarchy.test.ts
+++ b/packages/core/test/agent-team-hierarchy.test.ts
@@ -160,6 +160,24 @@ describe("AgentTeam hierarchy", () => {
       status: "idle",
     });
     expect(result.usage.totalTokens).toBe(7);
+    for (const member of result.members) {
+      const queued = events.findIndex(
+        (event) => event.type === "agent_queued" && event.instanceId === member.instanceId,
+      );
+      const started = events.findIndex(
+        (event) => event.type === "agent_started" && event.instanceId === member.instanceId,
+      );
+      expect(queued).toBeGreaterThan(-1);
+      expect(queued).toBeLessThan(started);
+      expect(events[queued]).toMatchObject({
+        member: {
+          instanceId: member.instanceId,
+          parentInstanceId: member.parentInstanceId,
+          depth: member.depth,
+          status: "queued",
+        },
+      });
+    }
     expect(
       events.flatMap((event) =>
         event.type === "message_queued"

--- a/packages/tool-studio/README.md
+++ b/packages/tool-studio/README.md
@@ -5,6 +5,48 @@ knowledge inspection.
 
 Use this package to serve local agents and pipelines over HTTP, inspect sessions, traces, tools, MCPs, Memory, Status, and Knowledge in the browser UI, and exercise tool approval workflows during development.
 
+## Agent teams
+
+Register existing team definitions alongside agents and pipelines:
+
+```ts
+import { Agent, AgentTeam } from "@anvia/core/agent";
+import { Studio } from "@anvia/studio";
+
+const researcher = new Agent({ id: "researcher", model });
+const team = new AgentTeam({ id: "research-team", model, members: [researcher] });
+await new Studio([researcher, team]).serve({ port: 4021 });
+```
+
+`GET /teams` and `/config` expose team IDs, registered member definitions, and limits.
+`GET /teams/:teamId` returns one definition. Duplicate team IDs are rejected; agent and team
+IDs occupy separate namespaces. Members are not automatically registered as standalone agents.
+
+| Endpoint                                                      | Request                                  | Behavior                                 |
+| ------------------------------------------------------------- | ---------------------------------------- | ---------------------------------------- |
+| `POST /teams/:teamId/runs`                                    | `{ prompt }` or `{ messages }`           | Start an attributed JSONL event stream   |
+| `POST /teams/:teamId/runs/:runId/steer`                       | `{ prompt }` or user-only `{ messages }` | Queue user input for the coordinator     |
+| `POST /teams/:teamId/runs/:runId/cancel`                      | `{}`                                     | Cancel the entire team                   |
+| `POST /teams/:teamId/runs/:runId/interactions/:interactionId` | `AgentInteractionResponse`               | Resolve one pending approval or question |
+
+The stream begins with `{ type: "team_run_started", teamId, runId }`; the same Studio control
+ID is available in the `x-anvia-team-run-id` response header. Subsequent events follow
+`AgentTeamEvent`, with core's separate `teamRunId`, instance IDs, parent IDs, and depth.
+Internal agent continuation events are omitted; attributed `interaction` events contain everything
+needed for the application's approval/question UI. Terminal failures emit an `error` event.
+Team requests accept at most 1 MiB of JSON and 256 messages; oversized bodies or message counts return 413.
+`StudioTeamRunRequest`, `StudioTeamRunEvent`, and `StudioTeamConfig` are exported for clients.
+
+Runs and pending interactions are scoped to the team and Studio run ID. Invalid replies leave
+the interaction pending; repeated replies are rejected. Several members may request approval
+simultaneously, and only the HTTP application can answer them. Apply authentication/authorization
+middleware to these routes when exposing Studio remotely, as with other Studio execution routes.
+
+Disconnecting the stream or shutting down Studio cancels the team and its pending interactions.
+Completed runs leave the live registry; later control requests return 404. Core's configured event
+buffer limit bounds unread events. Team runs currently use ephemeral conversations and are not
+stored in Studio's agent session history; this API does not provide reconnection or durable resume.
+
 ## Installation
 
 ```sh

--- a/packages/tool-studio/src/index.ts
+++ b/packages/tool-studio/src/index.ts
@@ -3,3 +3,4 @@ export * from "./sqlite";
 export { createInMemoryStudioStore } from "./storage/memory-store";
 export * from "./trace";
 export * from "./types";
+export * from "./team-types";

--- a/packages/tool-studio/src/runtime/config.ts
+++ b/packages/tool-studio/src/runtime/config.ts
@@ -15,6 +15,7 @@ import type {
 import { staticContextDocuments, vectorContexts } from "./agent-context";
 import { evalConfig } from "./eval-config";
 import { serializeUnknown } from "./json";
+import { teamConfig } from "./teams";
 import { agentHasKnowledge } from "./knowledge";
 import { createStudioModelRegistry, studioModelsConfig } from "./models";
 import type { ResolvedStores, StudioRuntimeOptions } from "./options";
@@ -126,6 +127,7 @@ export function buildConfig(
   const config: StudioConfig = {
     id: runnerId(options),
     agents: agents.map(agentConfig),
+    teams: (options.teams ?? []).map(teamConfig),
     pipelines: pipelines.map(pipelineConfig),
     graphs: options.graphs.map(graphConfig),
     evals: options.evals.map(evalConfig),

--- a/packages/tool-studio/src/runtime/options.ts
+++ b/packages/tool-studio/src/runtime/options.ts
@@ -12,6 +12,7 @@ import type {
   StudioTraceStore,
   StudioUiOptions,
 } from "../types";
+import type { AgentTeam } from "@anvia/core/agent";
 
 export type ResolvedStores = {
   sessions?: StudioSessionStore;
@@ -26,6 +27,7 @@ export type StudioRuntimeOptions = {
   description?: string;
   version?: string;
   agents: StudioAgent[];
+  teams?: readonly AgentTeam<unknown>[];
   pipelines: StudioPipeline[];
   evals: StudioEvalSuite[];
   models?: StudioModelConfig;

--- a/packages/tool-studio/src/runtime/studio.ts
+++ b/packages/tool-studio/src/runtime/studio.ts
@@ -1,5 +1,6 @@
 import type { JsonObject } from "@anvia/core/completion";
 import { Agent, getAgentToolState } from "@anvia/core/internal/agent";
+import { AgentTeam } from "@anvia/core/agent";
 import { Pipeline } from "@anvia/core/pipeline";
 import { serve, type WebSocketServerLike } from "@hono/node-server";
 import type { Hono } from "hono";
@@ -59,6 +60,7 @@ import { registerStatusRoutes } from "./status";
 import { toolRequiresApproval } from "./tool-metadata";
 import { registerToolRoutes } from "./tools";
 import { registerTraceRoutes } from "./trace-routes";
+import { registerTeamRoutes } from "./teams";
 
 type StudioApp = AnviaStudio & {
   readonly sessionStore?: StudioSessionStore;
@@ -308,6 +310,7 @@ function studioOptionsFromTargets(
   );
   const runtimeOptions: StudioRuntimeOptions = {
     agents: inferStudioAgents(agents, options.quickPrompts ?? {}),
+    teams: targets.filter((target): target is AgentTeam<unknown> => target instanceof AgentTeam),
     pipelines: inferStudioPipelines(pipelines),
     evals: options.evals ?? [],
     graphs: options.graphs === undefined ? [] : [...options.graphs],
@@ -485,6 +488,7 @@ function createStudioApp(options: StudioRuntimeOptions): StudioApp {
     continuationRegistry,
     runLifecycle,
   });
+  registerTeamRoutes(app, options.teams ?? [], runLifecycle);
 
   if (memorySources.size > 0 || stores.sessions !== undefined) {
     registerMemoryRoutes(app, {

--- a/packages/tool-studio/src/runtime/team-run.ts
+++ b/packages/tool-studio/src/runtime/team-run.ts
@@ -1,0 +1,137 @@
+import type { AgentTeam, AgentTeamInteraction, AgentTeamStream } from "@anvia/core/agent";
+import {
+  assertAgentInteractionResponse,
+  type AgentInteractionResponse,
+} from "@anvia/core/agent/interactions";
+import type { StudioTeamRunEvent, StudioTeamRunRequest } from "../team-types";
+import type { StudioRunLease } from "./run-lifecycle";
+
+type PendingInteraction = {
+  request: AgentTeamInteraction;
+  resolve(response: AgentInteractionResponse): void;
+  reject(error: Error): void;
+};
+
+/** Owns one live team and its application-only interaction responses. */
+export class StudioTeamRun {
+  readonly id = crypto.randomUUID();
+  private readonly stream: AgentTeamStream<unknown>;
+  private readonly pending = new Map<string, PendingInteraction>();
+  private readonly claimed = new Set<string>();
+  private readonly iterator: AsyncIterator<import("@anvia/core/agent").AgentTeamEvent<unknown>>;
+  private readonly first: ReturnType<typeof this.iterator.next>;
+  private finished = false;
+
+  constructor(
+    readonly teamId: string,
+    team: AgentTeam<unknown>,
+    input: StudioTeamRunRequest,
+    lease: StudioRunLease,
+    onFinish: () => void,
+  ) {
+    this.stream = team.stream({
+      ...input,
+      abortSignal: lease.abortSignal,
+      resolveInteraction: (request) => this.requestInteraction(request),
+    });
+    // Subscribe before reading result so core retains event consumption and bounds unread events.
+    this.iterator = this.stream.events[Symbol.asyncIterator]();
+    this.first = this.iterator.next();
+    void this.first.catch(() => undefined);
+    const finish = () => {
+      this.finished = true;
+      for (const interaction of this.pending.values())
+        interaction.reject(new Error("Team run ended."));
+      this.pending.clear();
+      this.claimed.clear();
+      lease.finish();
+      onFinish();
+    };
+    void this.stream.result.then(finish, finish);
+  }
+
+  steer(input: StudioTeamRunRequest) {
+    if (input.prompt !== undefined) return this.stream.steer({ prompt: input.prompt });
+    const messages = input.messages.filter((message) => message.role === "user");
+    if (messages.length !== input.messages.length)
+      throw new TypeError("Steering accepts only user messages.");
+    return this.stream.steer({ messages });
+  }
+  cancel() {
+    this.stream.cancel("Team run cancelled in Studio.");
+  }
+
+  respond(id: string, response: AgentInteractionResponse): "accepted" | "missing" | "claimed" {
+    if (this.claimed.has(id)) return "claimed";
+    const pending = this.pending.get(id);
+    if (pending === undefined) return "missing";
+    assertAgentInteractionResponse(pending.request.interaction, response);
+    this.claimed.add(id);
+    pending.resolve(response);
+    return "accepted";
+  }
+
+  events(): AsyncIterable<StudioTeamRunEvent> {
+    const iterator = this.consume();
+    return {
+      [Symbol.asyncIterator]: () => ({
+        next: () => iterator.next(),
+        return: async () => {
+          // Abort first: returning an async generator waits behind a pending next().
+          this.cancel();
+          return iterator.return();
+        },
+      }),
+    };
+  }
+
+  private async *consume(): AsyncGenerator<StudioTeamRunEvent, void> {
+    try {
+      yield { type: "team_run_started", teamId: this.teamId, runId: this.id };
+      let next = await this.first;
+      while (!next.done) {
+        // The attributed interaction event is sufficient; continuation state stays on the server.
+        if (next.value.type !== "agent_event" || next.value.event.type !== "interaction")
+          yield next.value;
+        next = await this.iterator.next();
+      }
+    } finally {
+      if (!this.finished) this.cancel();
+      await this.iterator.return?.();
+    }
+  }
+
+  private requestInteraction(request: AgentTeamInteraction): Promise<AgentInteractionResponse> {
+    const id = request.interaction.id;
+    return new Promise((resolve, reject) => {
+      const cleanup = () => {
+        this.pending.delete(id);
+        request.abortSignal.removeEventListener("abort", abort);
+      };
+      const abort = () => {
+        cleanup();
+        reject(new Error("Team interaction cancelled."));
+      };
+      if (request.abortSignal.aborted || this.finished) {
+        abort();
+        return;
+      }
+      if (this.pending.has(id) || this.claimed.has(id)) {
+        reject(new Error("Duplicate interaction ID."));
+        return;
+      }
+      this.pending.set(id, {
+        request,
+        resolve: (response) => {
+          cleanup();
+          resolve(response);
+        },
+        reject: (error) => {
+          cleanup();
+          reject(error);
+        },
+      });
+      request.abortSignal.addEventListener("abort", abort, { once: true });
+    });
+  }
+}

--- a/packages/tool-studio/src/runtime/teams.ts
+++ b/packages/tool-studio/src/runtime/teams.ts
@@ -1,0 +1,213 @@
+import type { AgentTeam } from "@anvia/core/agent";
+import { parseAgentInteractionResponse } from "@anvia/core/agent/interactions";
+import { parseMessages } from "@anvia/core/completion";
+import type { Context, Hono } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import { z } from "zod";
+import type { StudioTeamConfig, StudioTeamRunRequest } from "../team-types";
+import { errorResponse, parseJsonBody } from "./http";
+import { serializeError } from "./errors";
+import { toJsonValue } from "./json";
+import { streamStudioJsonl } from "./streams";
+import { StudioTeamRun } from "./team-run";
+import type { StudioRunLifecycle } from "./run-lifecycle";
+
+export function teamConfig(team: AgentTeam<unknown>): StudioTeamConfig {
+  return {
+    id: team.id,
+    members: team.members.map((member) => ({
+      id: member.id,
+      ...(member.name === undefined ? {} : { name: member.name }),
+      ...(member.description === undefined ? {} : { description: member.description }),
+    })),
+    limits: team.limits,
+  };
+}
+
+const inputSchema = z
+  .object({
+    prompt: z.string().min(1).max(32_768).optional(),
+    messages: z.array(z.unknown()).min(1).optional(),
+  })
+  .strict()
+  .refine(
+    (input) => (input.prompt === undefined) !== (input.messages === undefined),
+    "Provide exactly one of prompt or messages.",
+  );
+
+function parseInput(body: unknown): StudioTeamRunRequest {
+  if (
+    typeof body === "object" &&
+    body !== null &&
+    "messages" in body &&
+    Array.isArray(body.messages) &&
+    body.messages.length > 256
+  )
+    throw new RangeError("Team input accepts at most 256 messages.");
+  const input = inputSchema.parse(body);
+  if (input.prompt !== undefined) return { prompt: input.prompt };
+  const messages = parseMessages(input.messages!);
+  if (messages.at(-1)?.role !== "user")
+    throw new TypeError("Team input must end with a user message.");
+  return { messages };
+}
+
+function readBody<T>(c: Context, parse: (body: unknown) => T) {
+  return parseJsonBody(c, (body) => {
+    try {
+      return parse(body);
+    } catch (error) {
+      return {
+        error: errorResponse(
+          c,
+          error instanceof RangeError ? 413 : 400,
+          error instanceof RangeError ? "payload_too_large" : "bad_request",
+          error instanceof Error ? error.message : "Invalid input.",
+        ),
+      };
+    }
+  });
+}
+
+export function registerTeamRoutes(
+  app: Hono,
+  teams: readonly AgentTeam<unknown>[],
+  lifecycle: StudioRunLifecycle,
+): void {
+  const catalog = new Map<string, AgentTeam<unknown>>();
+  for (const team of teams) {
+    if (catalog.has(team.id)) throw new TypeError(`Duplicate Studio team ID "${team.id}".`);
+    catalog.set(team.id, team);
+  }
+  const runs = new Map<string, StudioTeamRun>();
+  app.use(
+    "/teams/*",
+    bodyLimit({
+      maxSize: 1_048_576,
+      onError: (c) =>
+        errorResponse(c, 413, "payload_too_large", "Team request body exceeds 1 MiB."),
+    }),
+  );
+  app.get("/teams", (c) => c.json({ teams: teams.map(teamConfig) }));
+  app.get("/teams/:teamId", (c) => {
+    const team = catalog.get(c.req.param("teamId"));
+    return team === undefined
+      ? errorResponse(c, 404, "not_found", "Team not found.")
+      : c.json(teamConfig(team));
+  });
+  app.post("/teams/:teamId/runs", async (c) => {
+    const team = catalog.get(c.req.param("teamId"));
+    if (team === undefined) return errorResponse(c, 404, "not_found", "Team not found.");
+    const input = await readBody(c, parseInput);
+    if ("error" in input) return input.error;
+    const lease = lifecycle.start(c.req.raw.signal);
+    if (lease === undefined)
+      return errorResponse(c, 503, "service_unavailable", "Studio is shutting down.");
+    let run: StudioTeamRun;
+    try {
+      run = new StudioTeamRun(team.id, team, input, lease, () => runs.delete(run.id));
+    } catch (error) {
+      lease.finish();
+      return errorResponse(
+        c,
+        400,
+        "bad_request",
+        error instanceof Error ? error.message : "Invalid run.",
+      );
+    }
+    runs.set(run.id, run);
+    // Preserve core's attributed event union. Normalize nested errors before JSON encoding.
+    const events = run.events();
+    const iterator = events[Symbol.asyncIterator]();
+    const response = streamStudioJsonl({
+      [Symbol.asyncIterator]: () => ({
+        next: async () => {
+          const next = await iterator.next();
+          if (next.done) return next;
+          const event = next.value;
+          if ("member" in event && event.member.error !== undefined)
+            return {
+              done: false,
+              value: toJsonValue({
+                ...event,
+                member: { ...event.member, error: serializeError(event.member.error) },
+              }),
+            };
+          if (event.type === "agent_event" && event.event.type === "error")
+            return {
+              done: false,
+              value: toJsonValue({
+                ...event,
+                event: { ...event.event, error: serializeError(event.event.error) },
+              }),
+            };
+          if (event.type === "response" || event.type === "blocked")
+            return {
+              done: false,
+              value: toJsonValue({
+                ...event,
+                members: event.members.map((member) => ({
+                  ...member,
+                  ...(member.error === undefined ? {} : { error: serializeError(member.error) }),
+                })),
+              }),
+            };
+          return { done: false, value: toJsonValue(event) };
+        },
+        return: async () => {
+          await iterator.return?.();
+          return { done: true, value: undefined };
+        },
+      }),
+    });
+    response.headers.set("x-anvia-team-run-id", run.id);
+    return response;
+  });
+  const findRun = (c: Context) => {
+    const run = runs.get(c.req.param("runId")!);
+    return run?.teamId === c.req.param("teamId") ? run : undefined;
+  };
+  app.post("/teams/:teamId/runs/:runId/steer", async (c) => {
+    const run = findRun(c);
+    if (run === undefined) return errorResponse(c, 404, "not_found", "Active team run not found.");
+    const input = await readBody(c, parseInput);
+    if ("error" in input) return input.error;
+    try {
+      return c.json(run.steer(input));
+    } catch (error) {
+      return errorResponse(
+        c,
+        400,
+        "bad_request",
+        error instanceof Error ? error.message : "Cannot steer this run.",
+      );
+    }
+  });
+  app.post("/teams/:teamId/runs/:runId/cancel", (c) => {
+    const run = findRun(c);
+    if (run === undefined) return errorResponse(c, 404, "not_found", "Active team run not found.");
+    run.cancel();
+    return c.json({ status: "cancelled" });
+  });
+  app.post("/teams/:teamId/runs/:runId/interactions/:interactionId", async (c) => {
+    const run = findRun(c);
+    if (run === undefined) return errorResponse(c, 404, "not_found", "Active team run not found.");
+    const response = await readBody(c, parseAgentInteractionResponse);
+    if ("error" in response) return response.error;
+    try {
+      const status = run.respond(c.req.param("interactionId"), response);
+      if (status === "missing")
+        return errorResponse(c, 404, "not_found", "Pending interaction not found.");
+      if (status === "claimed")
+        return errorResponse(c, 409, "conflict", "Interaction already answered.");
+      return c.json({ status });
+    } catch (error) {
+      return errorResponse(
+        c,
+        400,
+        "bad_request",
+        error instanceof Error ? error.message : "Invalid interaction response.",
+      );
+    }
+  });
+}

--- a/packages/tool-studio/src/team-types.ts
+++ b/packages/tool-studio/src/team-types.ts
@@ -1,0 +1,18 @@
+import type { AgentTeamEvent, AgentTeamLimits } from "@anvia/core/agent";
+import type { Message } from "@anvia/core/completion";
+
+export type StudioTeamConfig = {
+  id: string;
+  members: { id: string; name?: string; description?: string }[];
+  limits: Readonly<Required<AgentTeamLimits>>;
+};
+
+export type StudioTeamRunRequest =
+  | { prompt: string; messages?: never }
+  | { messages: readonly Message[]; prompt?: never };
+
+/** JSONL events; runId on team_run_started addresses Studio's live run controls. */
+export type StudioTeamRunEvent =
+  | { type: "team_run_started"; teamId: string; runId: string }
+  | AgentTeamEvent<unknown>
+  | { type: "error"; error: unknown };

--- a/packages/tool-studio/src/types.ts
+++ b/packages/tool-studio/src/types.ts
@@ -1,9 +1,11 @@
 import type {
   Agent,
+  AgentTeam,
   AgentInteractionOutcome,
   AgentOutcome,
   AgentStreamEvent,
 } from "@anvia/core/agent";
+import type { StudioTeamConfig } from "./team-types";
 import type { AgentInteractionResponse } from "@anvia/core/agent/interactions";
 import type {
   CompletionModel,
@@ -142,8 +144,11 @@ export type StudioAgent = {
 };
 
 // Studio accepts arbitrary pipelines and validates run inputs at the HTTP boundary.
-// oxlint-disable-next-line typescript/no-explicit-any -- Input/output types remain user-defined outside Studio.
-export type StudioTarget = Agent | Pipeline<any, any>;
+export type StudioTarget =
+  | Agent
+  | AgentTeam<unknown>
+  // oxlint-disable-next-line typescript/no-explicit-any -- Input/output types remain user-defined outside Studio.
+  | Pipeline<any, any>;
 
 export type StudioAgentConfig = {
   id: string;
@@ -315,6 +320,7 @@ export type StudioConfig = {
   description?: string;
   version?: string;
   agents: StudioAgentConfig[];
+  teams?: StudioTeamConfig[];
   models?: StudioModelsConfig;
   pipelines: StudioPipelineConfig[];
   graphs: StudioGraphConfig[];

--- a/packages/tool-studio/test/teams.test.ts
+++ b/packages/tool-studio/test/teams.test.ts
@@ -1,0 +1,346 @@
+import { Agent, AgentTeam } from "@anvia/core/agent";
+import {
+  Usage,
+  type CompletionModel,
+  type CompletionRequest,
+  type CompletionResponse,
+} from "@anvia/core/completion";
+import { AssistantContent } from "../../core/test/helpers/imports";
+import { createQuestionTool, createTool } from "@anvia/core/tool";
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { Studio, type StudioTeamRunEvent } from "../src/index";
+
+const say = (text: string): CompletionResponse => ({
+  choice: [AssistantContent.text(text)],
+  usage: Usage.empty(),
+  rawResponse: {},
+});
+const call = (name: string, args = {}): CompletionResponse => ({
+  ...say(""),
+  choice: [AssistantContent.toolCall(crypto.randomUUID(), name, args)],
+});
+function model(
+  reply: (request: CompletionRequest) => CompletionResponse | Promise<CompletionResponse>,
+): CompletionModel {
+  return {
+    provider: "test",
+    modelId: "team",
+    capabilities: {
+      streaming: false,
+      tools: true,
+      toolChoice: true,
+      imageInput: false,
+      documentInput: false,
+      outputSchema: true,
+      reasoning: false,
+    },
+    completion: async (request) => reply(request),
+  };
+}
+function post(studio: Studio, path: string, body: unknown = {}) {
+  return studio.fetch(
+    new Request(`http://studio${path}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+async function* events(response: Response): AsyncGenerator<StudioTeamRunEvent> {
+  expect(response.status).toBe(200);
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) break;
+      buffer += decoder.decode(next.value, { stream: true });
+      let end: number;
+      while ((end = buffer.indexOf("\n")) !== -1) {
+        const line = buffer.slice(0, end);
+        buffer = buffer.slice(end + 1);
+        if (line) yield JSON.parse(line) as StudioTeamRunEvent;
+      }
+    }
+  } finally {
+    await reader.cancel();
+  }
+}
+async function untilInteraction(iterator: AsyncGenerator<StudioTeamRunEvent>) {
+  for await (const event of { [Symbol.asyncIterator]: () => ({ next: () => iterator.next() }) }) {
+    if (event.type === "interaction") return event;
+    if (event.type === "error") throw new Error(JSON.stringify(event.error));
+  }
+  throw new Error("No interaction");
+}
+function approvalTeam(id = "team", siblings = false) {
+  const execute = vi.fn(() => "written");
+  const write = createTool({
+    name: "write",
+    description: "Write",
+    inputSchema: z.object({}),
+    requiresApproval: true,
+    execute,
+  });
+  const worker = new Agent({
+    id: "worker",
+    tools: [write],
+    model: model((request) =>
+      JSON.stringify(request.chatHistory).includes('"role":"tool"')
+        ? say("worker done")
+        : call("write"),
+    ),
+  });
+  const team = new AgentTeam({
+    id,
+    members: [worker],
+    model: model((request) => {
+      if (JSON.stringify(request.chatHistory).includes("spawn_worker")) return say("done");
+      const response = call("spawn_worker", { prompt: "work" });
+      if (siblings) response.choice.push(...call("spawn_worker", { prompt: "more work" }).choice);
+      return response;
+    }),
+    limits: { maxConcurrentAgents: 1 },
+  });
+  return { team, execute };
+}
+
+describe("Studio teams", () => {
+  it("registers heterogeneous targets, exposes definitions, and rejects duplicate team IDs", async () => {
+    const m = model(() => say('{"answer":"done"}'));
+    const team = new AgentTeam({
+      id: "team",
+      model: m,
+      outputSchema: z.object({ answer: z.string() }),
+      members: [],
+    });
+    const studio = new Studio([new Agent({ id: "agent", model: m }), team], { ui: false });
+    expect(studio.config().teams).toMatchObject([
+      { id: "team", members: [], limits: { maxDepth: 3 } },
+    ]);
+    expect(await (await studio.fetch(new Request("http://studio/teams"))).json()).toMatchObject({
+      teams: [{ id: "team" }],
+    });
+    expect((await studio.fetch(new Request("http://studio/teams/missing"))).status).toBe(404);
+    expect(() => new Studio([team, team], { ui: false })).toThrow("Duplicate Studio team ID");
+    const emitted = [];
+    for await (const event of events(await post(studio, "/teams/team/runs", { prompt: "start" })))
+      emitted.push(event);
+    expect(emitted.at(-1)).toMatchObject({ type: "response", output: { answer: "done" } });
+    await studio.shutdown();
+  });
+
+  it("rejects malformed requests before starting the model", async () => {
+    const completion = vi.fn(() => say("done"));
+    const studio = new Studio(
+      [new AgentTeam({ id: "team", model: model(completion), members: [] })],
+      { ui: false },
+    );
+    for (const body of [
+      {},
+      { prompt: "" },
+      { prompt: "x", messages: [] },
+      { prompt: "x", unknown: true },
+      { messages: [{ role: "assistant", content: "x" }] },
+    ]) {
+      expect((await post(studio, "/teams/team/runs", body)).status).toBe(400);
+    }
+    expect(completion).not.toHaveBeenCalled();
+    expect(
+      (
+        await post(studio, "/teams/team/runs", {
+          messages: Array.from({ length: 257 }, () => ({ role: "user", content: "x" })),
+        })
+      ).status,
+    ).toBe(413);
+    expect(
+      (
+        await post(studio, "/teams/team/runs", {
+          messages: [{ role: "user", content: "x".repeat(1_048_576) }],
+        })
+      ).status,
+    ).toBe(413);
+    expect(completion).not.toHaveBeenCalled();
+    expect((await post(studio, "/teams/missing/runs", { prompt: "x" })).status).toBe(404);
+    await studio.shutdown();
+    expect((await post(studio, "/teams/team/runs", { prompt: "x" })).status).toBe(503);
+  });
+
+  it("routes approval to its active run, validates replies, and permits steering while waiting", async () => {
+    const { team, execute } = approvalTeam();
+    const other = approvalTeam("other").team;
+    const studio = new Studio([team, other], { ui: false });
+    const response = await post(studio, "/teams/team/runs", { prompt: "start" });
+    const runId = response.headers.get("x-anvia-team-run-id")!;
+    const iterator = events(response);
+    const interaction = await untilInteraction(iterator);
+    const route = `/teams/team/runs/${runId}/interactions/${interaction.interaction.id}`;
+    expect(execute).not.toHaveBeenCalled();
+    expect(
+      (
+        await post(studio, route.replace("/team/", "/other/"), {
+          type: "tool-approval",
+          approved: true,
+        })
+      ).status,
+    ).toBe(404);
+    expect((await post(studio, route, { type: "tool-question", answers: [] })).status).toBe(400);
+    expect(
+      (await post(studio, `/teams/team/runs/${runId}/steer`, { prompt: "Follow-up from user" }))
+        .status,
+    ).toBe(200);
+    expect((await post(studio, route, { type: "tool-approval", approved: true })).status).toBe(200);
+    expect([404, 409]).toContain(
+      (await post(studio, route, { type: "tool-approval", approved: true })).status,
+    );
+    const emitted = [];
+    for await (const event of iterator) emitted.push(event);
+    expect(emitted.at(-1)).toMatchObject({ type: "response", members: [{ status: "idle" }] });
+    expect(JSON.stringify(emitted)).not.toContain('"continuation"');
+    expect(execute).toHaveBeenCalledOnce();
+    expect((await post(studio, `/teams/team/runs/${runId}/steer`, { prompt: "late" })).status).toBe(
+      404,
+    );
+    await studio.shutdown();
+  });
+
+  it.each(["cancel", "disconnect", "shutdown"])(
+    "cleans up pending approvals on %s",
+    async (action) => {
+      const { team, execute } = approvalTeam();
+      const studio = new Studio([team], { ui: false });
+      const response = await post(studio, "/teams/team/runs", { prompt: "start" });
+      const runId = response.headers.get("x-anvia-team-run-id")!;
+      const iterator = events(response);
+      const interaction = await untilInteraction(iterator);
+      if (action === "cancel") {
+        expect((await post(studio, `/teams/team/runs/${runId}/cancel`)).status).toBe(200);
+        const emitted = [];
+        for await (const event of iterator) emitted.push(event);
+        expect(emitted.at(-1)).toMatchObject({ type: "error" });
+      } else if (action === "disconnect") await iterator.return(undefined);
+      else await studio.shutdown({ timeoutMs: 1000 });
+      await studio.shutdown({ timeoutMs: 1000 });
+      expect(
+        (
+          await post(
+            studio,
+            `/teams/team/runs/${runId}/interactions/${interaction.interaction.id}`,
+            { type: "tool-approval", approved: true },
+          )
+        ).status,
+      ).toBe(404);
+      expect(execute).not.toHaveBeenCalled();
+    },
+  );
+
+  it("resumes a team after a valid user question answer", async () => {
+    const ask = createQuestionTool({ name: "ask", description: "Ask the user" });
+    const team = new AgentTeam({
+      id: "team",
+      members: [],
+      tools: [ask],
+      model: model((request) =>
+        JSON.stringify(request.chatHistory).includes('"role":"tool"')
+          ? say("answered")
+          : call("ask", { questions: [{ id: "scope", text: "What scope?" }] }),
+      ),
+    });
+    const studio = new Studio([team], { ui: false });
+    const response = await post(studio, "/teams/team/runs", { prompt: "start" });
+    const iterator = events(response);
+    const event = await untilInteraction(iterator);
+    expect(event.interaction.type).toBe("tool-question");
+    expect(
+      (
+        await post(
+          studio,
+          `/teams/team/runs/${response.headers.get("x-anvia-team-run-id")}/interactions/${event.interaction.id}`,
+          { type: "tool-question", answers: [{ questionId: "scope", value: "Runtime" }] },
+        )
+      ).status,
+    ).toBe(200);
+    const emitted = [];
+    for await (const next of iterator) emitted.push(next);
+    expect(emitted.at(-1)).toMatchObject({ type: "response", output: "answered" });
+    await studio.shutdown();
+  });
+
+  it("keeps simultaneous approvals independent", async () => {
+    const { team, execute } = approvalTeam();
+    const studio = new Studio([team], { ui: false });
+    const responses = await Promise.all([
+      post(studio, "/teams/team/runs", { prompt: "one" }),
+      post(studio, "/teams/team/runs", { prompt: "two" }),
+    ]);
+    const iterators = responses.map(events);
+    const interactions = await Promise.all(iterators.map(untilInteraction));
+    for (const [index, response] of responses.entries()) {
+      const route = `/teams/team/runs/${response.headers.get("x-anvia-team-run-id")}/interactions/${interactions[index]!.interaction.id}`;
+      expect(
+        (await post(studio, route, { type: "tool-approval", approved: index === 0 })).status,
+      ).toBe(200);
+    }
+    for (const iterator of iterators) {
+      const emitted = [];
+      for await (const event of iterator) emitted.push(event);
+      expect(emitted.at(-1)).toMatchObject({ type: "response" });
+    }
+    expect(execute).toHaveBeenCalledOnce();
+    await studio.shutdown();
+  });
+
+  it("resolves simultaneous sibling approvals separately within one run", async () => {
+    const { team, execute } = approvalTeam("team", true);
+    const studio = new Studio([team], { ui: false });
+    const response = await post(studio, "/teams/team/runs", { prompt: "start" });
+    const iterator = events(response);
+    const first = await untilInteraction(iterator);
+    const second = await untilInteraction(iterator);
+    expect(first.instanceId).not.toBe(second.instanceId);
+    for (const [index, event] of [first, second].entries()) {
+      const route = `/teams/team/runs/${response.headers.get("x-anvia-team-run-id")}/interactions/${event.interaction.id}`;
+      expect(
+        (await post(studio, route, { type: "tool-approval", approved: index === 0 })).status,
+      ).toBe(200);
+    }
+    const emitted = [];
+    for await (const event of iterator) emitted.push(event);
+    expect(emitted.at(-1)).toMatchObject({
+      type: "response",
+      members: [{ status: "idle" }, { status: "idle" }],
+    });
+    expect(execute).toHaveBeenCalledOnce();
+    await studio.shutdown();
+  });
+
+  it("cancels a pending stream read even when the model ignores abort", async () => {
+    let started!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    const team = new AgentTeam({
+      id: "team",
+      members: [],
+      model: model(() => {
+        started();
+        return new Promise(() => {});
+      }),
+    });
+    const studio = new Studio([team], { ui: false });
+    const response = await post(studio, "/teams/team/runs", { prompt: "start" });
+    const reader = response.body!.getReader();
+    await reader.read();
+    await ready;
+    const pending = reader.read();
+    await reader.cancel();
+    await pending;
+    await studio.shutdown({ timeoutMs: 1000 });
+    expect(
+      (await post(studio, `/teams/team/runs/${response.headers.get("x-anvia-team-run-id")}/cancel`))
+        .status,
+    ).toBe(404);
+  });
+});


### PR DESCRIPTION
Studio can register `AgentTeam` alongside agents and pipelines and run it over HTTP. A team stream preserves instance attribution and supports coordinator steering, whole-team cancellation, and independent application responses to pending approvals/questions.

- Add `/teams` discovery and `/teams/:teamId/runs` JSONL execution with run-scoped control routes. Validate inputs, cap bodies at 1 MiB and messages at 256, and reject wrong-run or repeated interaction responses.
- Keep continuations server-side. Abort disconnected or shutting-down runs and release live run/interaction state even when a model ignores abort.
- Add core `agent_queued` events so clients can display newly spawned members before they acquire a concurrency slot.
- Document the HTTP contract and include minor changesets for Studio and core.

This is the runtime PR of a two-PR stack. The following PR adds the Studio team playground. Team history persistence and durable resume remain follow-ups.

Validation: 660 core tests, 225 Studio tests (including 10 team route tests), core/Studio typechecks and builds, and `pnpm check` pass. Tests cover concurrent approvals within one team and across runs, questions, input bounds, queued-event ordering, steering, disconnects, and shutdown. Independent review approved the input-limit follow-up. No dependencies or tracked generated artifacts changed; no UI changes in this PR.
