### PR TITLE
feat(studio): add the AgentTeam playground

### DIFF
--- a/.changeset/studio-team-playground.md
+++ b/.changeset/studio-team-playground.md
@@ -1,0 +1,5 @@
+---
+"@anvia/studio": minor
+---
+
+Add a team playground with live instance trees, coordinator follow-ups, member conversations and tool activity, inter-agent messages, and attributed approval and question controls.

--- a/.changeset/studio-team-playground.md
+++ b/.changeset/studio-team-playground.md
@@ -2,4 +2,4 @@
 "@anvia/studio": minor
 ---
 
-Add a team playground with live instance trees, coordinator follow-ups, member conversations and tool activity, inter-agent messages, and attributed approval and question controls.
+Add a team playground with live instance trees, coordinator follow-ups, member conversations and tool activity, inter-agent messages, and attributed approval and question controls. Stopping or leaving a task explicitly requests server cancellation independently of stream cleanup.

--- a/packages/tool-studio/README.md
+++ b/packages/tool-studio/README.md
@@ -25,8 +25,8 @@ recursive children; selecting an instance reveals its output, tool activity, run
 usage. The Messages panel shows sender, recipient, and delivery status (the latest 500 messages).
 Approvals and questions appear as independent cards labeled with the requesting member.
 
-Team tasks are local to the current page. Leaving the page cancels active work; completed tasks
-remain visible until you choose **New task**. They do not appear in saved agent sessions.
+Team tasks are local to the current page. Stopping or leaving a task requests server cancellation
+independently of closing its stream. Completed tasks remain visible until you choose **New task**. They do not appear in saved agent sessions.
 
 `GET /teams` and `/config` expose team IDs, registered member definitions, and limits.
 `GET /teams/:teamId` returns one definition. Duplicate team IDs are rejected; agent and team

--- a/packages/tool-studio/README.md
+++ b/packages/tool-studio/README.md
@@ -18,6 +18,16 @@ const team = new AgentTeam({ id: "research-team", model, members: [researcher] }
 await new Studio([researcher, team]).serve({ port: 4021 });
 ```
 
+Select a team from the playground's agent/team selector. A Studio configured with only teams
+opens its first team automatically. Submit a task to the coordinator, send follow-ups while it
+runs, or stop the whole team. The Members panel shows queued and active instances, including
+recursive children; selecting an instance reveals its output, tool activity, run messages, and
+usage. The Messages panel shows sender, recipient, and delivery status (the latest 500 messages).
+Approvals and questions appear as independent cards labeled with the requesting member.
+
+Team tasks are local to the current page. Leaving the page cancels active work; completed tasks
+remain visible until you choose **New task**. They do not appear in saved agent sessions.
+
 `GET /teams` and `/config` expose team IDs, registered member definitions, and limits.
 `GET /teams/:teamId` returns one definition. Duplicate team IDs are rejected; agent and team
 IDs occupy separate namespaces. Members are not automatically registered as standalone agents.

--- a/packages/tool-studio/src/ui/app/app.tsx
+++ b/packages/tool-studio/src/ui/app/app.tsx
@@ -523,6 +523,7 @@ export function StudioConsole() {
   const contextValue = {
     activePage,
     agents,
+    teams: config?.teams,
     answeringQuestions,
     attachments,
     browserWorkspace,

--- a/packages/tool-studio/src/ui/app/modules/playground/playground-page.tsx
+++ b/packages/tool-studio/src/ui/app/modules/playground/playground-page.tsx
@@ -11,6 +11,7 @@ import {
   type CSSProperties,
   type KeyboardEvent,
   type RefObject,
+  type ReactNode,
   useState,
 } from "react";
 import type {
@@ -47,6 +48,7 @@ const explicitControlValuePrefix = "__anvia_option__";
 
 export function PlaygroundPage(props: {
   agents: StudioConfig["agents"];
+  targetSelector?: ReactNode;
   allSessions: StudioSessionSummary[];
   answeringQuestions: Set<string>;
   attachments: PromptAttachment[];
@@ -308,27 +310,28 @@ export function PlaygroundPage(props: {
                       </SelectContent>
                     </Select>
                   )}
-                  {props.agents.length > 1 ? (
-                    <Select
-                      value={props.selectedAgent?.id ?? props.selectedAgentId}
-                      onValueChange={props.onSelectAgent}
-                      disabled={props.runState === "running"}
-                    >
-                      <SelectTrigger
-                        aria-label="Select agent"
-                        className="flex h-8 min-h-8 w-auto max-w-64 gap-2 border-0 bg-transparent px-2 py-1 text-xs font-medium text-muted-foreground shadow-none hover:bg-transparent hover:text-foreground"
+                  {props.targetSelector ??
+                    (props.agents.length > 1 ? (
+                      <Select
+                        value={props.selectedAgent?.id ?? props.selectedAgentId}
+                        onValueChange={props.onSelectAgent}
+                        disabled={props.runState === "running"}
                       >
-                        <SelectValue placeholder="Agent" />
-                      </SelectTrigger>
-                      <SelectContent align="end">
-                        {props.agents.map((agent) => (
-                          <SelectItem value={agent.id} key={agent.id}>
-                            {agent.name ?? agent.id}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  ) : null}
+                        <SelectTrigger
+                          aria-label="Select agent"
+                          className="flex h-8 min-h-8 w-auto max-w-64 gap-2 border-0 bg-transparent px-2 py-1 text-xs font-medium text-muted-foreground shadow-none hover:bg-transparent hover:text-foreground"
+                        >
+                          <SelectValue placeholder="Agent" />
+                        </SelectTrigger>
+                        <SelectContent align="end">
+                          {props.agents.map((agent) => (
+                            <SelectItem value={agent.id} key={agent.id}>
+                              {agent.name ?? agent.id}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    ) : null)}
                   <Button
                     aria-label={
                       props.isStreaming

--- a/packages/tool-studio/src/ui/app/modules/playground/playground-target-select.tsx
+++ b/packages/tool-studio/src/ui/app/modules/playground/playground-target-select.tsx
@@ -1,0 +1,49 @@
+import type { StudioConfig } from "../../../../types";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../../components/ui/select";
+
+export function PlaygroundTargetSelect(props: {
+  agents: StudioConfig["agents"];
+  teams: NonNullable<StudioConfig["teams"]>;
+  value: string;
+  disabled: boolean;
+  onSelect: (kind: "agent" | "team", id: string) => void;
+}) {
+  return (
+    <Select
+      value={props.value}
+      disabled={props.disabled}
+      onValueChange={(value) => {
+        const separator = value.indexOf(":");
+        props.onSelect(
+          value.slice(0, separator) === "team" ? "team" : "agent",
+          value.slice(separator + 1),
+        );
+      }}
+    >
+      <SelectTrigger
+        aria-label="Select agent or team"
+        className="h-8 w-auto min-w-32 max-w-64 text-sm"
+      >
+        <SelectValue placeholder="Agent or team" />
+      </SelectTrigger>
+      <SelectContent>
+        {props.agents.map((agent) => (
+          <SelectItem key={`agent:${agent.id}`} value={`agent:${agent.id}`}>
+            {agent.name ?? agent.id}
+          </SelectItem>
+        ))}
+        {props.teams.map((team) => (
+          <SelectItem key={`team:${team.id}`} value={`team:${team.id}`}>
+            {team.id} · Team
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/packages/tool-studio/src/ui/app/modules/shell/studio-console-layout.tsx
+++ b/packages/tool-studio/src/ui/app/modules/shell/studio-console-layout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from "@tanstack/react-router";
+import { Outlet, useParams } from "@tanstack/react-router";
 import { Suspense } from "react";
 import { DeleteSessionDialog } from "../../app-pages";
 import { useStudioConsole } from "../../studio-console-context";
@@ -6,6 +6,7 @@ import { StudioHeader, StudioRail, StudioSidebar } from "./studio-shell";
 
 export function StudioConsoleLayout() {
   const studio = useStudioConsole();
+  const { teamId } = useParams({ strict: false });
   const navigation = {
     activePage: studio.activePage,
     graphsEnabled: studio.graphsEnabled,
@@ -30,16 +31,19 @@ export function StudioConsoleLayout() {
       <StudioRail {...navigation} />
       <StudioSidebar {...navigation} />
 
-      <main className="grid h-[100dvh] min-w-0 flex-1 grid-rows-[56px_minmax(0,1fr)] overflow-hidden bg-background">
+      <main className="grid h-[100dvh] min-w-0 flex-1 grid-cols-1 grid-rows-[56px_minmax(0,1fr)] overflow-hidden bg-background">
         <StudioHeader
           activePage={studio.activePage}
           knowledgeTab={studio.knowledgeTab}
           navigation={navigation}
           selectedAgentLabel={
-            studio.activePage === "sandboxes"
-              ? "Sandboxes"
-              : (studio.selectedAgent?.name ?? studio.selectedAgent?.id ?? "Agent")
+            teamId
+              ? teamId
+              : studio.activePage === "sandboxes"
+                ? "Sandboxes"
+                : (studio.selectedAgent?.name ?? studio.selectedAgent?.id ?? "Agent")
           }
+          showNewSession={!teamId}
           sessionsEnabled={studio.sessionsEnabled}
           theme={studio.theme}
           onNewSession={() => studio.startNewChat()}

--- a/packages/tool-studio/src/ui/app/modules/shell/studio-shell.tsx
+++ b/packages/tool-studio/src/ui/app/modules/shell/studio-shell.tsx
@@ -175,6 +175,7 @@ export function StudioSidebar(props: StudioNavigationProps) {
 }
 
 export function StudioHeader(props: {
+  showNewSession?: boolean;
   activePage: ActivePage;
   knowledgeTab: KnowledgeTab;
   navigation: StudioNavigationProps;
@@ -223,9 +224,11 @@ export function StudioHeader(props: {
       >
         <StudioIcon icon={themeIcon} aria-hidden="true" />
       </Button>
-      <Button type="button" disabled={!props.sessionsEnabled} onClick={props.onNewSession}>
-        New session
-      </Button>
+      {props.showNewSession !== false && (
+        <Button type="button" disabled={!props.sessionsEnabled} onClick={props.onNewSession}>
+          New session
+        </Button>
+      )}
     </header>
   );
 }

--- a/packages/tool-studio/src/ui/app/modules/teams/team-interactions.tsx
+++ b/packages/tool-studio/src/ui/app/modules/teams/team-interactions.tsx
@@ -1,0 +1,113 @@
+import type { AgentInteractionResponse } from "@anvia/core/agent/interactions";
+import { useState } from "react";
+import { Button } from "../../components/ui/button";
+import { Textarea } from "../../components/ui/textarea";
+import type { TeamInteraction } from "./team-state";
+
+export function TeamInteractionCard(props: {
+  item: TeamInteraction;
+  name: string;
+  busy: boolean;
+  respond: (id: string, response: AgentInteractionResponse) => Promise<boolean>;
+}) {
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const { request, status } = props.item;
+  const disabled = props.busy || status !== "pending";
+  return (
+    <section
+      className="space-y-3 rounded-xl border border-hair bg-card p-4"
+      aria-label={`${props.name}: ${request.toolName}`}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2 text-sm">
+        <strong>
+          {props.name} · {request.toolName}
+        </strong>
+        <span className="text-muted-foreground">
+          {props.busy ? "Submitting…" : status === "pending" ? "Needs your input" : status}
+        </span>
+      </div>
+      <p className="break-all text-xs text-muted-foreground">Instance {props.item.instanceId}</p>
+      {request.type === "tool-approval" ? (
+        <>
+          {request.reason && <p className="text-sm">{request.reason}</p>}
+          <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-all text-xs">
+            {JSON.stringify(request.input, null, 2)}
+          </pre>
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              disabled={disabled}
+              onClick={() =>
+                void props.respond(request.id, { type: "tool-approval", approved: true })
+              }
+            >
+              Approve
+            </Button>
+            <Button
+              size="sm"
+              variant="secondary"
+              disabled={disabled}
+              onClick={() =>
+                void props.respond(request.id, { type: "tool-approval", approved: false })
+              }
+            >
+              Deny
+            </Button>
+          </div>
+        </>
+      ) : (
+        <form
+          className="space-y-3"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void props.respond(request.id, {
+              type: "tool-question",
+              answers: request.questions.map((question) => ({
+                questionId: question.id,
+                value: answers[question.id] ?? "",
+              })),
+            });
+          }}
+        >
+          {request.questions.map((question) => (
+            <fieldset key={question.id} disabled={disabled} className="space-y-2">
+              <legend className="mb-2 text-sm">{question.text}</legend>
+              {question.choices?.map((choice) => (
+                <label key={choice.value} className="flex items-center gap-2 text-sm">
+                  <input
+                    type="radio"
+                    name={`${request.id}:${question.id}`}
+                    value={choice.value}
+                    checked={answers[question.id] === choice.value}
+                    onChange={() =>
+                      setAnswers((previous) => ({ ...previous, [question.id]: choice.value }))
+                    }
+                  />
+                  {choice.label}
+                </label>
+              ))}
+              {(!question.choices?.length || question.allowCustom) && (
+                <Textarea
+                  aria-label={question.text}
+                  placeholder="Your answer"
+                  value={answers[question.id] ?? ""}
+                  onChange={(event) =>
+                    setAnswers((previous) => ({ ...previous, [question.id]: event.target.value }))
+                  }
+                />
+              )}
+            </fieldset>
+          ))}
+          <Button
+            size="sm"
+            disabled={
+              disabled || request.questions.some((question) => !answers[question.id]?.trim())
+            }
+          >
+            Send answers
+          </Button>
+        </form>
+      )}
+    </section>
+  );
+}

--- a/packages/tool-studio/src/ui/app/modules/teams/team-members.tsx
+++ b/packages/tool-studio/src/ui/app/modules/teams/team-members.tsx
@@ -1,0 +1,138 @@
+import type { AgentTeamMemberSummary } from "@anvia/core/agent";
+import { MarkdownText } from "../shared/renderers";
+import { errorMessage } from "../shared/format";
+import { cn } from "../../lib/utils";
+import type { TeamState } from "./team-state";
+
+export function TeamMembers(props: {
+  state: TeamState;
+  selected: string;
+  select: (id: string) => void;
+}) {
+  const members = Object.values(props.state.members);
+  const selected =
+    props.state.members[props.selected] ?? members.find((member) => member.depth === 0);
+  function node(member: AgentTeamMemberSummary) {
+    return (
+      <li key={member.instanceId}>
+        <button
+          type="button"
+          onClick={() => props.select(member.instanceId)}
+          title={member.instanceId}
+          aria-pressed={selected?.instanceId === member.instanceId}
+          className={cn(
+            "flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2 text-left text-sm hover:bg-muted",
+            selected?.instanceId === member.instanceId && "bg-muted",
+          )}
+          style={{ paddingLeft: 12 + member.depth * 16 }}
+        >
+          <span className="min-w-0 truncate">
+            {member.depth > 0 ? "↳ " : ""}
+            {member.name}
+          </span>
+          <span className="shrink-0 text-xs text-muted-foreground">
+            {member.status.replaceAll("_", " ")}
+          </span>
+        </button>
+        <ul>{members.filter((child) => child.parentInstanceId === member.instanceId).map(node)}</ul>
+      </li>
+    );
+  }
+  return (
+    <div className="space-y-5">
+      <div>
+        <h2 className="mb-3 text-sm font-medium">
+          Members <span className="text-muted-foreground">{members.length}</span>
+        </h2>
+        {members.length ? (
+          <ul aria-label="Team members">
+            {members.filter((member) => !member.parentInstanceId).map(node)}
+          </ul>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            Spawned agents will appear here as the team works.
+          </p>
+        )}
+      </div>
+      {selected && (
+        <section className="space-y-4 border-t border-hair pt-4" aria-label="Member details">
+          <div>
+            <h3 className="text-sm font-medium">{selected.name}</h3>
+            <p className="break-all text-xs text-muted-foreground">
+              {selected.agentId} · {selected.instanceId}
+            </p>
+          </div>
+          {selected.error !== undefined && (
+            <p role="alert" className="text-sm text-status-danger-ink">
+              {errorMessage(selected.error)}
+            </p>
+          )}
+          <details className="text-xs">
+            <summary className="cursor-pointer text-muted-foreground">Token usage</summary>
+            <pre className="overflow-auto p-2">{JSON.stringify(selected.usage, null, 2)}</pre>
+          </details>
+          {props.state.turns
+            .filter((turn) => turn.instanceId === selected.instanceId)
+            .map((turn) => (
+              <div key={turn.key} className="space-y-3">
+                {turn.text && (
+                  <MarkdownText text={turn.text} live={props.state.status === "running"} />
+                )}
+                {turn.tools.length > 0 && (
+                  <details>
+                    <summary className="cursor-pointer text-xs text-muted-foreground">
+                      Tool activity ({turn.tools.length})
+                    </summary>
+                    {turn.tools.map((tool, index) => (
+                      <pre
+                        key={index}
+                        className="my-2 max-h-60 overflow-auto whitespace-pre-wrap break-all rounded-lg bg-muted p-3 text-xs"
+                      >
+                        {tool}
+                      </pre>
+                    ))}
+                  </details>
+                )}
+                {turn.messages && (
+                  <details>
+                    <summary className="cursor-pointer text-xs text-muted-foreground">
+                      Run messages
+                    </summary>
+                    <pre className="max-h-96 overflow-auto whitespace-pre-wrap break-all text-xs">
+                      {JSON.stringify(turn.messages, null, 2)}
+                    </pre>
+                  </details>
+                )}
+              </div>
+            ))}
+        </section>
+      )}
+    </div>
+  );
+}
+
+export function TeamMessages({ state }: { state: TeamState }) {
+  const name = (id: string) => state.members[id]?.name ?? id;
+  return (
+    <section className="space-y-3" aria-label="Messages between agents">
+      <h2 className="text-sm font-medium">
+        Messages <span className="text-muted-foreground">{state.messages.length}</span>
+      </h2>
+      {!state.messages.length && (
+        <p className="text-sm text-muted-foreground">Messages between agents will appear here.</p>
+      )}
+      {state.messages.map(({ message, delivered }) => (
+        <article key={message.id} className="space-y-2 rounded-lg border border-hair p-3">
+          <div className="text-xs font-medium">
+            {name(message.fromInstanceId)} → {name(message.toInstanceId)}
+          </div>
+          <p className="whitespace-pre-wrap break-words text-sm">{message.content}</p>
+          <p className="text-xs text-muted-foreground">
+            {delivered ? "Delivered" : "Queued"} ·{" "}
+            {new Date(message.createdAt).toLocaleTimeString()}
+          </p>
+        </article>
+      ))}
+    </section>
+  );
+}

--- a/packages/tool-studio/src/ui/app/modules/teams/team-playground.tsx
+++ b/packages/tool-studio/src/ui/app/modules/teams/team-playground.tsx
@@ -1,0 +1,199 @@
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import type { StudioTeamConfig } from "../../../../team-types";
+import { Button } from "../../components/ui/button";
+import { Textarea } from "../../components/ui/textarea";
+import { MarkdownText } from "../shared/renderers";
+import { TeamInteractionCard } from "./team-interactions";
+import { TeamMembers, TeamMessages } from "./team-members";
+import { useTeamRun } from "./use-team-run";
+
+export function TeamPlayground({
+  team,
+  targetSelector,
+}: {
+  team: StudioTeamConfig;
+  targetSelector: (running: boolean) => ReactNode;
+}) {
+  const run = useTeamRun(team.id);
+  const [prompt, setPrompt] = useState("");
+  const [selected, select] = useState("");
+  const [tab, setTab] = useState<"members" | "messages">("members");
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const stick = useRef(true);
+  const running = run.state.status === "running";
+  const started = run.state.status !== "idle";
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (element && stick.current) element.scrollTop = element.scrollHeight;
+  }, [run.state]);
+  async function send() {
+    const value = prompt.trim();
+    if (!value) return;
+    if (running) {
+      if (await run.steer(value)) setPrompt("");
+    } else {
+      setPrompt("");
+      stick.current = true;
+      void run.start(value);
+    }
+  }
+  return (
+    <div className="flex min-h-0 min-w-0 flex-col overflow-auto lg:overflow-hidden">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-hair px-5 py-3">
+        <div className="flex items-center gap-3">{targetSelector(running)}</div>
+        <div className="flex items-center gap-3">
+          <span role="status" className="text-xs text-muted-foreground">
+            {run.state.status}
+          </span>
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={running}
+            onClick={() => {
+              run.reset();
+              setPrompt("");
+              select("");
+            }}
+          >
+            New task
+          </Button>
+        </div>
+      </div>
+      <div className="grid min-h-0 min-w-0 flex-1 grid-cols-1 lg:grid-cols-[minmax(0,1fr)_360px] xl:grid-cols-[minmax(0,1fr)_420px]">
+        <div className="flex min-h-[480px] min-w-0 flex-col lg:min-h-0">
+          <div
+            ref={scrollRef}
+            className="min-h-0 flex-1 overflow-auto px-5 py-6"
+            onScroll={() => {
+              const element = scrollRef.current;
+              if (element)
+                stick.current =
+                  element.scrollHeight - element.scrollTop - element.clientHeight < 80;
+            }}
+          >
+            <div className="mx-auto max-w-3xl space-y-6">
+              {!started && (
+                <div className="py-16">
+                  <h1 className="text-2xl font-medium">Work with {team.id}</h1>
+                  <p className="mt-3 text-sm text-muted-foreground">
+                    Give the coordinator a task. Follow its agents, messages, and requests as they
+                    work.
+                  </p>
+                  <p className="mt-4 text-xs text-muted-foreground">
+                    Available members:{" "}
+                    {team.members.map((member) => member.name ?? member.id).join(", ") || "None"}
+                  </p>
+                </div>
+              )}
+              {run.state.conversation.map((entry, index) => {
+                if (entry.type === "prompt")
+                  return (
+                    <article key={`prompt:${index}`} className="rounded-xl bg-muted p-4">
+                      <div className="mb-2 text-xs text-muted-foreground">You</div>
+                      <p className="whitespace-pre-wrap break-words text-sm">{entry.text}</p>
+                    </article>
+                  );
+                const turn = run.state.turns.find((item) => item.key === entry.key);
+                return turn?.text ? (
+                  <article key={entry.key}>
+                    <div className="mb-2 text-xs text-muted-foreground">Coordinator</div>
+                    <MarkdownText text={turn.text} live={running} size="base" />
+                  </article>
+                ) : null;
+              })}
+              {Object.values(run.state.interactions).map((item) => (
+                <TeamInteractionCard
+                  key={item.request.id}
+                  item={item}
+                  name={run.state.members[item.instanceId]?.name ?? item.instanceId}
+                  busy={run.busy.has(item.request.id)}
+                  respond={run.respond}
+                />
+              ))}
+              {run.state.error && (
+                <p role="alert" className="text-sm text-status-danger-ink">
+                  {run.state.error}
+                </p>
+              )}
+              {run.controlError && (
+                <p role="alert" className="text-sm text-status-danger-ink">
+                  {run.controlError}
+                </p>
+              )}
+            </div>
+          </div>
+          <form
+            className="mx-auto w-full max-w-3xl space-y-3 px-5 pb-5 pt-3"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void send();
+            }}
+          >
+            <Textarea
+              aria-label={running ? "Message coordinator" : "Team task"}
+              placeholder={
+                running ? "Send a follow-up to the coordinator…" : "Give this team a task…"
+              }
+              value={prompt}
+              maxLength={32768}
+              onChange={(event) => setPrompt(event.target.value)}
+              disabled={started && !running}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing) {
+                  event.preventDefault();
+                  if ((!started || running) && !run.busy.has("steer")) void send();
+                }
+              }}
+            />
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-xs text-muted-foreground">
+                This run stays in this page. Leaving stops active work.
+              </p>
+              {running && (
+                <Button type="button" variant="secondary" size="sm" onClick={run.stop}>
+                  Stop team
+                </Button>
+              )}
+              <Button
+                size="sm"
+                disabled={
+                  !prompt.trim() ||
+                  (started && !running) ||
+                  (running && (!run.state.runId || run.busy.has("steer")))
+                }
+              >
+                {running ? "Send follow-up" : "Run team"}
+              </Button>
+            </div>
+          </form>
+        </div>
+        <aside
+          className="min-h-64 min-w-0 space-y-5 overflow-auto border-t border-hair p-5 lg:border-t-0 lg:border-l"
+          aria-label="Team activity"
+        >
+          <div className="flex gap-2">
+            <Button
+              variant={tab === "members" ? "secondary" : "ghost"}
+              size="sm"
+              onClick={() => setTab("members")}
+            >
+              Members
+            </Button>
+            <Button
+              variant={tab === "messages" ? "secondary" : "ghost"}
+              size="sm"
+              onClick={() => setTab("messages")}
+            >
+              Messages
+            </Button>
+          </div>
+          {tab === "members" ? (
+            <TeamMembers state={run.state} selected={selected} select={select} />
+          ) : (
+            <TeamMessages state={run.state} />
+          )}
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/packages/tool-studio/src/ui/app/modules/teams/team-state.ts
+++ b/packages/tool-studio/src/ui/app/modules/teams/team-state.ts
@@ -1,0 +1,202 @@
+import type { AgentTeamMemberSummary, AgentTeamMessage } from "@anvia/core/agent";
+import type { AgentInteractionRequest } from "@anvia/core/agent/interactions";
+import type { Message } from "@anvia/core/completion";
+import type { StudioTeamRunEvent } from "../../../../team-types";
+import { errorMessage } from "../shared/format";
+
+export type TeamInteraction = {
+  instanceId: string;
+  request: AgentInteractionRequest;
+  status: "pending" | "answered" | "cancelled";
+};
+export type TeamTurn = {
+  key: string;
+  instanceId: string;
+  coordinator: boolean;
+  text: string;
+  tools: string[];
+  messages?: readonly Message[];
+};
+export type TeamState = {
+  status: "idle" | "running" | "completed" | "blocked" | "cancelled" | "failed";
+  runId?: string;
+  error?: string;
+  members: Record<string, AgentTeamMemberSummary>;
+  turns: TeamTurn[];
+  messages: { message: AgentTeamMessage; delivered: boolean }[];
+  interactions: Record<string, TeamInteraction>;
+  conversation: ({ type: "prompt"; text: string } | { type: "turn"; key: string })[];
+};
+export const initialTeamState: TeamState = {
+  status: "idle",
+  members: {},
+  turns: [],
+  messages: [],
+  interactions: {},
+  conversation: [],
+};
+export type TeamAction =
+  | { type: "start"; prompt: string }
+  | { type: "prompt"; prompt: string }
+  | { type: "event"; event: StudioTeamRunEvent }
+  | { type: "answered"; id: string }
+  | { type: "stop"; error?: string }
+  | { type: "reset" };
+
+function closeInteractions(state: TeamState, instanceId?: string) {
+  return Object.fromEntries(
+    Object.entries(state.interactions).map(([id, item]) => [
+      id,
+      item.status === "pending" && (instanceId === undefined || item.instanceId === instanceId)
+        ? { ...item, status: "cancelled" as const }
+        : item,
+    ]),
+  );
+}
+
+export function teamReducer(state: TeamState, action: TeamAction): TeamState {
+  switch (action.type) {
+    case "reset":
+      return initialTeamState;
+    case "start":
+      return {
+        ...initialTeamState,
+        status: "running",
+        conversation: [{ type: "prompt", text: action.prompt }],
+      };
+    case "prompt":
+      return {
+        ...state,
+        conversation: [...state.conversation, { type: "prompt", text: action.prompt }],
+      };
+    case "stop":
+      return {
+        ...state,
+        status: action.error ? "failed" : "cancelled",
+        ...(action.error ? { error: action.error } : {}),
+        interactions: closeInteractions(state),
+        members: Object.fromEntries(
+          Object.entries(state.members).map(([id, member]) => [
+            id,
+            ["queued", "running", "waiting", "awaiting_interaction"].includes(member.status)
+              ? { ...member, status: "cancelled" }
+              : member,
+          ]),
+        ),
+      };
+    case "answered": {
+      const item = state.interactions[action.id];
+      return item !== undefined
+        ? {
+            ...state,
+            interactions: { ...state.interactions, [action.id]: { ...item, status: "answered" } },
+          }
+        : state;
+    }
+    case "event":
+      break;
+  }
+  const event = action.event;
+  if (event.type === "team_run_started") return { ...state, runId: event.runId };
+  if (event.type === "error")
+    return teamReducer(state, { type: "stop", error: errorMessage(event.error) });
+  if (event.type === "response" || event.type === "blocked")
+    return {
+      ...state,
+      status: event.type === "response" ? "completed" : "blocked",
+      // Terminal outcomes contain descendants only; retain the coordinator as the tree root.
+      members: {
+        ...state.members,
+        ...Object.fromEntries(event.members.map((member) => [member.instanceId, member])),
+      },
+      interactions: closeInteractions(state),
+    };
+  if ("member" in event)
+    return {
+      ...state,
+      members: { ...state.members, [event.instanceId]: event.member },
+      ...(event.type === "agent_cancelled" || event.type === "agent_failed"
+        ? { interactions: closeInteractions(state, event.instanceId) }
+        : {}),
+    };
+  if (event.type === "interaction")
+    return {
+      ...state,
+      interactions: {
+        ...state.interactions,
+        [event.interaction.id]: {
+          instanceId: event.instanceId,
+          request: event.interaction,
+          status: "pending",
+        },
+      },
+    };
+  if (event.type === "message_queued" || event.type === "message_delivered") {
+    const previous = state.messages.find((item) => item.message.id === event.message.id);
+    const item = {
+      message: event.message,
+      delivered: previous?.delivered === true || event.type === "message_delivered",
+    };
+    return {
+      ...state,
+      messages: previous
+        ? state.messages.map((old) => (old.message.id === item.message.id ? item : old))
+        : [...state.messages, item].slice(-500),
+    };
+  }
+  if (event.type !== "agent_event") return state;
+  const key = `${event.instanceId}:${event.runId ?? "initial"}`;
+  const turn = state.turns.find((item) => item.key === key) ?? {
+    key,
+    instanceId: event.instanceId,
+    coordinator: event.coordinator,
+    text: "",
+    tools: [],
+  };
+  const inner = event.event;
+  let updated: TeamTurn;
+  switch (inner.type) {
+    case "text_delta":
+      updated = { ...turn, text: turn.text + inner.delta };
+      break;
+    case "tool_call":
+      updated = { ...turn, tools: [...turn.tools, JSON.stringify(inner.toolCall)].slice(-100) };
+      break;
+    case "tool_result":
+      updated = {
+        ...turn,
+        tools: [...turn.tools, `${inner.toolName}: ${JSON.stringify(inner.output, null, 2)}`].slice(
+          -100,
+        ),
+      };
+      break;
+    case "response":
+    case "blocked":
+      updated = {
+        ...turn,
+        text: inner.text,
+        messages: inner.messages,
+        tools: inner.messages
+          .flatMap((message) => {
+            if (typeof message.content === "string") return [];
+            return message.content
+              .filter((part) => part.type === "tool-call" || part.type === "tool-result")
+              .map((part) => JSON.stringify(part, null, 2));
+          })
+          .slice(-100),
+      };
+      break;
+    default:
+      return state;
+  }
+  return {
+    ...state,
+    conversation:
+      updated.coordinator && !state.turns.some((item) => item.key === key)
+        ? [...state.conversation, { type: "turn" as const, key }].slice(-500)
+        : state.conversation,
+    turns: state.turns.some((item) => item.key === key)
+      ? state.turns.map((item) => (item.key === key ? updated : item))
+      : [...state.turns, updated].slice(-500),
+  };
+}

--- a/packages/tool-studio/src/ui/app/modules/teams/use-team-run.ts
+++ b/packages/tool-studio/src/ui/app/modules/teams/use-team-run.ts
@@ -9,10 +9,28 @@ import { initialTeamState, teamReducer } from "./team-state";
 
 type ActiveTeamRun = {
   controller: AbortController;
+  base: string;
   runId: string | undefined;
   pending: Set<string>;
   epoch: number;
 };
+
+function cancelTeamRun(run: ActiveTeamRun | undefined) {
+  if (!run || run.controller.signal.aborted) return;
+  if (run.runId) {
+    // Keep server cancellation independent of stream teardown, including page navigation.
+    void fetch(`${run.base}/${encodeURIComponent(run.runId)}/cancel`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+      keepalive: true,
+      signal: AbortSignal.timeout(5_000),
+    }).catch(() => {
+      // Teardown cannot wait for the server; disconnect remains the fallback on network failure.
+    });
+  }
+  run.controller.abort();
+}
 
 export function useTeamRun(teamId: string) {
   const [state, dispatch] = useReducer(teamReducer, initialTeamState);
@@ -23,7 +41,7 @@ export function useTeamRun(teamId: string) {
   const base = `/teams/${encodeURIComponent(teamId)}/runs`;
   useEffect(
     () => () => {
-      active.current?.controller.abort();
+      cancelTeamRun(active.current);
       active.current = undefined;
       epoch.current++;
     },
@@ -34,6 +52,7 @@ export function useTeamRun(teamId: string) {
     if (active.current) return;
     const run: ActiveTeamRun = {
       controller: new AbortController(),
+      base,
       runId: undefined,
       pending: new Set(),
       epoch: ++epoch.current,
@@ -104,7 +123,7 @@ export function useTeamRun(teamId: string) {
   }
 
   function stop() {
-    active.current?.controller.abort();
+    cancelTeamRun(active.current);
     dispatch({ type: "stop" });
   }
   return {

--- a/packages/tool-studio/src/ui/app/modules/teams/use-team-run.ts
+++ b/packages/tool-studio/src/ui/app/modules/teams/use-team-run.ts
@@ -1,0 +1,130 @@
+import type { AgentInteractionResponse } from "@anvia/core/agent/interactions";
+import { readJsonlStream } from "@anvia/client/transport";
+import { useEffect, useReducer, useRef, useState } from "react";
+import type { StudioTeamRunEvent } from "../../../../team-types";
+import { responseErrorMessage } from "../../app-errors";
+import { errorMessage } from "../shared/format";
+import { requestJson } from "../shared/request";
+import { initialTeamState, teamReducer } from "./team-state";
+
+type ActiveTeamRun = {
+  controller: AbortController;
+  runId: string | undefined;
+  pending: Set<string>;
+  epoch: number;
+};
+
+export function useTeamRun(teamId: string) {
+  const [state, dispatch] = useReducer(teamReducer, initialTeamState);
+  const [controlError, setControlError] = useState("");
+  const [busy, setBusy] = useState<ReadonlySet<string>>(new Set());
+  const active = useRef<ActiveTeamRun | undefined>(undefined);
+  const epoch = useRef(0);
+  const base = `/teams/${encodeURIComponent(teamId)}/runs`;
+  useEffect(
+    () => () => {
+      active.current?.controller.abort();
+      active.current = undefined;
+      epoch.current++;
+    },
+    [teamId],
+  );
+
+  async function start(prompt: string) {
+    if (active.current) return;
+    const run: ActiveTeamRun = {
+      controller: new AbortController(),
+      runId: undefined,
+      pending: new Set(),
+      epoch: ++epoch.current,
+    };
+    active.current = run;
+    setBusy(new Set());
+    setControlError("");
+    dispatch({ type: "start", prompt });
+    let terminal = false;
+    try {
+      const response = await fetch(base, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt }),
+        signal: run.controller.signal,
+      });
+      if (!response.ok) throw new Error(await responseErrorMessage(response, "Start team"));
+      if (!response.body) throw new Error("Team response has no stream");
+      run.runId = response.headers.get("x-anvia-team-run-id") ?? undefined;
+      for await (const event of readJsonlStream<StudioTeamRunEvent>(response.body)) {
+        if (active.current !== run || run.controller.signal.aborted) break;
+        if (event.type === "team_run_started") run.runId = event.runId;
+        terminal ||=
+          event.type === "response" || event.type === "blocked" || event.type === "error";
+        dispatch({ type: "event", event });
+      }
+      if (!terminal && !run.controller.signal.aborted)
+        throw new Error("Team stream ended before a result arrived");
+    } catch (error) {
+      if (active.current === run)
+        dispatch({
+          type: "stop",
+          ...(run.controller.signal.aborted ? {} : { error: errorMessage(error) }),
+        });
+    } finally {
+      if (active.current === run) active.current = undefined;
+    }
+  }
+
+  async function control(key: string, path: string, body: unknown, onSuccess: () => void) {
+    const run = active.current;
+    if (!run?.runId || run.pending.has(key)) return false;
+    run.pending.add(key);
+    setBusy(new Set(run.pending));
+    setControlError("");
+    try {
+      await requestJson(
+        `${base}/${encodeURIComponent(run.runId)}${path}`,
+        "Update team",
+        run.controller.signal,
+        "default",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        },
+      );
+      if (epoch.current === run.epoch && !run.controller.signal.aborted) onSuccess();
+      return true;
+    } catch (error) {
+      if (active.current === run && !run.controller.signal.aborted)
+        setControlError(errorMessage(error));
+      return false;
+    } finally {
+      run.pending.delete(key);
+      if (epoch.current === run.epoch) setBusy(new Set(run.pending));
+    }
+  }
+
+  function stop() {
+    active.current?.controller.abort();
+    dispatch({ type: "stop" });
+  }
+  return {
+    state,
+    busy,
+    controlError,
+    start,
+    stop,
+    reset: () => {
+      if (!active.current) {
+        epoch.current++;
+        dispatch({ type: "reset" });
+        setControlError("");
+      }
+    },
+    steer: (prompt: string) =>
+      control("steer", "/steer", { prompt }, () => dispatch({ type: "prompt", prompt })),
+    respond: (id: string, response: AgentInteractionResponse) =>
+      control(id, `/interactions/${encodeURIComponent(id)}`, response, () =>
+        dispatch({ type: "answered", id }),
+      ),
+  };
+}

--- a/packages/tool-studio/src/ui/app/routes/playground-route.tsx
+++ b/packages/tool-studio/src/ui/app/routes/playground-route.tsx
@@ -1,4 +1,5 @@
-import { useParams } from "@tanstack/react-router";
+import { PlaygroundTargetSelect } from "../modules/playground/playground-target-select";
+import { Navigate, useNavigate, useParams } from "@tanstack/react-router";
 import { useEffect, useRef } from "react";
 import { PlaygroundPage } from "../modules/playground/playground-page";
 import { errorMessage } from "../modules/shared/format";
@@ -6,6 +7,7 @@ import { useActivatedRoute } from "./route-helpers";
 
 export function PlaygroundRoute() {
   const studio = useActivatedRoute("playground");
+  const navigate = useNavigate();
   const params = useParams({ strict: false }) as { sessionId?: string };
   const sessionId = params.sessionId;
   const handledSessionIdRef = useRef<string | undefined | null>(null);
@@ -35,9 +37,29 @@ export function PlaygroundRoute() {
     }
   }, [sessionId, studio]);
 
+  if (!sessionId && !studio.agents.length && studio.teams?.[0]) {
+    return (
+      <Navigate to="/playground/teams/$teamId" params={{ teamId: studio.teams[0].id }} replace />
+    );
+  }
+
   return (
     <PlaygroundPage
       agents={studio.agents}
+      targetSelector={
+        studio.teams?.length ? (
+          <PlaygroundTargetSelect
+            agents={studio.agents}
+            teams={studio.teams}
+            value={`agent:${studio.selectedAgentId}`}
+            disabled={studio.runState === "running"}
+            onSelect={(kind, id) => {
+              if (kind === "agent") studio.selectPlaygroundAgent(id);
+              else void navigate({ to: "/playground/teams/$teamId", params: { teamId: id } });
+            }}
+          />
+        ) : undefined
+      }
       allSessions={studio.sessions.allSessions}
       answeringQuestions={studio.answeringQuestions}
       attachments={studio.attachments}

--- a/packages/tool-studio/src/ui/app/routes/team-playground-route.tsx
+++ b/packages/tool-studio/src/ui/app/routes/team-playground-route.tsx
@@ -1,0 +1,45 @@
+import { useNavigate, useParams } from "@tanstack/react-router";
+import { lazy, Suspense } from "react";
+import { PlaygroundTargetSelect } from "../modules/playground/playground-target-select";
+import { useActivatedRoute } from "./route-helpers";
+
+const TeamPlayground = lazy(() =>
+  import("../modules/teams/team-playground").then((module) => ({ default: module.TeamPlayground })),
+);
+
+export function TeamPlaygroundRoute() {
+  const studio = useActivatedRoute("playground");
+  const { teamId } = useParams({ strict: false });
+  const navigate = useNavigate();
+  const team = studio.teams?.find((item) => item.id === teamId);
+  if (!team)
+    return (
+      <p className="p-6 text-sm text-muted-foreground">
+        {studio.teams === undefined ? "Loading team…" : "This team is not registered in Studio."}
+      </p>
+    );
+  return (
+    <Suspense fallback={<p className="p-6 text-sm text-muted-foreground">Loading team…</p>}>
+      <TeamPlayground
+        key={team.id}
+        team={team}
+        targetSelector={(running) => (
+          <PlaygroundTargetSelect
+            agents={studio.agents}
+            teams={studio.teams ?? []}
+            value={`team:${team.id}`}
+            disabled={running}
+            onSelect={(kind, id) => {
+              if (kind === "team")
+                void navigate({ to: "/playground/teams/$teamId", params: { teamId: id } });
+              else {
+                studio.selectPlaygroundAgent(id);
+                void navigate({ to: "/playground" });
+              }
+            }}
+          />
+        )}
+      />
+    </Suspense>
+  );
+}

--- a/packages/tool-studio/src/ui/app/studio-console-context.tsx
+++ b/packages/tool-studio/src/ui/app/studio-console-context.tsx
@@ -19,6 +19,7 @@ type StudioTracesController = ReturnType<typeof useTraces>;
 export type StudioConsoleContextValue = {
   activePage: ActivePage;
   agents: StudioConfig["agents"];
+  teams?: StudioConfig["teams"];
   answeringQuestions: Set<string>;
   attachments: PromptAttachment[];
   browserWorkspace: BrowserWorkspace | undefined;

--- a/packages/tool-studio/src/ui/app/studio-router.tsx
+++ b/packages/tool-studio/src/ui/app/studio-router.tsx
@@ -1,3 +1,4 @@
+import { TeamPlaygroundRoute } from "./routes/team-playground-route";
 import { createRootRoute, createRoute, createRouter, Navigate } from "@tanstack/react-router";
 import { StudioConsoleLayout } from "./modules/shell/studio-console-layout";
 import { AgentsRoute } from "./routes/agents-route";
@@ -27,6 +28,12 @@ const playgroundRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "playground",
   component: PlaygroundRoute,
+});
+
+const teamPlaygroundRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "playground/teams/$teamId",
+  component: TeamPlaygroundRoute,
 });
 
 const playgroundSessionRoute = createRoute({
@@ -129,6 +136,7 @@ const routeTree = rootRoute.addChildren([
   indexRoute,
   playgroundRoute,
   playgroundSessionRoute,
+  teamPlaygroundRoute,
   tracingRoute,
   tracingTraceRoute,
   tracingSessionRoute,

--- a/packages/tool-studio/src/ui/routes.tsx
+++ b/packages/tool-studio/src/ui/routes.tsx
@@ -56,6 +56,9 @@ export function registerStudioUi(app: Hono, options: ResolvedStudioUiOptions): v
   app.get(`${options.path}/playground/:sessionId`, (c) =>
     redirectWithQuery(c, `/playground/${encodeURIComponent(c.req.param("sessionId"))}`),
   );
+  app.get(`${options.path}/playground/teams/:teamId`, (c) =>
+    redirectWithQuery(c, `/playground/teams/${encodeURIComponent(c.req.param("teamId"))}`),
+  );
   app.get(`${options.path}/tracing`, (c) => redirectWithQuery(c, "/tracing"));
   app.get(`${options.path}/tracing/:traceId`, (c) =>
     redirectWithQuery(c, `/tracing/${encodeURIComponent(c.req.param("traceId"))}`),
@@ -83,6 +86,7 @@ export function registerStudioUi(app: Hono, options: ResolvedStudioUiOptions): v
   if (options.rootRoutes) {
     app.get("/playground", async (c) => c.html(await renderShell()));
     app.get("/playground/:sessionId", async (c) => c.html(await renderShell()));
+    app.get("/playground/teams/:teamId", async (c) => c.html(await renderShell()));
     app.get("/tracing", async (c) => c.html(await renderShell()));
     app.get("/tracing/:traceId", async (c) => c.html(await renderShell()));
     app.get("/tracing/sessions/:sessionId", async (c) => c.html(await renderShell()));

--- a/packages/tool-studio/test/studio-routes.test.ts
+++ b/packages/tool-studio/test/studio-routes.test.ts
@@ -96,6 +96,21 @@ describe("Studio UI routes", () => {
     expect(graphShell.status).toBe(200);
   });
 
+  it("serves direct team links and preserves encoded IDs and queries in compatibility redirects", async () => {
+    const app = new Hono();
+    registerStudioUi(app, resolveStudioUiOptions({ path: "/studio", clientScript: "// test" }));
+    const shell = await app.request("http://studio.test/playground/teams/research%2Freview");
+    expect(shell.status).toBe(200);
+    expect(await shell.text()).toContain('id="anvia-ui"');
+    const redirect = await app.request(
+      "http://studio.test/studio/playground/teams/research%2Freview?panel=messages",
+    );
+    expect(redirect.status).toBe(302);
+    expect(redirect.headers.get("location")).toBe(
+      "/playground/teams/research%2Freview?panel=messages",
+    );
+  });
+
   it("serves configured client scripts and bundled assets", async () => {
     const app = new Hono();
     registerStudioUi(
@@ -146,6 +161,7 @@ describe("Studio UI routes", () => {
 
     expect((await app.request("http://studio.test/")).status).toBe(404);
     expect((await app.request("http://studio.test/tracing")).status).toBe(404);
+    expect((await app.request("http://studio.test/playground/teams/research")).status).toBe(404);
     expect((await app.request("http://studio.test/studio/assets/client.js")).status).toBe(404);
 
     const legacy = await app.request(

--- a/packages/tool-studio/test/team-state.test.ts
+++ b/packages/tool-studio/test/team-state.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import type { AgentTeamMemberSummary } from "@anvia/core/agent";
+import { Usage } from "@anvia/core/completion";
+import {
+  initialTeamState,
+  teamReducer,
+  type TeamState,
+} from "../src/ui/app/modules/teams/team-state";
+import type { StudioTeamRunEvent } from "../src/team-types";
+
+const member = (instanceId: string, parentInstanceId?: string): AgentTeamMemberSummary => ({
+  instanceId,
+  agentId: "worker",
+  name: "Worker",
+  status: "queued",
+  usage: Usage.empty(),
+  depth: parentInstanceId ? 1 : 0,
+  ...(parentInstanceId ? { parentInstanceId } : {}),
+});
+const apply = (state: TeamState, event: StudioTeamRunEvent) =>
+  teamReducer(state, { type: "event", event });
+const identity = { teamRunId: "core-id", instanceId: "root", runId: "assignment-1" };
+
+describe("Studio team state", () => {
+  it("keeps repeated agent instances, recursive parents, and message delivery distinct", () => {
+    let state = initialTeamState;
+    for (const item of [
+      member("root"),
+      member("a", "root"),
+      member("b", "root"),
+      { ...member("child", "a"), depth: 2 },
+    ]) {
+      state = apply(state, {
+        ...identity,
+        type: "agent_queued",
+        instanceId: item.instanceId,
+        member: item,
+      });
+    }
+    expect(Object.keys(state.members)).toHaveLength(4);
+    expect(state.members.child?.parentInstanceId).toBe("a");
+    expect(state.members.b?.status).toBe("queued");
+    const message = {
+      id: "message",
+      teamRunId: "core-id",
+      fromInstanceId: "a",
+      toInstanceId: "b",
+      content: "Review this",
+      createdAt: new Date().toISOString(),
+    };
+    state = apply(state, { ...identity, type: "message_queued", message });
+    state = apply(state, { ...identity, type: "message_delivered", message });
+    expect(state.messages).toEqual([{ message, delivered: true }]);
+  });
+
+  it("attributes overlapping approvals and closes only the cancelled instance", () => {
+    let state = initialTeamState;
+    for (const id of ["a", "b"])
+      state = apply(state, {
+        ...identity,
+        instanceId: id,
+        type: "interaction",
+        interaction: {
+          id,
+          type: "tool-approval",
+          toolName: "write",
+          toolCallId: id,
+          internalCallId: id,
+          input: {},
+        },
+      });
+    state = apply(state, {
+      ...identity,
+      instanceId: "a",
+      type: "agent_cancelled",
+      member: { ...member("a"), status: "cancelled" },
+    });
+    expect(state.interactions.a?.status).toBe("cancelled");
+    expect(state.interactions.b?.status).toBe("pending");
+    state = teamReducer(state, { type: "answered", id: "b" });
+    state = teamReducer(state, { type: "stop" });
+    expect(state.interactions.b?.status).toBe("answered");
+  });
+
+  it("retains conversation order and separates resumed assignments", () => {
+    let state = teamReducer(initialTeamState, { type: "start", prompt: "Work" });
+    const text = (runId: string, delta: string): StudioTeamRunEvent => ({
+      ...identity,
+      runId,
+      type: "agent_event",
+      coordinator: true,
+      event: { type: "text_delta", turn: 1, delta },
+    });
+    state = apply(state, text("first", "Starting"));
+    state = teamReducer(state, { type: "prompt", prompt: "Focus on tests" });
+    state = apply(state, text("second", "Testing"));
+    state = apply(state, text("second", " now"));
+    expect(state.conversation.map((entry) => entry.type)).toEqual([
+      "prompt",
+      "turn",
+      "prompt",
+      "turn",
+    ]);
+    expect(state.turns.map((turn) => turn.text)).toEqual(["Starting", "Testing now"]);
+    expect(teamReducer(state, { type: "reset" })).toEqual(initialTeamState);
+  });
+});

--- a/packages/tool-studio/test/team-ui.test.tsx
+++ b/packages/tool-studio/test/team-ui.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment happy-dom
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, expect, it, vi } from "vitest";
+import { Usage } from "@anvia/core/completion";
+import { TeamMembers } from "../src/ui/app/modules/teams/team-members";
+import { TeamInteractionCard } from "../src/ui/app/modules/teams/team-interactions";
+import { initialTeamState, teamReducer } from "../src/ui/app/modules/teams/team-state";
+
+afterEach(() => vi.unstubAllGlobals());
+it("keeps the coordinator and recursive member tree visible after terminal outcomes omit the coordinator", () => {
+  const root = {
+    instanceId: "root",
+    agentId: "team",
+    name: "Coordinator",
+    depth: 0,
+    status: "idle" as const,
+    usage: Usage.empty(),
+  };
+  const child = {
+    ...root,
+    instanceId: "child",
+    agentId: "worker",
+    name: "Researcher",
+    parentInstanceId: "root",
+    depth: 1,
+  };
+  const grandchild = {
+    ...child,
+    instanceId: "grandchild",
+    name: "Reviewer",
+    parentInstanceId: "child",
+    depth: 2,
+  };
+  const state = teamReducer(
+    { ...initialTeamState, members: { root, child, grandchild } },
+    {
+      type: "event",
+      event: {
+        type: "response",
+        teamRunId: "core",
+        runId: "run",
+        text: "Done",
+        output: "Done",
+        usage: Usage.empty(),
+        messages: [],
+        members: [child, grandchild],
+      },
+    },
+  );
+  const html = renderToStaticMarkup(
+    <TeamMembers state={state} selected="grandchild" select={() => undefined} />,
+  );
+  expect(html).toContain("Coordinator");
+  expect(html).toContain("Researcher");
+  expect(html).toContain("Reviewer");
+  expect(html).toContain('aria-pressed="true"');
+  expect(Object.keys(state.members)).toEqual(["root", "child", "grandchild"]);
+});
+
+it("submits question choice values with the originating interaction ID", async () => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  const respond = vi.fn(async () => true);
+  act(() =>
+    root.render(
+      <TeamInteractionCard
+        name="Reviewer"
+        busy={false}
+        respond={respond}
+        item={{
+          instanceId: "reviewer-instance",
+          status: "pending",
+          request: {
+            id: "question-id",
+            type: "tool-question",
+            toolName: "ask",
+            toolCallId: "tool",
+            internalCallId: "internal",
+            questions: [
+              {
+                id: "focus",
+                text: "What should I review?",
+                choices: [
+                  { label: "Runtime", value: "runtime" },
+                  { label: "UI", value: "ui" },
+                ],
+              },
+            ],
+          },
+        }}
+      />,
+    ),
+  );
+  try {
+    expect(container.querySelector("button")?.disabled).toBe(true);
+    expect(container.querySelector("textarea")).toBeNull();
+    act(() => container.querySelector<HTMLInputElement>('input[value="runtime"]')!.click());
+    expect(container.querySelector("button")?.disabled).toBe(false);
+    await act(async () =>
+      container
+        .querySelector("form")!
+        .dispatchEvent(new Event("submit", { bubbles: true, cancelable: true })),
+    );
+    expect(respond).toHaveBeenCalledWith("question-id", {
+      type: "tool-question",
+      answers: [{ questionId: "focus", value: "runtime" }],
+    });
+  } finally {
+    act(() => root.unmount());
+  }
+});
+
+it("shows custom answers and disables controls for cancelled interactions", () => {
+  const html = renderToStaticMarkup(
+    <TeamInteractionCard
+      name="Researcher"
+      busy={false}
+      respond={async () => true}
+      item={{
+        instanceId: "researcher-instance",
+        status: "cancelled",
+        request: {
+          id: "question-id",
+          type: "tool-question",
+          toolName: "ask",
+          toolCallId: "tool",
+          internalCallId: "internal",
+          questions: [
+            {
+              id: "scope",
+              text: "Scope?",
+              allowCustom: true,
+              choices: [{ label: "Small", value: "small" }],
+            },
+          ],
+        },
+      }}
+    />,
+  );
+  expect(html).toContain("researcher-instance");
+  expect(html).toContain("textarea");
+  expect(html).toContain('disabled=""');
+});

--- a/packages/tool-studio/test/use-team-run.test.tsx
+++ b/packages/tool-studio/test/use-team-run.test.tsx
@@ -11,8 +11,8 @@ let stream: ReadableStreamDefaultController<Uint8Array>;
 let signal: AbortSignal;
 let fetchMock: ReturnType<typeof vi.fn<typeof fetch>>;
 const encode = (event: unknown) => new TextEncoder().encode(`${JSON.stringify(event)}\n`);
-function Harness() {
-  const controller = useTeamRun("team/one");
+function Harness({ teamId = "team/one" }: { teamId?: string }) {
+  const controller = useTeamRun(teamId);
   useEffect(() => {
     run = controller;
   }, [controller]);
@@ -26,7 +26,8 @@ beforeEach(() => {
   vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
   container = document.createElement("div");
   root = createRoot(container);
-  fetchMock = vi.fn<typeof fetch>(async (_input, init) => {
+  fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+    if (String(input).endsWith("/cancel")) return new Response("{}");
     signal = init!.signal!;
     return new Response(
       new ReadableStream<Uint8Array>({
@@ -142,6 +143,71 @@ describe("useTeamRun", () => {
     await act(async () => resolveApproval(new Response("{}")));
     expect(run.state.interactions.a?.status).toBe("answered");
     expect(run.state.status).toBe("completed");
+  });
+
+  it.each(["stop", "unmount", "team change"])(
+    "requests independent server cancellation on %s without waiting for its response",
+    async (action) => {
+      await act(async () => {
+        void run.start("work");
+      });
+      const streamSignal = signal;
+      let resolveCancel!: (response: Response) => void;
+      fetchMock.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveCancel = resolve;
+          }),
+      );
+      await act(async () => {
+        if (action === "stop") {
+          run.stop();
+          run.stop();
+        } else if (action === "unmount") root.unmount();
+        else root.render(<Harness teamId="other-team" />);
+      });
+      expect(streamSignal.aborted).toBe(true);
+      const cancellations = fetchMock.mock.calls.filter(([url]) => String(url).endsWith("/cancel"));
+      expect(cancellations).toHaveLength(1);
+      const [url, request] = cancellations[0]!;
+      expect(url).toBe("/teams/team%2Fone/runs/studio%2Fcontrol/cancel");
+      expect(request).toMatchObject({ method: "POST", body: "{}", keepalive: true });
+      expect(request?.signal).not.toBe(streamSignal);
+      expect(request?.signal?.aborted).toBe(false);
+      if (action === "stop") expect(run.state.status).toBe("cancelled");
+      await act(async () => resolveCancel(new Response("{}")));
+    },
+  );
+
+  it("aborts promptly before a run ID is available", async () => {
+    fetchMock.mockImplementationOnce(
+      (_input, init) =>
+        new Promise((_resolve, reject) => {
+          signal = init!.signal!;
+          signal.addEventListener(
+            "abort",
+            () => reject(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        }),
+    );
+    await act(async () => {
+      void run.start("work");
+    });
+    await act(async () => run.stop());
+    expect(signal.aborted).toBe(true);
+    expect(run.state.status).toBe("cancelled");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("still aborts locally when the cancellation request fails", async () => {
+    await act(async () => {
+      void run.start("work");
+    });
+    fetchMock.mockRejectedValueOnce(new TypeError("Network unavailable"));
+    await act(async () => run.stop());
+    expect(signal.aborted).toBe(true);
+    expect(run.state.status).toBe("cancelled");
   });
 
   it("aborts on stop and unmount and reports a truncated stream", async () => {

--- a/packages/tool-studio/test/use-team-run.test.tsx
+++ b/packages/tool-studio/test/use-team-run.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment happy-dom
+import { act, useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useTeamRun } from "../src/ui/app/modules/teams/use-team-run";
+
+let root: Root;
+let container: HTMLDivElement;
+let run: ReturnType<typeof useTeamRun>;
+let stream: ReadableStreamDefaultController<Uint8Array>;
+let signal: AbortSignal;
+let fetchMock: ReturnType<typeof vi.fn<typeof fetch>>;
+const encode = (event: unknown) => new TextEncoder().encode(`${JSON.stringify(event)}\n`);
+function Harness() {
+  const controller = useTeamRun("team/one");
+  useEffect(() => {
+    run = controller;
+  }, [controller]);
+  return null;
+}
+async function emit(event: unknown) {
+  await act(async () => stream.enqueue(encode(event)));
+}
+
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  container = document.createElement("div");
+  root = createRoot(container);
+  fetchMock = vi.fn<typeof fetch>(async (_input, init) => {
+    signal = init!.signal!;
+    return new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          stream = controller;
+          signal.addEventListener(
+            "abort",
+            () => controller.error(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        },
+      }),
+      { headers: { "x-anvia-team-run-id": "studio/control" } },
+    );
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  act(() => root.render(<Harness />));
+});
+afterEach(() => {
+  act(() => root.unmount());
+  vi.unstubAllGlobals();
+});
+
+describe("useTeamRun", () => {
+  it("uses the Studio control ID, keeps invalid answers retryable, and resolves concurrent cards independently", async () => {
+    await act(async () => {
+      void run.start("work");
+    });
+    await emit({ type: "team_run_started", runId: "studio/control", teamId: "team/one" });
+    for (const id of ["a", "b"])
+      await emit({
+        type: "interaction",
+        teamRunId: "core-id",
+        instanceId: id,
+        interaction: {
+          type: "tool-approval",
+          id,
+          input: {},
+          toolName: "write",
+          toolCallId: id,
+          internalCallId: id,
+        },
+      });
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: { message: "Invalid answer" } }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await act(async () => {
+      expect(await run.respond("a", { type: "tool-approval", approved: true })).toBe(false);
+    });
+    expect(run.state.interactions.a?.status).toBe("pending");
+    expect(run.controlError).toContain("Invalid answer");
+    let resolveApproval!: (response: Response) => void;
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveApproval = resolve;
+        }),
+    );
+    await act(async () => {
+      void run.respond("a", { type: "tool-approval", approved: true });
+    });
+    expect(run.busy.has("a")).toBe(true);
+    expect(run.busy.has("b")).toBe(false);
+    fetchMock.mockResolvedValueOnce(new Response("{}"));
+    await act(async () => {
+      await run.respond("b", { type: "tool-approval", approved: false });
+    });
+    expect(run.state.interactions.b?.status).toBe("answered");
+    await act(async () => resolveApproval(new Response("{}")));
+    expect(run.state.interactions.a?.status).toBe("answered");
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      "/teams/team%2Fone/runs/studio%2Fcontrol/interactions/a",
+    );
+    fetchMock.mockResolvedValueOnce(new Response("{}"));
+    await act(async () => {
+      await run.steer("focus");
+    });
+    expect(run.state.conversation.at(-1)).toEqual({ type: "prompt", text: "focus" });
+  });
+
+  it("preserves an accepted answer when the terminal event precedes its HTTP response", async () => {
+    await act(async () => {
+      void run.start("work");
+    });
+    await emit({
+      type: "interaction",
+      teamRunId: "core",
+      instanceId: "a",
+      interaction: {
+        type: "tool-approval",
+        id: "a",
+        input: {},
+        toolName: "write",
+        toolCallId: "a",
+        internalCallId: "a",
+      },
+    });
+    let resolveApproval!: (response: Response) => void;
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveApproval = resolve;
+        }),
+    );
+    await act(async () => {
+      void run.respond("a", { type: "tool-approval", approved: true });
+    });
+    await emit({ type: "response", members: [], text: "done" });
+    await act(async () => stream.close());
+    await act(async () => resolveApproval(new Response("{}")));
+    expect(run.state.interactions.a?.status).toBe("answered");
+    expect(run.state.status).toBe("completed");
+  });
+
+  it("aborts on stop and unmount and reports a truncated stream", async () => {
+    await act(async () => {
+      void run.start("work");
+    });
+    await act(async () => run.stop());
+    expect(signal.aborted).toBe(true);
+    expect(run.state.status).toBe("cancelled");
+    await act(async () => {
+      run.reset();
+      void run.start("again");
+    });
+    await act(async () => stream.close());
+    expect(run.state.status).toBe("failed");
+    expect(run.state.error).toContain("before a result");
+    await act(async () => {
+      void run.start("last");
+    });
+    act(() => root.unmount());
+    expect(signal.aborted).toBe(true);
+  });
+});


### PR DESCRIPTION
Studio can register and run AgentTeams through #421, but its playground only presents standalone agents. This adds a team playground to the existing agent/team selector, with a coordinator conversation, live recursive member tree, member messages/tool activity/usage, and a sender/recipient message timeline.

Approvals and questions are attributed to their originating instance and can be answered independently while siblings remain pending. Users can send coordinator follow-ups, stop the whole team, and begin a new task. Stop and page cleanup explicitly request server cancellation with an independent timeout and keepalive, then immediately abort the local stream. Terminal outcomes preserve the coordinator and completed tree; delayed approval responses cannot overwrite a subsequent task.

Stacked on #421 (`feat/studio-team-runtime`); merge that PR first, then retarget this PR to `main`. The runtime API and core event addition belong to #421. This PR contains the UI, its focused state/transport modules, tests, documentation, and a Studio changeset. Team session persistence and reconnection remain deferred.

Validation:
- Studio suite: 240 tests across 35 files pass; 15 new tests cover instance attribution, recursive hierarchy after completion, message delivery, question values, overlapping approvals, response-order races, stop/unmount, truncated streams, pending cancellation requests, early stop before a run ID, route changes, and cancellation network failures.
- `pnpm --filter @anvia/studio exec tsc --noEmit`, `pnpm --filter @anvia/studio build`, and `pnpm check` pass. Workspace dependencies were built through Studio's build script.
- Independent code-review-and-quality review approved after the terminal tree fix.
- Local Chromium checks with a deterministic AgentTeam: team-only landing, direct team URL reload, simultaneous approval/question cards, completion, member inspection, message delivery, dark/light desktop layouts, mobile layout and clipping, and stop/disconnect cleanup. Screenshots captured locally for pending interactions, completion, messages, light theme, and mobile.

No dependency changes or tracked generated artifacts. The build retains the existing Vite chunk-size advisory.

