### PR TITLE
fix(studio): omit stack traces from persisted trace payloads

### DIFF
--- a/.changeset/studio-trace-error-stack.md
+++ b/.changeset/studio-trace-error-stack.md
@@ -1,0 +1,5 @@
+---
+"@anvia/studio": patch
+---
+
+Stop persisting stack traces in Studio trace error payloads. Trace observations and run errors were serialized with `serializeUnknown`, which keeps `error.stack`; they now use the stack-free `serializeError` helper, so persisted traces and trace API responses contain only the error name and message.

--- a/packages/tool-studio/src/traces/trace-observer.ts
+++ b/packages/tool-studio/src/traces/trace-observer.ts
@@ -17,11 +17,8 @@ import type {
   AgentToolStreamEventArgs,
   AgentToolSuspendedArgs,
 } from "@anvia/core/observability";
-import {
-  compactJsonObject,
-  serializeUnknown as serializeError,
-  toJsonValue,
-} from "../runtime/json";
+import { serializeError } from "../runtime/errors";
+import { compactJsonObject, toJsonValue } from "../runtime/json";
 import type {
   StudioTrace,
   StudioTraceObservation,

--- a/packages/tool-studio/test/trace-observer.test.ts
+++ b/packages/tool-studio/test/trace-observer.test.ts
@@ -66,4 +66,48 @@ describe("StudioTraceObserver", () => {
       ]),
     );
   });
+
+  it("omits stack traces from persisted error payloads", async () => {
+    let savedTrace: StudioTrace | undefined;
+    const store: StudioTraceStore = {
+      listSessionTraces: () => [],
+      getTrace: () => undefined,
+      saveTrace(trace) {
+        savedTrace = trace;
+        return trace;
+      },
+    };
+    const observer = new StudioTraceObserver({ store });
+    const run = observer.startRun({
+      runId: "run_error",
+      prompt: Message.user("boom"),
+      history: [],
+      maxTurns: 1,
+      trace: { sessionId: "session_1" },
+    });
+    const toolArgs: AgentToolStartArgs = {
+      turn: 1,
+      toolCall: AssistantContent.toolCall("call_tool", "explode", { prompt: "boom" }),
+      toolName: "explode",
+      args: '{"prompt":"boom"}',
+      internalCallId: "internal_tool",
+      toolCallId: "call_tool",
+    };
+    const tool = await run.startTool?.(toolArgs);
+
+    await tool?.error?.({ ...toolArgs, error: new Error("tool boom") });
+    await run.error?.({
+      status: "failed",
+      error: new Error("run boom"),
+      usage: Usage.empty(),
+      messages: [Message.user("boom")],
+    });
+
+    expect(savedTrace?.error).toEqual({ name: "Error", message: "run boom" });
+    const toolErrorObservation = savedTrace?.observations.find(
+      (observation) => observation.kind === "tool" && observation.name === "explode",
+    );
+    expect(toolErrorObservation?.error).toEqual({ name: "Error", message: "tool boom" });
+    expect(JSON.stringify(savedTrace)).not.toContain('"stack"');
+  });
 });


### PR DESCRIPTION
## Summary

Studio's trace observer persisted full stack traces into saved traces. Every error path through an agent run (generation errors, tool errors, run failures, and nested agent errors) serialized its error with a helper that keeps `error.stack`, and those payloads go straight into SQLite storage and come back verbatim from the `GET /traces` routes. Internal file paths and framework internals therefore end up baked into trace data that sticks around locally and is served through the trace API.

Route error responses already serialize without stacks. The trace observer simply imported the wrong helper: it aliased `serializeUnknown` from `runtime/json.ts` as `serializeError`, while the actual stack-free `serializeError` helper lives in `runtime/errors.ts` (the same one route error responses use, from #405). This PR points the observer at the right helper.

## What changed

- `packages/tool-studio/src/traces/trace-observer.ts`: import `serializeError` from `../runtime/errors` instead of aliasing `serializeUnknown` from `../runtime/json`. All four call sites (generation error, tool error, run error, nested agent error) already call `serializeError`, so the import swap covers every path with no call-site edits. For `Error` instances the payload becomes `{ name, message }`; non-Error throwables (strings, plain objects) fall through to the same JSON conversion as before.
- `packages/tool-studio/test/trace-observer.test.ts`: new test that drives a tool error and a run error with plain `Error` instances, asserts the persisted payloads equal `{ name, message }`, and asserts no `"stack"` key appears anywhere in the saved trace. It failed against the old import and passes after the swap.
- `.changeset/studio-trace-error-stack.md`: patch changeset for `@anvia/studio`.

## Validation

Run on Windows 11 with pnpm 11.0.4:

```sh
pnpm --filter @anvia/studio typecheck   # build:deps + tsc --noEmit, passes
pnpm --filter @anvia/studio exec vitest run test/trace-observer.test.ts test/trace-browser.test.ts test/studio-routes.test.ts   # 13 passed
pnpm --filter @anvia/studio test        # 235 passed, 9 failed
```

The 9 failures are pre-existing and unrelated. They are all in `test/runner.test.ts` (Windows-only SQLite persistence tests) and fail with identical names on `main` without this change.

`pnpm check` and `pnpm format` were skipped locally because a CRLF checkout breaks them on Windows; repo CI runs lint and format on Linux. No screenshots since nothing visible changes in the UI, the trace payloads just get smaller.

## Compatibility notes

- `StudioTrace.error` and observation `error` fields keep their `JsonValue` types, so nothing breaks at the type level. The runtime change is that `Error` values no longer carry a `stack` entry in persisted traces or trace API responses. Consumers that parse these payloads will see slightly smaller objects; anyone who genuinely needs the stack for local debugging would have to run the server in a debugger instead.
- `pnpm-lock.yaml` is untouched, there are no dependency updates, no new package exports, and no generated files in the diff.

Happy to keep stacks behind an opt-in debug flag instead if maintainers would rather have them available locally, but my leaning is that trace payloads do not need them now that route responses already omit them.