### PR TITLE
fix(release): avoid major bumps for compatible peer updates

### DIFF
--- a/.changeset/compatible-workspace-peers.md
+++ b/.changeset/compatible-workspace-peers.md
@@ -1,0 +1,37 @@
+---
+"@anvia/client": patch
+"@anvia/transformers": patch
+"@anvia/graph": patch
+"@anvia/memgraph": patch
+"@anvia/neo4j": patch
+"@anvia/logger": patch
+"@anvia/mcp": patch
+"@anvia/memory-drizzle": patch
+"@anvia/memory-postgres": patch
+"@anvia/memory-prisma": patch
+"@anvia/memory-sqlite": patch
+"@anvia/langfuse": patch
+"@anvia/lens": patch
+"@anvia/otel": patch
+"@anvia/anthropic": patch
+"@anvia/gemini": patch
+"@anvia/grok": patch
+"@anvia/mistral": patch
+"@anvia/openai": patch
+"@anvia/react": patch
+"@anvia/react-ui": patch
+"@anvia/server": patch
+"@anvia/browser": patch
+"@anvia/sandbox": patch
+"@anvia/studio": patch
+"@anvia/chroma": patch
+"@anvia/lancedb": patch
+"@anvia/milvus": patch
+"@anvia/pgvector": patch
+"@anvia/pinecone": patch
+"@anvia/qdrant": patch
+"@anvia/redis": patch
+"@anvia/weaviate": patch
+---
+
+Declare compatible workspace peer ranges so additive internal dependency releases do not force major releases of dependents.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,8 +178,8 @@ If a generator rewrites files unexpectedly, inspect the diff before continuing.
 ## Dependencies
 
 - Use package-scoped `pnpm --filter ... add ...` commands for dependency changes.
-- Keep local workspace dependencies using `workspace:*` where the repo already
-  does.
+- Use `workspace:^` for internal peer dependencies and `workspace:*` for other
+  local workspace dependencies. Peer ranges must allow compatible minor releases.
 - Keep related schema/SDK dependencies aligned across packages and examples,
   especially `zod`.
 - After dependency changes, run relevant package checks and usually:

--- a/docs/releases/v1.md
+++ b/docs/releases/v1.md
@@ -11,8 +11,9 @@ dependent package when its published dependency metadata must change.
 - `preview` contains commit-scoped builds for packages in the pending Changesets release plan.
 
 Applications may use different package versions when their declared dependency ranges are
-compatible. Internal workspace dependencies remain `workspace:*` in source and are packed as the
-exact version present in the release workspace.
+compatible. Internal peer dependencies use `workspace:^` and pack as a caret range for the
+corresponding workspace version. Other internal dependencies use `workspace:*` and pack as exact
+versions. Compatible minor releases therefore do not force major releases of peer dependents.
 
 ## Changesets
 
@@ -31,7 +32,7 @@ Stable releases use a manual dispatch of `.github/workflows/release.yml` from `m
 
 - no changesets remain pending;
 - every public package has a stable semantic version;
-- internal workspace dependencies use `workspace:*`; and
+- internal workspace peer dependencies use `workspace:^`, with `workspace:*` in other dependency fields; and
 - the complete build, typecheck, test, and package-verification suite passes.
 
 The publisher checks npm before packing. Versions already present on npm are skipped. Only newly

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -42,6 +42,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:^"
   }
 }

--- a/packages/embedding-transformers/package.json
+++ b/packages/embedding-transformers/package.json
@@ -40,6 +40,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:^"
   }
 }

--- a/packages/graph-memgraph/package.json
+++ b/packages/graph-memgraph/package.json
@@ -42,6 +42,6 @@
     "zod": "^4.5.4"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:^"
   }
 }

--- a/packages/graph-neo4j/package.json
+++ b/packages/graph-neo4j/package.json
@@ -42,7 +42,7 @@
     "zod": "^4.5.4"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*",
+    "@anvia/core": "workspace:^",
     "zod": "^4.4.0"
   }
 }

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -42,7 +42,7 @@
     "zod": "^4.5.4"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*",
+    "@anvia/core": "workspace:^",
     "zod": "^4.4.0"
   }
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -40,6 +40,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:^"
   }
 }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -43,7 +43,7 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:^"
   },
   "engines": {
     "node": ">=20"

--- a/packages/memory-drizzle/package.json
+++ b/packages/memory-drizzle/package.json
@@ -41,7 +41,7 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*",
+    "@anvia/core": "workspace:^",
     "drizzle-orm": ">=0.45.2 <1.0.0"
   }
 }

--- a/packages/memory-postgres/package.json
+++ b/packages/memory-postgres/package.json
@@ -41,6 +41,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:^"
   }
 }

--- a/packages/memory-prisma/package.json
+++ b/packages/memory-prisma/package.json
@@ -40,7 +40,7 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*",
+    "@anvia/core": "workspace:^",
     "@prisma/client": ">=7.10.0 <8.0.0"
   }
 }

--- a/packages/memory-sqlite/package.json
+++ b/packages/memory-sqlite/package.json
@@ -37,6 +37,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:^"
   }
 }

--- a/packages/observability-langfuse/package.json
+++ b/packages/observability-langfuse/package.json
@@ -45,6 +45,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:^"
   }
 }

--- a/packages/observability-lens/package.json
+++ b/packages/observability-lens/package.json
@@ -48,7 +48,7 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:^"
   },
   "engines": {
     "node": ">=24"

--- a/packages/observability-otel/package.json
+++ b/packages/observability-otel/package.json
@@ -43,6 +43,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:^"
   }
 }

--- a/packages/provider-anthropic/package.json
+++ b/packages/provider-anthropic/package.json
@@ -43,6 +43,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:^"
   }
 }

--- a/packages/provider-gemini/package.json
+++ b/packages/provider-gemini/package.json
@@ -42,6 +42,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:^"
   }
 }

--- a/packages/provider-grok/package.json
+++ b/packages/provider-grok/package.json
@@ -43,6 +43,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:^"
   }
 }

--- a/packages/provider-mistral/package.json
+++ b/packages/provider-mistral/package.json
@@ -42,6 +42,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:^"
   }
 }

--- a/packages/provider-openai/package.json
+++ b/packages/provider-openai/package.json
@@ -42,6 +42,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:^"
   }
 }

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -91,9 +91,9 @@
     "remark-gfm": "^4.0.1"
   },
   "peerDependencies": {
-    "@anvia/client": "workspace:*",
-    "@anvia/graph": "workspace:*",
-    "@anvia/react": "workspace:*",
+    "@anvia/client": "workspace:^",
+    "@anvia/graph": "workspace:^",
+    "@anvia/react": "workspace:^",
     "react": ">=18",
     "react-dom": ">=18"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -35,9 +35,9 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@anvia/client": "workspace:*",
-    "@anvia/core": "workspace:*",
-    "@anvia/graph": "workspace:*",
+    "@anvia/client": "workspace:^",
+    "@anvia/core": "workspace:^",
+    "@anvia/graph": "workspace:^",
     "react": ">=18"
   },
   "peerDependenciesMeta": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -39,6 +39,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/client": "workspace:*"
+    "@anvia/client": "workspace:^"
   }
 }

--- a/packages/tool-browser/package.json
+++ b/packages/tool-browser/package.json
@@ -46,7 +46,7 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:^"
   },
   "engines": {
     "node": ">=20.12.0"

--- a/packages/tool-sandbox/package.json
+++ b/packages/tool-sandbox/package.json
@@ -45,7 +45,7 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:^"
   },
   "engines": {
     "node": ">=20.12.0"

--- a/packages/tool-studio/package.json
+++ b/packages/tool-studio/package.json
@@ -76,7 +76,7 @@
     "zod": "^4.5.4"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:^"
   },
   "engines": {
     "node": ">=20.12.0"

--- a/packages/tool-studio/test/core-peer-dependencies.test.ts
+++ b/packages/tool-studio/test/core-peer-dependencies.test.ts
@@ -14,12 +14,12 @@ function readPackageManifest(relativePath: string): PackageManifest {
 }
 
 describe("Studio Core peer dependency boundaries", () => {
-  it("keeps Core as a synchronized workspace peer of React", () => {
+  it("keeps Core as a compatible workspace peer of React", () => {
     const packageManifest = readPackageManifest("../../react/package.json");
 
     expect(packageManifest.dependencies?.["@anvia/core"]).toBeUndefined();
     expect(packageManifest.devDependencies?.["@anvia/core"]).toBe("workspace:*");
-    expect(packageManifest.peerDependencies?.["@anvia/core"]).toBe("workspace:*");
+    expect(packageManifest.peerDependencies?.["@anvia/core"]).toBe("workspace:^");
   });
 
   it("keeps Client as the Server protocol peer", () => {
@@ -27,7 +27,7 @@ describe("Studio Core peer dependency boundaries", () => {
 
     expect(packageManifest.dependencies?.["@anvia/client"]).toBeUndefined();
     expect(packageManifest.devDependencies?.["@anvia/client"]).toBe("workspace:*");
-    expect(packageManifest.peerDependencies?.["@anvia/client"]).toBe("workspace:*");
+    expect(packageManifest.peerDependencies?.["@anvia/client"]).toBe("workspace:^");
     expect(packageManifest.peerDependencies?.["@anvia/core"]).toBeUndefined();
   });
 });

--- a/packages/vector-chroma/package.json
+++ b/packages/vector-chroma/package.json
@@ -40,6 +40,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:^"
   }
 }

--- a/packages/vector-lancedb/package.json
+++ b/packages/vector-lancedb/package.json
@@ -41,6 +41,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:^"
   }
 }

--- a/packages/vector-milvus/package.json
+++ b/packages/vector-milvus/package.json
@@ -40,6 +40,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:^"
   }
 }

--- a/packages/vector-pgvector/package.json
+++ b/packages/vector-pgvector/package.json
@@ -42,6 +42,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:^"
   }
 }

--- a/packages/vector-pinecone/package.json
+++ b/packages/vector-pinecone/package.json
@@ -40,6 +40,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:^"
   }
 }

--- a/packages/vector-qdrant/package.json
+++ b/packages/vector-qdrant/package.json
@@ -40,6 +40,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:^"
   }
 }

--- a/packages/vector-redis/package.json
+++ b/packages/vector-redis/package.json
@@ -40,6 +40,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:^"
   }
 }

--- a/packages/vector-weaviate/package.json
+++ b/packages/vector-weaviate/package.json
@@ -40,6 +40,6 @@
     "vitest": "^4.0.8"
   },
   "peerDependencies": {
-    "@anvia/core": "workspace:*"
+    "@anvia/core": "workspace:^"
   }
 }

--- a/scripts/release-train.mjs
+++ b/scripts/release-train.mjs
@@ -66,9 +66,10 @@ export function assertWorkspaceInternalDependencies(packages) {
   for (const { packageJson } of packages) {
     for (const field of DEPENDENCY_FIELDS) {
       for (const [name, range] of Object.entries(packageJson[field] ?? {})) {
-        if (packageNames.has(name) && range !== "workspace:*") {
+        const expected = field === "peerDependencies" ? "workspace:^" : "workspace:*";
+        if (packageNames.has(name) && range !== expected) {
           throw new Error(
-            `${packageJson.name} ${field}.${name} must use workspace:* (received ${range}).`,
+            `${packageJson.name} ${field}.${name} must use ${expected} (received ${range}).`,
           );
         }
       }
@@ -205,6 +206,7 @@ export function run(command, args, root = process.cwd()) {
 function findPackageDirs(dir) {
   const directories = [];
   for (const entry of readdirSync(dir).sort()) {
+    if (entry === "node_modules") continue;
     const entryPath = path.join(dir, entry);
     if (!statSync(entryPath).isDirectory()) {
       continue;

--- a/scripts/release-train.test.mjs
+++ b/scripts/release-train.test.mjs
@@ -132,6 +132,59 @@ test("compatible workspace peers prevent automatic major bumps for minor release
   }
 });
 
+for (const scenario of [
+  {
+    name: "0.x minor boundary",
+    current: "0.2.3",
+    next: "0.3.0",
+    dependentNext: "3.0.0",
+    prerelease: false,
+  },
+  {
+    name: "prerelease tuple boundary",
+    current: "1.2.3-rc.0",
+    next: "1.3.0-rc.1",
+    dependentNext: "3.0.0-rc.0",
+    prerelease: true,
+  },
+]) {
+  test(`workspace peers release unchanged dependents across the ${scenario.name}`, () => {
+    const fixture = createReleaseFixture();
+    try {
+      initializeGitFixture(fixture);
+      const dependencyPath = path.join(fixture, "packages", "a", "package.json");
+      writeJson(dependencyPath, { ...readJson(dependencyPath), version: scenario.current });
+      const dependentPath = path.join(fixture, "packages", "b", "package.json");
+      writeJson(dependentPath, {
+        ...readJson(dependentPath),
+        peerDependencies: { "@fixture/a": "workspace:^" },
+      });
+      if (scenario.prerelease) {
+        writeJson(path.join(fixture, ".changeset", "pre.json"), {
+          mode: "pre",
+          tag: "rc",
+          changesets: [],
+          initialVersions: { "@fixture/a": "1.2.2", "@fixture/b": "2.4.0" },
+        });
+      }
+      // Only A changes: B must be released solely because its peer range is exceeded.
+      writeChangeset(fixture, "a-minor", "minor", "Add an API to A.", ["a"]);
+      const output = path.join(fixture, "plan.json");
+      runCommand("pnpm", ["changeset", "status", "--output", output], fixture);
+      const { releases } = readJson(output);
+      assert.equal(releases.find(({ name }) => name === "@fixture/a").newVersion, scenario.next);
+      const dependent = releases.find(({ name }) => name === "@fixture/b");
+      assert.ok(dependent, "Out-of-range peers must receive an implicit release");
+      assert.deepEqual(dependent.changesets, []);
+      assert.equal(dependent.type, "major");
+      assert.equal(dependent.oldVersion, "2.4.0");
+      assert.equal(dependent.newVersion, scenario.dependentNext);
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+}
+
 test("preview versions use each package release plan version", () => {
   assert.equal(
     createPreviewVersion("1.4.2", "20260814T120102.sha-abcdef0"),

--- a/scripts/release-train.test.mjs
+++ b/scripts/release-train.test.mjs
@@ -39,6 +39,21 @@ test("repository config versions every public package independently", () => {
   assert.doesNotThrow(() => assertWorkspaceInternalDependencies(packages));
 });
 
+test("public package discovery ignores stale node_modules in directories without manifests", () => {
+  const fixture = createReleaseFixture();
+  try {
+    const stale = path.join(fixture, "packages", "removed-package", "node_modules", "dependency");
+    mkdirSync(stale, { recursive: true });
+    writeJson(path.join(stale, "package.json"), { name: "stale-dependency", version: "1.0.0" });
+    assert.deepEqual(
+      findPublicPackages(fixture).map(({ packageJson }) => packageJson.name),
+      ["@fixture/a", "@fixture/b"],
+    );
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
+});
+
 test("independent config rejects fixed, linked, and ignored public packages", () => {
   const fixture = createReleaseFixture();
   const configPath = path.join(fixture, ".changeset", "config.json");
@@ -52,6 +67,66 @@ test("independent config rejects fixed, linked, and ignored public packages", ()
 
     writeJson(configPath, { ...config, ignore: ["@fixture/a"] });
     assert.throws(() => assertIndependentVersioning(fixture), /must not ignore public packages/);
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
+});
+
+test("workspace validation requires compatible peers and exact ordinary dependencies", () => {
+  const a = { packageJson: { name: "@fixture/a", version: "1.0.2" } };
+  const b = {
+    packageJson: {
+      name: "@fixture/b",
+      version: "2.4.0",
+      peerDependencies: { "@fixture/a": "workspace:^" },
+      dependencies: { "@fixture/a": "workspace:*" },
+      devDependencies: { "@fixture/a": "workspace:*" },
+    },
+  };
+  assert.doesNotThrow(() => assertWorkspaceInternalDependencies([a, b]));
+  b.packageJson.peerDependencies["@fixture/a"] = "workspace:*";
+  assert.throws(
+    () => assertWorkspaceInternalDependencies([a, b]),
+    /peerDependencies.*must use workspace:\^/,
+  );
+  b.packageJson.peerDependencies["@fixture/a"] = "workspace:^";
+  b.packageJson.dependencies["@fixture/a"] = "workspace:^";
+  assert.throws(
+    () => assertWorkspaceInternalDependencies([a, b]),
+    /dependencies.*must use workspace:\*/,
+  );
+});
+
+test("compatible workspace peers prevent automatic major bumps for minor releases", () => {
+  const fixture = createReleaseFixture();
+  try {
+    initializeGitFixture(fixture);
+    const manifestPath = path.join(fixture, "packages", "b", "package.json");
+    const manifest = readJson(manifestPath);
+    manifest.peerDependencies = { "@fixture/a": "workspace:*" };
+    manifest.devDependencies = { "@fixture/a": "workspace:*" };
+    writeJson(manifestPath, manifest);
+    writeChangeset(fixture, "a-minor", "minor", "Add an API to A.", ["a"]);
+    writeChangeset(fixture, "b-minor", "minor", "Add a feature to B.", ["b"]);
+    const output = path.join(fixture, "plan.json");
+    const plan = () => {
+      runCommand("pnpm", ["changeset", "status", "--output", output], fixture);
+      return readJson(output).releases;
+    };
+    assert.equal(plan().find(({ name }) => name === "@fixture/b").newVersion, "3.0.0");
+    manifest.peerDependencies["@fixture/a"] = "workspace:^";
+    writeJson(manifestPath, manifest);
+    const compatible = plan();
+    assert.equal(compatible.find(({ name }) => name === "@fixture/a").newVersion, "1.1.0");
+    assert.equal(compatible.find(({ name }) => name === "@fixture/b").newVersion, "2.5.0");
+    assert.equal(
+      compatible.some(({ type }) => type === "major"),
+      false,
+    );
+
+    // A real breaking dependency release must still be visible in the plan.
+    writeChangeset(fixture, "a-minor", "major", "Change A's contract.", ["a"]);
+    assert.equal(plan().find(({ name }) => name === "@fixture/b").type, "major");
   } finally {
     rmSync(fixture, { recursive: true, force: true });
   }
@@ -203,7 +278,11 @@ function createReleaseFixture() {
     packageManager: "pnpm@11.0.4",
     workspaces: ["packages/*"],
   });
-  writeFileSync(path.join(root, "pnpm-workspace.yaml"), "packages:\n  - packages/*\n");
+  // Fixtures borrow the repository install; pnpm must never reinstall through that symlink.
+  writeFileSync(
+    path.join(root, "pnpm-workspace.yaml"),
+    "packages:\n  - packages/*\nverifyDepsBeforeRun: false\n",
+  );
   writeJson(path.join(root, ".changeset", "config.json"), {
     changelog: "@changesets/cli/changelog",
     commit: false,

--- a/scripts/verify-release-train-packs.mjs
+++ b/scripts/verify-release-train-packs.mjs
@@ -44,10 +44,11 @@ export function assertPackedInternalVersions(manifest, packagesByName) {
       if (internalPackage === undefined) {
         continue;
       }
-      const expected = internalPackage.packageJson.version;
+      const version = internalPackage.packageJson.version;
+      const expected = field === "peerDependencies" ? `^${version}` : version;
       if (range !== expected) {
         throw new Error(
-          `${manifest.name} packed ${field}.${name} as ${range}; expected exact ${expected}.`,
+          `${manifest.name} packed ${field}.${name} as ${range}; expected ${expected}.`,
         );
       }
     }


### PR DESCRIPTION
Exact internal peer dependencies (`workspace:*`) make Changesets treat core's additive 1.1.2 → 1.2.0 update as incompatible and promote 33 dependent packages to major releases. In the pending Version Packages PR #416, Studio therefore becomes 2.0.0 even though its changeset explicitly requests a minor release.

Use `workspace:^` for internal peers while retaining `workspace:*` for ordinary/dev dependencies. pnpm packs peers as compatible caret ranges and ordinary dependencies as exact versions. Update source/packed-manifest release validation and release documentation, and add patch changesets so all affected packages publish the corrected peer metadata. Existing minor changesets still determine Studio/core's releases.

The release-plan regression reproduces the major bump with exact peers, verifies that compatible peers preserve minor releases, and confirms that genuine breaking dependency releases still propagate major bumps. Additional 0.x and prerelease boundary fixtures verify implicit dependent releases without an explicit dependent changeset. Release test fixtures disable pnpm's automatic install check because they borrow the repository dependency directory; package discovery also ignores stale node_modules under removed package directories.

Merge this before #416. The release workflow will regenerate that PR from main; there is no need to manually edit its generated versions or changelogs.

Verified current pending plan:
- `@anvia/studio`: 1.1.2 → 1.2.0 (minor)
- `@anvia/core`: 1.1.2 → 1.2.0 (minor)
- Other affected public packages: patch releases
- Major releases: 0 (previously 33)

Validation:
- `pnpm --filter @anvia/studio test`: all 225 tests pass, including updated peer-range assertions.
- `node --test scripts/release-train.test.mjs`: 14 tests pass.
- `pnpm releases:validate`: 35 public packages pass.
- `pnpm releases:verify-packs`: all 13 representative tarballs have the expected ranges.
- `pnpm changeset status --output ...`: verified the release plan without changing versions.
- `pnpm check` and `git diff --check`: pass.
- Independent code-review-and-quality review approved.

No runtime source, package version numbers, generated changelogs, lockfile, or external dependency versions changed. The full Studio suite and its dependency builds pass locally; CI also passed all package builds and typechecks before exposing the two stale peer-range assertions corrected here. No publishing, tagging, or release dispatch was performed.


