### PR TITLE
refactor: remove conditional spreads in vector and memory packages

### DIFF
--- a/packages/memory-drizzle/src/store.ts
+++ b/packages/memory-drizzle/src/store.ts
@@ -14,6 +14,7 @@ import type {
 } from "@anvia/core/memory";
 import { createMemoryScopeKey, isMemoryCompactionMessage } from "@anvia/core/memory";
 import { and, asc, desc, eq, gte, sql } from "drizzle-orm";
+import type { PgUpdateSetSource } from "drizzle-orm/pg-core";
 import { parseMemoryMessage, serializeUnknownError } from "./message.js";
 import { drizzleMemorySchema } from "./schema.js";
 import type {
@@ -430,24 +431,30 @@ export class DrizzleMemoryStore implements MemoryStore {
     compactionState?: StoredCompactionState,
   ): Promise<SessionRow> {
     const { agentMemorySessions: sessions } = this.schema;
+    const values: typeof sessions.$inferInsert = {
+      scopeKey,
+      sessionId: context.sessionId,
+      userId: context.userId ?? null,
+      metadata: metadata(context),
+    };
+    if (compactionState !== undefined) {
+      values.compactionState = compactionState;
+    }
+    const set: PgUpdateSetSource<typeof sessions> = {
+      sessionId: context.sessionId,
+      userId: context.userId ?? null,
+      metadata: metadata(context),
+    };
+    if (compactionState !== undefined) {
+      set.compactionState = compactionState;
+    }
+    set.updatedAt = sql`now()`;
     const rows = (await db
       .insert(sessions)
-      .values({
-        scopeKey,
-        sessionId: context.sessionId,
-        userId: context.userId ?? null,
-        metadata: metadata(context),
-        ...(compactionState === undefined ? {} : { compactionState }),
-      })
+      .values(values)
       .onConflictDoUpdate({
         target: sessions.scopeKey,
-        set: {
-          sessionId: context.sessionId,
-          userId: context.userId ?? null,
-          metadata: metadata(context),
-          ...(compactionState === undefined ? {} : { compactionState }),
-          updatedAt: sql`now()`,
-        },
+        set,
       })
       .returning({ id: sessions.id })) as SessionRow[];
 

--- a/packages/memory-prisma/src/store.ts
+++ b/packages/memory-prisma/src/store.ts
@@ -206,11 +206,14 @@ export class PrismaMemoryStore implements MemoryStore {
       return { revision: compactionRevision([], undefined), messages: [] };
     }
     const state = this.compactionStateFromValue(session.compactionState);
+    const where: { memorySessionId: string; position?: { gte: number } } = {
+      memorySessionId: session.id,
+    };
+    if (state !== undefined) {
+      where.position = { gte: state.summarizedThroughPosition };
+    }
     const rows = (await this.delegates.messages.findMany({
-      where: {
-        memorySessionId: session.id,
-        ...(state === undefined ? {} : { position: { gte: state.summarizedThroughPosition } }),
-      },
+      where,
       orderBy: { position: "asc" },
       select: { id: true, memorySessionId: true, position: true, message: true },
     })) as PrismaCompactionMessageRow[];
@@ -241,11 +244,14 @@ export class PrismaMemoryStore implements MemoryStore {
       })) as PrismaCompactionSessionRow | null;
       if (session === null) return { status: "conflict" };
       const state = this.compactionStateFromValue(session.compactionState);
+      const where: { memorySessionId: string; position?: { gte: number } } = {
+        memorySessionId: session.id,
+      };
+      if (state !== undefined) {
+        where.position = { gte: state.summarizedThroughPosition };
+      }
       const rows = (await tx.messages.findMany({
-        where: {
-          memorySessionId: session.id,
-          ...(state === undefined ? {} : { position: { gte: state.summarizedThroughPosition } }),
-        },
+        where,
         orderBy: { position: "asc" },
         select: { id: true, memorySessionId: true, position: true, message: true },
       })) as PrismaCompactionMessageRow[];
@@ -363,18 +369,27 @@ async function upsertSession(
   scopeKey: string,
   compactionState?: StoredCompactionState,
 ): Promise<{ id: string }> {
+  const update: {
+    sessionId: string;
+    userId: string | null;
+    metadata: JsonObject;
+    compactionState?: StoredCompactionState;
+  } = {
+    sessionId: context.sessionId,
+    userId: context.userId ?? null,
+    metadata: metadata(context),
+  };
+  if (compactionState !== undefined) {
+    update.compactionState = compactionState;
+  }
+  const create = sessionCreateData(context, scopeKey);
+  if (compactionState !== undefined) {
+    create.compactionState = compactionState;
+  }
   return delegates.sessions.upsert({
     where: { scopeKey },
-    update: {
-      sessionId: context.sessionId,
-      userId: context.userId ?? null,
-      metadata: metadata(context),
-      ...(compactionState === undefined ? {} : { compactionState }),
-    },
-    create: {
-      ...sessionCreateData(context, scopeKey),
-      ...(compactionState === undefined ? {} : { compactionState }),
-    },
+    update,
+    create,
     select: { id: true },
   });
 }
@@ -382,7 +397,13 @@ async function upsertSession(
 function sessionCreateData(
   context: MemoryScope,
   scopeKey: string,
-): { scopeKey: string; sessionId: string; userId?: string; metadata: JsonObject } {
+): {
+  scopeKey: string;
+  sessionId: string;
+  userId?: string;
+  metadata: JsonObject;
+  compactionState?: StoredCompactionState;
+} {
   const data: { scopeKey: string; sessionId: string; userId?: string; metadata: JsonObject } = {
     scopeKey,
     sessionId: context.sessionId,


### PR DESCRIPTION
## Summary
Removed all conditional spread operators of the form `...(cond ? { x } : {})` in the target packages and replaced them with the repository's conditional-assignment idiom (plain `if` + property assignment).

Hit list (6 sites across 2 packages — these were the only conditional-spread ternaries present; the other 11 listed packages contained none):

- packages/memory-prisma/src/store.ts (4 sites)
  - `loadCompactionSnapshot`: `where` object — built up front, `position` filter assigned under `if (state !== undefined)`.
  - `replaceCompactionPrefix`: same `where` pattern for the transactional `findMany`.
  - `upsertSession`: `update` and `create` payloads — `compactionState` assigned conditionally; key insertion order preserved.
- packages/memory-drizzle/src/store.ts (2 sites)
  - `upsertSession`: insert `values` and `onConflictDoUpdate` `set` payloads — `compactionState` assigned conditionally, `updatedAt` still applied last to `set`.

Note: remaining `...(x ?? [])` / `?? {}` usages in these packages are nullish-coalescing spreads, not the conditional ternary form, and were left untouched.

## Behavior
No behavior change. Optional keys appear iff they appeared before, with the same values, and object key insertion order is unchanged (matters for JSON serialization). Lazy evaluation preserved — no conditional work is executed when the key is absent.

## Validation
- `pnpm check` — clean (oxfmt + oxlint, 0 warnings/errors)
- `pnpm --filter @anvia/memory-prisma typecheck` — pass
- `pnpm --filter @anvia/memory-drizzle typecheck` — pass
- `pnpm --filter @anvia/memory-prisma test` — 45/45 passed
- `pnpm --filter @anvia/memory-drizzle test` — 41/41 passed
- The 9 vector-* packages plus memory-sqlite and memory-postgres had no conditional-spread sites, so no typecheck/test runs were needed for them.