### PR TITLE
fix(langfuse): reject non-finite numeric score values

### DIFF
--- a/.changeset/langfuse-finite-score.md
+++ b/.changeset/langfuse-finite-score.md
@@ -1,0 +1,5 @@
+---
+"@anvia/langfuse": patch
+---
+
+Reject non-finite numeric score values (`NaN`, `Infinity`) in `LangfuseClient.score()` instead of serializing them as `null` in the score request body, matching the existing OpenTelemetry score validation.

--- a/packages/observability-langfuse/src/tracing.ts
+++ b/packages/observability-langfuse/src/tracing.ts
@@ -520,6 +520,9 @@ function scoreMaxAttempts(retries: { maxAttempts: number } | undefined): number 
 }
 
 function assertScoreValue(value: number | string, dataType: LangfuseScoreArgs["dataType"]): void {
+  if (typeof value === "number" && !Number.isFinite(value)) {
+    throw new TypeError(`Langfuse score value must be finite`);
+  }
   if (dataType === "NUMERIC") {
     if (typeof value !== "number") {
       throw new TypeError(`Langfuse score dataType=NUMERIC requires a number value`);

--- a/packages/observability-langfuse/test/langfuse.test.ts
+++ b/packages/observability-langfuse/test/langfuse.test.ts
@@ -1637,6 +1637,35 @@ describe("langfuse", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it("rejects non-finite numeric score values", async () => {
+    const tracing = new LangfuseClient({ publicKey: "pk", secretKey: "sk" });
+
+    await expect(
+      tracing.score({
+        traceId: "trace-1",
+        name: "quality",
+        value: Number.NaN,
+        dataType: "NUMERIC",
+      }),
+    ).rejects.toThrow(/finite/);
+    await expect(
+      tracing.score({
+        traceId: "trace-1",
+        name: "quality",
+        value: Number.POSITIVE_INFINITY,
+        dataType: "NUMERIC",
+      }),
+    ).rejects.toThrow(/finite/);
+    await expect(
+      tracing.score({
+        traceId: "trace-1",
+        name: "quality",
+        value: Number.NaN,
+      }),
+    ).rejects.toThrow(/finite/);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("sends configId and accepts scoreConfigId as an alias", async () => {
     const tracing = new LangfuseClient({ publicKey: "pk", secretKey: "sk" });
 


### PR DESCRIPTION
## What this fixes

`LangfuseClient.score()` accepted `NaN` and `Infinity` for numeric scores. The validation in `assertScoreValue` only checked `typeof value !== "number"`, and both values pass that check. They then hit `JSON.stringify` on the way out, which serializes them to `null`, so the request body sent to `POST /api/public/scores` contained `"value": null`. Depending on the Langfuse side that either stores a null score or fails the batch with a 400, and either way the caller never learns their metric computation produced garbage. A division by zero in a custom eval metric is all it takes to get there.

There is a second gap in the same function: when `dataType` is omitted, none of the three branches matched, so no value validation ran at all. A NaN score without an explicit `dataType` went straight into the score queue.

## What changed

`assertScoreValue` in `packages/observability-langfuse/src/tracing.ts` now starts with a finite check before the per-`dataType` branches:

```ts
if (typeof value === "number" && !Number.isFinite(value)) {
  throw new TypeError(`Langfuse score value must be finite`);
}
```

This mirrors how `@anvia/otel` validates the same input in its score path (`packages/observability-otel/src/scoring.ts` throws `OpenTelemetry score value must be finite`), so the two observability adapters now behave the same way. Because the check runs before the `dataType` branches, it covers explicit `NUMERIC` scores and the unspecified-`dataType` path in one place. The `BOOLEAN` branch already rejected NaN implicitly since it only allows `0` or `1`, so behavior there is unchanged apart from the error message.

## Tests

Added `rejects non-finite numeric score values` to `packages/observability-langfuse/test/langfuse.test.ts`. It covers three cases: `NaN` with `dataType: "NUMERIC"`, `Infinity` with `dataType: "NUMERIC"`, and `NaN` with no `dataType`. Each case also asserts nothing reached `fetch`, consistent with the neighboring validation tests. I confirmed the test fails against the old code (`promise resolved "undefined" instead of rejecting`) and passes after the fix, so it actually pins the behavior.

Also added a changeset: patch bump for `@anvia/langfuse`.

## Compatibility

This changes behavior for anyone who was scoring with non-finite numbers, but the previous behavior was to silently send `value: null` to the API, which is hard to call a feature. Callers passing finite numbers see no difference. If a workflow somehow depended on NaN scores reaching Langfuse, the fix on their side is to compute a finite value or record a categorical score instead. No public API surface changed and no dependencies were touched.

## Validation

- `pnpm --filter @anvia/langfuse test` → 154/154 passing (2 test files)
- `pnpm --filter @anvia/langfuse typecheck` → clean
- `oxlint` on the two changed files → 0 warnings, 0 errors
- `oxfmt --check` on the changed files passes on LF content. My local Windows checkout is CRLF repo-wide (an untouched file fails the same check), so the meaningful signal is that the LF-normalized files are format-clean; CI on Linux will see the same.