### PR TITLE
docs(core): add JSDoc to public API surface and document the convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,27 @@ Before requesting review, make sure:
 - Use Oxlint and Oxfmt through the existing scripts rather than invoking them ad hoc.
 - Avoid unrelated refactors in bug-fix pull requests.
 
+### JSDoc Convention
+
+Public exports in `packages/*` carry JSDoc so that editor hover documentation
+stays useful. `packages/core/src/completion/types.ts` is the reference example.
+
+Rules:
+
+- Document every exported symbol with one concise line focused on intent, not
+  on restating the name.
+- Document a property only when it carries non-obvious information:
+  - a non-obvious default (use a `@default` tag rather than prose),
+  - conditional behavior ("Present only when...", "Rejected by models without..."),
+  - a non-obvious unit, subset relation, or invariant,
+  - a deprecation (use `@deprecated` with a concrete migration snippet).
+- Discriminated unions get a bullet list on the type explaining each variant.
+- Leave obviously named properties undocumented. Never restate the name.
+- Never guess semantics in a comment. Verify the behavior in code, or omit the
+  comment and leave a question for review.
+- Private helpers (`src/internal/**`, non-exported functions) stay undocumented
+  unless the implementation trick is genuinely non-obvious.
+
 ## Tests
 
 Tests live beside the package they cover, usually under `test/`. Use focused tests for narrow fixes and broader coverage when changing shared runtime behavior.

--- a/packages/core/src/agent/run-types.ts
+++ b/packages/core/src/agent/run-types.ts
@@ -34,8 +34,17 @@ import type {
 } from "./interactions";
 import type { AgentLifecycle } from "./lifecycle";
 
+/** A run prompt: plain text or a full user message. */
 export type AgentPrompt = string | UserMessage;
 
+/**
+ * What a run starts from — exactly one of:
+ *
+ * - `prompt`: a new run from a prompt
+ * - `messages`: a new run from a full message history
+ * - `continuation` + `response`: resumption of a run suspended on a human
+ *   interaction, delivering the human's answer
+ */
 export type AgentInput =
   | {
       prompt: AgentPrompt;
@@ -59,15 +68,20 @@ export type AgentInput =
       session?: never;
     };
 
+/** Mid-run input that is queued and applied at the next turn boundary. */
 export type AgentSteerInput =
   | { prompt: AgentPrompt; messages?: never }
   | { messages: readonly UserMessage[]; prompt?: never };
 
+/**
+ * Per-run overrides applied on top of the agent's constructor settings.
+ */
 export type AgentRunSettings<
   Output = string,
   RawResponse = unknown,
   Controls extends CompletionModelControls = CompletionModelControls,
 > = {
+  /** Maximum tool-loop turns for this run; overrides the agent's `defaultMaxTurns`. */
   maxTurns?: number | undefined;
   retries?: RetrySetting | undefined;
   abortSignal?: AbortSignal | undefined;
@@ -79,43 +93,55 @@ export type AgentRunSettings<
   controls?: CompletionControlValues<Controls> | undefined;
 };
 
+/** Input and settings for one agent run. */
 export type AgentRunOptions<
   Output = string,
   RawResponse = unknown,
   Controls extends CompletionModelControls = CompletionModelControls,
 > = AgentInput & AgentRunSettings<Output, RawResponse, Controls>;
 
+/** Options for triggering memory compaction on a session. */
 export type AgentMemoryCompactionOptions = {
   session: MemoryScope;
   abortSignal?: AbortSignal | undefined;
 };
 
+/** Links a resumed run to the suspended run it continues. */
 export type AgentRunLink = Readonly<{
   runId: string;
   interactionId: string;
 }>;
 
+/** Fields shared by every terminal run outcome. */
 export type AgentOutcomeBase = {
   runId: string;
+  /** The final assistant text of the run. */
   text: string;
   usage: Usage;
   finishReason?: CompletionFinishReason | undefined;
   providerFinishReason?: string | undefined;
   contextUsage?: ContextUsage | undefined;
+  /** The full message history produced by the run, ready to replay. */
   messages: MessageType[];
   trace?: AgentTraceInfo | undefined;
   guardrails?: GuardrailDecisionRecord[] | undefined;
   sources?: CompletionSource[] | undefined;
   providerToolCalls?: ProviderToolCall[] | undefined;
   memoryCompaction?: MemoryCompactionInfo | undefined;
+  /** Set when this run resumed a prior run suspended on an interaction. */
   resumedFrom?: AgentRunLink | undefined;
 };
 
+/** The run finished and produced an output. */
 export type AgentResponse<Output = string> = AgentOutcomeBase & {
   type: "response";
   output: Output;
 };
 
+/**
+ * The run was stopped by a guardrail. `stage` reports whether the input prompt
+ * or the generated output was rejected.
+ */
 export type AgentBlockedOutcome = AgentOutcomeBase & {
   type: "blocked";
   stage: "input" | "output";
@@ -123,17 +149,27 @@ export type AgentBlockedOutcome = AgentOutcomeBase & {
   message?: string | undefined;
 };
 
+/**
+ * The run suspended to wait for a human interaction (approval or question).
+ * Resume it by passing the returned `continuation` together with an
+ * {@link AgentInteractionResponse} as the next run's input.
+ */
 export type AgentInteractionOutcome = AgentOutcomeBase & {
   type: "interaction";
   interaction: AgentInteractionRequest;
   continuation: AgentContinuation;
 };
 
+/**
+ * Terminal result of a run: a response, a guardrail block, or a suspension on
+ * a human interaction.
+ */
 export type AgentOutcome<Output = string> =
   | AgentResponse<Output>
   | AgentBlockedOutcome
   | AgentInteractionOutcome;
 
+/** Run-level content deltas, not tagged with a turn. */
 export type AgentDeltaEvent =
   | { type: "text_delta"; delta: string }
   | {
@@ -147,12 +183,14 @@ export type AgentDeltaEvent =
   | { type: "source"; source: CompletionSource }
   | { type: "provider_tool_call"; toolCall: ProviderToolCall };
 
+/** Terminal error event carrying the usage accumulated before the failure. */
 export type AgentErrorStreamEvent = {
   type: "error";
   error: unknown;
   usage: Usage;
 };
 
+/** Partial tool-call input arriving mid-generation within one turn. */
 export type AgentToolCallDeltaEvent = {
   type: "tool_call_delta";
   turn: number;
@@ -164,21 +202,25 @@ export type AgentToolCallDeltaEvent = {
   signature?: string;
 };
 
+/** Emitted when the run compacts session memory mid-run. */
 export type AgentMemoryCompactionEvent = MemoryCompactionInfo & {
   type: "memory_compaction";
 };
 
+/** Emitted when a sibling run in the same session answers a tool interaction. */
 export type AgentInteractionResponseEvent = {
   type: "interaction_response";
   response: ToolInteractionResponsePart;
   sourceRunId: string;
 };
 
+/** Acknowledgement that steering input was accepted and queued. */
 export type AgentSteerReceipt = Readonly<{
   id: string;
   status: "queued";
 }>;
 
+/** Confirms a queued steer input was applied, at the turn it landed in. */
 export type AgentSteeringAppliedEvent = {
   type: "steering_applied";
   id: string;
@@ -256,6 +298,11 @@ type AgentChildStreamEventBase<Output = string, RawResponse = unknown> =
   | AgentOutcome<Output>
   | AgentErrorStreamEvent;
 
+/**
+ * Events of a single agent run, each tagged with the turn that produced it.
+ * The stream always ends with an {@link AgentOutcome} or an
+ * {@link AgentErrorStreamEvent}.
+ */
 export type AgentChildStreamEvent<Output = string, RawResponse = unknown> =
   | AgentChildStreamEventBase<Output, RawResponse>
   | AgentToolCallDeltaEvent;
@@ -271,17 +318,28 @@ type AgentToolStreamEvent = {
   event: AgentChildStreamEvent<unknown, unknown>;
 };
 
+/** An event from a child agent run surfaced inside a parent run's stream. */
 export type AgentStreamEvent<Output = string, RawResponse = unknown> =
   | AgentChildStreamEvent<Output, RawResponse>
   | AgentToolStreamEvent;
 
+/**
+ * Async stream of run events. The run is driven by consuming the stream —
+ * iterating events or awaiting `text`/`result`. The stream can be consumed
+ * once; abandoning it before completion cancels the run.
+ */
 export interface AgentStream<Output = string, RawResponse = unknown> extends AsyncIterable<
   AgentStreamEvent<Output, RawResponse>
 > {
   readonly events: AsyncIterable<AgentStreamEvent<Output, RawResponse>>;
+  /** Incremental text deltas only, with turn metadata stripped. */
   readonly textStream: AsyncIterable<string>;
+  /** Resolves with the run's final assistant text; rejects if the run errors. */
   readonly text: Promise<string>;
+  /** Resolves with the run's terminal outcome; rejects if the run errors. */
   readonly result: Promise<AgentOutcome<Output>>;
+  /** Queues input to inject at the next turn boundary. Throws if the run already ended. */
   steer(input: AgentSteerInput): AgentSteerReceipt;
+  /** Cancels the run; in-flight tool calls and generation are aborted. */
   cancel(reason?: string): void;
 }

--- a/packages/core/src/agent/run-types.ts
+++ b/packages/core/src/agent/run-types.ts
@@ -299,8 +299,10 @@ type AgentChildStreamEventBase<Output = string, RawResponse = unknown> =
   | AgentErrorStreamEvent;
 
 /**
- * Events of a single agent run, each tagged with the turn that produced it.
- * The stream always ends with an {@link AgentOutcome} or an
+ * Events of a single agent run: turn-tagged progress events (deltas, tool
+ * calls and results, guardrail decisions), plus run-level events such as
+ * steering confirmations, memory compaction, and interaction responses. The
+ * stream always ends with an {@link AgentOutcome} or an
  * {@link AgentErrorStreamEvent}.
  */
 export type AgentChildStreamEvent<Output = string, RawResponse = unknown> =
@@ -318,7 +320,10 @@ type AgentToolStreamEvent = {
   event: AgentChildStreamEvent<unknown, unknown>;
 };
 
-/** An event from a child agent run surfaced inside a parent run's stream. */
+/**
+ * The complete event family for an agent run: the run's own child stream
+ * events, plus events from child agent runs invoked through agent tools.
+ */
 export type AgentStreamEvent<Output = string, RawResponse = unknown> =
   | AgentChildStreamEvent<Output, RawResponse>
   | AgentToolStreamEvent;

--- a/packages/core/src/completion/types.ts
+++ b/packages/core/src/completion/types.ts
@@ -2,28 +2,41 @@ import type { ModelCallOptions } from "../model-call-options";
 import { isJsonValue } from "./json";
 
 export type JsonPrimitive = string | number | boolean | null;
+/** Any JSON-compatible value: primitives, objects, or readonly arrays of JSON values. */
 export type JsonValue = JsonPrimitive | JsonObject | readonly JsonValue[];
 export type JsonObject = { [key: string]: JsonValue };
 
+/** A retrievable text document passed to a completion as grounding context. */
 export type Document = {
   id: string;
   text: string;
+  /** String metadata rendered as a `<metadata ... />` header above the text when documents are serialized into prompts. */
   additionalProps?: Record<string, string>;
 };
 
+/**
+ * A text segment, optionally carrying a provider reasoning signature.
+ */
 export type TextPart = Readonly<{
   type: "text";
   text: string;
+  /** Provider signature preserved so reasoning can be replayed on later turns. */
   signature?: string;
 }>;
 
+/** Image input fidelity hint forwarded to providers that support it. */
 export type ImageDetail = "auto" | "low" | "high";
 
+/**
+ * File payload for image/file parts: a remote URL, base64 data, or literal text
+ * interpreted as a document.
+ */
 export type FileData =
   | Readonly<{ type: "url"; url: string }>
   | Readonly<{ type: "data"; data: string }>
   | Readonly<{ type: "text"; text: string }>;
 
+/** Image input with an optional media type override and detail hint. */
 export type ImagePart = Readonly<{
   type: "image";
   image: Exclude<FileData, Readonly<{ type: "text"; text: string }>>;
@@ -31,6 +44,7 @@ export type ImagePart = Readonly<{
   detail?: ImageDetail;
 }>;
 
+/** Document/file input part; non-text data is rejected by models without `documentInput`. */
 export type FilePart = Readonly<{
   type: "file";
   data: FileData;
@@ -38,6 +52,7 @@ export type FilePart = Readonly<{
   filename?: string;
 }>;
 
+/** Model reasoning content, replayable across turns to preserve thinking state. */
 export type ReasoningPart = Readonly<{
   type: "reasoning";
   text: string;
@@ -45,6 +60,13 @@ export type ReasoningPart = Readonly<{
   details?: readonly ReasoningDetail[];
 }>;
 
+/**
+ * Reasoning detail variants:
+ *
+ * - `text` / `summary`: displayable reasoning text
+ * - `encrypted` / `redacted`: opaque payloads that can only be echoed back to
+ *   the provider; their content is not readable by the application
+ */
 export type ReasoningDetail =
   | Readonly<{
       type: "text";
@@ -66,6 +88,7 @@ export type ReasoningDetail =
 
 export type ReasoningContentType = ReasoningDetail["type"];
 
+/** A tool call requested by the model; `signature` preserves provider replay state. */
 export type ToolCallPart = Readonly<{
   type: "tool-call";
   toolCallId: string;
@@ -75,8 +98,18 @@ export type ToolCallPart = Readonly<{
   signature?: string;
 }>;
 
+/** The content variants allowed inside a tool result payload. */
 export type ToolResultContentPart = TextPart | FilePart;
 
+/**
+ * Outcome of one tool execution, as recorded in tool messages:
+ *
+ * - `text` / `json`: successful result as plain text or JSON
+ * - `content`: successful result as mixed content parts
+ * - `execution-denied`: the call was blocked (e.g. by a required approval)
+ * - `error-text` / `error-json`: failure surfaced to the model so the run can
+ *   continue instead of aborting
+ */
 export type ToolResultOutput =
   | Readonly<{ type: "text"; value: string }>
   | Readonly<{ type: "json"; value: JsonValue }>
@@ -85,6 +118,7 @@ export type ToolResultOutput =
   | Readonly<{ type: "error-text"; value: string }>
   | Readonly<{ type: "error-json"; value: JsonValue }>;
 
+/** Tool result reported back to the model, matched to its call via `toolCallId`. */
 export type ToolResultPart = Readonly<{
   type: "tool-result";
   toolCallId: string;
@@ -93,6 +127,7 @@ export type ToolResultPart = Readonly<{
   output: ToolResultOutput;
 }>;
 
+/** Human decision on a tool call that required approval before execution. */
 export type ToolApprovalResponsePart = Readonly<{
   type: "tool-approval-response";
   interactionId: string;
@@ -103,11 +138,13 @@ export type ToolApprovalResponsePart = Readonly<{
   reason?: string;
 }>;
 
+/** Answer to one question asked by a tool suspended on a human interaction. */
 export type ToolQuestionAnswer = Readonly<{
   questionId: string;
   value: string;
 }>;
 
+/** Answers to tool questions, delivered back through the suspended run. */
 export type ToolQuestionResponsePart = Readonly<{
   type: "tool-question-response";
   interactionId: string;
@@ -117,9 +154,12 @@ export type ToolQuestionResponsePart = Readonly<{
   answers: readonly ToolQuestionAnswer[];
 }>;
 
+/** A tool or human-interaction response delivered inside a `role: "tool"` message. */
 export type ToolInteractionResponsePart = ToolApprovalResponsePart | ToolQuestionResponsePart;
 
+/** Content parts allowed in user messages. */
 export type UserContentPart = TextPart | ImagePart | FilePart;
+/** Content parts allowed in assistant messages, including replayed reasoning and tool calls. */
 export type AssistantContentPart = TextPart | ImagePart | FilePart | ReasoningPart | ToolCallPart;
 
 export type SystemMessage<Metadata extends JsonObject = JsonObject> = Readonly<{
@@ -147,12 +187,20 @@ export type ToolMessage<Metadata extends JsonObject = JsonObject> = Readonly<{
   metadata?: Metadata;
 }>;
 
+/**
+ * A conversation message from the system, user, assistant, or tool role.
+ *
+ * Framework-generated metadata (provider, model, usage of the generation that
+ * produced an assistant message) is stored under the `anvia` key of `metadata`;
+ * read it back with {@link getAssistantGenerationMetadata}.
+ */
 export type Message<Metadata extends JsonObject = JsonObject> =
   | SystemMessage<Metadata>
   | UserMessage<Metadata>
   | AssistantMessage<Metadata>
   | ToolMessage<Metadata>;
 
+/** Joins the human-readable text of a reasoning part or its details. */
 export function reasoningDisplayText(
   reasoning: ReasoningPart | readonly ReasoningDetail[],
 ): string {
@@ -170,6 +218,10 @@ export function reasoningDisplayText(
     .join("");
 }
 
+/**
+ * How the model may call tools: freely, mandatorily, never, or a named function.
+ * Requires the model's `toolChoice` capability.
+ */
 export type ToolChoice =
   | "auto"
   | "required"
@@ -179,6 +231,7 @@ export type ToolChoice =
       name: string;
     };
 
+/** JSON Schema-shaped tool description sent to the model (a local tool's public face). */
 export type ToolDefinition = {
   name: string;
   description: string;
@@ -200,6 +253,7 @@ export type ProviderTool = {
 
 export type CompletionTool = ToolDefinition | ProviderTool;
 
+/** Narrows an unknown value to a well-formed {@link ProviderTool}. */
 export function isProviderTool(value: unknown): value is ProviderTool {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return false;
@@ -219,6 +273,7 @@ export function isProviderTool(value: unknown): value is ProviderTool {
   );
 }
 
+/** A grounding source (e.g. web result) returned by the provider, with optional text offsets. */
 export type CompletionSource = {
   type: "url";
   url: string;
@@ -228,6 +283,7 @@ export type CompletionSource = {
   endIndex?: number;
 };
 
+/** A tool call executed on the provider side, surfaced for observability. */
 export type ProviderToolCall = {
   id: string;
   name: string;
@@ -243,6 +299,13 @@ export type ProviderToolCall = {
  */
 export type UsageDetails = Record<string, number>;
 
+/**
+ * Token usage for one or more generations.
+ *
+ * `cachedInputTokens` counts input tokens served from the provider's prompt
+ * cache; `cacheCreationInputTokens` counts input tokens billed for writing to
+ * that cache. Both are subsets of `inputTokens`.
+ */
 export type Usage = {
   inputTokens: number;
   outputTokens: number;
@@ -252,17 +315,20 @@ export type Usage = {
   details?: UsageDetails;
 };
 
+/** Model context window bounds; unset input/output caps fall back to the window. */
 export type ModelContextLimits = {
   contextWindow: number;
   maxInputTokens?: number;
   maxOutputTokens?: number;
 };
 
+/** Identifies a model together with its context limits. */
 export type CompletionModelInfo = {
   modelId: string;
   context: ModelContextLimits;
 };
 
+/** Snapshot of how much of a model's context window a request consumed. */
 export type ContextUsage = {
   model: CompletionModelInfo;
   usedTokens: number;
@@ -271,6 +337,7 @@ export type ContextUsage = {
   remainingPercent: number;
 };
 
+/** Computes context usage, or undefined when the model or usage data is unusable. */
 export function calculateContextUsage(
   usage: Usage,
   model: CompletionModelInfo | undefined,
@@ -297,6 +364,7 @@ export function calculateContextUsage(
   };
 }
 
+/** Attaches context usage to a response when model limits are known. */
 export function withContextUsage<RawResponse>(
   response: CompletionResponse<RawResponse>,
   model: CompletionModelInfo | undefined,
@@ -305,6 +373,7 @@ export function withContextUsage<RawResponse>(
   return contextUsage === undefined ? response : { ...response, contextUsage };
 }
 
+/** Resolves a model's context limits: explicit override wins over catalog lookup. */
 export function resolveModelContextLimits(
   modelId: string,
   catalog: Readonly<Record<string, ModelContextLimits>>,
@@ -313,6 +382,7 @@ export function resolveModelContextLimits(
   return override ?? catalog[modelId];
 }
 
+/** Provider/model/usage metadata embedded in assistant message metadata by the runtime. */
 export type AssistantGenerationMetadata = {
   provider: string;
   modelId: string;
@@ -324,7 +394,11 @@ export type AssistantGenerationMetadata = {
   providerToolCalls?: ProviderToolCall[];
 };
 
+/**
+ * Helpers for constructing and combining token usage.
+ */
 export const Usage = {
+  /** Returns an all-zero usage value. */
   empty(): Usage {
     return {
       inputTokens: 0,
@@ -334,6 +408,10 @@ export const Usage = {
       cacheCreationInputTokens: 0,
     };
   },
+  /**
+   * Sums two usage values bucket by bucket. `details` are merged only when
+   * both sides carry them; if either side omits them, the result omits them.
+   */
   add(left: Usage, right: Usage): Usage {
     const result: Usage = {
       inputTokens: left.inputTokens + right.inputTokens,
@@ -348,6 +426,7 @@ export const Usage = {
     }
     return result;
   },
+  /** Returns true when every bucket, including `details`, is zero. */
   isEmpty(usage: Usage): boolean {
     return (
       isEmptyUsage(usage) &&
@@ -383,6 +462,10 @@ function isEmptyUsage(usage: Usage): boolean {
   );
 }
 
+/**
+ * Reads the generation metadata the runtime embeds in assistant messages, when
+ * present and structurally valid.
+ */
 export function getAssistantGenerationMetadata(
   message: Message,
 ): AssistantGenerationMetadata | undefined {
@@ -561,6 +644,7 @@ function isProviderToolCallArray(value: JsonValue | undefined): value is Provide
   );
 }
 
+/** Provider-agnostic completion request assembled by the runtime for adapters. */
 export type CompletionRequest = {
   instructions?: string;
   chatHistory: Message[];
@@ -570,28 +654,48 @@ export type CompletionRequest = {
   temperature?: number;
   maxTokens?: number;
   toolChoice?: ToolChoice;
+  /** Values for the model's declared completion controls; validated before sending. */
   controls?: Readonly<Record<string, string>>;
+  /** Provider-specific passthrough options; never validated by the core runtime. */
   providerOptions?: JsonObject;
+  /** JSON Schema the output must conform to; requires the `outputSchema` capability. */
   outputSchema?: JsonObject;
 };
 
+/** Normalized finish reasons:
+ *
+ * - `stop`: the model finished naturally
+ * - `length`: an output token limit was hit
+ * - `content-filter`: output was blocked by a safety filter
+ * - `tool-calls`: the model stopped to request tool calls
+ * - `other`: any provider-specific reason
+ */
 export type CompletionFinishReason = "stop" | "length" | "content-filter" | "tool-calls" | "other";
 
+/** A provider's raw completion response: normalized parts plus usage and metadata. */
 export type CompletionResponse<RawResponse = unknown> = {
   choice: AssistantContentPart[];
   usage: Usage;
   finishReason?: CompletionFinishReason;
   providerFinishReason?: string;
   contextUsage?: ContextUsage;
+  /** The provider SDK's original response object, unmodified. */
   rawResponse: RawResponse;
   messageId?: string;
   sources?: CompletionSource[];
   providerToolCalls?: ProviderToolCall[];
 };
 
+/** Final result of a completion: typed output, plain text, full content, and usage. */
 export type CompletionResult<Output = string, RawResponse = unknown> = {
+  /**
+   * The typed output. When an output schema was requested this is the parsed,
+   * validated object; otherwise it is the plain text.
+   */
   output: Output;
+  /** The generated text, joined from the response's text parts. */
   text: string;
+  /** Every content part the model produced, including reasoning and tool calls. */
   content: readonly AssistantContentPart[];
   usage: Usage;
   finishReason?: CompletionFinishReason;
@@ -613,6 +717,7 @@ function isCompletionFinishReason(value: JsonValue | undefined): value is Comple
   );
 }
 
+/** Feature flags a model declares; requests are validated against these at runtime. */
 export type CompletionModelCapabilities = {
   streaming: boolean;
   tools: boolean;
@@ -624,6 +729,7 @@ export type CompletionModelCapabilities = {
   providerTools?: boolean;
 };
 
+/** A selectable model control exposed to applications (e.g. "reasoning effort"). */
 export type CompletionModelSelectControl<Option extends string = string> = Readonly<{
   type: "select";
   label: string;
@@ -632,12 +738,15 @@ export type CompletionModelSelectControl<Option extends string = string> = Reado
   defaultValue?: Option | undefined;
 }>;
 
+/** Named set of controls a model supports, keyed by control id. */
 export type CompletionModelControls = Readonly<
   Record<string, CompletionModelSelectControl<string>>
 >;
 
+/** Marker type for models that accept no completion controls. */
 export type NoCompletionModelControls = Readonly<Record<string, never>>;
 
+/** The option values a model's controls accept, keyed by control id. */
 export type CompletionControlValues<Controls extends CompletionModelControls> = Readonly<
   Partial<{
     [Key in keyof Controls]: Controls[Key] extends CompletionModelSelectControl<infer Option>
@@ -646,9 +755,14 @@ export type CompletionControlValues<Controls extends CompletionModelControls> = 
   }>
 >;
 
+/** Extracts a model's control types, defaulting to the open controls record. */
 export type CompletionModelControlsOf<Model> =
   Model extends CompletionModel<unknown, infer Controls> ? Controls : CompletionModelControls;
 
+/**
+ * The provider-agnostic model contract every adapter implements: non-streaming
+ * completions plus capability, context, and control metadata.
+ */
 export interface CompletionModel<
   RawResponse = unknown,
   Controls extends CompletionModelControls = CompletionModelControls,
@@ -658,6 +772,11 @@ export interface CompletionModel<
   readonly contextLimits?: ModelContextLimits | undefined;
   readonly capabilities: CompletionModelCapabilities;
   readonly controls?: Controls | undefined;
+  /**
+   * Returns a JSON-safe representation of the outgoing request for
+   * observability traces, or undefined to omit the trace payload. Errors
+   * thrown here are swallowed by the runtime and recorded as a trace error.
+   */
   traceRequest?(
     request: CompletionRequest,
     options?: { stream?: boolean | undefined },
@@ -668,8 +787,21 @@ export interface CompletionModel<
   ): Promise<CompletionResponse<RawResponse>>;
 }
 
+/** How a `tool_call_delta` updates arguments: append to, or replace, accumulated JSON. */
 export type ToolCallArgumentsMode = "append" | "replace";
 
+/**
+ * Incremental completion stream content:
+ *
+ * - `text_delta` / `reasoning_delta`: incremental text or reasoning content
+ * - `tool_call_delta`: partial tool call input; argument fragments accumulate
+ *   according to `argumentsMode` (`append` continues the JSON string, `replace`
+ *   restarts it)
+ * - `tool_call`: a complete tool call
+ * - `source`: a grounding source discovered during generation
+ * - `provider_tool_call`: progress on a provider-executed tool
+ * - `message_id`: the id of the message being generated
+ */
 export type CompletionStreamPart =
   | {
       type: "text_delta";
@@ -680,6 +812,7 @@ export type CompletionStreamPart =
       delta: string;
       id?: string;
       contentType?: ReasoningContentType;
+      /** Provider signature preserved for reasoning replay. */
       signature?: string;
     }
   | {
@@ -708,6 +841,7 @@ export type CompletionStreamPart =
       id: string;
     };
 
+/** Raw model stream events: stream parts, the final response, or a terminal error. */
 export type CompletionModelStreamEvent<RawResponse = unknown> =
   | CompletionStreamPart
   | {
@@ -720,6 +854,7 @@ export type CompletionModelStreamEvent<RawResponse = unknown> =
       usage?: Usage;
     };
 
+/** High-level stream events: stream parts, the final typed result, or a terminal error. */
 export type CompletionStreamEvent<Output = string, RawResponse = unknown> =
   | CompletionStreamPart
   | {
@@ -732,6 +867,7 @@ export type CompletionStreamEvent<Output = string, RawResponse = unknown> =
       usage: Usage;
     };
 
+/** A completion model that can additionally stream events as they are produced. */
 export interface StreamingCompletionModel<
   RawResponse = unknown,
   Controls extends CompletionModelControls = CompletionModelControls,
@@ -742,6 +878,7 @@ export interface StreamingCompletionModel<
   ): AsyncIterable<CompletionModelStreamEvent<RawResponse>>;
 }
 
+/** Thrown when a request uses a capability the target model does not declare. */
 export class CompletionCapabilityError extends Error {
   constructor(message: string) {
     super(message);
@@ -749,6 +886,7 @@ export class CompletionCapabilityError extends Error {
   }
 }
 
+/** Validates a request against a model's declared capabilities; throws {@link CompletionCapabilityError}. */
 export function assertCompletionRequestSupported(
   model: CompletionModel,
   request: CompletionRequest,
@@ -788,6 +926,7 @@ export function assertCompletionRequestSupported(
   }
 }
 
+/** Validates control values against a model's controls; throws {@link CompletionCapabilityError}. */
 export function assertCompletionControlsSupported(
   model: CompletionModel,
   controls: Readonly<Record<string, string | undefined>> | undefined,
@@ -813,6 +952,7 @@ export function assertCompletionControlsSupported(
   }
 }
 
+/** Joins the text parts of assistant content with newlines. */
 export function textFromAssistantContent(content: readonly AssistantContentPart[]): string {
   return content.flatMap((item) => (item.type === "text" ? [item.text] : [])).join("\n");
 }

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -5,23 +5,40 @@ import type {
   Usage,
 } from "../completion/types";
 
+/**
+ * Outcome requested by a run-lifecycle hook: keep going, or terminate the run
+ * with a reason.
+ */
 export type HookAction = { type: "continue" } | { type: "terminate"; reason: string };
+
 export type ToolApprovalRequestOptions = {
+  /** Human-facing reason attached to the approval request. */
   reason?: string;
+  /** Message returned to the model when the approval is denied. */
   rejectMessage?: string;
 };
 
+/**
+ * Outcome requested by a tool-call hook:
+ *
+ * - `continue`: execute the tool
+ * - `skip`: bypass this call and tell the model why
+ * - `terminate`: end the run
+ * - `approval_request`: suspend the call until a human approves or denies it
+ */
 export type ToolCallHookAction =
   | { type: "continue" }
   | { type: "skip"; reason: string }
   | { type: "terminate"; reason: string }
   | ({ type: "approval_request" } & ToolApprovalRequestOptions);
 
+/** Control surface for run-lifecycle hooks. */
 export type RunControl = {
   continue(): HookAction;
   cancel(reason: string): HookAction;
 };
 
+/** Control surface for tool-call hooks; each method returns the matching action. */
 export type ToolCallControl = {
   run(): ToolCallHookAction;
   skip(reason: string): ToolCallHookAction;
@@ -36,12 +53,14 @@ type ToolCallHookCallback<Args> = (
   args: Args,
 ) => ToolCallHookAction | Promise<ToolCallHookAction | undefined> | Promise<void> | void;
 
+/** Arguments for the hook invoked before a completion request leaves the runtime. */
 export type CompletionCallHookArgs = {
   prompt: Message;
   history: Message[];
   run: RunControl;
 };
 
+/** Arguments for the hook invoked when a run starts. */
 export type RunStartHookArgs = {
   prompt: Message;
   history: Message[];
@@ -49,6 +68,7 @@ export type RunStartHookArgs = {
   run: RunControl;
 };
 
+/** Arguments for the hook invoked after a run completes successfully. */
 export type RunEndHookArgs = {
   status: "completed";
   output: unknown;
@@ -58,6 +78,7 @@ export type RunEndHookArgs = {
   run: RunControl;
 };
 
+/** Arguments for the hook invoked when a run fails. */
 export type RunErrorHookArgs = {
   error: unknown;
   usage: Usage;
@@ -65,6 +86,7 @@ export type RunErrorHookArgs = {
   run: RunControl;
 };
 
+/** Arguments for the hooks around each agent turn. */
 export type TurnStartHookArgs = {
   turn: number;
   prompt: Message;
@@ -72,24 +94,28 @@ export type TurnStartHookArgs = {
   run: RunControl;
 };
 
+/** Arguments for the hook invoked after each agent turn completes. */
 export type TurnEndHookArgs<RawResponse = unknown> = {
   turn: number;
   response: CompletionResponse<RawResponse>;
   run: RunControl;
 };
 
+/** Arguments for the hook invoked when a raw provider response arrives. */
 export type CompletionResponseHookArgs<RawResponse = unknown> = {
   prompt: Message;
   response: CompletionResponse<RawResponse>;
   run: RunControl;
 };
 
+/** Arguments for the hook invoked when a completion request fails. */
 export type CompletionErrorHookArgs = {
   prompt: Message;
   error: unknown;
   run: RunControl;
 };
 
+/** Common fields identifying the tool call a hook fired for. */
 export type ToolHookArgs = {
   toolName: string;
   toolCallId: string;
@@ -98,21 +124,29 @@ export type ToolHookArgs = {
   args: string;
 };
 
+/** Arguments for the hook invoked before a tool executes; can steer or block the call. */
 export type ToolCallHookArgs = ToolHookArgs & {
   tool: ToolCallControl;
 };
 
+/** Arguments for the hook invoked after a tool produces a result. */
 export type ToolResultHookArgs = ToolHookArgs & {
   result: string;
   structuredResult?: readonly ToolResultContentPart[] | undefined;
   run: RunControl;
 };
 
+/** Arguments for the hook invoked when a tool execution fails. */
 export type ToolErrorHookArgs = ToolHookArgs & {
   error: unknown;
   run: RunControl;
 };
 
+/**
+ * Lifecycle hooks observing an agent run. Every hook is optional; returning an
+ * action (see {@link HookAction} / {@link ToolCallHookAction}) steers or stops
+ * the run, while returning nothing simply observes.
+ */
 export interface AgentHook<RawResponse = unknown> {
   onRunStart?: HookCallback<RunStartHookArgs>;
   onRunEnd?: HookCallback<RunEndHookArgs>;

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -7,16 +7,27 @@ import type {
 } from "../completion/types";
 import type { RetrySetting } from "../retry";
 
+/**
+ * Granularity at which produced messages are persisted:
+ *
+ * - `message`: after each individual message
+ * - `turn`: after each agent turn completes
+ * - `run`: once when the run finishes
+ */
 export type MemorySavePolicy = "message" | "turn" | "run";
 
+/** Identifies a conversation within a memory store. */
 export type MemoryScope = {
   sessionId: string;
   userId?: string | undefined;
   metadata?: JsonObject | undefined;
 };
 
+/** Options controlling how a memory scope is reduced to a storage key. */
 export type MemoryScopeKeyOptions = {
+  /** Includes `scope.userId` in the derived key. */
   includeUserId?: boolean | undefined;
+  /** Metadata entries (by key) included in the derived key. */
   metadataKeys?: readonly string[] | undefined;
 };
 
@@ -24,6 +35,7 @@ export type CreateMemoryScopeKeyOptions = MemoryScopeKeyOptions & {
   scope: MemoryScope;
 };
 
+/** Either key-derivation options or a custom resolver function. */
 export type MemoryScopeKeyResolver =
   | MemoryScopeKeyOptions
   | ((options: { scope: MemoryScope }) => string);
@@ -59,6 +71,7 @@ export type MemoryConversationGetOptions = {
   ref: string;
 };
 
+/** Persisted summary of a stored conversation. */
 export type MemoryConversationSummary = {
   /** Opaque, store-specific reference used to retrieve this exact conversation. */
   ref: string;
@@ -70,6 +83,7 @@ export type MemoryConversationSummary = {
   messageCount: number;
 };
 
+/** One stored message with its position and originating run/turn. */
 export type MemoryConversationMessage = {
   position: number;
   runId: string;
@@ -78,6 +92,7 @@ export type MemoryConversationMessage = {
   message: Message;
 };
 
+/** A full stored conversation: summary plus replayable messages. */
 export type MemoryConversation = MemoryConversationSummary & {
   messages: MemoryConversationMessage[];
 };
@@ -88,6 +103,11 @@ export interface MemoryInspector {
   getConversation(options: MemoryConversationGetOptions): Promise<MemoryConversation | undefined>;
 }
 
+/**
+ * Append-only conversation storage. The runtime loads history at run start,
+ * appends produced messages per the configured {@link MemorySavePolicy}, and
+ * clears on demand. `load` must return the canonical, replayable history.
+ */
 export interface MemoryStore {
   readonly inspector?: MemoryInspector | undefined;
   readonly compaction?: MemoryCompactionCapability | undefined;
@@ -95,14 +115,18 @@ export interface MemoryStore {
   load(options: MemoryLoadOptions): Promise<Message[]>;
   append(options: MemoryAppendOptions): Promise<void>;
   clear(options: MemoryClearOptions): Promise<void>;
+  /** Records a failed run for debugging; unsupported stores may omit it. */
   recordError?(options: MemoryErrorOptions): Promise<void>;
 }
 
+/** Metadata embedded in a compaction summary message. */
 export type MemoryCompactionMetadata = {
+  /** Schema version of the compaction marker. */
   version: 1;
   compactedMessageCount: number;
 };
 
+/** A system message that stores a summary checkpoint in the conversation history. */
 export type MemoryCompactionMessage = Omit<SystemMessage, "metadata"> & {
   metadata: {
     anvia: {
@@ -131,6 +155,7 @@ export type MemoryCompactionReplacePrefixOptions = {
   runId: string;
 };
 
+/** Result of a prefix replacement: `conflict` means the revision was stale and the replacement was rejected. */
 export type MemoryCompactionReplacePrefixResult = {
   status: "committed" | "conflict";
 };
@@ -159,11 +184,13 @@ export type MemoryCompactorResult = {
   usage?: Usage | undefined;
 };
 
+/** Summarizes a list of messages into a compact replacement. */
 export type MemoryCompactor = (input: MemoryCompactorInput) => Promise<MemoryCompactorResult>;
 
 /** Counts the approximate or exact model tokens represented by a message list. */
 export type MemoryTokenCounter = (messages: readonly Message[]) => number | Promise<number>;
 
+/** Options for the built-in, model-backed summary compactor. */
 export type CreateSummaryMemoryCompactorOptions = {
   model: CompletionModel;
   instructions?: string | undefined;
@@ -177,23 +204,31 @@ export type MemoryCompactionConflictRetryOptions = {
   maxAttempts: number;
 };
 
+/** When and how session memory is compacted. */
 export type MemoryCompactionOptions = {
   trigger: {
+    /** Compaction runs when the projected context exceeds this token count. */
     afterTokens: number;
   };
   retention?: {
+    /** Messages within this token budget of the end stay unsummarized. */
     recentTokens?: number | undefined;
   };
+  /** Overrides the default approximate counter; use a model counter for exact budgets. */
   tokenCounter?: MemoryTokenCounter | undefined;
   compactor: MemoryCompactor;
+  /** `false` disables retrying when a store reports a revision conflict. */
   conflictRetries?: false | MemoryCompactionConflictRetryOptions | undefined;
 };
 
+/** Memory settings for an agent. */
 export type MemoryOptions = {
+  /** @default "message" */
   savePolicy?: MemorySavePolicy | undefined;
   compaction?: MemoryCompactionOptions | undefined;
 };
 
+/** Measurements recorded for one compaction attempt. */
 export type MemoryCompactionInfo = {
   originalMessageCount: number;
   compactedMessageCount: number;
@@ -206,6 +241,7 @@ export type MemoryCompactionInfo = {
   usage: Usage;
 };
 
+/** Outcome of a compaction attempt: performed, or skipped because there was nothing to compact. */
 export type MemoryCompactionResult =
   | ({ type: "compacted" } & MemoryCompactionInfo)
   | {

--- a/packages/core/src/tool/tool.ts
+++ b/packages/core/src/tool/tool.ts
@@ -8,6 +8,7 @@ import type {
   ToolResultOutput,
 } from "../completion/types";
 
+/** Identifies the agent run that requested a tool approval. */
 export type ToolApprovalRunContext = {
   agentId: string;
   runId: string;
@@ -15,9 +16,11 @@ export type ToolApprovalRunContext = {
   metadata?: JsonObject;
 };
 
+/** Details of the pending tool call being evaluated for approval. */
 export type ToolApprovalContext<Args = unknown> = {
   toolName: string;
   args: Args;
+  /** The raw, unparsed argument string exactly as produced by the model. */
   rawArgs: string;
   toolCallId: string;
   callId?: string;
@@ -25,10 +28,18 @@ export type ToolApprovalContext<Args = unknown> = {
   run: ToolApprovalRunContext;
 };
 
+/** An approval demand, with an optional human-readable reason. */
 export type ToolApprovalRequirement = {
   reason?: string | undefined;
 };
 
+/**
+ * Whether a tool call needs human approval before execution:
+ *
+ * - `boolean`: a static requirement
+ * - `ToolApprovalRequirement`: a requirement with a reason
+ * - a function: evaluated per call, receiving the parsed args and call context
+ */
 export type ToolRequiresApproval<Args = unknown> =
   | boolean
   | ToolApprovalRequirement
@@ -37,17 +48,26 @@ export type ToolRequiresApproval<Args = unknown> =
       context: ToolApprovalContext<Args>,
     ) => boolean | ToolApprovalRequirement | Promise<boolean | ToolApprovalRequirement>);
 
+/** A child-agent event forwarded through a tool into the parent run's stream. */
 export type ToolCallStreamEvent = {
   agentId: string;
   agentName?: string | undefined;
   event: unknown;
 };
 
+/** Execution context handed to a tool when the run invokes it. */
 export type ToolCallContext = {
+  /** Emits a child-agent event into the parent run's stream. */
   emitStreamEvent?(event: ToolCallStreamEvent): void | Promise<void>;
+  /** Aborted when the run is cancelled or the stream consumer leaves. */
   abortSignal?: AbortSignal | undefined;
 };
 
+/**
+ * A model-callable tool. `definition` builds the model-facing JSON description,
+ * `call` executes it, and the optional `parseInput` converts raw model-supplied
+ * JSON arguments into the typed `Args` before `call` runs.
+ */
 export interface Tool<Args = unknown, Output = unknown> {
   readonly name: string;
   readonly requiresApproval?: ToolRequiresApproval<Args>;
@@ -56,19 +76,27 @@ export interface Tool<Args = unknown, Output = unknown> {
   parseInput?(args: JsonValue): Args;
 }
 
+/** A tool with its argument and output types erased, e.g. as stored in an agent's catalog. */
 export type AnyTool = Omit<Tool<unknown, unknown>, "requiresApproval"> & {
   readonly requiresApproval?: unknown;
 };
 
 const richToolOutput: unique symbol = Symbol.for("anvia.tool-output.content");
 
+/**
+ * A tool result carrying mixed content parts (text, files), created with
+ * {@link ToolOutput.content}. The brand symbol keeps plain objects from
+ * impersonating rich outputs.
+ */
 export type RichToolOutput = Readonly<{
   [richToolOutput]: true;
   content: readonly ToolResultContentPart[];
 }>;
 
+/** Normalized tool result as stored in tool messages. */
 export type NormalizedToolOutput = ToolResultOutput;
 
+/** Thrown when a tool returns a value that cannot be represented as a tool result. */
 export class ToolResultSerializationError extends TypeError {
   constructor(readonly output: unknown) {
     super("Tool output must be a string, a strict JSON value, or ToolOutput.content(...).");
@@ -76,12 +104,19 @@ export class ToolResultSerializationError extends TypeError {
   }
 }
 
+/** Helpers for building tool results. */
 export const ToolOutput = {
+  /** Wraps content parts so a tool can return text and files together. */
   content(content: readonly ToolResultContentPart[]): RichToolOutput {
     return { [richToolOutput]: true, content };
   },
 };
 
+/**
+ * Coerces a tool's return value into a normalized result: strings become text,
+ * rich outputs are validated, and strict JSON values become JSON results.
+ * Anything else throws {@link ToolResultSerializationError}.
+ */
 export function normalizeToolResultOutput(output: unknown): NormalizedToolOutput {
   if (typeof output === "string") {
     return { type: "text", value: output };
@@ -114,6 +149,7 @@ export function normalizeToolResultOutput(output: unknown): NormalizedToolOutput
   throw new ToolResultSerializationError(output);
 }
 
+/** Renders tool result content as text; file parts become `[file:<mediaType>]` placeholders. */
 export function toolResultContentToText(content: readonly ToolResultContentPart[]): string {
   return content
     .map((item) => (item.type === "text" ? item.text : `[file:${item.mediaType}]`))
@@ -125,6 +161,7 @@ function isRichToolOutput(value: unknown): value is RichToolOutput {
   return Object.getOwnPropertyDescriptor(value, richToolOutput)?.value === true;
 }
 
+/** Parses and JSON-validates the raw argument string supplied by the model. */
 export function parseToolArgs(args: string): JsonValue {
   const value: unknown = JSON.parse(args);
   if (!isJsonValue(value)) {

--- a/packages/core/src/tool/tool.ts
+++ b/packages/core/src/tool/tool.ts
@@ -20,7 +20,7 @@ export type ToolApprovalRunContext = {
 export type ToolApprovalContext<Args = unknown> = {
   toolName: string;
   args: Args;
-  /** The raw, unparsed argument string exactly as produced by the model. */
+  /** The serialized argument string passed to hooks and approval checks. */
   rawArgs: string;
   toolCallId: string;
   callId?: string;


### PR DESCRIPTION
## Summary

Adds JSDoc to the public API surface of `@anvia/core` and records the convention in CONTRIBUTING.md, so editor hover documentation stays useful for consumers (provider/vector adapters, react, studio, cookbook users).

## What changed

**Documented modules (comment-only, zero code changes):**
- `packages/core/src/completion/types.ts` — content parts, message types, tool/usage types, `CompletionModel` contracts, stream events
- `packages/core/src/agent/run-types.ts` — `AgentInput` modes, `AgentOutcome` variants, stream event family, `AgentStream` semantics
- `packages/core/src/tool/tool.ts` — `Tool` interface, approval types, `ToolOutput`/output normalization
- `packages/core/src/memory/types.ts` — `MemoryStore`, save policies, compaction capability and options
- `packages/core/src/hooks/types.ts` — `AgentHook` lifecycle, hook actions and control surfaces

**Convention (CONTRIBUTING.md, new "JSDoc Convention" section):**
- One concise intent-focused line per exported symbol; never restate the name
- Property docs only for non-obvious defaults (`@default`), conditional behavior, invariants, or deprecations (with migration snippet)
- Discriminated unions get a bullet list per variant
- Never guess semantics — verify in code or omit
- `internal/**` and private helpers stay undocumented unless genuinely non-obvious

`packages/core/src/completion/types.ts` serves as the reference example.

## Notes

- Documentation verified against implementation while writing (e.g. `AgentStream` single-consumption/early-cancel semantics, `Usage.add` details-merge behavior, `Document.additionalProps` serialization, `traceRequest` error swallowing) — not inferred from types alone.
- Comment-only change: no behavior change, so no changeset.

## Validation

- `pnpm --filter @anvia/core typecheck` ✅
- `pnpm --filter @anvia/core test` ✅ (662/662)
- `oxfmt --check` and `oxlint` on all five files ✅