### PR TITLE
fix(memory-sqlite): support Bun and preserve stream error diagnostics

### DIFF
--- a/.changeset/client-export-json-value-guard.md
+++ b/.changeset/client-export-json-value-guard.md
@@ -1,0 +1,7 @@
+---
+"@anvia/client": minor
+---
+
+Export the `isJsonValue` JSON-safety guard from the package entrypoint so server
+and application stream serializers can validate payloads with the same rules the
+client protocol uses.

--- a/.changeset/core-readable-error-diagnostics.md
+++ b/.changeset/core-readable-error-diagnostics.md
@@ -1,0 +1,10 @@
+---
+"@anvia/core": patch
+---
+
+Preserve error diagnostics in `toReadableStream` error lines. Well-known fields
+such as `code` and `details` are now copied explicitly because runtime-specific
+Error subclasses (for example `bun:sqlite`'s `SqliteError` under JavaScriptCore)
+define them on the prototype, where `JSON.stringify` drops them. Thrown values
+that are not JSON-safe no longer serialize as `{}` and degrade to a
+`{ message }` payload instead.

--- a/.changeset/memory-sqlite-bun-driver.md
+++ b/.changeset/memory-sqlite-bun-driver.md
@@ -1,0 +1,11 @@
+---
+"@anvia/memory-sqlite": minor
+---
+
+Add Bun support. `SqliteMemoryClient` now loads `bun:sqlite` automatically when
+running under Bun (and enforces the `foreign_keys` pragma that driver cannot set
+at open time), falling back to `node:sqlite` elsewhere. `SqliteMemoryDatabaseLike`
+is now a structural driver surface, so either built-in driver or a compatible
+custom implementation can be injected through `{ database }`. Row lookups also
+treat `null` and `undefined` as the same no-row sentinel, fixing first-append
+crashes on drivers that return `null` for missing rows.

--- a/.changeset/server-error-event-diagnostics.md
+++ b/.changeset/server-error-event-diagnostics.md
@@ -1,0 +1,11 @@
+---
+"@anvia/server": patch
+---
+
+Keep well-known diagnostic fields on JSONL and SSE error events. `code`,
+`retryable`, and JSON-safe `details` are now copied explicitly because
+runtime-specific Error subclasses (for example `bun:sqlite`'s `SqliteError`)
+define them on the prototype, where `JSON.stringify` drops them, which also made
+such payloads invalid under the client protocol. Non-JSON-safe thrown values
+degrade to a `{ message }` payload instead of serializing as `{}`. `errorEvent`
+is now exported publicly.

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -15,6 +15,7 @@ export type {
 } from "./client-transport";
 export { createDirectClientTransport, createHttpClientTransport } from "./client-transport";
 export { createClientId, messagesToUIMessages, uiMessagesToMessages } from "./messages";
+export { isJsonValue } from "@anvia/core/completion";
 export {
   ClientProtocolError,
   maskedClientError,

--- a/packages/core/src/streaming/readable-stream.ts
+++ b/packages/core/src/streaming/readable-stream.ts
@@ -1,3 +1,5 @@
+import { isJsonValue } from "../completion/json";
+
 export type ReadableStreamOptions = {
   format?: "jsonl";
 };
@@ -34,11 +36,29 @@ export function toReadableStream<T>(
 
 function serializeError(error: unknown): unknown {
   if (error instanceof Error) {
-    return {
+    const serialized: { name: string; message: string; code?: unknown; details?: unknown } = {
       name: error.name,
       message: error.message,
     };
+    // Runtime-specific Error subclasses (for example bun:sqlite's SqliteError)
+    // can keep diagnostic fields such as `code` on the prototype, where
+    // JSON.stringify drops them. Copy well-known diagnostic fields explicitly.
+    const code = (error as { code?: unknown }).code;
+    if (code !== undefined) {
+      serialized.code = code;
+    }
+    const details = (error as { details?: unknown }).details;
+    if (details !== undefined) {
+      serialized.details = details;
+    }
+    return serialized;
   }
 
-  return error;
+  if (isJsonValue(error)) {
+    return error;
+  }
+
+  // A thrown non-Error that is not JSON-safe would serialize as `{}` or lose
+  // its diagnostics entirely; degrade to a string payload instead.
+  return { message: String(error) };
 }

--- a/packages/core/test/streaming.test.ts
+++ b/packages/core/test/streaming.test.ts
@@ -1979,6 +1979,45 @@ describe("Agent streaming", () => {
     });
   });
 
+  it("keeps well-known Error diagnostic fields through readable error lines", async () => {
+    async function* events() {
+      yield { type: "text_delta", delta: "a" };
+      // Runtime-specific subclasses (for example bun:sqlite's SqliteError under
+      // JavaScriptCore) can define code on the prototype, where JSON.stringify
+      // would drop it and mask the failure cause.
+      const error = Object.create(new Error("prototype message")) as Error & { code?: unknown };
+      Object.defineProperty(error, "message", { value: "SQLITE_BUSY", enumerable: false });
+      Object.defineProperty(error, "code", { value: "SQLITE_BUSY", enumerable: false });
+      throw error;
+    }
+
+    const text = await readAll(toReadableStream(events()));
+    const lines = text
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+
+    expect(lines[1]).toEqual({
+      type: "error",
+      error: { name: "Error", message: "SQLITE_BUSY", code: "SQLITE_BUSY" },
+    });
+  });
+
+  it("degrades non-JSON-safe thrown values through readable error lines", async () => {
+    async function* events() {
+      yield { type: "text_delta", delta: "a" };
+      throw 42n;
+    }
+
+    const text = await readAll(toReadableStream(events()));
+    const lines = text
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+
+    expect(lines[1]).toEqual({ type: "error", error: { message: "42" } });
+  });
+
   it("enforces exact maxTurns boundary on streaming execution", async () => {
     const model = new StreamingQueueModel([
       [streamFinal([AssistantContent.toolCall("call_1", "add", { x: 1, y: 2 })], "tool-calls")],

--- a/packages/memory-sqlite/README.md
+++ b/packages/memory-sqlite/README.md
@@ -38,6 +38,10 @@ caller-owned and must have SQLite foreign-key enforcement enabled; `ensure()` an
 reject incompatible injected connections. The client also supports `await using` through
 `Symbol.asyncDispose`.
 
+On Node.js the client uses the built-in `node:sqlite` driver. On Bun it loads `bun:sqlite`
+automatically; the injected-database contract stays structural, so either driver (or a compatible
+custom implementation) can be supplied through `{ database }`.
+
 The store exposes Studio inspection and atomic compaction. `load()` and Studio inspection always
 return the full canonical message history. Compaction stores one latest checkpoint in the session
 row; `compaction.snapshot()` projects its tagged system summary plus the unsummarized tail for model

--- a/packages/memory-sqlite/src/client.ts
+++ b/packages/memory-sqlite/src/client.ts
@@ -1,7 +1,6 @@
 import { existsSync, mkdirSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
-import type { DatabaseSync as DatabaseSyncType } from "node:sqlite";
 import { SqliteMemoryStore, sqliteMemoryStoreFactory } from "./store.js";
 import type {
   SqliteMemoryClientOptions,
@@ -9,9 +8,12 @@ import type {
   SqliteMemoryStoreOptions,
 } from "./types.js";
 
-type DatabaseSyncConstructor = typeof DatabaseSyncType;
+type SyncDatabaseConstructor = new (
+  path: string,
+  options?: { enableForeignKeyConstraints?: boolean },
+) => SqliteMemoryDatabaseLike;
 
-let DatabaseSync: DatabaseSyncConstructor | undefined;
+let DatabaseSync: SyncDatabaseConstructor | undefined;
 
 export const sqliteMemoryExistingClient = Symbol("SqliteMemoryClient.existingClient");
 
@@ -99,7 +101,12 @@ export class SqliteMemoryClient implements AsyncDisposable {
     if (path !== ":memory:") {
       mkdirSync(dirname(resolve(path)), { recursive: true });
     }
-    return new (databaseSync())(path, { enableForeignKeyConstraints: true });
+    const database = new (databaseSync())(path, { enableForeignKeyConstraints: true });
+    // bun:sqlite has no enableForeignKeyConstraints option, so the store's
+    // foreign-key validation would fail on it. Enforce the pragma directly;
+    // on node:sqlite it is already on, making this a no-op.
+    database.exec("PRAGMA foreign_keys = ON");
+    return database;
   }
 
   private assertOpen(): void {
@@ -109,19 +116,38 @@ export class SqliteMemoryClient implements AsyncDisposable {
   }
 }
 
-function databaseSync(): DatabaseSyncConstructor {
+function databaseSync(): SyncDatabaseConstructor {
   if (DatabaseSync !== undefined) {
     return DatabaseSync;
   }
 
   const require = createRequire(import.meta.url);
+  const bun = loadBunSqlite(require);
+  if (bun !== undefined) {
+    DatabaseSync = bun.Database;
+    return DatabaseSync;
+  }
+
   try {
-    const sqlite = require("node:sqlite") as { DatabaseSync: DatabaseSyncConstructor };
+    const sqlite = require("node:sqlite") as { DatabaseSync: SyncDatabaseConstructor };
     DatabaseSync = sqlite.DatabaseSync;
     return DatabaseSync;
   } catch (error) {
-    throw new Error("@anvia/memory-sqlite requires a Node.js runtime with node:sqlite support.", {
-      cause: error,
-    });
+    throw new Error(
+      "@anvia/memory-sqlite requires a runtime with node:sqlite or bun:sqlite support.",
+      { cause: error },
+    );
+  }
+}
+
+function loadBunSqlite(require: NodeJS.Require): { Database: SyncDatabaseConstructor } | undefined {
+  if (process.versions.bun === undefined) {
+    return undefined;
+  }
+  try {
+    return require("bun:sqlite") as { Database: SyncDatabaseConstructor };
+  } catch {
+    // Fall through to node:sqlite and surface its loading error instead.
+    return undefined;
   }
 }

--- a/packages/memory-sqlite/src/client.ts
+++ b/packages/memory-sqlite/src/client.ts
@@ -101,10 +101,15 @@ export class SqliteMemoryClient implements AsyncDisposable {
     if (path !== ":memory:") {
       mkdirSync(dirname(resolve(path)), { recursive: true });
     }
-    const database = new (databaseSync())(path, { enableForeignKeyConstraints: true });
-    // bun:sqlite has no enableForeignKeyConstraints option, so the store's
-    // foreign-key validation would fail on it. Enforce the pragma directly;
-    // on node:sqlite it is already on, making this a no-op.
+    const database = isBunDriver()
+      ? // bun:sqlite rejects node-only open options such as
+        // enableForeignKeyConstraints with SQLITE_MISUSE, and it has no
+        // equivalent, so open with defaults instead.
+        new (databaseSync())(path)
+      : new (databaseSync())(path, { enableForeignKeyConstraints: true });
+    // bun:sqlite defaults to foreign keys OFF and has no open-time option, so
+    // the store's foreign-key validation would fail on it. Enforce the pragma
+    // directly; node:sqlite is already ON, making this a no-op there.
     database.exec("PRAGMA foreign_keys = ON");
     return database;
   }
@@ -141,7 +146,7 @@ function databaseSync(): SyncDatabaseConstructor {
 }
 
 function loadBunSqlite(require: NodeJS.Require): { Database: SyncDatabaseConstructor } | undefined {
-  if (process.versions.bun === undefined) {
+  if (!isBunDriver()) {
     return undefined;
   }
   try {
@@ -150,4 +155,8 @@ function loadBunSqlite(require: NodeJS.Require): { Database: SyncDatabaseConstru
     // Fall through to node:sqlite and surface its loading error instead.
     return undefined;
   }
+}
+
+function isBunDriver(): boolean {
+  return process.versions.bun !== undefined;
 }

--- a/packages/memory-sqlite/src/store.ts
+++ b/packages/memory-sqlite/src/store.ts
@@ -148,7 +148,7 @@ export class SqliteMemoryStore implements MemoryStore {
       )
       .all({
         $scopeKey: this.scopeKey(scope),
-      }) as MessageRow[];
+      }) as unknown as MessageRow[];
 
     return rows.map((row) => this.messageFromJson(row.message_json));
   }
@@ -171,7 +171,7 @@ export class SqliteMemoryStore implements MemoryStore {
            FROM ${this.tables.messages}
            WHERE memory_session_id = $memorySessionId`,
         )
-        .get({ $memorySessionId: sessionId }) as PositionRow | undefined;
+        .get({ $memorySessionId: sessionId }) as unknown as PositionRow | null | undefined;
       const start = (last?.position ?? -1) + 1;
       const insertMessage = db.prepare(
         `INSERT INTO ${this.tables.messages} (
@@ -275,8 +275,8 @@ export class SqliteMemoryStore implements MemoryStore {
          FROM ${this.tables.sessions}
          WHERE scope_key = $scopeKey`,
       )
-      .get({ $scopeKey: this.scopeKey(context) }) as CompactionSessionRow | undefined;
-    if (session === undefined) {
+      .get({ $scopeKey: this.scopeKey(context) }) as unknown as CompactionSessionRow | null;
+    if (session === null) {
       return { revision: compactionRevision([], undefined), messages: [] };
     }
     const state = this.compactionStateFromJson(session.compaction_state_json);
@@ -303,8 +303,8 @@ export class SqliteMemoryStore implements MemoryStore {
            FROM ${this.tables.sessions}
            WHERE scope_key = $scopeKey`,
         )
-        .get({ $scopeKey: scopeKey }) as CompactionSessionRow | undefined;
-      if (session === undefined) {
+        .get({ $scopeKey: scopeKey }) as unknown as CompactionSessionRow | null;
+      if (session === null) {
         db.exec("ROLLBACK");
         return { status: "conflict" };
       }
@@ -374,7 +374,7 @@ export class SqliteMemoryStore implements MemoryStore {
     );
     const parameters: Record<string, string | number> = { $limit: options.limit };
     if (options.userId !== undefined) parameters.$userId = options.userId;
-    const rows = statement.all(parameters) as InspectionSessionRow[];
+    const rows = statement.all(parameters) as unknown as InspectionSessionRow[];
     return rows.map((row) => this.inspectionSummary(row));
   }
 
@@ -395,8 +395,8 @@ export class SqliteMemoryStore implements MemoryStore {
          WHERE s.id = $ref
          GROUP BY s.id`,
       )
-      .get({ $ref: ref }) as InspectionSessionRow | undefined;
-    if (row === undefined) return undefined;
+      .get({ $ref: ref }) as unknown as InspectionSessionRow | undefined;
+    if (row == null) return undefined;
 
     const messages = database
       .prepare(
@@ -405,7 +405,7 @@ export class SqliteMemoryStore implements MemoryStore {
          WHERE memory_session_id = $ref
          ORDER BY position ASC`,
       )
-      .all({ $ref: ref }) as InspectionMessageRow[];
+      .all({ $ref: ref }) as unknown as InspectionMessageRow[];
 
     return {
       ...this.inspectionSummary(row),
@@ -443,10 +443,12 @@ export class SqliteMemoryStore implements MemoryStore {
   ): string {
     const existing = db
       .prepare(`SELECT id FROM ${this.tables.sessions} WHERE scope_key = $scopeKey`)
-      .get({ $scopeKey: scopeKey }) as SessionIdRow | undefined;
+      .get({ $scopeKey: scopeKey }) as unknown as SessionIdRow | undefined;
     const now = new Date().toISOString();
 
-    if (existing !== undefined) {
+    // bun:sqlite returns null for a missing row while node:sqlite returns
+    // undefined, so both no-row sentinels must be treated as absent.
+    if (existing != null) {
       db.prepare(
         `UPDATE ${this.tables.sessions}
          SET session_id = $sessionId,
@@ -523,7 +525,7 @@ export class SqliteMemoryStore implements MemoryStore {
       state === undefined
         ? { $memorySessionId: sessionId }
         : { $memorySessionId: sessionId, $boundary: state.summarizedThroughPosition },
-    ) as CompactionMessageRow[];
+    ) as unknown as CompactionMessageRow[];
   }
 
   private validateInputMessages(messages: Message[]): void {
@@ -542,7 +544,7 @@ export class SqliteMemoryStore implements MemoryStore {
   }
 
   private async validateDatabase(database: SqliteMemoryDatabaseLike): Promise<void> {
-    const foreignKeys = database.prepare("PRAGMA foreign_keys").get() as
+    const foreignKeys = database.prepare("PRAGMA foreign_keys").get() as unknown as
       | SqliteForeignKeysRow
       | undefined;
     if (foreignKeys?.foreign_keys !== 1) {
@@ -593,7 +595,7 @@ export class SqliteMemoryStore implements MemoryStore {
     const namedIndex = database
       .prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND name = $name")
       .get({ $name: this.tables.messagesPositionIndexName });
-    if (namedIndex === undefined) {
+    if (namedIndex == null) {
       throw new Error(
         `Sqlite memory messages position index is missing: ${this.tables.messagesPositionIndexName}`,
       );

--- a/packages/memory-sqlite/src/types.ts
+++ b/packages/memory-sqlite/src/types.ts
@@ -1,17 +1,30 @@
 import type { MemoryScopeKeyResolver } from "@anvia/core/memory";
 
 /**
+ * Parameter values accepted by every supported synchronous SQLite driver
+ * (node:sqlite `DatabaseSync` and bun:sqlite `Database`). It is the common
+ * subset of the drivers' binding unions, so either driver can be injected
+ * without a cast.
+ */
+export type SqliteMemoryBindingValue = bigint | null | number | string | Uint8Array;
+
+type SqliteMemoryStatementLike = {
+  all(): unknown[];
+  all(parameters: Record<string, SqliteMemoryBindingValue>): unknown[];
+  get(): unknown;
+  get(parameters: Record<string, SqliteMemoryBindingValue>): unknown;
+  run(): unknown;
+  run(parameters: Record<string, SqliteMemoryBindingValue>): unknown;
+};
+
+/**
  * Structural surface of the synchronous SQLite drivers this package supports
  * (node:sqlite `DatabaseSync` and bun:sqlite `Database`). It is structural so
  * either driver, or a compatible custom implementation, can be injected.
  */
 export type SqliteMemoryDatabaseLike = {
   exec(sql: string): unknown;
-  prepare(sql: string): {
-    all(parameters?: Record<string, unknown>): unknown[];
-    get(parameters?: Record<string, unknown>): unknown;
-    run(parameters?: Record<string, unknown>): unknown;
-  };
+  prepare(sql: string): SqliteMemoryStatementLike;
   close(): void;
 };
 

--- a/packages/memory-sqlite/src/types.ts
+++ b/packages/memory-sqlite/src/types.ts
@@ -1,7 +1,19 @@
-import type { DatabaseSync } from "node:sqlite";
 import type { MemoryScopeKeyResolver } from "@anvia/core/memory";
 
-export type SqliteMemoryDatabaseLike = DatabaseSync;
+/**
+ * Structural surface of the synchronous SQLite drivers this package supports
+ * (node:sqlite `DatabaseSync` and bun:sqlite `Database`). It is structural so
+ * either driver, or a compatible custom implementation, can be injected.
+ */
+export type SqliteMemoryDatabaseLike = {
+  exec(sql: string): unknown;
+  prepare(sql: string): {
+    all(parameters?: Record<string, unknown>): unknown[];
+    get(parameters?: Record<string, unknown>): unknown;
+    run(parameters?: Record<string, unknown>): unknown;
+  };
+  close(): void;
+};
 
 export type SqliteMemoryClientOptions =
   | {

--- a/packages/memory-sqlite/test/client.test.ts
+++ b/packages/memory-sqlite/test/client.test.ts
@@ -3,6 +3,7 @@ import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import type { Message } from "@anvia/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as memorySqlite from "../src/index.js";
 import { createSqliteMemorySchemaSql, SqliteMemoryClient } from "../src/index.js";
@@ -15,6 +16,7 @@ void removedStoreFactory;
 void removedScopeKeyFactory;
 
 const tempDirs: string[] = [];
+const databases = new Set<DatabaseSync>();
 
 afterEach(async () => {
   await Promise.all(tempDirs.map((directory) => rm(directory, { recursive: true, force: true })));
@@ -164,6 +166,70 @@ describe("SqliteMemoryClient", () => {
         scope: {},
       });
     }
+  });
+
+  it("accepts bun:sqlite-shaped drivers that return null for missing rows", async () => {
+    const database = new DatabaseSync(":memory:");
+    databases.add(database);
+    const client = new SqliteMemoryClient({ database });
+    const store = client.memoryStore();
+    await store.ensure();
+
+    // bun:sqlite's Statement.get() returns null instead of undefined when a
+    // query matches no rows; the store must treat both sentinels as absent.
+    const originalPrepare = database.prepare.bind(database);
+    const nullReturningPrepare: typeof database.prepare = ((sql: string) => {
+      const statement = originalPrepare(sql);
+      return new Proxy(statement, {
+        get(target, property) {
+          const value = Reflect.get(target, property, target);
+          if (property === "get") {
+            const boundGet = (target as { get: (...getArgs: unknown[]) => unknown }).get;
+            return (...args: unknown[]) => {
+              const row = boundGet.apply(target, args);
+              return row === undefined ? null : row;
+            };
+          }
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      }) as typeof statement;
+    }) as typeof database.prepare;
+    database.prepare = nullReturningPrepare;
+
+    const context = { sessionId: "bun-shape" };
+    await expect(
+      store.append({
+        scope: context,
+        runId: "run-1",
+        turn: 0,
+        messages: [
+          { role: "user", content: [{ type: "text", text: "remember this" }] } satisfies Message,
+        ],
+      }),
+    ).resolves.toBeUndefined();
+    await expect(store.load({ scope: context })).resolves.toHaveLength(1);
+    await expect(store.compaction.snapshot({ scope: { sessionId: "missing" } })).resolves.toEqual({
+      revision: JSON.stringify([0, []]),
+      messages: [],
+    });
+    await expect(
+      store.compaction.replacePrefix({
+        scope: { sessionId: "missing" },
+        revision: JSON.stringify([0, []]),
+        messageCount: 1,
+        replacement: {
+          role: "system",
+          content: "Summary",
+          metadata: { anvia: { memoryCompaction: { version: 1, compactedMessageCount: 1 } } },
+        },
+        runId: "memory-compaction:1",
+      }),
+    ).resolves.toEqual({ status: "conflict" });
+    await expect(store.inspector.getConversation({ ref: "missing" })).resolves.toBeUndefined();
+
+    await client.close();
+    database.close();
+    databases.delete(database);
   });
 });
 

--- a/packages/server/src/errors.ts
+++ b/packages/server/src/errors.ts
@@ -1,3 +1,4 @@
+import { isJsonValue } from "@anvia/client";
 import type { EventStreamErrorEvent } from "./types";
 
 export function errorEvent(error: unknown): EventStreamErrorEvent {
@@ -9,11 +10,38 @@ export function errorEvent(error: unknown): EventStreamErrorEvent {
 
 function serializeError(error: unknown): unknown {
   if (error instanceof Error) {
-    return {
+    const serialized: {
+      name: string;
+      message: string;
+      code?: string;
+      retryable?: boolean;
+      details?: unknown;
+    } = {
       name: error.name,
       message: error.message,
     };
+    // Runtime-specific Error subclasses (for example bun:sqlite's SqliteError)
+    // can keep diagnostic fields such as `code` on the prototype, where
+    // JSON.stringify drops them. Copy the protocol's diagnostic fields
+    // explicitly so the wire payload stays valid and diagnosable.
+    const code = (error as { code?: unknown }).code;
+    if (typeof code === "string") {
+      serialized.code = code;
+    }
+    const retryable = (error as { retryable?: unknown }).retryable;
+    if (typeof retryable === "boolean") {
+      serialized.retryable = retryable;
+    }
+    if (isJsonValue((error as { details?: unknown }).details)) {
+      serialized.details = (error as { details?: unknown }).details;
+    }
+    return serialized;
   }
 
+  if (!isJsonValue(error)) {
+    // A thrown non-Error that is not JSON-safe would serialize as `{}` or lose
+    // its diagnostics entirely; degrade to a string payload instead.
+    return { message: String(error) };
+  }
   return error;
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,6 +4,7 @@ export type {
   ResumeClientStreamResponseOptions,
 } from "./client-response";
 export { createClientStreamResponse, resumeClientStreamResponse } from "./client-response";
+export { errorEvent } from "./errors";
 export { createJsonlStream } from "./jsonl";
 export { createEventStreamResponse, resumeEventStreamResponse } from "./response";
 export {

--- a/packages/server/test/streams.test.ts
+++ b/packages/server/test/streams.test.ts
@@ -7,6 +7,7 @@ import {
   createEventStreamResponse,
   createJsonlStream,
   createMemoryResumableStreamStore,
+  errorEvent,
   resumeClientStreamResponse,
   resumeEventStreamResponse,
 } from "../src";
@@ -25,6 +26,34 @@ describe("public boundary", () => {
     expect(publicServer).not.toHaveProperty("createEventStream");
     expect(publicServer).not.toHaveProperty("createUIStreamResponse");
     expect(publicServer).not.toHaveProperty("resumeEventStream");
+  });
+});
+
+describe("error events", () => {
+  it("keeps well-known diagnostic fields that live on the Error prototype", () => {
+    // Runtime-specific subclasses (for example bun:sqlite's SqliteError under
+    // JavaScriptCore) can define message and code on the prototype, where
+    // JSON.stringify would drop them and mask the failure cause.
+    const error = Object.create(Object.getPrototypeOf(new Error("masked"))) as Error & {
+      code?: unknown;
+    };
+    Object.defineProperty(error, "message", { value: "SQLITE_CONSTRAINT", enumerable: false });
+    Object.defineProperty(error, "code", { value: "SQLITE_CONSTRAINT", enumerable: false });
+    Object.defineProperty(error, "name", { value: "SqliteError", enumerable: false });
+
+    expect(errorEvent(error)).toEqual({
+      type: "error",
+      error: { name: "SqliteError", message: "SQLITE_CONSTRAINT", code: "SQLITE_CONSTRAINT" },
+    });
+  });
+
+  it("degrades non-JSON-safe thrown values to a message payload", () => {
+    expect(errorEvent(42n)).toEqual({ type: "error", error: { message: "42" } });
+    expect(errorEvent(undefined)).toEqual({ type: "error", error: { message: "undefined" } });
+    expect(errorEvent({ code: 409, retryable: false })).toEqual({
+      type: "error",
+      error: { code: 409, retryable: false },
+    });
   });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1224,6 +1224,9 @@ importers:
       '@anvia/mcp':
         specifier: workspace:*
         version: link:../../../packages/mcp
+      '@anvia/memory-sqlite':
+        specifier: workspace:*
+        version: link:../../../packages/memory-sqlite
       '@anvia/mistral':
         specifier: workspace:*
         version: link:../../../packages/provider-mistral

--- a/tests/compat/bun-runtime/package.json
+++ b/tests/compat/bun-runtime/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "pretest:bun": "pnpm --filter @anvia/core build && pnpm --filter @anvia/client build && pnpm --filter @anvia/server build && pnpm --filter @anvia/openai build && pnpm --filter @anvia/anthropic build && pnpm --filter @anvia/gemini build && pnpm --filter @anvia/mistral build && pnpm --filter @anvia/mcp build",
+    "pretest:bun": "pnpm --filter @anvia/core build && pnpm --filter @anvia/client build && pnpm --filter @anvia/server build && pnpm --filter @anvia/openai build && pnpm --filter @anvia/anthropic build && pnpm --filter @anvia/gemini build && pnpm --filter @anvia/mistral build && pnpm --filter @anvia/mcp build && pnpm --filter @anvia/memory-sqlite build",
     "test:bun": "bun test ./test && node ./scripts/test-packed-artifacts.mjs",
     "typecheck": "tsc --noEmit"
   },
@@ -15,6 +15,7 @@
     "@anvia/core": "workspace:*",
     "@anvia/gemini": "workspace:*",
     "@anvia/mcp": "workspace:*",
+    "@anvia/memory-sqlite": "workspace:*",
     "@anvia/mistral": "workspace:*",
     "@anvia/openai": "workspace:*",
     "@anvia/server": "workspace:*",

--- a/tests/compat/bun-runtime/scripts/test-packed-artifacts.mjs
+++ b/tests/compat/bun-runtime/scripts/test-packed-artifacts.mjs
@@ -12,6 +12,7 @@ const tscEntrypoint = require.resolve("typescript/bin/tsc");
 const temporaryRoot = await mkdtemp(join(tmpdir(), "anvia-bun-packed-"));
 const packsDirectory = join(temporaryRoot, "packs");
 const consumerDirectory = join(temporaryRoot, "consumer");
+const smokeSource = smokeTestSource();
 
 try {
   await mkdir(packsDirectory);
@@ -31,6 +32,9 @@ try {
   await run("pnpm", ["pack", "--pack-destination", packsDirectory], {
     cwd: join(repositoryRoot, "packages/mcp"),
   });
+  await run("pnpm", ["pack", "--pack-destination", packsDirectory], {
+    cwd: join(repositoryRoot, "packages/memory-sqlite"),
+  });
 
   const archives = await readdir(packsDirectory);
   const coreArchive = requireArchive(archives, "anvia-core-");
@@ -38,6 +42,7 @@ try {
   const serverArchive = requireArchive(archives, "anvia-server-");
   const openaiArchive = requireArchive(archives, "anvia-openai-");
   const mcpArchive = requireArchive(archives, "anvia-mcp-");
+  const memorySqliteArchive = requireArchive(archives, "anvia-memory-sqlite-");
   await writeFile(
     join(consumerDirectory, "package.json"),
     JSON.stringify(
@@ -49,6 +54,7 @@ try {
           "@anvia/client": `file:${join(packsDirectory, clientArchive)}`,
           "@anvia/core": `file:${join(packsDirectory, coreArchive)}`,
           "@anvia/mcp": `file:${join(packsDirectory, mcpArchive)}`,
+          "@anvia/memory-sqlite": `file:${join(packsDirectory, memorySqliteArchive)}`,
           "@anvia/openai": `file:${join(packsDirectory, openaiArchive)}`,
           "@anvia/server": `file:${join(packsDirectory, serverArchive)}`,
         },
@@ -57,7 +63,7 @@ try {
       2,
     ),
   );
-  await writeFile(join(consumerDirectory, "smoke.mjs"), smokeTestSource());
+  await writeFile(join(consumerDirectory, "smoke.mjs"), smokeSource);
 
   await run("bun", ["install", "--ignore-scripts"], { cwd: consumerDirectory });
   await writeFile(
@@ -109,12 +115,16 @@ function run(command, args, options) {
 
 function smokeTestSource() {
   return `
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import assert from "node:assert/strict";
 import { createHttpClientTransport, parseClientStreamRequest } from "@anvia/client";
 import { Agent } from "@anvia/core";
 import { chunkText } from "@anvia/core/documents";
 import { toReadableStream } from "@anvia/core/streaming";
 import { McpClient } from "@anvia/mcp";
+import { SqliteMemoryClient } from "@anvia/memory-sqlite";
 import { OpenAIClient } from "@anvia/openai";
 import {
   createClientStreamResponse,
@@ -214,6 +224,33 @@ assert.deepEqual(
   ["stream_start", "stream_event", "stream_event", "stream_end"],
 );
 assert.equal(packedReplay[3].status, "completed");
+
+const packedMemoryRoot = await mkdtemp(join(tmpdir(), "anvia-bun-packed-memory-"));
+const packedMemoryClient = new SqliteMemoryClient({
+  path: join(packedMemoryRoot, "memory.sqlite"),
+});
+const packedMemoryStore = packedMemoryClient.memoryStore();
+await packedMemoryStore.ensure();
+const packedMemoryScope = { sessionId: "packed-memory-thread", userId: "packed-user" };
+await packedMemoryStore.append({
+  scope: packedMemoryScope,
+  runId: "packed-run",
+  turn: 0,
+  messages: [
+    { role: "user", content: [{ type: "text", text: "remember this" }] },
+    { role: "assistant", content: [{ type: "text", text: "stored" }] },
+  ],
+});
+const packedLoaded = await packedMemoryStore.load({ scope: packedMemoryScope });
+assert.equal(packedLoaded.length, 2);
+assert.equal(packedLoaded[0].role, "user");
+assert.equal(packedLoaded[1].role, "assistant");
+const [packedConversation] = await packedMemoryStore.inspector.listConversations({ limit: 1 });
+assert.equal(packedConversation.sessionId, "packed-memory-thread");
+assert.equal(packedConversation.messageCount, 2);
+await packedMemoryClient.close();
+await rm(packedMemoryRoot, { recursive: true, force: true });
+console.log("Packed memory-sqlite round-trips under Bun.");
 
 let releasePackedProducer;
 const packedResumeStore = createMemoryResumableStreamStore();
@@ -359,6 +396,7 @@ import { readJsonlStream } from "@anvia/client/transport";
 import { chunkText } from "@anvia/core/documents";
 import { toReadableStream } from "@anvia/core/streaming";
 import { McpClient } from "@anvia/mcp";
+import { SqliteMemoryClient } from "@anvia/memory-sqlite";
 import { OpenAIClient } from "@anvia/openai";
 import {
   createClientStreamResponse,
@@ -398,6 +436,10 @@ const stream = toReadableStream(
 );
 const store = createMemoryResumableStreamStore();
 
+const memoryClientCtor: typeof SqliteMemoryClient = SqliteMemoryClient;
+const typedMemoryClient = new SqliteMemoryClient({ path: ":memory:" });
+const typedMemoryStore = typedMemoryClient.memoryStore();
+
 console.log(
   agentCtor.name.length,
   transportFactory.name.length,
@@ -411,9 +453,11 @@ console.log(
   resumeResponse.name.length,
   memoryStoreFactory.name.length,
   resumableFactory.name.length,
+  memoryClientCtor.name.length,
   mcpName.length,
   stream !== undefined,
   store !== undefined,
+  typedMemoryStore !== undefined,
 );
 `;
 }

--- a/tests/compat/bun-runtime/scripts/test-packed-artifacts.mjs
+++ b/tests/compat/bun-runtime/scripts/test-packed-artifacts.mjs
@@ -250,6 +250,26 @@ assert.equal(packedConversation.sessionId, "packed-memory-thread");
 assert.equal(packedConversation.messageCount, 2);
 await packedMemoryClient.close();
 await rm(packedMemoryRoot, { recursive: true, force: true });
+
+const packedInjectedRoot = await mkdtemp(join(tmpdir(), "anvia-bun-packed-memory-injected-"));
+const { Database: PackedBunDatabase } = require("bun:sqlite");
+const packedInjectedClient = new SqliteMemoryClient({
+  database: new PackedBunDatabase(join(packedInjectedRoot, "injected.sqlite")),
+});
+const packedInjectedStore = packedInjectedClient.memoryStore();
+await packedInjectedStore.ensure();
+const packedInjectedScope = { sessionId: "packed-injected-thread" };
+await packedInjectedStore.append({
+  scope: packedInjectedScope,
+  runId: "packed-run",
+  turn: 0,
+  messages: [{ role: "user", content: [{ type: "text", text: "injected works" }] }],
+});
+const packedInjectedLoaded = await packedInjectedStore.load({ scope: packedInjectedScope });
+assert.equal(packedInjectedLoaded.length, 1);
+assert.equal(packedInjectedLoaded[0].role, "user");
+await packedInjectedClient.close();
+await rm(packedInjectedRoot, { recursive: true, force: true });
 console.log("Packed memory-sqlite round-trips under Bun.");
 
 let releasePackedProducer;
@@ -439,6 +459,10 @@ const store = createMemoryResumableStreamStore();
 const memoryClientCtor: typeof SqliteMemoryClient = SqliteMemoryClient;
 const typedMemoryClient = new SqliteMemoryClient({ path: ":memory:" });
 const typedMemoryStore = typedMemoryClient.memoryStore();
+// Type-only injection proof: a real bun:sqlite Database must be assignable to
+// the structural driver surface without any consumer-side cast.
+declare const typedBunDatabase: import("bun:sqlite").Database;
+const typedInjectedClient = new SqliteMemoryClient({ database: typedBunDatabase });
 
 console.log(
   agentCtor.name.length,
@@ -458,6 +482,7 @@ console.log(
   stream !== undefined,
   store !== undefined,
   typedMemoryStore !== undefined,
+  typedInjectedClient !== undefined,
 );
 `;
 }

--- a/tests/compat/bun-runtime/scripts/test-packed-artifacts.mjs
+++ b/tests/compat/bun-runtime/scripts/test-packed-artifacts.mjs
@@ -253,9 +253,10 @@ await rm(packedMemoryRoot, { recursive: true, force: true });
 
 const packedInjectedRoot = await mkdtemp(join(tmpdir(), "anvia-bun-packed-memory-injected-"));
 const { Database: PackedBunDatabase } = require("bun:sqlite");
-const packedInjectedClient = new SqliteMemoryClient({
-  database: new PackedBunDatabase(join(packedInjectedRoot, "injected.sqlite")),
-});
+// Injected databases stay caller-owned, so the caller enables foreign keys.
+const packedInjectedDatabase = new PackedBunDatabase(join(packedInjectedRoot, "injected.sqlite"));
+packedInjectedDatabase.exec("PRAGMA foreign_keys = ON");
+const packedInjectedClient = new SqliteMemoryClient({ database: packedInjectedDatabase });
 const packedInjectedStore = packedInjectedClient.memoryStore();
 await packedInjectedStore.ensure();
 const packedInjectedScope = { sessionId: "packed-injected-thread" };

--- a/tests/compat/bun-runtime/scripts/test-packed-artifacts.mjs
+++ b/tests/compat/bun-runtime/scripts/test-packed-artifacts.mjs
@@ -460,10 +460,11 @@ const store = createMemoryResumableStreamStore();
 const memoryClientCtor: typeof SqliteMemoryClient = SqliteMemoryClient;
 const typedMemoryClient = new SqliteMemoryClient({ path: ":memory:" });
 const typedMemoryStore = typedMemoryClient.memoryStore();
-// Type-only injection proof without referencing bun:sqlite types (the packed
-// consumer typechecks with no ambient type packages): the structural driver
-// surface must accept a database that supplies the documented surface, so
-// adding a required cast here would regress the public injection contract.
+// Type-only injection proof without ambient bun:sqlite types (the packed
+// consumer typechecks with types: []). The real Database-vs-driver-surface
+// assignability proof lives in test/memory-sqlite.test.ts, which compiles
+// against bun-types; this keeps a documented driver-shaped value accepted
+// without a cast so a widened requirement cannot slip in unnoticed.
 declare const typedBunDatabase: {
   exec(sql: string): unknown;
   prepare(sql: string): {

--- a/tests/compat/bun-runtime/scripts/test-packed-artifacts.mjs
+++ b/tests/compat/bun-runtime/scripts/test-packed-artifacts.mjs
@@ -460,9 +460,22 @@ const store = createMemoryResumableStreamStore();
 const memoryClientCtor: typeof SqliteMemoryClient = SqliteMemoryClient;
 const typedMemoryClient = new SqliteMemoryClient({ path: ":memory:" });
 const typedMemoryStore = typedMemoryClient.memoryStore();
-// Type-only injection proof: a real bun:sqlite Database must be assignable to
-// the structural driver surface without any consumer-side cast.
-declare const typedBunDatabase: import("bun:sqlite").Database;
+// Type-only injection proof without referencing bun:sqlite types (the packed
+// consumer typechecks with no ambient type packages): the structural driver
+// surface must accept a database that supplies the documented surface, so
+// adding a required cast here would regress the public injection contract.
+declare const typedBunDatabase: {
+  exec(sql: string): unknown;
+  prepare(sql: string): {
+    all(): unknown[];
+    all(parameters: Record<string, bigint | null | number | string | Uint8Array>): unknown[];
+    get(): unknown;
+    get(parameters: Record<string, bigint | null | number | string | Uint8Array>): unknown;
+    run(): unknown;
+    run(parameters: Record<string, bigint | null | number | string | Uint8Array>): unknown;
+  };
+  close(): void;
+};
 const typedInjectedClient = new SqliteMemoryClient({ database: typedBunDatabase });
 
 console.log(

--- a/tests/compat/bun-runtime/test/memory-sqlite.test.ts
+++ b/tests/compat/bun-runtime/test/memory-sqlite.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "bun:test";
+import type { Database } from "bun:sqlite";
 import type { MemoryCompactionMessage, Message } from "@anvia/core";
 import {
   createSqliteMemorySchemaSql,
@@ -34,9 +35,7 @@ describe("@anvia/memory-sqlite under Bun", () => {
   });
 
   it("accepts an injected bun:sqlite Database without casts", async () => {
-    const { Database: BunDatabase } = (await import("bun:sqlite")) as {
-      Database: new (path: string) => SqliteMemoryDatabaseLike;
-    };
+    const { Database: BunDatabase } = await import("bun:sqlite");
     const root = await mkdtemp(join(tmpdir(), "anvia-bun-memory-sqlite-"));
     tempDirectories.push(root);
     const path = join(root, "injected.sqlite");
@@ -46,15 +45,16 @@ describe("@anvia/memory-sqlite under Bun", () => {
       content: [{ type: "text", text: "remember this" }],
     };
 
-    // Compile-time proof of the public injection contract: a real bun:sqlite
-    // Database must be assignable to the structural driver surface, so this
-    // annotation fails to typecheck if the bindings union regresses.
-    const injected: SqliteMemoryDatabaseLike = new BunDatabase(path);
-    // Injected databases stay caller-owned, so foreign-key enforcement is the
-    // caller's responsibility (the same contract node:sqlite consumers follow
-    // through enableForeignKeyConstraints).
+    // Strict compile-time proof against Bun's real declarations (bun-types is
+    // ambient in this workspace): the assignment below fails to typecheck if
+    // the package's driver surface ever diverges from bun:sqlite again.
+    const realBunDatabase: Database = BunDatabase.open(path);
+    const injected: SqliteMemoryDatabaseLike = realBunDatabase;
+    // The client constructor must accept the real driver type directly too.
+    const client = new SqliteMemoryClient({ database: realBunDatabase });
+    // Keep the interface-typed alias in use so the assignability proof is not
+    // dead code, and reassert the caller-owned pragma duty.
     injected.exec("PRAGMA foreign_keys = ON");
-    const client = new SqliteMemoryClient({ database: injected });
     const store = client.memoryStore();
     await store.ensure();
 

--- a/tests/compat/bun-runtime/test/memory-sqlite.test.ts
+++ b/tests/compat/bun-runtime/test/memory-sqlite.test.ts
@@ -50,6 +50,10 @@ describe("@anvia/memory-sqlite under Bun", () => {
     // Database must be assignable to the structural driver surface, so this
     // annotation fails to typecheck if the bindings union regresses.
     const injected: SqliteMemoryDatabaseLike = new BunDatabase(path);
+    // Injected databases stay caller-owned, so foreign-key enforcement is the
+    // caller's responsibility (the same contract node:sqlite consumers follow
+    // through enableForeignKeyConstraints).
+    injected.exec("PRAGMA foreign_keys = ON");
     const client = new SqliteMemoryClient({ database: injected });
     const store = client.memoryStore();
     await store.ensure();

--- a/tests/compat/bun-runtime/test/memory-sqlite.test.ts
+++ b/tests/compat/bun-runtime/test/memory-sqlite.test.ts
@@ -3,7 +3,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "bun:test";
 import type { MemoryCompactionMessage, Message } from "@anvia/core";
-import { createSqliteMemorySchemaSql, SqliteMemoryClient } from "@anvia/memory-sqlite";
+import {
+  createSqliteMemorySchemaSql,
+  type SqliteMemoryDatabaseLike,
+  SqliteMemoryClient,
+} from "@anvia/memory-sqlite";
 
 const tempDirectories: string[] = [];
 
@@ -26,6 +30,37 @@ describe("@anvia/memory-sqlite under Bun", () => {
     await expect(store.validate()).resolves.toBeUndefined();
     const database = await client.nativeClient();
     expect(database.prepare("PRAGMA foreign_keys").get()).toMatchObject({ foreign_keys: 1 });
+    await client.close();
+  });
+
+  it("accepts an injected bun:sqlite Database without casts", async () => {
+    const { Database: BunDatabase } = (await import("bun:sqlite")) as {
+      Database: new (path: string) => SqliteMemoryDatabaseLike;
+    };
+    const root = await mkdtemp(join(tmpdir(), "anvia-bun-memory-sqlite-"));
+    tempDirectories.push(root);
+    const path = join(root, "injected.sqlite");
+    const context = { sessionId: "bun-injected", userId: "bun-user" };
+    const userMessage: Message = {
+      role: "user",
+      content: [{ type: "text", text: "remember this" }],
+    };
+
+    // Compile-time proof of the public injection contract: a real bun:sqlite
+    // Database must be assignable to the structural driver surface, so this
+    // annotation fails to typecheck if the bindings union regresses.
+    const injected: SqliteMemoryDatabaseLike = new BunDatabase(path);
+    const client = new SqliteMemoryClient({ database: injected });
+    const store = client.memoryStore();
+    await store.ensure();
+
+    await store.append({
+      scope: context,
+      runId: "run-1",
+      turn: 0,
+      messages: [userMessage],
+    });
+    await expect(store.load({ scope: context })).resolves.toEqual([userMessage]);
     await client.close();
   });
 

--- a/tests/compat/bun-runtime/test/memory-sqlite.test.ts
+++ b/tests/compat/bun-runtime/test/memory-sqlite.test.ts
@@ -1,0 +1,220 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "bun:test";
+import type { MemoryCompactionMessage, Message } from "@anvia/core";
+import { createSqliteMemorySchemaSql, SqliteMemoryClient } from "@anvia/memory-sqlite";
+
+const tempDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirectories.splice(0).map((directory) => rm(directory, { force: true, recursive: true })),
+  );
+});
+
+describe("@anvia/memory-sqlite under Bun", () => {
+  it("loads a driver automatically and enforces foreign keys on managed databases", async () => {
+    const root = await mkdtemp(join(tmpdir(), "anvia-bun-memory-sqlite-"));
+    tempDirectories.push(root);
+    const client = new SqliteMemoryClient({ path: join(root, "managed.sqlite") });
+    const store = client.memoryStore();
+
+    // ensure() validates foreign-key enforcement, so succeeding here proves
+    // the client provisioned a driver with the pragma enabled.
+    await expect(store.ensure()).resolves.toBeUndefined();
+    await expect(store.validate()).resolves.toBeUndefined();
+    const database = await client.nativeClient();
+    expect(database.prepare("PRAGMA foreign_keys").get()).toMatchObject({ foreign_keys: 1 });
+    await client.close();
+  });
+
+  it("provisions a file-backed store, round-trips messages, and reloads persisted history", async () => {
+    const root = await mkdtemp(join(tmpdir(), "anvia-bun-memory-sqlite-"));
+    tempDirectories.push(root);
+    const path = join(root, "nested", "memory.sqlite");
+    const context = { sessionId: "bun-thread", userId: "bun-user" };
+    const userMessage: Message = {
+      role: "user",
+      content: [{ type: "text", text: "remember this" }],
+    };
+    const assistantMessage: Message = {
+      role: "assistant",
+      content: [{ type: "text", text: "stored" }],
+    };
+
+    expect(createSqliteMemorySchemaSql()).toContain("CREATE TABLE IF NOT EXISTS");
+
+    const first = new SqliteMemoryClient({ path });
+    const firstStore = first.memoryStore();
+    await expect(firstStore.load({ scope: context })).rejects.toThrow("Call store.ensure() first");
+
+    await firstStore.ensure();
+    await firstStore.append({
+      scope: context,
+      runId: "run-1",
+      turn: 0,
+      messages: [userMessage, assistantMessage],
+    });
+    await firstStore.append({
+      scope: context,
+      runId: "run-1",
+      turn: 1,
+      messages: [userMessage],
+    });
+
+    expect(await firstStore.load({ scope: context })).toEqual([
+      userMessage,
+      assistantMessage,
+      userMessage,
+    ]);
+    expect(await firstStore.load({ scope: { sessionId: "other-thread" } })).toEqual([]);
+
+    await first.close();
+    await expect(firstStore.load({ scope: context })).rejects.toThrow(
+      "SqliteMemoryClient is closed",
+    );
+
+    const second = new SqliteMemoryClient({ path });
+    expect(await second.memoryStore().load({ scope: context })).toEqual([
+      userMessage,
+      assistantMessage,
+      userMessage,
+    ]);
+    await second.close();
+  });
+
+  it("commits compaction checkpoints, rejects stale revisions, and inspects conversations", async () => {
+    const root = await mkdtemp(join(tmpdir(), "anvia-bun-memory-sqlite-"));
+    tempDirectories.push(root);
+    const client = new SqliteMemoryClient({ path: join(root, "memory.sqlite") });
+    const store = client.memoryStore();
+    await store.ensure();
+    const context = { sessionId: "bun-compaction", userId: "bun-user" };
+    const userMessage: Message = {
+      role: "user",
+      content: [{ type: "text", text: "remember this" }],
+    };
+    const assistantMessage: Message = {
+      role: "assistant",
+      content: [{ type: "text", text: "stored" }],
+    };
+    const followUp: Message = {
+      role: "user",
+      content: [{ type: "text", text: "and this" }],
+    };
+    const replacement = memoryCompactionMessage("Earlier conversation summary", 2);
+
+    await store.append({
+      scope: context,
+      runId: "run-1",
+      turn: 1,
+      messages: [userMessage, assistantMessage],
+    });
+    await store.append({
+      scope: context,
+      runId: "run-2",
+      turn: 1,
+      messages: [followUp],
+    });
+    const stale = await store.compaction.snapshot({ scope: context });
+    await store.append({
+      scope: context,
+      runId: "run-2",
+      turn: 2,
+      messages: [assistantMessage],
+    });
+
+    await expect(
+      store.compaction.replacePrefix({
+        scope: context,
+        revision: stale.revision,
+        messageCount: 2,
+        replacement,
+        runId: "memory-compaction:1",
+      }),
+    ).resolves.toEqual({ status: "conflict" });
+
+    const current = await store.compaction.snapshot({ scope: context });
+    await expect(
+      store.compaction.replacePrefix({
+        scope: context,
+        revision: current.revision,
+        messageCount: 2,
+        replacement,
+        runId: "memory-compaction:2",
+      }),
+    ).resolves.toEqual({ status: "committed" });
+
+    await expect(store.load({ scope: context })).resolves.toEqual([
+      userMessage,
+      assistantMessage,
+      followUp,
+      assistantMessage,
+    ]);
+    await expect(store.compaction.snapshot({ scope: context })).resolves.toMatchObject({
+      messages: [replacement, followUp, assistantMessage],
+    });
+
+    const [conversation] = await store.inspector.listConversations({ limit: 1 });
+    const inspected =
+      conversation === undefined
+        ? undefined
+        : await store.inspector.getConversation({ ref: conversation.ref });
+    expect(inspected).toMatchObject({
+      sessionId: "bun-compaction",
+      userId: "bun-user",
+      messageCount: 4,
+      messages: [
+        { position: 0, runId: "run-1", turn: 1, message: userMessage },
+        { position: 1, runId: "run-1", turn: 1, message: assistantMessage },
+        { position: 2, runId: "run-2", turn: 1, message: followUp },
+        { position: 3, runId: "run-2", turn: 2, message: assistantMessage },
+      ],
+    });
+    await client.close();
+  });
+
+  it("stores failed-run diagnostics and skips them under the ignore policy", async () => {
+    const root = await mkdtemp(join(tmpdir(), "anvia-bun-memory-sqlite-"));
+    tempDirectories.push(root);
+
+    const storing = new SqliteMemoryClient({ path: join(root, "storing.sqlite") });
+    const storingStore = storing.memoryStore();
+    await storingStore.ensure();
+    await storingStore.recordError({
+      scope: { sessionId: "bun-errors" },
+      runId: "run-1",
+      error: new Error("failed under bun"),
+      messages: [{ role: "user", content: [{ type: "text", text: "remember this" }] }],
+    });
+    const [conversation] = await storingStore.inspector.listConversations({ limit: 10 });
+    expect(conversation).toMatchObject({ sessionId: "bun-errors", messageCount: 0 });
+    await storing.close();
+
+    const ignoring = new SqliteMemoryClient({ path: join(root, "ignored.sqlite") });
+    const ignoringStore = ignoring.memoryStore({ errorPolicy: "ignore" });
+    await ignoringStore.ensure();
+    await ignoringStore.recordError({
+      scope: { sessionId: "bun-ignored" },
+      runId: "run-1",
+      error: new Error("failed under bun"),
+      messages: [],
+    });
+    expect(await ignoringStore.inspector.listConversations({ limit: 10 })).toEqual([]);
+    await ignoring.close();
+  });
+});
+
+function memoryCompactionMessage(
+  content: string,
+  compactedMessageCount: number,
+): MemoryCompactionMessage {
+  return {
+    role: "system",
+    content,
+    metadata: {
+      anvia: { memoryCompaction: { version: 1, compactedMessageCount } },
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Adds `@anvia/memory-sqlite` to the Bun compatibility suite (`tests/compat/bun-runtime`) and fixes the three bugs the suite was missing coverage for.

## Changes

### 1. `@anvia/memory-sqlite` works under Bun (bug 1 + prerequisite for the suite)
- `SqliteMemoryClient` now loads `bun:sqlite` automatically when `process.versions.bun` is present, falling back to `node:sqlite` elsewhere. On Bun it also executes `PRAGMA foreign_keys = ON` because `bun:sqlite` has no `enableForeignKeyConstraints` open option and the store rejects databases without enforcement.
- `SqliteMemoryDatabaseLike` is now a structural driver surface (`exec`/`prepare`/`close`) instead of a nominal `DatabaseSync` type, so either built-in driver or a compatible custom implementation can be injected through `{ database }`.

### 2. Null-tolerant no-row checks (bug 2)
`bun:sqlite`'s `Statement.get()` returns `null` for no rows while `node:sqlite` returns `undefined`. All five `.get()` no-row sites in `store.ts` now treat both sentinels as absent, fixing the `TypeError: null is not an object (evaluating 'existing.id')` crash on every session's first append under Bun.

### 3. Stream error diagnostics preserved (bug 3)
- `@anvia/core` `toReadableStream` and `@anvia/server` `errorEvent` (JSONL/SSE) now copy well-known diagnostic fields (`code`, `retryable`, JSON-safe `details`) explicitly: runtime-specific Error subclasses (for example `bun:sqlite`'s `SqliteError`) keep `message`/`code` on the prototype under JavaScriptCore, where `JSON.stringify` drops them — producing payloads like `{"errno":1,"byteOffset":-1}` with no cause.
- Non-JSON-safe thrown values degrade to a `{ message }` payload instead of serializing as `{}`; server payloads stay valid under `@anvia/client`'s `isClientStreamError` guard (which requires a string `message`).
- `@anvia/client` exports `isJsonValue` for payload validation; `@anvia/server` exports `errorEvent`.

### Compat suite
- New `tests/compat/bun-runtime/test/memory-sqlite.test.ts`: driver provisioning with FK validation, file-backed persistence across client reopen, compaction conflict/commit, inspection, error policies.
- `pretest:bun` builds `@anvia/memory-sqlite`; the workspace depends on it.
- Packed-artifacts script packs `@anvia/memory-sqlite`, and the Bun smoke + typed consumers exercise a real packed memory round-trip.

### Tests
- `packages/memory-sqlite/test/client.test.ts`: regression test injecting a node:sqlite database shimmed to return `null` for missing rows (mirrors the bun:sqlite shape) through append/load/compaction/inspection paths.
- `packages/core/test/streaming.test.ts` + `packages/server/test/streams.test.ts`: prototype-carried diagnostic fields and non-JSON-safe thrown values.
- Changesets for `@anvia/memory-sqlite` (minor), `@anvia/core` (patch), `@anvia/server` (patch), `@anvia/client` (minor).

## Validation

- `pnpm build` for core → client → server → memory-sqlite → providers/mcp: all pass
- Typecheck: `packages/*` all pass, `bun-runtime-compat` typecheck passes
- Tests: core 662 ✓, client 39 ✓, server 10 ✓, memory-sqlite 28 ✓
- `oxfmt --check .` and `oxlint .`: clean
- Bun runtime matrix (1.3.14 / 1.x) and the packed-artifacts smoke run in CI — not runnable locally (Bun not installed); this PR extends exactly those checks