### PR TITLE
refactor(studio): remove conditional spreads

### DIFF
--- a/packages/tool-studio/src/internal/type-utils.ts
+++ b/packages/tool-studio/src/internal/type-utils.ts
@@ -1,0 +1,1 @@
+export type Writable<T> = { -readonly [K in keyof T]: T[K] };

--- a/packages/tool-studio/src/runtime/teams.ts
+++ b/packages/tool-studio/src/runtime/teams.ts
@@ -15,11 +15,12 @@ import type { StudioRunLifecycle } from "./run-lifecycle";
 export function teamConfig(team: AgentTeam<unknown>): StudioTeamConfig {
   return {
     id: team.id,
-    members: team.members.map((member) => ({
-      id: member.id,
-      ...(member.name === undefined ? {} : { name: member.name }),
-      ...(member.description === undefined ? {} : { description: member.description }),
-    })),
+    members: team.members.map((member) => {
+      const view: { id: string; name?: string; description?: string } = { id: member.id };
+      if (member.name !== undefined) view.name = member.name;
+      if (member.description !== undefined) view.description = member.description;
+      return view;
+    }),
     limits: team.limits,
   };
 }
@@ -146,10 +147,11 @@ export function registerTeamRoutes(
               done: false,
               value: toJsonValue({
                 ...event,
-                members: event.members.map((member) => ({
-                  ...member,
-                  ...(member.error === undefined ? {} : { error: serializeError(member.error) }),
-                })),
+                members: event.members.map((member) => {
+                  const view = { ...member };
+                  if (member.error !== undefined) view.error = serializeError(member.error);
+                  return view;
+                }),
               }),
             };
           return { done: false, value: toJsonValue(event) };

--- a/packages/tool-studio/src/ui/app/modules/teams/team-state.ts
+++ b/packages/tool-studio/src/ui/app/modules/teams/team-state.ts
@@ -69,21 +69,23 @@ export function teamReducer(state: TeamState, action: TeamAction): TeamState {
         ...state,
         conversation: [...state.conversation, { type: "prompt", text: action.prompt }],
       };
-    case "stop":
-      return {
+    case "stop": {
+      const next: TeamState = {
         ...state,
         status: action.error ? "failed" : "cancelled",
-        ...(action.error ? { error: action.error } : {}),
-        interactions: closeInteractions(state),
-        members: Object.fromEntries(
-          Object.entries(state.members).map(([id, member]) => [
-            id,
-            ["queued", "running", "waiting", "awaiting_interaction"].includes(member.status)
-              ? { ...member, status: "cancelled" }
-              : member,
-          ]),
-        ),
       };
+      if (action.error) next.error = action.error;
+      next.interactions = closeInteractions(state);
+      next.members = Object.fromEntries(
+        Object.entries(state.members).map(([id, member]) => [
+          id,
+          ["queued", "running", "waiting", "awaiting_interaction"].includes(member.status)
+            ? { ...member, status: "cancelled" }
+            : member,
+        ]),
+      );
+      return next;
+    }
     case "answered": {
       const item = state.interactions[action.id];
       return item !== undefined
@@ -111,14 +113,16 @@ export function teamReducer(state: TeamState, action: TeamAction): TeamState {
       },
       interactions: closeInteractions(state),
     };
-  if ("member" in event)
-    return {
+  if ("member" in event) {
+    const next: TeamState = {
       ...state,
       members: { ...state.members, [event.instanceId]: event.member },
-      ...(event.type === "agent_cancelled" || event.type === "agent_failed"
-        ? { interactions: closeInteractions(state, event.instanceId) }
-        : {}),
     };
+    if (event.type === "agent_cancelled" || event.type === "agent_failed") {
+      next.interactions = closeInteractions(state, event.instanceId);
+    }
+    return next;
+  }
   if (event.type === "interaction")
     return {
       ...state,

--- a/packages/tool-studio/src/ui/app/modules/teams/use-team-run.ts
+++ b/packages/tool-studio/src/ui/app/modules/teams/use-team-run.ts
@@ -5,7 +5,7 @@ import type { StudioTeamRunEvent } from "../../../../team-types";
 import { responseErrorMessage } from "../../app-errors";
 import { errorMessage } from "../shared/format";
 import { requestJson } from "../shared/request";
-import { initialTeamState, teamReducer } from "./team-state";
+import { initialTeamState, teamReducer, type TeamAction } from "./team-state";
 
 type ActiveTeamRun = {
   controller: AbortController;
@@ -84,11 +84,11 @@ export function useTeamRun(teamId: string) {
       if (!run.controller.signal.aborted)
         throw new Error("Team stream ended before a result arrived");
     } catch (error) {
-      if (active.current === run)
-        dispatch({
-          type: "stop",
-          ...(run.controller.signal.aborted ? {} : { error: errorMessage(error) }),
-        });
+      if (active.current === run) {
+        const action: TeamAction = { type: "stop" };
+        if (!run.controller.signal.aborted) action.error = errorMessage(error);
+        dispatch(action);
+      }
     } finally {
       if (active.current === run) active.current = undefined;
     }

--- a/packages/tool-studio/src/ui/app/modules/tracing/trace-payload.ts
+++ b/packages/tool-studio/src/ui/app/modules/tracing/trace-payload.ts
@@ -224,8 +224,8 @@ function parseMessage(
     ...toolCallsFrom(value.tool_calls, `${key}:tool-call`),
     ...toolCallsFrom(value.toolCalls, `${key}:tool-calls`),
     ...toolCallsFromContent(value.content, `${key}:content-tool-call`),
-    ...(isToolPayload(value) ? [parseTool(value, `${key}:tool`)] : []),
   ];
+  if (isToolPayload(value)) toolCalls.push(parseTool(value, `${key}:tool`));
   return { key, role, content, toolCalls };
 }
 

--- a/packages/tool-studio/test/team-state.test.ts
+++ b/packages/tool-studio/test/team-state.test.ts
@@ -7,16 +7,20 @@ import {
   type TeamState,
 } from "../src/ui/app/modules/teams/team-state";
 import type { StudioTeamRunEvent } from "../src/team-types";
+import { type Writable } from "../src/internal/type-utils";
 
-const member = (instanceId: string, parentInstanceId?: string): AgentTeamMemberSummary => ({
-  instanceId,
-  agentId: "worker",
-  name: "Worker",
-  status: "queued",
-  usage: Usage.empty(),
-  depth: parentInstanceId ? 1 : 0,
-  ...(parentInstanceId ? { parentInstanceId } : {}),
-});
+const member = (instanceId: string, parentInstanceId?: string): AgentTeamMemberSummary => {
+  const summary: Writable<AgentTeamMemberSummary> = {
+    instanceId,
+    agentId: "worker",
+    name: "Worker",
+    status: "queued",
+    usage: Usage.empty(),
+    depth: parentInstanceId ? 1 : 0,
+  };
+  if (parentInstanceId) summary.parentInstanceId = parentInstanceId;
+  return summary;
+};
 const apply = (state: TeamState, event: StudioTeamRunEvent) =>
   teamReducer(state, { type: "event", event });
 const identity = { teamRunId: "core-id", instanceId: "root", runId: "assignment-1" };


### PR DESCRIPTION
## Summary
- Remove all conditional spread operators (`...(cond ? { x } : {})` and the array variant) from `packages/tool-studio`, replacing them with the repository's conditional-assignment idiom (if + property assignment on a local mutable object).
- Sites converted: `src/ui/app/modules/teams/team-state.ts` (2), `src/ui/app/modules/teams/use-team-run.ts` (1), `src/ui/app/modules/tracing/trace-payload.ts` (1), `src/runtime/teams.ts` (3), `test/team-state.test.ts` (1) — 8 total.
- Added `src/internal/type-utils.ts` with `Writable<T>` (mirrors `@anvia/core` internal type utils) so the test helper can assign a readonly `parentInstanceId` without an `as` cast.
- Other grep hits were plain ternary returns or `?? {} / ?? []` nullish fallbacks and were intentionally left unchanged.

## Behavior
- No behavior change. Optional keys are present iff they were present before, with the same values and the same key insertion order (error/interactions/members ordering in the team reducer preserved explicitly).
- Lazy computation preserved: `errorMessage(error)` in `use-team-run` is only evaluated when the abort condition allows the assignment.

## Validation
- `pnpm check` — clean (oxfmt + oxlint, 0 warnings/errors)
- `pnpm --filter @anvia/studio typecheck` — clean
- `pnpm --filter @anvia/studio test` — full suite: 35 files / 243 tests passed