### PR TITLE
feat(cli): add update command for installed component drift

### DIFF
--- a/.changeset/anvia-cli-update-command.md
+++ b/.changeset/anvia-cli-update-command.md
@@ -1,0 +1,8 @@
+---
+"@anvia/cli": minor
+---
+
+Add `anvia update` command that compares installed Anvia UI components against the current
+registry. It previews out-of-date, modified, and missing files by default and writes updates
+with `--overwrite`. Also adds `closestRegistryItemName`, `inspectInstalledItems`, and
+`updateInstalledItems` exports with did-you-mean suggestions for unknown item names.

--- a/.changeset/anvia-cli-update-command.md
+++ b/.changeset/anvia-cli-update-command.md
@@ -4,5 +4,5 @@
 
 Add `anvia update` command that compares installed Anvia UI components against the current
 registry. It previews out-of-date, modified, and missing files by default and writes updates
-with `--overwrite`. Also adds `closestRegistryItemName`, `inspectInstalledItems`, and
+to installed components with `--overwrite` (it never installs new items; use `add`). Also adds `closestRegistryItemName`, `inspectInstalledItems`, and
 `updateInstalledItems` exports with did-you-mean suggestions for unknown item names.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -26,5 +26,6 @@ pnpm dlx @anvia/cli update --overwrite
 
 Without `--overwrite`, `update` is a preview: it reports each file as `up-to-date`,
 `modified` (the installed copy differs from the registry), or `missing`. Pass `--overwrite`
-to write the registry content over out-of-date and missing files. Locally edited copies are
+to write the registry content over out-of-date and missing files of installed components.
+`update` never installs new items — use `add` for that. Locally edited copies are
 overwritten, so commit or stash your changes first.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -13,3 +13,18 @@ pnpm dlx @anvia/cli add chat
 
 Available items: `chat`, `thread`, `message`, `composer`, `attachment`, `markdown`, and
 `tool-fallback`.
+
+## Updating installed components
+
+`update` compares the Anvia components in your project against the current registry:
+
+```sh
+pnpm dlx @anvia/cli update            # check every item (preview only, writes nothing)
+pnpm dlx @anvia/cli update composer   # check a single item
+pnpm dlx @anvia/cli update --overwrite
+```
+
+Without `--overwrite`, `update` is a preview: it reports each file as `up-to-date`,
+`modified` (the installed copy differs from the registry), or `missing`. Pass `--overwrite`
+to write the registry content over out-of-date and missing files. Locally edited copies are
+overwritten, so commit or stash your changes first.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -58,32 +58,42 @@ function main(args: string[]): void {
     const options: Parameters<typeof updateInstalledItems>[0] = { overwrite };
     if (cwd !== undefined) options.cwd = cwd;
     if (items.length > 0) options.items = items;
-    const { report } = updateInstalledItems(options);
+    const { report, updated } = updateInstalledItems(options);
+    const updatedPaths = new Set(updated);
+    if (overwrite === true) {
+      for (const item of report) {
+        if (!item.installed) {
+          console.log(`Anvia ${item.name}: not installed. Use \`anvia add ${item.name}\` first.`);
+          continue;
+        }
+        const changed = item.files.some(
+          (file) => file.status !== "up-to-date" && updatedPaths.has(file.path),
+        );
+        console.log(`Anvia ${item.name}: ${changed ? "updated" : "up to date"}.`);
+      }
+      console.log(
+        updated.length === 0
+          ? "All installed Anvia components are up to date."
+          : `Updated ${updated.length} ${updated.length === 1 ? "file" : "files"}.`,
+      );
+      return;
+    }
     let changeCount = 0;
     for (const item of report) {
-      if (!item.installed && overwrite !== true) {
+      if (!item.installed) {
         console.log(`Anvia ${item.name}: not installed.`);
         continue;
       }
       for (const file of item.files) {
-        const label = overwrite === true && file.status !== "up-to-date" ? "updated" : file.status;
-        if (label !== "up-to-date") changeCount += 1;
-        console.log(`Anvia ${item.name}: ${label} ${file.path}`);
+        if (file.status !== "up-to-date") changeCount += 1;
+        console.log(`Anvia ${item.name}: ${file.status} ${file.path}`);
       }
     }
-    if (overwrite === true) {
-      console.log(
-        changeCount === 0
-          ? "All installed Anvia components are up to date."
-          : `Updated ${changeCount} ${changeCount === 1 ? "file" : "files"}.`,
-      );
-    } else {
-      console.log(
-        changeCount === 0
-          ? "Everything is up to date."
-          : `Found ${changeCount} out-of-date ${changeCount === 1 ? "file" : "files"}. Re-run with --overwrite to apply.`,
-      );
-    }
+    console.log(
+      changeCount === 0
+        ? "Everything is up to date."
+        : `Found ${changeCount} out-of-date ${changeCount === 1 ? "file" : "files"}. Re-run with --overwrite to apply.`,
+    );
     return;
   }
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,5 +1,12 @@
 #!/usr/bin/env node
-import { addRegistryItem, initializeProject, isRegistryItemName, registryItemNames } from "./index";
+import {
+  addRegistryItem,
+  closestRegistryItemName,
+  initializeProject,
+  isRegistryItemName,
+  registryItemNames,
+  updateInstalledItems,
+} from "./index";
 
 function main(args: string[]): void {
   const [command, ...commandArgs] = args;
@@ -38,9 +45,52 @@ function main(args: string[]): void {
     return;
   }
 
+  if (command === "update") {
+    const items = positional.map((value) => {
+      if (isRegistryItemName(value)) return value;
+      const suggestion = closestRegistryItemName(value);
+      const suffix = suggestion === undefined ? "" : ` Did you mean "${suggestion}"?`;
+      throw new Error(
+        `Unknown registry item "${value}".${suffix} Choose an item: ${registryItemNames.join(", ")}.`,
+      );
+    });
+    const overwrite = commandArgs.includes("--overwrite");
+    const options: Parameters<typeof updateInstalledItems>[0] = { overwrite };
+    if (cwd !== undefined) options.cwd = cwd;
+    if (items.length > 0) options.items = items;
+    const { report } = updateInstalledItems(options);
+    let changeCount = 0;
+    for (const item of report) {
+      if (!item.installed && overwrite !== true) {
+        console.log(`Anvia ${item.name}: not installed.`);
+        continue;
+      }
+      for (const file of item.files) {
+        const label = overwrite === true && file.status !== "up-to-date" ? "updated" : file.status;
+        if (label !== "up-to-date") changeCount += 1;
+        console.log(`Anvia ${item.name}: ${label} ${file.path}`);
+      }
+    }
+    if (overwrite === true) {
+      console.log(
+        changeCount === 0
+          ? "All installed Anvia components are up to date."
+          : `Updated ${changeCount} ${changeCount === 1 ? "file" : "files"}.`,
+      );
+    } else {
+      console.log(
+        changeCount === 0
+          ? "Everything is up to date."
+          : `Found ${changeCount} out-of-date ${changeCount === 1 ? "file" : "files"}. Re-run with --overwrite to apply.`,
+      );
+    }
+    return;
+  }
+
   console.log(`Usage:
   anvia init [next|vite] [--cwd <path>] [--force]
-  anvia add <${registryItemNames.join("|")}> [--cwd <path>] [--overwrite]`);
+  anvia add <${registryItemNames.join("|")}> [--cwd <path>] [--overwrite]
+  anvia update [${registryItemNames.join("|")}] [--cwd <path>] [--overwrite]`);
 }
 
 function optionValue(args: string[], name: string): string | undefined {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,8 +1,8 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { basename, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 export const registryItemNames = [
@@ -134,6 +134,173 @@ export function addRegistryItem(
 
 export function isRegistryItemName(value: string): value is RegistryItemName {
   return registryItemNames.includes(value as RegistryItemName);
+}
+
+export type InstalledFileStatus = "up-to-date" | "modified" | "missing";
+
+export type InstalledItemFile = {
+  filename: string;
+  path: string;
+  status: InstalledFileStatus;
+};
+
+export type InstalledItemReport = {
+  name: RegistryItemName;
+  installed: boolean;
+  complete: boolean;
+  files: InstalledItemFile[];
+};
+
+export function inspectInstalledItems(
+  options: {
+    cwd?: string;
+    items?: readonly RegistryItemName[];
+    registryDirectory?: string;
+  } = {},
+): InstalledItemReport[] {
+  const names = options.items ?? registryItemNames;
+  const directory = componentsDirectory(options);
+  const registry = options.registryDirectory ?? bundledRegistryDirectory();
+  return names.map((name) => {
+    const files = itemFiles[name].map((filename) => {
+      const path = join(directory, "anvia", filename);
+      let status: InstalledFileStatus = "missing";
+      if (existsSync(path)) {
+        const installed = readFileSync(path, "utf8");
+        status = installed === registryFileContent(registry, filename) ? "up-to-date" : "modified";
+      }
+      return { filename, path, status };
+    });
+    return {
+      name,
+      installed: files.some((file) => file.status !== "missing"),
+      complete: files.every((file) => file.status !== "missing"),
+      files,
+    };
+  });
+}
+
+export function updateInstalledItems(
+  options: {
+    cwd?: string;
+    items?: readonly RegistryItemName[];
+    overwrite?: boolean;
+    registryDirectory?: string;
+  } = {},
+): { report: InstalledItemReport[]; updated: string[] } {
+  const registry = options.registryDirectory ?? bundledRegistryDirectory();
+  const report = inspectInstalledItems(options);
+  const updated: string[] = [];
+  if (options.overwrite === true) {
+    for (const item of report) {
+      for (const file of item.files) {
+        if (file.status === "up-to-date") continue;
+        mkdirSync(dirname(file.path), { recursive: true });
+        writeFileSync(file.path, registryFileContent(registry, file.filename));
+        updated.push(file.path);
+      }
+    }
+  }
+  return { report, updated };
+}
+
+export function closestRegistryItemName(value: string): RegistryItemName | undefined {
+  let best: RegistryItemName | undefined;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (const name of registryItemNames) {
+    const distance = levenshteinDistance(value, name);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = name;
+    }
+  }
+  return bestDistance <= 2 ? best : undefined;
+}
+
+function componentsDirectory(options: { cwd?: string } = {}): string {
+  const cwd = options.cwd ?? process.cwd();
+  const manifestPath = join(cwd, "components.json");
+  let manifest: { aliases?: { components?: string } };
+  try {
+    manifest = JSON.parse(stripJsonComments(readFileSync(manifestPath, "utf8"))) as {
+      aliases?: { components?: string };
+    };
+  } catch {
+    throw new Error(`Missing or unreadable components.json in ${cwd}. Run \`anvia init\` first.`);
+  }
+  const alias = manifest.aliases?.components ?? "@/components";
+  return resolveAliasDirectory(cwd, alias);
+}
+
+function resolveAliasDirectory(cwd: string, alias: string): string {
+  for (const configName of ["tsconfig.json", "jsconfig.json"]) {
+    let config: { compilerOptions?: { baseUrl?: string; paths?: Record<string, string[]> } };
+    try {
+      config = JSON.parse(stripJsonComments(readFileSync(join(cwd, configName), "utf8"))) as {
+        compilerOptions?: { baseUrl?: string; paths?: Record<string, string[]> };
+      };
+    } catch {
+      continue;
+    }
+    const paths = config.compilerOptions?.paths;
+    if (paths === undefined) continue;
+    const key = Object.keys(paths).find((candidate) => candidate.replace(/\/\*$/, "") === alias);
+    const target = key === undefined ? undefined : paths[key]?.[0];
+    if (target === undefined) continue;
+    return join(cwd, config.compilerOptions?.baseUrl ?? ".", target.replace(/\/\*$/, ""));
+  }
+  throw new Error(
+    `Cannot resolve the components alias "${alias}" from tsconfig.json or jsconfig.json in ${cwd}.`,
+  );
+}
+
+function stripJsonComments(source: string): string {
+  let result = "";
+  let inString = false;
+  let escaped = false;
+  for (let index = 0; index < source.length; index += 1) {
+    const character = source[index];
+    if (inString) {
+      result += character;
+      if (escaped) escaped = false;
+      else if (character === "\\") escaped = true;
+      else if (character === '"') inString = false;
+      continue;
+    }
+    if (character === '"') {
+      inString = true;
+      result += character;
+      continue;
+    }
+    if (character === "/" && source[index + 1] === "/") {
+      while (index < source.length && source[index] !== "\n") index += 1;
+      continue;
+    }
+    result += character;
+  }
+  return result;
+}
+
+function registryFileContent(registryDirectory: string, filename: string): string {
+  return readFileSync(join(registryDirectory, filename), "utf8");
+}
+
+function levenshteinDistance(left: string, right: string): number {
+  const previous = Array.from({ length: right.length + 1 }, (_, index) => index);
+  for (let i = 1; i <= left.length; i += 1) {
+    let diagonal = previous[0]!;
+    previous[0] = i;
+    for (let j = 1; j <= right.length; j += 1) {
+      const above = previous[j]!;
+      previous[j] = Math.min(
+        above + 1,
+        previous[j - 1]! + 1,
+        diagonal + (left[i - 1] === right[j - 1] ? 0 : 1),
+      );
+      diagonal = above;
+    }
+  }
+  return previous[right.length]!;
 }
 
 function runShadcn(args: string[]): void {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -192,13 +192,18 @@ export function updateInstalledItems(
   const report = inspectInstalledItems(options);
   const updated: string[] = [];
   if (options.overwrite === true) {
+    const actionable = new Map<string, string>();
     for (const item of report) {
+      if (!item.installed) continue;
       for (const file of item.files) {
-        if (file.status === "up-to-date") continue;
-        mkdirSync(dirname(file.path), { recursive: true });
-        writeFileSync(file.path, registryFileContent(registry, file.filename));
-        updated.push(file.path);
+        if (file.status === "up-to-date" || actionable.has(file.path)) continue;
+        actionable.set(file.path, registryFileContent(registry, file.filename));
       }
+    }
+    for (const [path, content] of actionable) {
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, content);
+      updated.push(path);
     }
   }
   return { report, updated };
@@ -244,14 +249,30 @@ function resolveAliasDirectory(cwd: string, alias: string): string {
     }
     const paths = config.compilerOptions?.paths;
     if (paths === undefined) continue;
-    const key = Object.keys(paths).find((candidate) => candidate.replace(/\/\*$/, "") === alias);
-    const target = key === undefined ? undefined : paths[key]?.[0];
+    const target = resolveAliasTarget(alias, paths);
     if (target === undefined) continue;
-    return join(cwd, config.compilerOptions?.baseUrl ?? ".", target.replace(/\/\*$/, ""));
+    return join(cwd, config.compilerOptions?.baseUrl ?? ".", target);
   }
   throw new Error(
     `Cannot resolve the components alias "${alias}" from tsconfig.json or jsconfig.json in ${cwd}.`,
   );
+}
+
+function resolveAliasTarget(alias: string, paths: Record<string, string[]>): string | undefined {
+  for (const [key, targets] of Object.entries(paths)) {
+    const target = targets[0];
+    if (target === undefined) continue;
+    if (key.endsWith("/*")) {
+      const prefix = key.slice(0, -2);
+      if (alias === prefix) return target.replace(/\/\*$/, "");
+      if (alias.startsWith(`${prefix}/`)) {
+        return join(target.replace(/\/\*$/, ""), alias.slice(prefix.length + 1));
+      }
+    } else if (key === alias) {
+      return target;
+    }
+  }
+  return undefined;
 }
 
 function stripJsonComments(source: string): string {

--- a/packages/cli/test/update.test.ts
+++ b/packages/cli/test/update.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -12,7 +12,9 @@ import {
 
 const registryDirectory = join(import.meta.dirname, "../registry");
 
-function createProject(options: { components?: boolean } = {}): string {
+function createProject(
+  options: { components?: boolean; paths?: Record<string, string[]> } = {},
+): string {
   const cwd = mkdtempSync(join(tmpdir(), "anvia-update-"));
   writeFileSync(
     join(cwd, "components.json"),
@@ -21,7 +23,11 @@ function createProject(options: { components?: boolean } = {}): string {
   writeFileSync(
     join(cwd, "tsconfig.json"),
     `${JSON.stringify(
-      { compilerOptions: { paths: { "@/components/*": ["./src/components/*"] } } },
+      {
+        compilerOptions: {
+          paths: options.paths ?? { "@/components/*": ["./src/components/*"] },
+        },
+      },
       null,
       2,
     )}\n`,
@@ -71,6 +77,14 @@ describe("inspectInstalledItems", () => {
     rmSync(cwd, { recursive: true, force: true });
   });
 
+  it("resolves the standard shadcn alias shape via a wildcard prefix", () => {
+    const cwd = createProject({ paths: { "@/*": ["./src/*"] } });
+    const report = inspectInstalledItems({ cwd, registryDirectory });
+    expect(report.every((item) => !item.installed)).toBe(true);
+    expect(report[0]?.files[0]?.path).toBe(join(cwd, "src/components/anvia", "attachment.tsx"));
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
   it("detects up-to-date, modified, and missing files", () => {
     const cwd = createProject();
     writeFileSync(installedPath(cwd, "attachment.tsx"), registryContent("attachment.tsx"));
@@ -110,6 +124,42 @@ describe("updateInstalledItems", () => {
     });
     expect(updated).toEqual([]);
     expect(readFileSync(installedPath(cwd, "markdown.tsx"), "utf8")).toBe("// old\n");
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it("does not install uninstalled items, even with overwrite", () => {
+    const cwd = createProject();
+    const { updated } = updateInstalledItems({ cwd, registryDirectory, overwrite: true });
+    expect(updated).toEqual([]);
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it("restores missing files of installed items only", () => {
+    const cwd = createProject();
+    // attachment.tsx makes composer installed (attachment + composer) but leaves markdown
+    // uninstalled, so update must restore composer.tsx while never creating markdown.tsx.
+    writeFileSync(installedPath(cwd, "attachment.tsx"), registryContent("attachment.tsx"));
+    const { updated } = updateInstalledItems({
+      cwd,
+      items: ["composer", "markdown"],
+      overwrite: true,
+      registryDirectory,
+    });
+    expect(updated).toEqual([installedPath(cwd, "composer.tsx")]);
+    expect(existsSync(installedPath(cwd, "markdown.tsx"))).toBe(false);
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it("writes shared files once across overlapping items", () => {
+    const cwd = createProject();
+    writeFileSync(installedPath(cwd, "attachment.tsx"), "// locally edited\n");
+    const { updated } = updateInstalledItems({
+      cwd,
+      items: ["composer", "message", "thread"],
+      overwrite: true,
+      registryDirectory,
+    });
+    expect(updated.filter((path) => path.endsWith("attachment.tsx"))).toHaveLength(1);
     rmSync(cwd, { recursive: true, force: true });
   });
 

--- a/packages/cli/test/update.test.ts
+++ b/packages/cli/test/update.test.ts
@@ -1,0 +1,131 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  closestRegistryItemName,
+  inspectInstalledItems,
+  registryItemNames,
+  updateInstalledItems,
+} from "../src";
+
+const registryDirectory = join(import.meta.dirname, "../registry");
+
+function createProject(options: { components?: boolean } = {}): string {
+  const cwd = mkdtempSync(join(tmpdir(), "anvia-update-"));
+  writeFileSync(
+    join(cwd, "components.json"),
+    `${JSON.stringify({ aliases: { components: "@/components" } }, null, 2)}\n`,
+  );
+  writeFileSync(
+    join(cwd, "tsconfig.json"),
+    `${JSON.stringify(
+      { compilerOptions: { paths: { "@/components/*": ["./src/components/*"] } } },
+      null,
+      2,
+    )}\n`,
+  );
+  if (options.components !== false) {
+    mkdirSync(join(cwd, "src/components/anvia"), { recursive: true });
+  }
+  return cwd;
+}
+
+function installedPath(cwd: string, filename: string): string {
+  return join(cwd, "src/components/anvia", filename);
+}
+
+function registryContent(filename: string): string {
+  return readFileSync(join(registryDirectory, filename), "utf8");
+}
+
+function itemReport(cwd: string, name: "composer" | "markdown") {
+  const report = inspectInstalledItems({ cwd, items: [name], registryDirectory });
+  expect(report).toHaveLength(1);
+  const item = report[0];
+  if (item === undefined) throw new Error("missing report item");
+  return item;
+}
+
+describe("closestRegistryItemName", () => {
+  it("suggests near matches and ignores distant ones", () => {
+    expect(closestRegistryItemName("thred")).toBe("thread");
+    expect(closestRegistryItemName("compser")).toBe("composer");
+    expect(closestRegistryItemName("completely-unrelated")).toBeUndefined();
+  });
+});
+
+describe("inspectInstalledItems", () => {
+  it("requires a configured project", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "anvia-update-"));
+    expect(() => inspectInstalledItems({ cwd, registryDirectory })).toThrow("components.json");
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it("reports items as not installed in a fresh project", () => {
+    const cwd = createProject();
+    const report = inspectInstalledItems({ cwd, registryDirectory });
+    expect(report).toHaveLength(registryItemNames.length);
+    expect(report.every((item) => !item.installed && !item.complete)).toBe(true);
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it("detects up-to-date, modified, and missing files", () => {
+    const cwd = createProject();
+    writeFileSync(installedPath(cwd, "attachment.tsx"), registryContent("attachment.tsx"));
+    writeFileSync(installedPath(cwd, "composer.tsx"), "// locally edited\n");
+    const composer = itemReport(cwd, "composer");
+    expect(composer.files.map((file) => [file.filename, file.status])).toEqual([
+      ["attachment.tsx", "up-to-date"],
+      ["composer.tsx", "modified"],
+    ]);
+    expect(composer.installed).toBe(true);
+    expect(composer.complete).toBe(true);
+    const message = inspectInstalledItems({
+      cwd,
+      items: ["message"],
+      registryDirectory,
+    })[0];
+    if (message === undefined) throw new Error("missing report item");
+    expect(message.files.map((file) => file.status)).toEqual([
+      "up-to-date",
+      "missing",
+      "missing",
+      "missing",
+    ]);
+    expect(message.complete).toBe(false);
+    rmSync(cwd, { recursive: true, force: true });
+  });
+});
+
+describe("updateInstalledItems", () => {
+  it("does not write anything by default", () => {
+    const cwd = createProject();
+    writeFileSync(installedPath(cwd, "markdown.tsx"), "// old\n");
+    const { updated } = updateInstalledItems({
+      cwd,
+      items: ["markdown"],
+      registryDirectory,
+    });
+    expect(updated).toEqual([]);
+    expect(readFileSync(installedPath(cwd, "markdown.tsx"), "utf8")).toBe("// old\n");
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it("overwrites out-of-date and missing files, then reports up to date", () => {
+    const cwd = createProject();
+    writeFileSync(installedPath(cwd, "markdown.tsx"), "// old\n");
+    const { updated } = updateInstalledItems({
+      cwd,
+      items: ["markdown"],
+      overwrite: true,
+      registryDirectory,
+    });
+    expect(updated).toEqual([installedPath(cwd, "markdown.tsx")]);
+    const item = itemReport(cwd, "markdown");
+    expect(item.files.every((file) => file.status === "up-to-date")).toBe(true);
+    expect(item.complete).toBe(true);
+    rmSync(cwd, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- New `anvia update [items...] [--cwd] [--overwrite]` command: compares installed Anvia UI components (resolved via `components.json` + tsconfig/jsconfig path aliases) against the bundled registry.
- Preview by default — reports each file as `up-to-date`, `modified`, or `missing` and writes nothing. `--overwrite` applies registry content to out-of-date and missing files.
- Unknown item names get did-you-mean suggestions (Levenshtein ≤ 2).
- New public exports: `inspectInstalledItems`, `updateInstalledItems`, `closestRegistryItemName`, plus `InstalledItemReport` types.

## Validation
- `pnpm --filter @anvia/cli typecheck` ✅
- `pnpm --filter @anvia/cli test` — 15/15 (7 new tests covering detection, preview no-write, overwrite, suggestions) ✅
- `pnpm --filter @anvia/cli build` ✅
- `pnpm check` (oxfmt + oxlint) ✅
- Manual smoke test of the built CLI in a temp project (preview → overwrite → typo suggestion) ✅