### PR TITLE
refactor: remove conditional spreads in tool packages

### DIFF
--- a/packages/mcp/src/tool.ts
+++ b/packages/mcp/src/tool.ts
@@ -33,9 +33,11 @@ export function createMcpTool(options: {
       return parseMcpToolArguments(args);
     },
     async call(args, context) {
+      const callOptions: { signal?: AbortSignal } = {};
+      if (context?.abortSignal !== undefined) callOptions.signal = context.abortSignal;
       const result = await client.callTool(
         createCallToolParams(definition.name, args),
-        context?.abortSignal === undefined ? {} : { signal: context.abortSignal },
+        callOptions,
       );
       return ToolOutput.content(mapMcpToolResult(result));
     },

--- a/packages/tool-browser/src/connection.ts
+++ b/packages/tool-browser/src/connection.ts
@@ -35,18 +35,20 @@ export async function connectPlaywrightBrowser(options: {
   const timeoutMs = options.timeoutMs ?? defaultConnectionTimeoutMs;
   assertPositiveSafeInteger(timeoutMs, "timeoutMs");
   options.abortSignal?.throwIfAborted();
-  const backend = await AutomationWorkerClient.connect({
+  const connectOptions: Parameters<typeof AutomationWorkerClient.connect>[0] = {
     endpointUrl: options.endpointUrl,
     timeoutMs,
-    ...(options.abortSignal === undefined ? {} : { abortSignal: options.abortSignal }),
-    ...(options.workerFactory === undefined ? {} : { workerFactory: options.workerFactory }),
-  });
-  return new PlaywrightBrowserConnectionImpl({
+  };
+  if (options.abortSignal !== undefined) connectOptions.abortSignal = options.abortSignal;
+  if (options.workerFactory !== undefined) connectOptions.workerFactory = options.workerFactory;
+  const backend = await AutomationWorkerClient.connect(connectOptions);
+  const connectionOptions: ConstructorParameters<typeof PlaywrightBrowserConnectionImpl>[0] = {
     backend,
     control: options.control,
     scheduling: options.scheduling,
-    ...(options.onClosed === undefined ? {} : { onClosed: options.onClosed }),
-  });
+  };
+  if (options.onClosed !== undefined) connectionOptions.onClosed = options.onClosed;
+  return new PlaywrightBrowserConnectionImpl(connectionOptions);
 }
 
 export class PlaywrightBrowserConnectionImpl implements PlaywrightBrowserConnection {

--- a/packages/tool-browser/src/control.ts
+++ b/packages/tool-browser/src/control.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { BrowserError, cancellationError } from "./errors";
+import { Writable } from "./internal/type-utils";
 import type {
   AcquireBrowserHumanControlOptions,
   BrowserControl,
@@ -38,19 +39,18 @@ export class BrowserControlState implements BrowserControl {
           : this.activeAgentActions > 0
             ? "agent-active"
             : "agent";
-    return Object.freeze({
+    const snapshot: Writable<BrowserControlSnapshot> = {
       mode: lease === undefined ? "agent" : "human",
       state,
       availability: this.availability,
       activeAgentActions: this.activeAgentActions,
       humanPending: this.humanPending,
-      ...(lease === undefined
-        ? {}
-        : {
-            ownerId: lease.ownerId,
-            expiresAt: lease.expiresAt,
-          }),
-    });
+    };
+    if (lease !== undefined) {
+      snapshot.ownerId = lease.ownerId;
+      snapshot.expiresAt = lease.expiresAt;
+    }
+    return Object.freeze(snapshot);
   }
 
   async acquireHumanControl(

--- a/packages/tool-browser/src/docker-browser.ts
+++ b/packages/tool-browser/src/docker-browser.ts
@@ -6,7 +6,8 @@ import type {
 } from "@anvia/sandbox";
 import { connectPlaywrightBrowser, type PlaywrightBrowserConnectionImpl } from "./connection";
 import { BrowserControlState } from "./control";
-import { BrowserError, cancellationError } from "./errors";
+import { BrowserError, cancellationError, type BrowserErrorOptions } from "./errors";
+import { Writable } from "./internal/type-utils";
 import {
   assertOptionsObject,
   assertPositiveSafeInteger,
@@ -266,24 +267,22 @@ export class DockerBrowserHandle implements DockerBrowser {
             this.handleState === "active" &&
             this.state === "running"
           ) {
+            const disconnectOptions: Writable<BrowserErrorOptions> = {};
+            if (cleanupError !== undefined) disconnectOptions.cause = cleanupError;
+            disconnectOptions.phase = "connect";
             throw new BrowserError(
               "Browser disconnected while automation was initializing.",
               "connection_closed",
-              {
-                ...(cleanupError === undefined ? {} : { cause: cleanupError }),
-                phase: "connect",
-              },
+              disconnectOptions,
             );
           }
           const lifecycleError = this.lifecycleError(
             "Browser stopped while the connection was initializing.",
           );
-          throw cleanupError === undefined
-            ? lifecycleError
-            : new BrowserError(lifecycleError.message, lifecycleError.code, {
-                cause: cleanupError,
-                ...(lifecycleError.phase === undefined ? {} : { phase: lifecycleError.phase }),
-              });
+          if (cleanupError === undefined) throw lifecycleError;
+          const cleanupOptions: Writable<BrowserErrorOptions> = { cause: cleanupError };
+          if (lifecycleError.phase !== undefined) cleanupOptions.phase = lifecycleError.phase;
+          throw new BrowserError(lifecycleError.message, lifecycleError.code, cleanupOptions);
         }
         return connection;
       } catch (error) {
@@ -457,15 +456,13 @@ export class DockerBrowserHandle implements DockerBrowser {
     state: BrowserCapabilitySnapshot["state"],
     error?: BrowserError,
   ): void {
-    this.capabilityStates.set(
+    const snapshot: Writable<BrowserCapabilitySnapshot> = {
       capability,
-      Object.freeze({
-        capability,
-        state,
-        checkedAt: new Date().toISOString(),
-        ...(error === undefined ? {} : { error }),
-      }),
-    );
+      state,
+      checkedAt: new Date().toISOString(),
+    };
+    if (error !== undefined) snapshot.error = error;
+    this.capabilityStates.set(capability, Object.freeze(snapshot));
   }
 
   private updateControlAvailability(): void {

--- a/packages/tool-browser/src/internal/type-utils.ts
+++ b/packages/tool-browser/src/internal/type-utils.ts
@@ -1,0 +1,1 @@
+export type Writable<T> = { -readonly [K in keyof T]: T[K] };

--- a/packages/tool-browser/src/scheduler.ts
+++ b/packages/tool-browser/src/scheduler.ts
@@ -66,9 +66,9 @@ export class ResourceScheduler {
         operation,
         resolve,
         reject,
-        ...(abortSignal === undefined ? {} : { abortSignal }),
       };
       if (abortSignal !== undefined) {
+        task.abortSignal = abortSignal;
         task.abort = () => {
           const current = this.resources.get(key);
           const index = current?.tasks.indexOf(task as Task<unknown>) ?? -1;
@@ -201,9 +201,9 @@ export class AsyncMutex {
       const waiter: MutexWaiter = {
         resolve,
         reject,
-        ...(abortSignal === undefined ? {} : { abortSignal }),
       };
       if (abortSignal !== undefined) {
+        waiter.abortSignal = abortSignal;
         waiter.abort = () => {
           const index = this.waiters.indexOf(waiter);
           if (index === -1) return;

--- a/packages/tool-sandbox/src/docker-sandbox.ts
+++ b/packages/tool-sandbox/src/docker-sandbox.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { assertDockerCli, decodeUtf8, runDockerCli } from "./docker-cli";
 import { DockerProcessManager } from "./docker-process";
 import { DockerSandboxError } from "./errors";
+import { Writable } from "./internal/type-utils";
 import { containerPath, normalizeSandboxPath, parentSandboxPath } from "./path";
 import { createTextFilePage } from "./text-file";
 import type {
@@ -920,9 +921,17 @@ async function applyInitialContent(
 ): Promise<void> {
   for (const directory of options.directories ?? []) {
     const marker = path.posix.join(normalizeSandboxPath(directory), ".anvia-keep");
-    const abort = options.abortSignal === undefined ? {} : { abortSignal: options.abortSignal };
-    await runtime.writeFile({ path: marker, data: new Uint8Array(), ...abort });
-    const removed = await runtime.exec({ command: "rm", args: [marker], ...abort });
+    const markerWriteOptions: Writable<DockerSandboxWriteFileOptions> = {
+      path: marker,
+      data: new Uint8Array(),
+    };
+    const markerExecOptions: Writable<DockerSandboxExecOptions> = { command: "rm", args: [marker] };
+    if (options.abortSignal !== undefined) {
+      markerWriteOptions.abortSignal = options.abortSignal;
+      markerExecOptions.abortSignal = options.abortSignal;
+    }
+    await runtime.writeFile(markerWriteOptions);
+    const removed = await runtime.exec(markerExecOptions);
     if (removed.status !== "exited" || removed.exitCode !== 0) {
       throw new DockerSandboxError(
         `Unable to create initial sandbox directory: ${directory}`,

--- a/packages/tool-sandbox/src/internal/type-utils.ts
+++ b/packages/tool-sandbox/src/internal/type-utils.ts
@@ -1,0 +1,1 @@
+export type Writable<T> = { -readonly [K in keyof T]: T[K] };

--- a/packages/tool-sandbox/src/tools.ts
+++ b/packages/tool-sandbox/src/tools.ts
@@ -7,10 +7,12 @@ import type {
   DockerSandboxCommandPolicy,
   DockerSandboxExecOptions,
   DockerSandboxExecResult,
+  DockerSandboxListProcessesOptions,
   DockerSandboxProcessInfo,
   DockerSandboxRuntime,
   DockerSandboxToolName,
 } from "./types";
+import { Writable } from "./internal/type-utils";
 import { shellInterpreters } from "./types";
 
 const allToolNames = [
@@ -309,13 +311,13 @@ function createListProcessesTool(sandbox: DockerSandboxRuntime): AnyTool {
     description: "List processes managed by this live sandbox handle.",
     inputSchema: emptyInput,
     outputSchema: listProcessesOutput,
-    execute: async (_, context) => ({
-      processes: (
-        await sandbox.listProcesses(
-          context.abortSignal === undefined ? {} : { abortSignal: context.abortSignal },
-        )
-      ).map(serializeProcessInfo),
-    }),
+    execute: async (_, context) => {
+      const listOptions: Writable<DockerSandboxListProcessesOptions> = {};
+      if (context.abortSignal !== undefined) listOptions.abortSignal = context.abortSignal;
+      return {
+        processes: (await sandbox.listProcesses(listOptions)).map(serializeProcessInfo),
+      };
+    },
   });
 }
 
@@ -493,6 +495,18 @@ function validateFactoryOptions(options: CreateDockerSandboxToolsOptions): void 
   }
 }
 
+function snapshotCommandPolicy(policy: DockerSandboxCommandPolicy): DockerSandboxCommandPolicy {
+  const values = Object.freeze([...policy.values]);
+  if (policy.mode === "allow" && policy.allowShellInterpreters !== undefined) {
+    return Object.freeze({
+      mode: policy.mode,
+      values,
+      allowShellInterpreters: policy.allowShellInterpreters,
+    });
+  }
+  return Object.freeze({ mode: policy.mode, values });
+}
+
 function snapshotFactoryOptions(
   options: CreateDockerSandboxToolsOptions,
 ): CreateDockerSandboxToolsOptions {
@@ -503,14 +517,7 @@ function snapshotFactoryOptions(
   const commands =
     options.exec?.commands === undefined
       ? undefined
-      : Object.freeze({
-          mode: options.exec.commands.mode,
-          values: Object.freeze([...options.exec.commands.values]),
-          ...(options.exec.commands.mode === "allow" &&
-          options.exec.commands.allowShellInterpreters !== undefined
-            ? { allowShellInterpreters: options.exec.commands.allowShellInterpreters }
-            : {}),
-        });
+      : Object.freeze(snapshotCommandPolicy(options.exec.commands));
   let snapshot: CreateDockerSandboxToolsOptions = {
     sandbox: options.sandbox,
     tools: toolNames,

--- a/packages/tool-sandbox/test/tools.test.ts
+++ b/packages/tool-sandbox/test/tools.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { createDockerSandboxTools } from "../src/tools";
-import type { DockerSandboxRuntime } from "../src/types";
+import { Writable } from "../src/internal/type-utils";
+import type { DockerSandboxCommandPolicy, DockerSandboxRuntime } from "../src/types";
 
 describe("createDockerSandboxTools", () => {
   it("requires an explicit, ordered, non-empty tool selection", () => {
@@ -138,16 +139,14 @@ describe("createDockerSandboxTools", () => {
     async (toolName) => {
       for (const allowShellInterpreters of [undefined, false, true]) {
         const sandbox = createRuntime();
+        const commands: Writable<DockerSandboxCommandPolicy> = { mode: "allow", values: ["sh"] };
+        if (allowShellInterpreters !== undefined) {
+          commands.allowShellInterpreters = allowShellInterpreters;
+        }
         const [tool] = createDockerSandboxTools({
           sandbox,
           tools: [toolName],
-          exec: {
-            commands: {
-              mode: "allow",
-              values: ["sh"],
-              ...(allowShellInterpreters === undefined ? {} : { allowShellInterpreters }),
-            },
-          },
+          exec: { commands },
         });
         if (tool === undefined) throw new Error(`Expected ${toolName} tool.`);
         const input = { command: "sh", args: ["-c", "echo hello"] };


### PR DESCRIPTION
## Summary
- Removed all conditional spread operators (`...(cond ? { x } : {})` forms) from `@anvia/sandbox`, `@anvia/browser`, and `@anvia/mcp` (src/ and test/), replacing them with the repository's plain if-and-assignment idiom (as in `packages/core/src/retry.ts`).
- Added `src/internal/type-utils.ts` with `Writable<T>` to `@anvia/sandbox` and `@anvia/browser` for mutable views over readonly option/snapshot types (no `as` casts).
- Merged the duplicated `abortSignal` check in `scheduler.ts` (enqueue and mutex acquire) into the existing `if (abortSignal !== undefined)` blocks.
- Verified the remaining grep hits (`?? {}`, `?? []`, plain ternary values in `mcp/src/client.ts`, `mcp/test/client.test.ts`, `tool-sandbox/test/docker-sandbox-client.test.ts`) are not conditional spreads and left them untouched.

## Behavior
No behavior change. Optional keys remain present iff they were present before, with the same values and key insertion order (matters for JSON.stringify/comparison); lazily computed values stay guarded.

## Validation
- `pnpm check` — clean (oxfmt + oxlint)
- `pnpm --filter @anvia/sandbox typecheck` / `test` — pass (docker-gated tests skip)
- `pnpm --filter @anvia/browser typecheck` / `test` — pass (86 passed, 1 docker-gated skip)
- `pnpm --filter @anvia/mcp typecheck` / `test` — pass (65 passed)