### PR TITLE
fix(ci): add explicit permissions to browser-image build job

### DIFF
--- a/.github/workflows/browser-image.yml
+++ b/.github/workflows/browser-image.yml
@@ -25,6 +25,8 @@ jobs:
   build:
     name: Build browser image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

This PR adds an explicit `permissions` block to the `build` job in the browser-image workflow to follow the principle of least privilege in GitHub Actions.

Currently, the `build` job inherits default repository permissions, which include write access to repository contents and pull requests. The job only needs read access to check out code and run Docker builds. The `publish` job already has explicit permissions defined (`contents: read` + `packages: write`), but the `build` job was missing this security hardening.

## What Changed

**File:** `.github/workflows/browser-image.yml`

Added explicit permissions to the `build` job:

```yaml
jobs:
  build:
    name: Build browser image
    runs-on: ubuntu-latest
    permissions:
      contents: read  # Only read access needed for checkout and build

    steps:
      - name: Checkout
```

This aligns the `build` job with GitHub Actions security best practices and matches the explicit permissions pattern already used in the `publish` job (lines 75-77) and across other workflows in the repository (`.github/workflows/ci.yml` line 12, `.github/workflows/release.yml` line 20).

## Why This Matters

**Security hardening:** GitHub Actions jobs without explicit permissions inherit the default `GITHUB_TOKEN` permissions configured at the repository or organization level. In many configurations, this includes write access to repository contents, issues, pull requests, and other resources. By explicitly declaring `contents: read`, we:

1. **Minimize attack surface:** If the build job or any of its dependencies were compromised, the attacker would only have read access to the repository, not write access.
2. **Follow least privilege:** The job only requests the minimum permissions needed to perform its work (checkout and Docker build).
3. **Improve auditability:** Explicit permissions make it immediately clear what access each job has without needing to check repository settings.
4. **Match existing patterns:** The `publish` job and other workflows in the repository already use explicit permissions, making this change a consistency improvement.

## Validation

### Commands Run

```bash
# Verified only the workflow file was modified
git diff .github/workflows/browser-image.yml

# Confirmed no unrelated files staged
git status --short
git diff --name-only
git diff --cached --name-only

# Verified commit contains only the workflow change
git show --stat HEAD
```

### What Was Validated

✅ **File changes:** Only `.github/workflows/browser-image.yml` was modified  
✅ **Commit cleanliness:** No generated files, no formatting changes
✅ **Git history:** Single focused commit with conventional commit format  
✅ **Permissions syntax:** YAML syntax matches existing patterns in other workflows

### What Will Be Validated By CI

1. **Workflow execution:** GitHub Actions will validate the workflow runs successfully with the new permissions on PRs and pushes  
2. **Docker build:** The build job will verify it can still checkout code and build the browser image  
3. **Integration:** The publish job (which depends on build) will verify the workflow chain still functions

No local validation can fully test GitHub Actions permission changes—they must be validated in the GitHub Actions environment itself.

## Known Limitations and Follow-up Work

**No functional change:** This PR only changes permissions declarations. The build job's behavior remains identical because it already only performed read operations.

**Other workflows:** This PR only addresses the browser-image workflow. Similar permission hardening could be applied to other workflows as follow-up work if desired, though `.github/workflows/ci.yml` and `.github/workflows/release.yml` already have explicit permissions on their jobs.

**Repository-level default:** This change is orthogonal to the repository's default `GITHUB_TOKEN` permission settings. Even if the repository default is changed to restrictive settings in the future, explicit declarations are still preferred for clarity and defense-in-depth.

## Testing Notes

This change will be validated by:

1. **CI on this PR:** The workflow will run on this PR's branch to verify the permissions work correctly
2. **Build verification:** Docker image build will proceed normally with read-only access
3. **Integration test:** The publish job (on push to main or workflow_dispatch) will verify the workflow chain

No additional testing infrastructure is required. The change is validated by the workflow running successfully in CI.

## References

- **GitHub Actions security hardening:** [GitHub Docs - Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-permissions)
- **Principle of least privilege:** Only grant the minimum permissions necessary for the job to function
- **Similar patterns in repo:**
  - `.github/workflows/ci.yml` line 11-12: `permissions: contents: read`
  - `.github/workflows/release.yml` line 19-20: `permissions: contents: read`
  - `.github/workflows/browser-image.yml` line 75-77: `permissions: contents: read, packages: write` (publish job)

## Checklist

- [x] Change is scoped to a single focused improvement
- [x] No dependencies changed (`pnpm-lock.yaml` unchanged)
- [x] No generated files modified
- [x] Follows existing workflow patterns in the repository
- [x] Commit follows conventional commit format
- [x] No breaking changes
- [x] No migration needed