### PR TITLE
refactor: remove conditional spreads in provider, observability, graph, and misc packages

### DIFF
--- a/packages/graph-neo4j/src/graph.ts
+++ b/packages/graph-neo4j/src/graph.ts
@@ -266,14 +266,13 @@ export class ManagedNeo4jKnowledgeGraph<
       entryRelationshipType: "ANVIA_MENTIONS",
     };
     if (this.resources.indexes.chunks.fulltext !== undefined) {
+      const chunkFulltextProperties = ["__anvia_text"];
+      if (this.namespace !== undefined) chunkFulltextProperties.push("__anvia_namespace");
       chunks = {
         ...chunks,
         fulltextIndex: Object.freeze({
           ...this.resources.indexes.chunks.fulltext,
-          properties: Object.freeze([
-            "__anvia_text",
-            ...(this.namespace === undefined ? [] : ["__anvia_namespace"]),
-          ]),
+          properties: Object.freeze(chunkFulltextProperties),
         }),
       };
     }
@@ -287,14 +286,15 @@ export class ManagedNeo4jKnowledgeGraph<
         this.namespace === undefined ? undefined : Object.freeze(["__anvia_namespace"]),
     };
     if (this.resources.indexes.entities.fulltext !== undefined) {
+      const entityFulltextProperties = [
+        ...(this.resources.indexes.entities.fulltext.properties ?? []),
+      ];
+      if (this.namespace !== undefined) entityFulltextProperties.push("__anvia_namespace");
       entities = {
         ...entities,
         fulltextIndex: Object.freeze({
           ...this.resources.indexes.entities.fulltext,
-          properties: Object.freeze([
-            ...(this.resources.indexes.entities.fulltext.properties ?? []),
-            ...(this.namespace === undefined ? [] : ["__anvia_namespace"]),
-          ]),
+          properties: Object.freeze(entityFulltextProperties),
         }),
       };
     }
@@ -332,19 +332,17 @@ export class ManagedNeo4jKnowledgeGraph<
       vectorIndex(indexes.entities.vector, labels.entity, this.namespace !== undefined),
     ];
     if (indexes.chunks.fulltext !== undefined) {
+      const chunkIndexProperties = ["__anvia_text"];
+      if (this.namespace !== undefined) chunkIndexProperties.push("__anvia_namespace");
       statements.push(
-        fulltextIndex(indexes.chunks.fulltext.name, labels.chunk, [
-          "__anvia_text",
-          ...(this.namespace === undefined ? [] : ["__anvia_namespace"]),
-        ]),
+        fulltextIndex(indexes.chunks.fulltext.name, labels.chunk, chunkIndexProperties),
       );
     }
     if (indexes.entities.fulltext !== undefined) {
+      const entityIndexProperties = [...(indexes.entities.fulltext.properties ?? [])];
+      if (this.namespace !== undefined) entityIndexProperties.push("__anvia_namespace");
       statements.push(
-        fulltextIndex(indexes.entities.fulltext.name, labels.entity, [
-          ...(indexes.entities.fulltext.properties ?? []),
-          ...(this.namespace === undefined ? [] : ["__anvia_namespace"]),
-        ]),
+        fulltextIndex(indexes.entities.fulltext.name, labels.entity, entityIndexProperties),
       );
     }
     for (const statement of statements)

--- a/packages/graph/src/ingest.ts
+++ b/packages/graph/src/ingest.ts
@@ -274,9 +274,15 @@ function ingestionReceipt<Schema extends GraphSchemaLike>(
   revision: string | undefined,
   vectorStatus: GraphIngestionReceipt["vectorWrite"]["status"],
 ): GraphIngestionReceipt {
-  return {
+  const head: {
+    documentIds: readonly string[];
+    revision?: string | undefined;
+  } = {
     documentIds: prepared.documents.map((document) => document.id),
-    ...(revision === undefined ? {} : { revision }),
+  };
+  if (revision !== undefined) head.revision = revision;
+  return {
+    ...head,
     entityKeys: prepared.entities.map((entity) => entity.id),
     relationshipKeys: prepared.relationships.map((relationship) => relationship.key),
     vectorDocumentIds: prepared.vectorDocuments.map((document) => document.id),

--- a/packages/observability-lens/src/prompt-client.ts
+++ b/packages/observability-lens/src/prompt-client.ts
@@ -1,6 +1,7 @@
 import type { JsonValue } from "@anvia/core/completion";
 import type { ResolvedLensConfig } from "./config.js";
 import { isRecord } from "./type-guards.js";
+import type { Writable } from "./type-utils.js";
 import type {
   LensChatMessage,
   LensPrompt,
@@ -353,11 +354,12 @@ function parsePrompt(
     ) {
       throw invalid();
     }
-    return Object.freeze({
+    const parsed: Writable<LensChatMessage> = {
       role: message.role,
       content: message.content,
-      ...(message.name === undefined ? {} : { name: message.name }),
-    });
+    };
+    if (message.name !== undefined) parsed.name = message.name;
+    return Object.freeze(parsed);
   });
   const parts = messages.map((message) => parseTemplate(message.content, variables));
   return Object.freeze({

--- a/packages/observability-lens/src/type-utils.ts
+++ b/packages/observability-lens/src/type-utils.ts
@@ -1,0 +1,1 @@
+export type Writable<T> = { -readonly [K in keyof T]: T[K] };

--- a/packages/provider-gemini/src/gemini/controls.ts
+++ b/packages/provider-gemini/src/gemini/controls.ts
@@ -1,9 +1,11 @@
 import {
   defineCompletionModelControls,
+  type CompletionModelSelectControl,
   type NoCompletionModelControls,
   type ReasoningEffortControls,
 } from "@anvia/core/completion";
 import type { GeminiCompletionModelId } from "./models";
+import type { Writable } from "./type-utils";
 
 export const GEMINI_REASONING_EFFORTS = ["minimal", "low", "medium", "high"] as const;
 
@@ -86,13 +88,14 @@ function reasoningControls<const Efforts extends readonly GeminiReasoningEffort[
   efforts: Efforts,
   defaultValue?: Efforts[number],
 ): ReasoningEffortControls<Efforts[number]> {
+  const effortControl: Writable<CompletionModelSelectControl<Efforts[number]>> = {
+    type: "select",
+    label: "Reasoning effort",
+    description: "Controls how much reasoning the model applies before responding.",
+    options: efforts,
+  };
+  if (defaultValue !== undefined) effortControl.defaultValue = defaultValue;
   return defineCompletionModelControls({
-    reasoningEffort: {
-      type: "select",
-      label: "Reasoning effort",
-      description: "Controls how much reasoning the model applies before responding.",
-      options: efforts,
-      ...(defaultValue === undefined ? {} : { defaultValue }),
-    },
+    reasoningEffort: effortControl,
   });
 }

--- a/packages/provider-gemini/src/gemini/type-utils.ts
+++ b/packages/provider-gemini/src/gemini/type-utils.ts
@@ -1,0 +1,1 @@
+export type Writable<T> = { -readonly [K in keyof T]: T[K] };

--- a/packages/provider-grok/src/grok/controls.ts
+++ b/packages/provider-grok/src/grok/controls.ts
@@ -1,9 +1,11 @@
 import {
   defineCompletionModelControls,
+  type CompletionModelSelectControl,
   type NoCompletionModelControls,
   type ReasoningEffortControls,
 } from "@anvia/core/completion";
 import type { GrokCompletionModelId } from "./models";
+import type { Writable } from "./type-utils";
 
 export const GROK_REASONING_EFFORTS = ["none", "low", "medium", "high", "xhigh"] as const;
 
@@ -47,13 +49,14 @@ function reasoningControls<const Efforts extends readonly GrokReasoningEffort[]>
   efforts: Efforts,
   defaultValue?: Efforts[number],
 ): ReasoningEffortControls<Efforts[number]> {
+  const effortControl: Writable<CompletionModelSelectControl<Efforts[number]>> = {
+    type: "select",
+    label: "Reasoning effort",
+    description: "Controls how much reasoning the model applies before responding.",
+    options: efforts,
+  };
+  if (defaultValue !== undefined) effortControl.defaultValue = defaultValue;
   return defineCompletionModelControls({
-    reasoningEffort: {
-      type: "select",
-      label: "Reasoning effort",
-      description: "Controls how much reasoning the model applies before responding.",
-      options: efforts,
-      ...(defaultValue === undefined ? {} : { defaultValue }),
-    },
+    reasoningEffort: effortControl,
   });
 }

--- a/packages/provider-grok/src/grok/type-utils.ts
+++ b/packages/provider-grok/src/grok/type-utils.ts
@@ -1,0 +1,1 @@
+export type Writable<T> = { -readonly [K in keyof T]: T[K] };

--- a/packages/provider-openai/src/openai/controls.ts
+++ b/packages/provider-openai/src/openai/controls.ts
@@ -1,9 +1,11 @@
 import {
   defineCompletionModelControls,
+  type CompletionModelSelectControl,
   type NoCompletionModelControls,
   type ReasoningEffortControls,
 } from "@anvia/core/completion";
 import type { OpenAICompletionModelId } from "./models";
+import type { Writable } from "../utils";
 
 export const OPENAI_REASONING_EFFORTS = [
   "none",
@@ -89,13 +91,14 @@ function reasoningControls<const Efforts extends readonly OpenAIReasoningEffort[
   efforts: Efforts,
   defaultValue?: Efforts[number],
 ): ReasoningEffortControls<Efforts[number]> {
+  const effortControl: Writable<CompletionModelSelectControl<Efforts[number]>> = {
+    type: "select",
+    label: "Reasoning effort",
+    description: "Controls how much reasoning the model applies before responding.",
+    options: efforts,
+  };
+  if (defaultValue !== undefined) effortControl.defaultValue = defaultValue;
   return defineCompletionModelControls({
-    reasoningEffort: {
-      type: "select",
-      label: "Reasoning effort",
-      description: "Controls how much reasoning the model applies before responding.",
-      options: efforts,
-      ...(defaultValue === undefined ? {} : { defaultValue }),
-    },
+    reasoningEffort: effortControl,
   });
 }

--- a/packages/provider-openai/src/utils.ts
+++ b/packages/provider-openai/src/utils.ts
@@ -69,3 +69,5 @@ export function parseToolArguments(toolCallId: string, text: string, usage?: Usa
 export function schemaName(schema: JsonObject): string {
   return typeof schema.title === "string" ? schema.title : "response_schema";
 }
+
+export type Writable<T> = { -readonly [K in keyof T]: T[K] };


### PR DESCRIPTION
## Summary
- Replace the remaining conditional spread patterns `...(cond ? { x } : {})` and the array variant `...(cond ? [] : [x])` with the repository's if-and-conditional-assignment idiom (9 sites across 6 packages).
- Array sites build the array first, then conditionally push, preserving element order and the frozen-result semantics.
- Added small internal `Writable<T>` type-utils where a local had to be typed as a mutable view of a readonly type (no `as` casts).

## Behavior
- No behavior change: optional keys are present iff they were present before, with the same values and the same key insertion order; laziness is preserved (values only computed when the key is added).

## Validation
- `pnpm check` — clean (oxfmt + oxlint).
- `pnpm --filter <pkg> typecheck` for @anvia/gemini, @anvia/openai, @anvia/grok, @anvia/graph, @anvia/neo4j, @anvia/lens — all clean.
- `pnpm --filter <pkg> test` for all six — all pass (1 neo4j docker-gated test skipped).