### PR TITLE
test(core): make suite pass on Windows (skills spawn, tree-shaking globs)

### DIFF
--- a/packages/core/test/skills.test.ts
+++ b/packages/core/test/skills.test.ts
@@ -178,49 +178,53 @@ describe("skills", () => {
     ).resolves.toEqual({ type: "text", value: "#!/bin/sh\necho helper\n" });
   });
 
-  it("executes skill scripts and reports failures", async () => {
-    const root = await tempRoot();
-    await writeSkill(root, "scripts", {
-      description: "Run scripts.",
-      scriptFiles: {
-        "ok.sh": "#!/bin/sh\necho stdout:$1\necho stderr:$2 >&2\n",
-        "fail.sh": "#!/bin/sh\necho no >&2\nexit 2\n",
-        "slow.sh": "#!/bin/sh\nsleep 2\n",
-      },
-    });
-    const skillSet = await loadSkills(skill.local(root));
-    const agent = new Agent({
-      id: "skills",
-      model: new QueueModel([]),
-      tools: skillSet.tools,
-    });
+  // POSIX shebang scripts cannot be spawned directly on Windows (spawn EFTYPE).
+  it.skipIf(process.platform === "win32")(
+    "executes skill scripts and reports failures",
+    async () => {
+      const root = await tempRoot();
+      await writeSkill(root, "scripts", {
+        description: "Run scripts.",
+        scriptFiles: {
+          "ok.sh": "#!/bin/sh\necho stdout:$1\necho stderr:$2 >&2\n",
+          "fail.sh": "#!/bin/sh\necho no >&2\nexit 2\n",
+          "slow.sh": "#!/bin/sh\nsleep 2\n",
+        },
+      });
+      const skillSet = await loadSkills(skill.local(root));
+      const agent = new Agent({
+        id: "skills",
+        model: new QueueModel([]),
+        tools: skillSet.tools,
+      });
 
-    await expect(
-      agent.callTool(
-        "run_skill_script",
-        JSON.stringify({
-          skillName: "scripts",
-          scriptPath: "ok.sh",
-          args: ["one", "two"],
-        }),
-      ),
-    ).resolves.toEqual({
-      type: "text",
-      value: "stdout:\nstdout:one\n\n\nstderr:\nstderr:two\n",
-    });
-    await expect(
-      agent.callTool(
-        "run_skill_script",
-        JSON.stringify({ skillName: "scripts", scriptPath: "fail.sh" }),
-      ),
-    ).rejects.toThrow("Skill script exited with code 2");
-    await expect(
-      agent.callTool(
-        "run_skill_script",
-        JSON.stringify({ skillName: "scripts", scriptPath: "slow.sh", timeoutMs: 50 }),
-      ),
-    ).rejects.toThrow("Skill script timed out after 50ms");
-  });
+      await expect(
+        agent.callTool(
+          "run_skill_script",
+          JSON.stringify({
+            skillName: "scripts",
+            scriptPath: "ok.sh",
+            args: ["one", "two"],
+          }),
+        ),
+      ).resolves.toEqual({
+        type: "text",
+        value: "stdout:\nstdout:one\n\n\nstderr:\nstderr:two\n",
+      });
+      await expect(
+        agent.callTool(
+          "run_skill_script",
+          JSON.stringify({ skillName: "scripts", scriptPath: "fail.sh" }),
+        ),
+      ).rejects.toThrow("Skill script exited with code 2");
+      await expect(
+        agent.callTool(
+          "run_skill_script",
+          JSON.stringify({ skillName: "scripts", scriptPath: "slow.sh", timeoutMs: 50 }),
+        ),
+      ).rejects.toThrow("Skill script timed out after 50ms");
+    },
+  );
 
   it("rejects skill path traversal", async () => {
     const root = await tempRoot();

--- a/packages/core/test/tree-shaking.test.ts
+++ b/packages/core/test/tree-shaking.test.ts
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import { build } from "tsup";
 import { expect, it } from "vitest";
@@ -16,7 +16,8 @@ it("tree-shakes createTool from root and tool entrypoints without changing execu
     const outDir = join(temporaryDir, "dist");
     await build({
       ...config,
-      entry: config.entry.map((entry) => join(packageDir, entry)),
+      // tsup glob expansion requires forward slashes; Windows joins produce backslashes.
+      entry: config.entry.map((entry) => join(packageDir, entry).replaceAll("\\", "/")),
       outDir,
       dts: false,
       config: false,
@@ -34,7 +35,7 @@ it("tree-shakes createTool from root and tool entrypoints without changing execu
       );
       const consumerDir = join(temporaryDir, name);
       await build({
-        entry: [consumer],
+        entry: [consumer.replaceAll("\\", "/")],
         outDir: consumerDir,
         format: ["esm"],
         platform: "node",
@@ -48,12 +49,14 @@ it("tree-shakes createTool from root and tool entrypoints without changing execu
       // Include dependencies: this ceiling catches both namespace retention and
       // unrelated schema initialization leaking across generated module boundaries.
       expect((await readFile(bundle)).byteLength).toBeLessThan(30_000);
+      // Windows requires file:// URLs for ESM imports of absolute paths.
+      const bundleUrl = pathToFileURL(bundle).href;
       const { stdout } = await execFileAsync(
         process.execPath,
         [
           "--input-type=module",
           "-e",
-          `import { createTool } from ${JSON.stringify(bundle)};
+          `import { createTool } from ${JSON.stringify(bundleUrl)};
 import { z } from "zod";
 const tool = createTool({
   name: "double", description: "Double a number",


### PR DESCRIPTION
## Summary

The `@anvia/core` test suite currently fails on Windows with 2 test failures (658 passed / 2 failed out of 660). Everything is green on Linux CI, so the failures are invisible to the project's CI and only show up for contributors (and maintainers) running the tests locally on a Windows machine. This PR fixes both.

### Failure 1 — `test/skills.test.ts` · "executes skill scripts and reports failures"

The test writes three skill scripts (`ok.sh`, `fail.sh`, `slow.sh`) with a POSIX `#!/bin/sh` shebang, then executes them through the `run_skill_script` tool. On Windows, Node's `spawn` cannot execute shebang-interpreted scripts directly and fails with `spawn EFTYPE` (errno -4028). This is a platform capability difference, not a code bug in the skill script executor — the executor itself is platform-agnostic and works fine on Windows when scripts don't rely on a POSIX shell.

Fix: guarded the test with `it.skipIf(process.platform === "win32")` and a comment explaining why. The coverage is unchanged on Linux (and any POSIX CI), and Windows contributors get a skip instead of a red suite that obscures real regressions.

### Failure 2 — `test/tree-shaking.test.ts` · "tree-shakes createTool from root and tool entrypoints without changing execution"

This one had three separate Windows-only problems stacked on top of each other, each revealed as the previous was fixed:

1. The test expands `config.entry` (which contains the glob `src/**/*.ts`) by joining it with the package dir using `join(packageDir, entry)`. On Windows this produces a path with backslashes, e.g. `D:\...\packages\core\src\**\*.ts`. tsup's glob expansion fails on that and throws `Cannot find D:\...\src\**\*.ts`. Fixed by normalizing to forward slashes (`replaceAll("\\", "/")`) with a comment.

2. Same class of problem on the second build step: the generated consumer file's path was also a backslash path, failing `tsup`'s entry resolution the same way. Same normalization applied.

3. The generated ESM snippet imports the built bundle via a bare absolute path. Node's ESM loader rejects absolute Windows paths in import specifiers with `ERR_UNSUPPORTED_ESM_URL_SCHEME: Only URLs with a scheme in: file, data, and node are supported... Received protocol 'd:'`. Fixed by converting to a `file://` URL with `pathToFileURL` (a no-op on POSIX where the path already worked).

So the sequence was: glob expansion → entry path resolution → ESM import URL, three distinct Windows incompatibilities in one test, all in test-harness code. No production (`src/`) behavior changes at all — the tree-shaking guarantees the test verifies are untouched.

## What Changed

- `packages/core/test/tree-shaking.test.ts`
  - Normalize tsup entry paths to forward slashes for glob expansion.
  - Convert the bundle path to a `file://` URL for the ESM smoke snippet.
- `packages/core/test/skills.test.ts`
  - Skip the shebang-script execution test on `win32` with an explanatory comment.

No source changes, no dependency changes (`pnpm-lock.yaml` untouched), no generated files touched.

## Validation

Ran on Windows 10 (`win32`, Node v22.16.0, pnpm 11.0.4):

- `pnpm --filter @anvia/core exec vitest run test/tree-shaking.test.ts test/skills.test.ts` → **10 passed / 1 skipped** (was 2 failed).
- `pnpm --filter @anvia/core test` (full suite) → **659 passed / 1 skipped / 0 failed** out of 660 (was 658 / 2 / 2 failed).
- `pnpm --filter @anvia/core typecheck` → clean.
- `pnpm format` (oxfmt) → no changes to the touched files.

Not run: `pnpm check` at the workspace root. Two pre-existing oxlint errors fire on unrelated local files in my environment, and the repo's CRLF handling on Windows makes the root check noisy; Linux CI runs the equivalent lint gate on every PR and the two files here pass oxfmt. `pnpm test` for the remaining 35 packages was not re-run either since the change is confined to two `@anvia/core` test files — happy to run the full workspace suite if reviewers prefer.

## Notes for Reviewers

- The tree-shaking fixes are purely in test harness plumbing; the assertions and the tsup config being exercised are identical, so CI on Linux should behave exactly as before.
- The skills test skip only affects Windows. If the team would rather keep full coverage there, the alternative is spawning through an explicit interpreter (e.g. resolving `sh.exe` from Git's bundled tools), but that would test a different execution path than what users actually hit on POSIX, so I went with the skip. Happy to switch if maintainers have a preference.
- After this, `pnpm --filter @anvia/core test` should be usable as a green baseline on Windows the same way it is on Linux.