### PR TITLE
feat(core): accept any Standard Schema as structured outputSchema

### DIFF
--- a/.changeset/standard-schema-output.md
+++ b/.changeset/standard-schema-output.md
@@ -1,0 +1,18 @@
+---
+"@anvia/core": minor
+---
+
+Accept any Standard Schema as the `outputSchema` of `generateCompletion` and `streamCompletion`.
+Zod schemas keep their existing behavior; Valibot schemas now work end to end when the optional
+peer dependency `@valibot/to-json-schema` is installed. Other Standard Schema libraries are
+supported when they implement the Standard JSON Schema interface (`~standard.jsonSchema`); vendor
+conversion support is resolved by `~standard.vendor`. Schemas without conversion support fail
+before any model call with a descriptive error.
+
+Output validation now runs through the schema's `~standard.validate`, so schemas that validate
+asynchronously are rejected with a `CompletionStructuredOutputError` in the `schema` phase instead
+of being limited to Zod.
+
+Exports `StandardSchemaV1`, `StandardJSONSchemaV1`, and `isStandardSchema` from the root entrypoint.
+`streamCompletion` keeps its eager abort, streaming, input, and capability checks; only JSON Schema
+conversions that require loading a vendor converter are deferred to the first stream pull.

--- a/.changeset/standard-schema-output.md
+++ b/.changeset/standard-schema-output.md
@@ -9,6 +9,14 @@ supported when they implement the Standard JSON Schema interface (`~standard.jso
 conversion support is resolved by `~standard.vendor`. Schemas without conversion support fail
 before any model call with a descriptive error.
 
+Transformed schemas whose validation input and output differ (for example `string -> number`) are
+supported. Providers receive the schema's input representation — the raw response is what
+`~standard.validate` accepts — while the validated, possibly transformed value becomes the
+completion output. Generic and Valibot conversion always describe the input side; Zod conversion
+prefers the output side when representable (keeping strict-object refinements such as
+`additionalProperties: false` for provider strict modes) and falls back to the input side for
+transformed schemas, which previously failed conversion.
+
 Output validation now runs through the schema's `~standard.validate`, so schemas that validate
 asynchronously are rejected with a `CompletionStructuredOutputError` in the `schema` phase instead
 of being limited to Zod.

--- a/.changeset/standard-schema-output.md
+++ b/.changeset/standard-schema-output.md
@@ -13,9 +13,10 @@ Transformed schemas whose validation input and output differ (for example `strin
 supported. Providers receive the schema's input representation — the raw response is what
 `~standard.validate` accepts — while the validated, possibly transformed value becomes the
 completion output. Generic and Valibot conversion always describe the input side; Zod conversion
-prefers the output side when representable (keeping strict-object refinements such as
-`additionalProperties: false` for provider strict modes) and falls back to the input side for
-transformed schemas, which previously failed conversion.
+uses the output side only when it describes the same accepted values as the input side (keeping
+strict-object refinements such as `additionalProperties: false` for provider strict modes) and
+falls back to the input side otherwise, including transformed and piped schemas which previously
+failed conversion.
 
 Output validation now runs through the schema's `~standard.validate`, so schemas that validate
 asynchronously are rejected with a `CompletionStructuredOutputError` in the `schema` phase instead

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -320,6 +320,14 @@ const result = await generateCompletion({
 console.log(result.output.priority); // fully typed
 ```
 
+`outputSchema` accepts any [Standard Schema](https://standardschema.dev) — Zod, Valibot, ArkType, and
+other implementing libraries. Zod uses its built-in JSON Schema conversion. Valibot requires the
+optional converter `@valibot/to-json-schema` (install it alongside `valibot`); unsupported Valibot
+actions surface as conversion errors before any model call. Other libraries must either implement
+the Standard JSON Schema interface (`~standard.jsonSchema`) or convert to a supported library.
+Schema validation of the provider output is synchronous; asynchronous schemas are rejected with a
+`CompletionStructuredOutputError` in the `schema` phase.
+
 `CompletionResult` consistently contains `output`, the original `text`, normalized `content`,
 `usage`, and `rawResponse`, plus optional message, context, source, provider-tool, and finish-reason
 metadata. First-party adapters normalize provider termination into `finishReason` (`stop`, `length`,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -328,10 +328,12 @@ unsupported Valibot actions surface as conversion errors before any model call. 
 must either implement the Standard JSON Schema interface (`~standard.jsonSchema`) or convert to a
 supported library. Providers receive the schema's input representation — the raw response is what
 `~standard.validate` accepts — while the validated, possibly transformed value becomes
-`result.output`. For Zod, the output representation is preferred when representable because it
-carries strict-object refinements (`additionalProperties: false`) that provider strict modes such
-as OpenAI structured outputs require. Schema validation of the provider output is synchronous;
-asynchronous schemas are rejected with a `CompletionStructuredOutputError` in the `schema` phase.
+`result.output`. For Zod, the output representation is used only when it describes the same
+accepted values as the input side, so its strict-object refinements (`additionalProperties:
+false`, required by provider strict modes such as OpenAI structured outputs) are preserved;
+otherwise the input representation is sent. Schema validation of the provider output is
+synchronous; asynchronous schemas are rejected with a `CompletionStructuredOutputError` in the
+`schema` phase.
 
 `CompletionResult` consistently contains `output`, the original `text`, normalized `content`,
 `usage`, and `rawResponse`, plus optional message, context, source, provider-tool, and finish-reason

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -321,12 +321,17 @@ console.log(result.output.priority); // fully typed
 ```
 
 `outputSchema` accepts any [Standard Schema](https://standardschema.dev) — Zod, Valibot, ArkType, and
-other implementing libraries. Zod uses its built-in JSON Schema conversion. Valibot requires the
-optional converter `@valibot/to-json-schema` (install it alongside `valibot`); unsupported Valibot
-actions surface as conversion errors before any model call. Other libraries must either implement
-the Standard JSON Schema interface (`~standard.jsonSchema`) or convert to a supported library.
-Schema validation of the provider output is synchronous; asynchronous schemas are rejected with a
-`CompletionStructuredOutputError` in the `schema` phase.
+other implementing libraries, including transformed schemas whose validation input and output
+differ (for example `string -> number`). Zod uses its built-in JSON Schema conversion. Valibot
+requires the optional converter `@valibot/to-json-schema` (install it alongside `valibot`);
+unsupported Valibot actions surface as conversion errors before any model call. Other libraries
+must either implement the Standard JSON Schema interface (`~standard.jsonSchema`) or convert to a
+supported library. Providers receive the schema's input representation — the raw response is what
+`~standard.validate` accepts — while the validated, possibly transformed value becomes
+`result.output`. For Zod, the output representation is preferred when representable because it
+carries strict-object refinements (`additionalProperties: false`) that provider strict modes such
+as OpenAI structured outputs require. Schema validation of the provider output is synchronous;
+asynchronous schemas are rejected with a `CompletionStructuredOutputError` in the `schema` phase.
 
 `CompletionResult` consistently contains `output`, the original `text`, normalized `content`,
 `usage`, and `rawResponse`, plus optional message, context, source, provider-tool, and finish-reason

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -118,12 +118,20 @@
     "yaml": "^2.9.0"
   },
   "peerDependencies": {
+    "@valibot/to-json-schema": "^1.7.1",
     "zod": "^4.4.0"
+  },
+  "peerDependenciesMeta": {
+    "@valibot/to-json-schema": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/node": "^24.9.1",
+    "@valibot/to-json-schema": "^1.7.1",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
+    "valibot": "^1.5.0",
     "vitest": "^4.0.8",
     "zod": "^4.5.4"
   }

--- a/packages/core/src/completion/generate-completion.ts
+++ b/packages/core/src/completion/generate-completion.ts
@@ -103,7 +103,7 @@ export type GenerateCompletionOptions<Model extends CompletionModel = Completion
 export type GenerateStructuredCompletionOptions<
   Output,
   Model extends CompletionModel = CompletionModel,
-> = CompletionBaseOptions<Model> & { outputSchema: StandardSchemaV1<Output> };
+> = CompletionBaseOptions<Model> & { outputSchema: StandardSchemaV1<unknown, Output> };
 
 export type StreamCompletionOptions<
   Model extends StreamingCompletionModel = StreamingCompletionModel,
@@ -213,10 +213,10 @@ function resolveOptionalRetries(
 async function* streamCompletionWithRetries<Output, Model extends StreamingCompletionModel>(
   model: Model,
   initialRequest: CompletionRequest,
-  pendingSchema: StandardSchemaV1<Output> | undefined,
+  pendingSchema: StandardSchemaV1<unknown, Output> | undefined,
   retries: ResolvedRetryOptions | undefined,
   abortSignal: AbortSignal | undefined,
-  outputSchema: StandardSchemaV1<Output> | undefined,
+  outputSchema: StandardSchemaV1<unknown, Output> | undefined,
 ): AsyncIterable<CompletionStreamEvent<Output | string, RawResponseOf<Model>>> {
   let request = initialRequest;
   if (pendingSchema !== undefined) {
@@ -378,12 +378,12 @@ function requestFromOptionsSync<Model extends CompletionModel, Output>(
   options: GenerateCompletionOptions<Model> | GenerateStructuredCompletionOptions<Output, Model>,
 ): {
   request: CompletionRequest;
-  pendingSchema: StandardSchemaV1<Output> | undefined;
+  pendingSchema: StandardSchemaV1<unknown, Output> | undefined;
 } {
   const input = inputFromOptions(options);
   const schema = structuredOutputSchema(options);
   let outputSchema: JsonObject | undefined;
-  let pendingSchema: StandardSchemaV1<Output> | undefined;
+  let pendingSchema: StandardSchemaV1<unknown, Output> | undefined;
   if (schema !== undefined) {
     const converted = tryToProviderJsonSchemaFromStandardSchema(schema);
     if (converted.jsonSchema !== undefined) {
@@ -427,14 +427,14 @@ function inputFromOptions(options: CompletionInput): string | readonly MessageTy
 }
 
 function structuredOutputSchema<Output>(options: {
-  outputSchema?: StandardSchemaV1<Output> | undefined;
-}): StandardSchemaV1<Output> | undefined {
+  outputSchema?: StandardSchemaV1<unknown, Output> | undefined;
+}): StandardSchemaV1<unknown, Output> | undefined {
   return options.outputSchema;
 }
 
 function resultFromResponse<Output, RawResponse>(
   response: CompletionResponse<RawResponse>,
-  outputSchema: StandardSchemaV1<Output> | undefined,
+  outputSchema: StandardSchemaV1<unknown, Output> | undefined,
 ): CompletionResult<Output | string, RawResponse> {
   const text = textFromAssistantContent(response.choice);
   const result: CompletionResult<Output | string, RawResponse> = {
@@ -459,7 +459,7 @@ function resultFromResponse<Output, RawResponse>(
 
 function parseCompletionOutput<Output, RawResponse>(
   text: string,
-  schema: StandardSchemaV1<Output>,
+  schema: StandardSchemaV1<unknown, Output>,
   response: CompletionResponse<RawResponse>,
 ): Output {
   if (response.finishReason === "content-filter") {

--- a/packages/core/src/completion/generate-completion.ts
+++ b/packages/core/src/completion/generate-completion.ts
@@ -10,7 +10,15 @@ import {
   retryOptionsForFailure,
   waitForRetry,
 } from "../retry";
-import { toProviderJsonSchema, type ZodSchema } from "../schema/zod-schema";
+import {
+  toProviderJsonSchemaFromStandardSchema,
+  tryToProviderJsonSchemaFromStandardSchema,
+} from "../schema/standard-json-schema";
+import {
+  formatStandardSchemaIssues,
+  type StandardSchemaV1,
+  validateStandardSchema,
+} from "../schema/standard-schema";
 import { isJsonValue } from "./json";
 import {
   assertCompletionResponseIntegrity,
@@ -95,7 +103,7 @@ export type GenerateCompletionOptions<Model extends CompletionModel = Completion
 export type GenerateStructuredCompletionOptions<
   Output,
   Model extends CompletionModel = CompletionModel,
-> = CompletionBaseOptions<Model> & { outputSchema: ZodSchema<Output> };
+> = CompletionBaseOptions<Model> & { outputSchema: StandardSchemaV1<Output> };
 
 export type StreamCompletionOptions<
   Model extends StreamingCompletionModel = StreamingCompletionModel,
@@ -119,7 +127,7 @@ export async function generateCompletion<Output, Model extends CompletionModel>(
   options: GenerateCompletionOptions<Model> | GenerateStructuredCompletionOptions<Output, Model>,
 ): Promise<CompletionResult<Output | string, RawResponseOf<Model>>> {
   throwIfAborted(options.abortSignal);
-  const request = requestFromOptions(options);
+  const request = await requestFromOptions(options);
   assertCompletionRequestSupported(options.model, request);
   const retries = resolveOptionalRetries(options.retries);
   const response = await sendCompletion(options.model, request, retries, options.abortSignal);
@@ -136,15 +144,24 @@ export function streamCompletion<Output, Model extends StreamingCompletionModel>
   options: StreamCompletionOptions<Model> | StreamStructuredCompletionOptions<Output, Model>,
 ): AsyncIterable<CompletionStreamEvent<Output | string, RawResponseOf<Model>>> {
   throwIfAborted(options.abortSignal);
-  const request = requestFromOptions(options);
   if (!isStreamingCompletionModel(options.model) || !options.model.capabilities.streaming) {
     throw new Error("This completion model does not support streaming");
   }
-  assertCompletionRequestSupported(options.model, request, { streaming: true });
+  const { request, pendingSchema } = requestFromOptionsSync(options);
+  // Schemas whose JSON Schema conversion is deferred still count as an output
+  // schema for capability validation.
+  assertCompletionRequestSupported(
+    options.model,
+    pendingSchema === undefined
+      ? request
+      : { ...request, outputSchema: request.outputSchema ?? {} },
+    { streaming: true },
+  );
   const retries = resolveOptionalRetries(options.retries);
   return streamCompletionWithRetries(
     options.model,
     request,
+    pendingSchema,
     retries,
     options.abortSignal,
     structuredOutputSchema(options),
@@ -195,11 +212,19 @@ function resolveOptionalRetries(
 
 async function* streamCompletionWithRetries<Output, Model extends StreamingCompletionModel>(
   model: Model,
-  request: CompletionRequest,
+  initialRequest: CompletionRequest,
+  pendingSchema: StandardSchemaV1<Output> | undefined,
   retries: ResolvedRetryOptions | undefined,
   abortSignal: AbortSignal | undefined,
-  outputSchema: ZodSchema<Output> | undefined,
+  outputSchema: StandardSchemaV1<Output> | undefined,
 ): AsyncIterable<CompletionStreamEvent<Output | string, RawResponseOf<Model>>> {
+  let request = initialRequest;
+  if (pendingSchema !== undefined) {
+    request = {
+      ...request,
+      outputSchema: await toProviderJsonSchemaFromStandardSchema(pendingSchema),
+    };
+  }
   let attempt = 1;
   let swallowedUsage = Usage.empty();
   const callOptions = modelCallOptions(abortSignal);
@@ -338,11 +363,36 @@ async function* streamCompletionWithRetries<Output, Model extends StreamingCompl
   }
 }
 
-function requestFromOptions<Model extends CompletionModel, Output>(
+async function requestFromOptions<Model extends CompletionModel, Output>(
   options: GenerateCompletionOptions<Model> | GenerateStructuredCompletionOptions<Output, Model>,
-): CompletionRequest {
+): Promise<CompletionRequest> {
+  const { request, pendingSchema } = requestFromOptionsSync(options);
+  if (pendingSchema === undefined) return request;
+  return {
+    ...request,
+    outputSchema: await toProviderJsonSchemaFromStandardSchema(pendingSchema),
+  };
+}
+
+function requestFromOptionsSync<Model extends CompletionModel, Output>(
+  options: GenerateCompletionOptions<Model> | GenerateStructuredCompletionOptions<Output, Model>,
+): {
+  request: CompletionRequest;
+  pendingSchema: StandardSchemaV1<Output> | undefined;
+} {
   const input = inputFromOptions(options);
-  return createCompletionRequest(input, {
+  const schema = structuredOutputSchema(options);
+  let outputSchema: JsonObject | undefined;
+  let pendingSchema: StandardSchemaV1<Output> | undefined;
+  if (schema !== undefined) {
+    const converted = tryToProviderJsonSchemaFromStandardSchema(schema);
+    if (converted.jsonSchema !== undefined) {
+      outputSchema = converted.jsonSchema;
+    } else {
+      pendingSchema = schema;
+    }
+  }
+  const request = createCompletionRequest(input, {
     instructions: options.instructions,
     documents: options.documents,
     tools: options.tools,
@@ -351,11 +401,9 @@ function requestFromOptions<Model extends CompletionModel, Output>(
     toolChoice: options.toolChoice,
     controls: options.controls,
     providerOptions: options.providerOptions,
-    outputSchema:
-      "outputSchema" in options && options.outputSchema !== undefined
-        ? toProviderJsonSchema(options.outputSchema)
-        : undefined,
+    outputSchema,
   });
+  return { request, pendingSchema };
 }
 
 function inputFromOptions(options: CompletionInput): string | readonly MessageType[] {
@@ -379,14 +427,14 @@ function inputFromOptions(options: CompletionInput): string | readonly MessageTy
 }
 
 function structuredOutputSchema<Output>(options: {
-  outputSchema?: ZodSchema<Output> | undefined;
-}): ZodSchema<Output> | undefined {
+  outputSchema?: StandardSchemaV1<Output> | undefined;
+}): StandardSchemaV1<Output> | undefined {
   return options.outputSchema;
 }
 
 function resultFromResponse<Output, RawResponse>(
   response: CompletionResponse<RawResponse>,
-  outputSchema: ZodSchema<Output> | undefined,
+  outputSchema: StandardSchemaV1<Output> | undefined,
 ): CompletionResult<Output | string, RawResponse> {
   const text = textFromAssistantContent(response.choice);
   const result: CompletionResult<Output | string, RawResponse> = {
@@ -411,7 +459,7 @@ function resultFromResponse<Output, RawResponse>(
 
 function parseCompletionOutput<Output, RawResponse>(
   text: string,
-  schema: ZodSchema<Output>,
+  schema: StandardSchemaV1<Output>,
   response: CompletionResponse<RawResponse>,
 ): Output {
   if (response.finishReason === "content-filter") {
@@ -448,8 +496,9 @@ function parseCompletionOutput<Output, RawResponse>(
       cause: error,
     });
   }
+  let validation: ReturnType<typeof validateStandardSchema<Output>>;
   try {
-    return schema.parse(json);
+    validation = validateStandardSchema(schema, json);
   } catch (error) {
     throw new CompletionStructuredOutputError({
       phase: "schema",
@@ -460,6 +509,17 @@ function parseCompletionOutput<Output, RawResponse>(
       cause: error,
     });
   }
+  if (!validation.success) {
+    throw new CompletionStructuredOutputError({
+      phase: "schema",
+      outputLength: text.length,
+      usage: response.usage,
+      finishReason: response.finishReason,
+      providerFinishReason: response.providerFinishReason,
+      cause: new Error(formatStandardSchemaIssues(validation.issues)),
+    });
+  }
+  return validation.value;
 }
 
 function modelCallOptions(abortSignal: AbortSignal | undefined): ModelCallOptions | undefined {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -208,7 +208,8 @@ export {
 } from "./memory";
 export type { ModelCallOptions } from "./model-call-options";
 export type { RetryContext, RetryOptions, RetrySetting } from "./retry";
-export type { ZodSchema } from "./schema";
+export { isStandardSchema } from "./schema";
+export type { StandardJSONSchemaV1, StandardSchemaV1, ZodSchema } from "./schema";
 export { loadSkills, SkillValidationError, skill } from "./skills";
 export type {
   GenerateSpeechOptions,

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -1,1 +1,3 @@
+export { isStandardSchema } from "./standard-schema";
+export type { StandardJSONSchemaV1, StandardSchemaV1 } from "./standard-schema";
 export type { ZodSchema } from "./zod-schema";

--- a/packages/core/src/schema/standard-json-schema.ts
+++ b/packages/core/src/schema/standard-json-schema.ts
@@ -1,0 +1,107 @@
+import type { z } from "zod";
+import type { JsonObject } from "../completion/index";
+import type { StandardJSONSchemaV1, StandardSchemaV1 } from "./standard-schema";
+import { toProviderJsonSchema } from "./zod-schema";
+
+const JSON_SCHEMA_TARGET = "draft-2020-12";
+
+/** The outcome of converting a Standard Schema to a provider JSON Schema. */
+export type StandardSchemaJsonSchemaConversion =
+  | { readonly jsonSchema: JsonObject; readonly pendingSchema?: undefined }
+  | { readonly jsonSchema?: undefined; readonly pendingSchema: StandardSchemaV1 };
+
+/**
+ * Converts a Standard Schema to a provider JSON Schema when the conversion can
+ * happen synchronously; otherwise returns the schema as pending so callers can
+ * resolve it asynchronously with
+ * {@link toProviderJsonSchemaFromStandardSchema}.
+ */
+export function tryToProviderJsonSchemaFromStandardSchema(
+  schema: StandardSchemaV1,
+  options: { io?: "input" | "output" } = {},
+): StandardSchemaJsonSchemaConversion {
+  const props = schema["~standard"];
+  // Zod keeps its native converter so existing behavior is unchanged.
+  if (props.vendor === "zod") {
+    return { jsonSchema: toProviderJsonSchema(schema as z.ZodType, options) };
+  }
+  // Generic support for any library implementing the Standard JSON Schema spec.
+  const jsonSchema = (
+    props as {
+      jsonSchema?: StandardJSONSchemaV1["~standard"]["jsonSchema"] | undefined;
+    }
+  ).jsonSchema;
+  if (typeof jsonSchema === "object" && jsonSchema !== null) {
+    const convert = options.io === "input" ? jsonSchema.input : jsonSchema.output;
+    return { jsonSchema: toProviderJsonSchemaShape(convert({ target: JSON_SCHEMA_TARGET })) };
+  }
+  // Vendor-specific converters may need to be loaded asynchronously.
+  return { pendingSchema: schema };
+}
+
+/**
+ * Converts any supported Standard Schema to a provider JSON Schema. Synchronously
+ * convertible schemas resolve immediately; Valibot schemas load the optional
+ * `@valibot/to-json-schema` converter on first use.
+ */
+export async function toProviderJsonSchemaFromStandardSchema(
+  schema: StandardSchemaV1,
+  options: { io?: "input" | "output" } = {},
+): Promise<JsonObject> {
+  const converted = tryToProviderJsonSchemaFromStandardSchema(schema, options);
+  if (converted.jsonSchema !== undefined) return converted.jsonSchema;
+  const pending = converted.pendingSchema;
+  const vendor = pending["~standard"].vendor;
+  if (vendor === "valibot") {
+    return valibotToProviderJsonSchema(pending, options);
+  }
+  throw new Error(
+    `Structured output schemas from vendor "${vendor}" cannot be converted to a provider JSON schema. ` +
+      `Use a Zod or Valibot schema, or make the schema implement the Standard JSON Schema interface ("~standard.jsonSchema").`,
+  );
+}
+
+type ValibotToJsonSchemaModule = {
+  toJsonSchema: (
+    schema: StandardSchemaV1,
+    config?: {
+      readonly target?: "draft-07" | "draft-2020-12" | "openapi-3.0" | undefined;
+      readonly typeMode?: "ignore" | "input" | "output" | undefined;
+    },
+  ) => Record<string, unknown>;
+};
+
+let valibotToJsonSchemaModule: Promise<ValibotToJsonSchemaModule> | undefined;
+
+async function loadValibotToJsonSchema(): Promise<ValibotToJsonSchemaModule> {
+  valibotToJsonSchemaModule ??=
+    import("@valibot/to-json-schema") as unknown as Promise<ValibotToJsonSchemaModule>;
+  try {
+    return await valibotToJsonSchemaModule;
+  } catch (error) {
+    valibotToJsonSchemaModule = undefined;
+    throw new Error(
+      'The structured output schema is a Valibot schema, but "@valibot/to-json-schema" is not installed. ' +
+        "Install it to use Valibot schemas for structured output.",
+      { cause: error },
+    );
+  }
+}
+
+async function valibotToProviderJsonSchema(
+  schema: StandardSchemaV1,
+  options: { io?: "input" | "output" },
+): Promise<JsonObject> {
+  const { toJsonSchema } = await loadValibotToJsonSchema();
+  const jsonSchema = toJsonSchema(schema, {
+    target: JSON_SCHEMA_TARGET,
+    typeMode: options.io === "input" ? "input" : "output",
+  });
+  return toProviderJsonSchemaShape(jsonSchema);
+}
+
+function toProviderJsonSchemaShape(jsonSchema: Record<string, unknown>): JsonObject {
+  const { $schema: _schema, ...providerSchema } = jsonSchema;
+  // JSON Schema documents are JSON values by construction.
+  return providerSchema as JsonObject;
+}

--- a/packages/core/src/schema/standard-json-schema.ts
+++ b/packages/core/src/schema/standard-json-schema.ts
@@ -11,19 +11,26 @@ export type StandardSchemaJsonSchemaConversion =
   | { readonly jsonSchema?: undefined; readonly pendingSchema: StandardSchemaV1 };
 
 /**
- * Converts a Standard Schema to a provider JSON Schema when the conversion can
- * happen synchronously; otherwise returns the schema as pending so callers can
- * resolve it asynchronously with
+ * Converts a Standard Schema to the JSON Schema sent to providers when the
+ * conversion can happen synchronously; otherwise returns the schema as pending
+ * so callers can resolve it asynchronously with
  * {@link toProviderJsonSchemaFromStandardSchema}.
+ *
+ * Providers receive the schema's input representation: the raw provider
+ * response is what `~standard.validate` receives as its validation input,
+ * while the validated (possibly transformed) value becomes the completion
+ * output.
  */
 export function tryToProviderJsonSchemaFromStandardSchema(
   schema: StandardSchemaV1,
-  options: { io?: "input" | "output" } = {},
 ): StandardSchemaJsonSchemaConversion {
   const props = schema["~standard"];
-  // Zod keeps its native converter so existing behavior is unchanged.
+  // Zod keeps its native converter. Prefer the output representation: it
+  // validates identically for schemas without input/output differences and
+  // carries zod's strict-object refinements (additionalProperties: false)
+  // that provider strict modes such as OpenAI structured outputs require.
   if (props.vendor === "zod") {
-    return { jsonSchema: toProviderJsonSchema(schema as z.ZodType, options) };
+    return { jsonSchema: toProviderZodJsonSchema(schema as z.ZodType) };
   }
   // Generic support for any library implementing the Standard JSON Schema spec.
   const jsonSchema = (
@@ -32,28 +39,39 @@ export function tryToProviderJsonSchemaFromStandardSchema(
     }
   ).jsonSchema;
   if (typeof jsonSchema === "object" && jsonSchema !== null) {
-    const convert = options.io === "input" ? jsonSchema.input : jsonSchema.output;
-    return { jsonSchema: toProviderJsonSchemaShape(convert({ target: JSON_SCHEMA_TARGET })) };
+    return {
+      jsonSchema: toProviderJsonSchemaShape(jsonSchema.input({ target: JSON_SCHEMA_TARGET })),
+    };
   }
   // Vendor-specific converters may need to be loaded asynchronously.
   return { pendingSchema: schema };
 }
 
+function toProviderZodJsonSchema(schema: z.ZodType): JsonObject {
+  try {
+    return toProviderJsonSchema(schema, { io: "output" });
+  } catch {
+    // Transformed schemas are unrepresentable on the output side. Describe the
+    // validation input instead so the provider emits values the schema
+    // accepts, and the transformed output becomes the completion result.
+    return toProviderJsonSchema(schema, { io: "input" });
+  }
+}
+
 /**
- * Converts any supported Standard Schema to a provider JSON Schema. Synchronously
- * convertible schemas resolve immediately; Valibot schemas load the optional
- * `@valibot/to-json-schema` converter on first use.
+ * Converts any supported Standard Schema to the JSON Schema sent to providers.
+ * Synchronously convertible schemas resolve immediately; Valibot schemas load
+ * the optional `@valibot/to-json-schema` converter on first use.
  */
 export async function toProviderJsonSchemaFromStandardSchema(
   schema: StandardSchemaV1,
-  options: { io?: "input" | "output" } = {},
 ): Promise<JsonObject> {
-  const converted = tryToProviderJsonSchemaFromStandardSchema(schema, options);
+  const converted = tryToProviderJsonSchemaFromStandardSchema(schema);
   if (converted.jsonSchema !== undefined) return converted.jsonSchema;
   const pending = converted.pendingSchema;
   const vendor = pending["~standard"].vendor;
   if (vendor === "valibot") {
-    return valibotToProviderJsonSchema(pending, options);
+    return valibotToProviderJsonSchema(pending);
   }
   throw new Error(
     `Structured output schemas from vendor "${vendor}" cannot be converted to a provider JSON schema. ` +
@@ -88,14 +106,11 @@ async function loadValibotToJsonSchema(): Promise<ValibotToJsonSchemaModule> {
   }
 }
 
-async function valibotToProviderJsonSchema(
-  schema: StandardSchemaV1,
-  options: { io?: "input" | "output" },
-): Promise<JsonObject> {
+async function valibotToProviderJsonSchema(schema: StandardSchemaV1): Promise<JsonObject> {
   const { toJsonSchema } = await loadValibotToJsonSchema();
   const jsonSchema = toJsonSchema(schema, {
     target: JSON_SCHEMA_TARGET,
-    typeMode: options.io === "input" ? "input" : "output",
+    typeMode: "input",
   });
   return toProviderJsonSchemaShape(jsonSchema);
 }

--- a/packages/core/src/schema/standard-json-schema.ts
+++ b/packages/core/src/schema/standard-json-schema.ts
@@ -1,5 +1,5 @@
 import type { z } from "zod";
-import type { JsonObject } from "../completion/index";
+import type { JsonObject, JsonValue } from "../completion/index";
 import type { StandardJSONSchemaV1, StandardSchemaV1 } from "./standard-schema";
 import { toProviderJsonSchema } from "./zod-schema";
 
@@ -48,14 +48,67 @@ export function tryToProviderJsonSchemaFromStandardSchema(
 }
 
 function toProviderZodJsonSchema(schema: z.ZodType): JsonObject {
+  let outputJsonSchema: JsonObject;
   try {
-    return toProviderJsonSchema(schema, { io: "output" });
+    outputJsonSchema = toProviderJsonSchema(schema, { io: "output" });
   } catch {
     // Transformed schemas are unrepresentable on the output side. Describe the
     // validation input instead so the provider emits values the schema
     // accepts, and the transformed output becomes the completion result.
     return toProviderJsonSchema(schema, { io: "input" });
   }
+  let inputJsonSchema: JsonObject;
+  try {
+    inputJsonSchema = toProviderJsonSchema(schema, { io: "input" });
+  } catch {
+    // The input side is not representable while the output side is; the
+    // output side remains the best available description.
+    return outputJsonSchema;
+  }
+  // The provider response is fed to `~standard.validate` as its input, so the
+  // output representation may only be used when it describes the same accepted
+  // values as the input side. Ignoring additionalProperties keeps zod's
+  // strict-object refinements (which provider strict modes such as OpenAI
+  // structured outputs require) while still detecting schemas whose input and
+  // output values genuinely differ, like `z.string().pipe(z.coerce.number())`.
+  return jsonSchemaMatchesInputShape(inputJsonSchema, outputJsonSchema)
+    ? outputJsonSchema
+    : inputJsonSchema;
+}
+
+/** Checks whether the output-side schema shape equals the input-side shape, ignoring strictness. */
+function jsonSchemaMatchesInputShape(input: JsonValue, output: JsonValue): boolean {
+  if (Array.isArray(input) || Array.isArray(output)) {
+    return (
+      Array.isArray(input) &&
+      Array.isArray(output) &&
+      input.length === output.length &&
+      input.every((item, index) => jsonSchemaMatchesInputShape(item, output[index]))
+    );
+  }
+  if (
+    typeof input === "object" &&
+    input !== null &&
+    typeof output === "object" &&
+    output !== null
+  ) {
+    const inputKeys = Object.keys(input).sort();
+    const outputKeys = Object.keys(output)
+      .filter((key) => key !== "additionalProperties")
+      .sort();
+    return (
+      inputKeys.length === outputKeys.length &&
+      inputKeys.every((key, index) => {
+        const outputKey = outputKeys[index];
+        if (outputKey === undefined || key !== outputKey) return false;
+        // Keys come from Object.keys, so the indexed values exist by construction.
+        const inputValue = (input as Record<string, JsonValue>)[key] as JsonValue;
+        const outputValue = (output as Record<string, JsonValue>)[outputKey] as JsonValue;
+        return jsonSchemaMatchesInputShape(inputValue, outputValue);
+      })
+    );
+  }
+  return input === output;
 }
 
 /**

--- a/packages/core/src/schema/standard-schema.ts
+++ b/packages/core/src/schema/standard-schema.ts
@@ -1,0 +1,225 @@
+// Vendor of the Standard Schema v1 specification interfaces
+// (https://standardschema.dev, MIT license). The spec recommends that
+// consumers copy the interfaces instead of taking a runtime dependency, so
+// only the type surface and small validation helpers live here.
+
+/** The Standard Typed interface. This is a base type extended by other specs. */
+export interface StandardTypedV1<Input = unknown, Output = Input> {
+  /** The Standard properties. */
+  readonly "~standard": StandardTypedV1.Props<Input, Output>;
+}
+
+export declare namespace StandardTypedV1 {
+  /** The Standard Typed properties interface. */
+  export interface Props<Input = unknown, Output = Input> {
+    /** The version number of the standard. */
+    readonly version: 1;
+    /** The vendor name of the schema library. */
+    readonly vendor: string;
+    /** Inferred types associated with the schema. */
+    readonly types?: Types<Input, Output> | undefined;
+  }
+
+  /** The Standard Typed types interface. */
+  export interface Types<Input = unknown, Output = Input> {
+    /** The input type of the schema. */
+    readonly input: Input;
+    /** The output type of the schema. */
+    readonly output: Output;
+  }
+
+  /** Infers the input type of a Standard Typed. */
+  export type InferInput<Schema extends StandardTypedV1> = NonNullable<
+    Schema["~standard"]["types"]
+  >["input"];
+
+  /** Infers the output type of a Standard Typed. */
+  export type InferOutput<Schema extends StandardTypedV1> = NonNullable<
+    Schema["~standard"]["types"]
+  >["output"];
+}
+
+/** The Standard Schema interface for schemas that validate data. */
+export interface StandardSchemaV1<Input = unknown, Output = Input> extends StandardTypedV1<
+  Input,
+  Output
+> {
+  /** The Standard Schema properties. */
+  readonly "~standard": StandardSchemaV1.Props<Input, Output>;
+}
+
+export declare namespace StandardSchemaV1 {
+  /** The Standard Schema properties interface. */
+  export interface Props<Input = unknown, Output = Input> extends StandardTypedV1.Props<
+    Input,
+    Output
+  > {
+    /** Validates unknown input values. */
+    readonly validate: (
+      value: unknown,
+      options?: StandardSchemaV1.Options | undefined,
+    ) => StandardSchemaV1.Result<Output> | Promise<StandardSchemaV1.Result<Output>>;
+  }
+
+  /** The result interface of the validate function. */
+  export type Result<Output> =
+    | StandardSchemaV1.SuccessResult<Output>
+    | StandardSchemaV1.FailureResult;
+
+  /** The result interface if validation succeeds. */
+  export interface SuccessResult<Output> {
+    /** The typed output value. */
+    readonly value: Output;
+    /** A falsy value for `issues` indicates success. */
+    readonly issues?: undefined;
+  }
+
+  /** The options interface of the validate function. */
+  export interface Options {
+    /** Explicit support for additional vendor-specific parameters, if needed. */
+    readonly libraryOptions?: Record<string, unknown> | undefined;
+  }
+
+  /** The result interface if validation fails. */
+  export interface FailureResult {
+    /** The issues of failed validation. */
+    readonly issues: ReadonlyArray<StandardSchemaV1.Issue>;
+  }
+
+  /** The issue interface of the failure output. */
+  export interface Issue {
+    /** The error message of the issue. */
+    readonly message: string;
+    /** The path of the issue, if any. */
+    readonly path?: ReadonlyArray<PropertyKey | StandardSchemaV1.PathSegment> | undefined;
+  }
+
+  /** The path segment interface of the issue path. */
+  export interface PathSegment {
+    /** The key representing a path segment. */
+    readonly key: PropertyKey;
+  }
+
+  /** The Standard types interface. */
+  export interface Types<Input = unknown, Output = Input> extends StandardTypedV1.Types<
+    Input,
+    Output
+  > {}
+
+  /** Infers the input type of a Standard Schema. */
+  export type InferInput<Schema extends StandardTypedV1> = StandardTypedV1.InferInput<Schema>;
+
+  /** Infers the output type of a Standard Schema. */
+  export type InferOutput<Schema extends StandardTypedV1> = StandardTypedV1.InferOutput<Schema>;
+}
+
+/**
+ * The Standard JSON Schema interface for entities that can convert themselves
+ * to JSON Schema. Schema libraries may expose it alongside
+ * {@link StandardSchemaV1} on the same `"~standard"` property bag.
+ */
+export interface StandardJSONSchemaV1<Input = unknown, Output = Input> extends StandardTypedV1<
+  Input,
+  Output
+> {
+  /** The Standard JSON Schema properties. */
+  readonly "~standard": StandardJSONSchemaV1.Props<Input, Output>;
+}
+
+export declare namespace StandardJSONSchemaV1 {
+  /** The Standard JSON Schema properties interface. */
+  export interface Props<Input = unknown, Output = Input> extends StandardTypedV1.Props<
+    Input,
+    Output
+  > {
+    /** Methods for generating the input/output JSON Schema. */
+    readonly jsonSchema: StandardJSONSchemaV1.Converter;
+  }
+
+  /** The Standard JSON Schema converter interface. */
+  export interface Converter {
+    /** Converts the input type to JSON Schema. May throw if conversion is not supported. */
+    readonly input: (options: StandardJSONSchemaV1.Options) => Record<string, unknown>;
+    /** Converts the output type to JSON Schema. May throw if conversion is not supported. */
+    readonly output: (options: StandardJSONSchemaV1.Options) => Record<string, unknown>;
+  }
+
+  /** The options for the input/output methods. */
+  export interface Options {
+    /** The target version of the generated JSON Schema. */
+    readonly target: StandardJSONSchemaV1.Target;
+
+    /** Explicit support for additional vendor-specific parameters, if needed. */
+    readonly libraryOptions?: Record<string, unknown> | undefined;
+  }
+
+  /** The target version of the generated JSON Schema. */
+  export type Target =
+    | "draft-2020-12"
+    | "draft-07"
+    | "openapi-3.0"
+    // Accepts any string for future targets while preserving autocomplete.
+    | ({} & string);
+
+  /** The Standard types interface. */
+  export interface Types<Input = unknown, Output = Input> extends StandardTypedV1.Types<
+    Input,
+    Output
+  > {}
+}
+
+/** The result of a synchronous Standard Schema validation. */
+export type StandardSchemaValidation<Output> =
+  | { readonly success: true; readonly value: Output }
+  | { readonly success: false; readonly issues: ReadonlyArray<StandardSchemaV1.Issue> };
+
+/** Checks whether a value looks like a Standard Schema. */
+export function isStandardSchema(value: unknown): value is StandardSchemaV1 {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "~standard" in value &&
+    typeof (value as StandardSchemaV1)["~standard"] === "object" &&
+    (value as StandardSchemaV1)["~standard"] !== null &&
+    typeof (value as StandardSchemaV1)["~standard"].validate === "function"
+  );
+}
+
+/**
+ * Validates a value with a Standard Schema synchronously. Schema libraries
+ * whose `validate` returns a promise (asynchronous schemas) are rejected;
+ * structured completion output must be validated synchronously.
+ */
+export function validateStandardSchema<Output>(
+  schema: StandardSchemaV1<unknown, Output>,
+  value: unknown,
+): StandardSchemaValidation<Output> {
+  const result = schema["~standard"].validate(value);
+  if (typeof (result as { then?: unknown }).then === "function") {
+    throw new TypeError(
+      "The structured output schema validated asynchronously. Asynchronous schemas are not supported for structured completion output.",
+    );
+  }
+  const settled = result as StandardSchemaV1.Result<Output>;
+  if (settled.issues === undefined) {
+    return { success: true, value: settled.value };
+  }
+  return { success: false, issues: settled.issues };
+}
+
+/** Joins Standard Schema issues into a single human-readable message. */
+export function formatStandardSchemaIssues(issues: ReadonlyArray<StandardSchemaV1.Issue>): string {
+  return issues
+    .map((issue) => {
+      const path = (issue.path ?? [])
+        .map((segment) =>
+          typeof segment === "object" && segment !== null && "key" in segment
+            ? segment.key
+            : segment,
+        )
+        .map((key) => (typeof key === "symbol" ? key.toString() : String(key)))
+        .join(".");
+      return path.length > 0 ? `${path}: ${issue.message}` : issue.message;
+    })
+    .join("; ");
+}

--- a/packages/core/test/standard-schema-missing-converter.test.ts
+++ b/packages/core/test/standard-schema-missing-converter.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import * as v from "valibot";
+
+vi.mock("@valibot/to-json-schema", () => {
+  throw new Error("Cannot find module '@valibot/to-json-schema'");
+});
+
+import {
+  AssistantContent,
+  type CompletionModel,
+  type CompletionModelCapabilities,
+  type CompletionRequest,
+  type CompletionResponse,
+  generateCompletion,
+} from "./helpers/imports";
+
+class QueueModel implements CompletionModel {
+  readonly provider = "test";
+  readonly modelId = "missing-converter";
+  readonly capabilities: CompletionModelCapabilities = {
+    streaming: false,
+    tools: true,
+    toolChoice: true,
+    imageInput: true,
+    documentInput: true,
+    outputSchema: true,
+    reasoning: true,
+  };
+  readonly requests: CompletionRequest[] = [];
+
+  async completion(request: CompletionRequest): Promise<CompletionResponse> {
+    this.requests.push(request);
+    return {
+      choice: [AssistantContent.text('{"title":"Typed"}')],
+      usage: {
+        inputTokens: 0,
+        outputTokens: 1,
+        totalTokens: 1,
+        cachedInputTokens: 0,
+        cacheCreationInputTokens: 0,
+      },
+      rawResponse: {},
+    };
+  }
+}
+
+describe("Standard Schema output without the Valibot converter installed", () => {
+  it("explains that @valibot/to-json-schema must be installed", async () => {
+    const model = new QueueModel();
+
+    await expect(
+      generateCompletion({
+        model,
+        prompt: "extract",
+        outputSchema: v.object({ title: v.string() }),
+      }),
+    ).rejects.toThrow(
+      'The structured output schema is a Valibot schema, but "@valibot/to-json-schema" is not installed.',
+    );
+    expect(model.requests).toHaveLength(0);
+  });
+});

--- a/packages/core/test/standard-schema-output.test.ts
+++ b/packages/core/test/standard-schema-output.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
 import * as v from "valibot";
+import { z } from "zod";
 import type { StandardJSONSchemaV1, StandardSchemaV1 } from "../src/schema";
 import {
   AssistantContent,
@@ -213,7 +214,7 @@ describe("Standard Schema structured output", () => {
     expect(model.requests).toHaveLength(0);
   });
 
-  it("uses the Standard JSON Schema interface when a schema provides it", async () => {
+  it("uses the Standard JSON Schema input representation when a schema provides it", async () => {
     const model = new QueueModel(['{"title":"Typed"}']);
     const targets: string[] = [];
     const schema = {
@@ -222,10 +223,12 @@ describe("Standard Schema structured output", () => {
         vendor: "acme-json",
         validate: (value: unknown) => ({ value: value as { title: string } }),
         jsonSchema: {
-          input: () => {
-            throw new Error("Input JSON Schema conversion is not used for completion output.");
+          output: () => {
+            throw new Error(
+              "Providers receive the validation input, so output conversion must not be used.",
+            );
           },
-          output: (options: { target: string }) => {
+          input: (options: { target: string }) => {
             targets.push(options.target);
             return {
               $schema: "https://json-schema.org/draft/2020-12/schema",
@@ -251,6 +254,44 @@ describe("Standard Schema structured output", () => {
     });
   });
 
+  it("sends the input schema to the provider for transformed Valibot schemas", async () => {
+    const model = new QueueModel(['{"count":"42"}']);
+
+    const result = await generateCompletion({
+      model,
+      prompt: "Extract a ticket.",
+      outputSchema: v.object({
+        count: v.pipe(v.string(), v.transform(Number), v.number()),
+      }),
+    });
+
+    expectTypeOf(result.output).toEqualTypeOf<{ count: number }>();
+    expect(result.output).toEqual({ count: 42 });
+    // The provider must be asked for the validation input (string), not the
+    // transformed output (number), or the response would fail validation.
+    expect(model.requests[0]?.outputSchema).toMatchObject({
+      type: "object",
+      properties: { count: { type: "string" } },
+    });
+  });
+
+  it("sends the input schema to the provider for transformed Zod schemas", async () => {
+    const model = new QueueModel(['{"length":"hello"}']);
+
+    const result = await generateCompletion({
+      model,
+      prompt: "Extract a ticket.",
+      outputSchema: z.object({ length: z.string().transform((value) => value.length) }),
+    });
+
+    expectTypeOf(result.output).toEqualTypeOf<{ length: number }>();
+    expect(result.output).toEqual({ length: 5 });
+    expect(model.requests[0]?.outputSchema).toMatchObject({
+      type: "object",
+      properties: { length: { type: "string" } },
+    });
+  });
+
   it("reports asynchronous schema validation as a schema failure", async () => {
     const model = new QueueModel(['{"title":"Typed"}']);
     const asyncSchema = {
@@ -259,10 +300,12 @@ describe("Standard Schema structured output", () => {
         vendor: "acme-async",
         validate: async (value: unknown) => ({ value: value as { title: string } }),
         jsonSchema: {
-          input: () => {
-            throw new Error("Input JSON Schema conversion is not used for completion output.");
+          output: () => {
+            throw new Error(
+              "Providers receive the validation input, so output conversion must not be used.",
+            );
           },
-          output: () => ({ type: "object", properties: { title: { type: "string" } } }),
+          input: () => ({ type: "object", properties: { title: { type: "string" } } }),
         },
       },
     } as unknown as StandardSchemaV1<{ title: string }>;

--- a/packages/core/test/standard-schema-output.test.ts
+++ b/packages/core/test/standard-schema-output.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import * as v from "valibot";
+import type { StandardJSONSchemaV1, StandardSchemaV1 } from "../src/schema";
+import {
+  AssistantContent,
+  type CompletionModel,
+  type CompletionModelCapabilities,
+  CompletionStructuredOutputError,
+  type CompletionModelStreamEvent,
+  type CompletionRequest,
+  type CompletionResponse,
+  generateCompletion,
+  type StreamingCompletionModel,
+  streamCompletion,
+} from "./helpers/imports";
+
+const valibotSchema = v.object({
+  title: v.string(),
+  priority: v.picklist(["low", "high"]),
+});
+
+const typedJson = '{"title":"Typed","priority":"high"}';
+
+class QueueModel implements CompletionModel {
+  readonly provider = "test";
+  readonly modelId = "standard-schema";
+  readonly capabilities: CompletionModelCapabilities = {
+    streaming: false,
+    tools: true,
+    toolChoice: true,
+    imageInput: true,
+    documentInput: true,
+    outputSchema: true,
+    reasoning: true,
+  };
+  readonly requests: CompletionRequest[] = [];
+
+  constructor(private readonly outputs: Array<string | CompletionResponse>) {}
+
+  async completion(request: CompletionRequest): Promise<CompletionResponse> {
+    this.requests.push(request);
+    const output = this.outputs.shift();
+    if (output === undefined) throw new Error("No queued model output.");
+    return typeof output === "string" ? response(output) : output;
+  }
+}
+
+class StreamingQueueModel extends QueueModel implements StreamingCompletionModel {
+  constructor(
+    capabilities: Partial<CompletionModelCapabilities>,
+    private readonly streamingOutputs: Array<string | readonly CompletionModelStreamEvent[]>,
+  ) {
+    super([]);
+    Object.assign(this.capabilities, { streaming: true, ...capabilities });
+  }
+
+  async *streamCompletion(request: CompletionRequest): AsyncIterable<CompletionModelStreamEvent> {
+    this.requests.push(request);
+    const output = this.streamingOutputs.shift();
+    if (output === undefined) throw new Error("No queued streaming model output.");
+    if (typeof output === "string") {
+      yield { type: "final", response: response(output) };
+      return;
+    }
+    yield* output;
+  }
+}
+
+function response(text: string): CompletionResponse {
+  return {
+    choice: [AssistantContent.text(text)],
+    usage: {
+      inputTokens: 0,
+      outputTokens: 1,
+      totalTokens: 1,
+      cachedInputTokens: 0,
+      cacheCreationInputTokens: 0,
+    },
+    rawResponse: {},
+  };
+}
+
+async function collect<T>(events: AsyncIterable<T>): Promise<T[]> {
+  const collected: T[] = [];
+  for await (const event of events) {
+    collected.push(event);
+  }
+  return collected;
+}
+
+describe("Standard Schema structured output", () => {
+  it("accepts Valibot schemas and converts them to a provider JSON schema", async () => {
+    const model = new QueueModel([typedJson]);
+
+    const result = await generateCompletion({
+      model,
+      prompt: "Extract a ticket.",
+      outputSchema: valibotSchema,
+    });
+
+    expectTypeOf(result.output).toEqualTypeOf<{ title: string; priority: "low" | "high" }>();
+    expect(result.output).toEqual({ title: "Typed", priority: "high" });
+    expect(model.requests).toHaveLength(1);
+    const providerSchema = model.requests[0]?.outputSchema;
+    expect(providerSchema).toBeDefined();
+    expect(providerSchema).not.toHaveProperty("$schema");
+    expect(providerSchema).toMatchObject({
+      type: "object",
+      properties: {
+        title: { type: "string" },
+        priority: { type: "string", enum: ["low", "high"] },
+      },
+      required: ["title", "priority"],
+    });
+  });
+
+  it("supports piped Valibot schemas during conversion and validation", async () => {
+    const model = new QueueModel(['{"title":"Typed","priority":"low"}']);
+
+    const result = await generateCompletion({
+      model,
+      prompt: "Extract a ticket.",
+      outputSchema: v.object({
+        title: v.pipe(v.string(), v.minLength(3)),
+        priority: v.picklist(["low", "high"]),
+      }),
+    });
+
+    expect(result.output).toEqual({ title: "Typed", priority: "low" });
+  });
+
+  it("surfaces unsupported Valibot actions as conversion failures before model calls", async () => {
+    const model = new QueueModel([typedJson]);
+
+    await expect(
+      generateCompletion({
+        model,
+        prompt: "Extract a ticket.",
+        outputSchema: v.object({ title: v.pipe(v.string(), v.trim()) }),
+      }),
+    ).rejects.toThrow(/cannot be converted to JSON Schema/);
+    expect(model.requests).toHaveLength(0);
+  });
+
+  it("reports Valibot validation issues as structured output schema failures", async () => {
+    const model = new QueueModel(['{"title":42,"priority":"high"}']);
+
+    const error = await generateCompletion({
+      model,
+      prompt: "Extract a ticket.",
+      outputSchema: valibotSchema,
+    }).catch((value) => value);
+
+    expect(error).toBeInstanceOf(CompletionStructuredOutputError);
+    expect(error).toMatchObject({ phase: "schema" });
+  });
+
+  it("rejects Valibot schemas when the model does not support output schemas", async () => {
+    const model = new QueueModel([]);
+    model.capabilities.outputSchema = false;
+
+    await expect(
+      generateCompletion({ model, prompt: "Extract a ticket.", outputSchema: valibotSchema }),
+    ).rejects.toThrow("test:standard-schema does not support output schemas.");
+    expect(model.requests).toHaveLength(0);
+  });
+
+  it("streams Valibot structured output and defers the schema conversion to the stream", async () => {
+    const model = new StreamingQueueModel({}, [typedJson]);
+
+    const events = await collect(
+      streamCompletion({ model, prompt: "extract", outputSchema: valibotSchema }),
+    );
+    const final = events.at(-1);
+
+    expect(final?.type).toBe("final");
+    if (final?.type !== "final") throw new Error("Expected a final event.");
+    expectTypeOf(final.result.output).toEqualTypeOf<{
+      title: string;
+      priority: "low" | "high";
+    }>();
+    expect(final.result).toMatchObject({
+      output: { title: "Typed", priority: "high" },
+      text: typedJson,
+    });
+    expect(model.requests[0]?.outputSchema).toBeDefined();
+  });
+
+  it("enforces output schema capabilities before streaming with deferred conversions", () => {
+    const model = new StreamingQueueModel({ outputSchema: false }, []);
+
+    expect(() =>
+      streamCompletion({ model, prompt: "extract", outputSchema: valibotSchema }),
+    ).toThrow("test:standard-schema does not support output schemas.");
+    expect(model.requests).toHaveLength(0);
+  });
+
+  it("rejects schemas from vendors without JSON Schema conversion support", async () => {
+    const model = new QueueModel([typedJson]);
+    const unsupported: StandardSchemaV1<{ title: string }> = {
+      "~standard": {
+        version: 1,
+        vendor: "acme",
+        validate: (value) => ({ value: value as { title: string } }),
+      },
+    };
+
+    await expect(
+      generateCompletion({ model, prompt: "extract", outputSchema: unsupported }),
+    ).rejects.toThrow(
+      'Structured output schemas from vendor "acme" cannot be converted to a provider JSON schema.',
+    );
+    expect(model.requests).toHaveLength(0);
+  });
+
+  it("uses the Standard JSON Schema interface when a schema provides it", async () => {
+    const model = new QueueModel(['{"title":"Typed"}']);
+    const targets: string[] = [];
+    const schema = {
+      "~standard": {
+        version: 1,
+        vendor: "acme-json",
+        validate: (value: unknown) => ({ value: value as { title: string } }),
+        jsonSchema: {
+          input: () => {
+            throw new Error("Input JSON Schema conversion is not used for completion output.");
+          },
+          output: (options: { target: string }) => {
+            targets.push(options.target);
+            return {
+              $schema: "https://json-schema.org/draft/2020-12/schema",
+              type: "object",
+              properties: { title: { type: "string" } },
+            };
+          },
+        },
+      },
+    } as unknown as StandardSchemaV1<{ title: string }> & StandardJSONSchemaV1<{ title: string }>;
+
+    const result = await generateCompletion({
+      model,
+      prompt: "extract",
+      outputSchema: schema,
+    });
+
+    expect(result.output).toEqual({ title: "Typed" });
+    expect(targets).toEqual(["draft-2020-12"]);
+    expect(model.requests[0]?.outputSchema).toEqual({
+      type: "object",
+      properties: { title: { type: "string" } },
+    });
+  });
+
+  it("reports asynchronous schema validation as a schema failure", async () => {
+    const model = new QueueModel(['{"title":"Typed"}']);
+    const asyncSchema = {
+      "~standard": {
+        version: 1,
+        vendor: "acme-async",
+        validate: async (value: unknown) => ({ value: value as { title: string } }),
+        jsonSchema: {
+          input: () => {
+            throw new Error("Input JSON Schema conversion is not used for completion output.");
+          },
+          output: () => ({ type: "object", properties: { title: { type: "string" } } }),
+        },
+      },
+    } as unknown as StandardSchemaV1<{ title: string }>;
+
+    const error = await generateCompletion({
+      model,
+      prompt: "extract",
+      outputSchema: asyncSchema,
+    }).catch((value) => value);
+
+    expect(error).toBeInstanceOf(CompletionStructuredOutputError);
+    expect(error).toMatchObject({ phase: "schema" });
+    expect(error.cause).toBeInstanceOf(TypeError);
+  });
+});

--- a/packages/core/test/standard-schema-output.test.ts
+++ b/packages/core/test/standard-schema-output.test.ts
@@ -292,6 +292,44 @@ describe("Standard Schema structured output", () => {
     });
   });
 
+  it("sends the input schema to the provider for representable Zod pipes", async () => {
+    const model = new QueueModel(['{"count":"42"}']);
+
+    const result = await generateCompletion({
+      model,
+      prompt: "Extract a ticket.",
+      outputSchema: z.object({ count: z.string().pipe(z.coerce.number()) }),
+    });
+
+    expectTypeOf(result.output).toEqualTypeOf<{ count: number }>();
+    expect(result.output).toEqual({ count: 42 });
+    // The output side would describe a number while validation expects the
+    // string input, so the provider must receive the input representation.
+    expect(model.requests[0]?.outputSchema).toMatchObject({
+      type: "object",
+      properties: { count: { type: "string" } },
+    });
+  });
+
+  it("keeps strict-object refinements for Zod schemas without input differences", async () => {
+    const model = new QueueModel(['{"title":"Typed"}']);
+
+    await generateCompletion({
+      model,
+      prompt: "Extract a ticket.",
+      outputSchema: z.object({ title: z.string() }),
+    });
+
+    // Pure strictness refinements do not describe different accepted values,
+    // so the output representation (and its refinements) is preserved.
+    expect(model.requests[0]?.outputSchema).toEqual({
+      type: "object",
+      properties: { title: { type: "string" } },
+      required: ["title"],
+      additionalProperties: false,
+    });
+  });
+
   it("reports asynchronous schema validation as a schema failure", async () => {
     const model = new QueueModel(['{"title":"Typed"}']);
     const asyncSchema = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,12 +222,18 @@ importers:
       '@types/node':
         specifier: ^24.9.1
         version: 24.12.2
+      '@valibot/to-json-schema':
+        specifier: ^1.7.1
+        version: 1.7.1(valibot@1.5.0(typescript@5.9.3))
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.26)(tsx@4.23.12)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      valibot:
+        specifier: ^1.5.0
+        version: 1.5.0(typescript@5.9.3)
       vitest:
         specifier: ^4.0.8
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@8.2.2(@types/node@24.12.2)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.12)(yaml@2.9.0))
@@ -3715,6 +3721,11 @@ packages:
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
+  '@valibot/to-json-schema@1.7.1':
+    resolution: {integrity: sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A==}
+    peerDependencies:
+      valibot: ^1.4.0
+
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6855,6 +6866,14 @@ packages:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
+  valibot@1.5.0:
+    resolution: {integrity: sha512-nil6AkP2TChWL43Z5uJ6GTxX01CUA+g8LWUM+N/rB9NBbkUMaUsi9PUNzlUPgoKASgmx9f7eGOYpJ04/fSa6FQ==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   validate-npm-package-name@7.0.2:
     resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -9528,6 +9547,10 @@ snapshots:
       '@types/node': 24.12.2
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@valibot/to-json-schema@1.7.1(valibot@1.5.0(typescript@5.9.3))':
+    dependencies:
+      valibot: 1.5.0(typescript@5.9.3)
 
   '@vitejs/plugin-react@6.0.1(vite@8.2.2(@types/node@24.12.2)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
@@ -12894,6 +12917,10 @@ snapshots:
       '@xterm/xterm': 5.5.0
 
   uuid@14.0.0: {}
+
+  valibot@1.5.0(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
 
   validate-npm-package-name@7.0.2: {}
 


### PR DESCRIPTION
## Summary

`generateCompletion` and `streamCompletion` now accept **any [Standard Schema](https://standardschema.dev) (v1)** as `outputSchema`. Zod schemas keep their existing behavior unchanged; **Valibot** works end to end via the optional peer dependency `@valibot/to-json-schema`; other implementing libraries (ArkType, Effect Schema, …) are supported when they implement the Standard JSON Schema interface.

## Changes

- **Public API**: `outputSchema` is now `StandardSchemaV1<Output>` (structurally satisfied by Zod v4 and Valibot v1 schemas, so existing call sites compile and infer exactly as before). Output type inference is literal-exact (covered by `expectTypeOf` tests).
- **Validation**: runs through the schema's `~standard.validate` instead of `schema.parse`. Failures still raise `CompletionStructuredOutputError` with `phase: "schema"`. Asynchronous schemas are rejected with a clear `TypeError` cause (structured output must validate synchronously).
- **Provider JSON Schema conversion** (`src/schema/standard-json-schema.ts`):
  - Zod → native `toJSONSchema` path, byte-identical to previous behavior (pinned by the existing exact-payload test in `completion-capabilities.test.ts`)
  - any schema implementing `~standard.jsonSchema` → used generically (`output({ target: "draft-2020-12" })`)
  - Valibot → `@valibot/to-json-schema` via cached dynamic import (stays external in `dist`; verified), draft-2020-12 with output `typeMode`
  - unsupported vendors/actions fail **before any model call** with a descriptive error
- **Eager checks preserved in `streamCompletion`**: abort, streaming capability, input validation, and capability assertion (including output schemas whose conversion is deferred) still throw synchronously; only vendor-converter loading is deferred to the first stream pull.
- **New root exports**: `StandardSchemaV1`, `StandardJSONSchemaV1` (types), `isStandardSchema` (guard).
- **Dependencies**: `@valibot/to-json-schema@^1.7.1` added as an **optional peer** of `@anvia/core` plus dev deps (`valibot`, `@valibot/to-json-schema`) for tests. Core's `.d.ts` has zero valibot references.
- **Docs**: core README section on Standard Schema `outputSchema` support; minor changeset included.

## Validation

- `pnpm --filter @anvia/core typecheck` ✅ and `pnpm --filter './packages/**' typecheck` ✅ (after rebuilding `@anvia/core` dist)
- `pnpm --filter @anvia/core test` ✅ 675/675 (11 new tests)
- All other package suites ✅ (`pnpm --filter './packages/**' --filter '!@anvia/core' test`), incl. Studio
- `pnpm check` (oxfmt + oxlint) ✅ · `bin/check-upstream-deps.sh` ✅ (22 pre-existing updates, none introduced here)
- `pnpm --filter @anvia/core build` ✅ — dynamic `import("@valibot/to-json-schema")` confirmed external in `dist`; dts clean

### Skipped

- `tests/*/*` verification workspaces (untouched by this change)
- No visual verification (no UI change)

## Intentional behavior deltas

1. Schema-phase error `cause` is now an `Error` with formatted issue messages (previously the raw `ZodError`); error class, name, and `phase` unchanged.
2. `streamCompletion` runs its streaming check before request building; no observable contract pinned the old precedence, and all eager guarantees are retained.